### PR TITLE
feat(recipe): implement the ADR-015 profile core

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -39,10 +39,11 @@ info:
 
     - **Interactive Sigstore attestation** (`aicr bundle --attest` with browser-based OIDC):
       the interactive, user-authenticated signing flow is CLI-only. The API server instead
-      offers non-interactive server-side attestation: `POST /v1/bundle?attest=true` returns a
+      offers non-interactive server-side attestation: `POST /v1/bundle?attest=true`
+      or `POST /v2/bundle?attest=true` returns a
       signed bundle, with the server signing as itself using its operator-configured KMS key or
       private-Sigstore keyless identity. No signing identity is ever taken from the request.
-      See the `attest` query parameter on POST /v1/bundle.
+      See the `attest` query parameter on POST /v1/bundle and POST /v2/bundle.
 
     - **OCI registry push** (`aicr bundle --output oci://...`) — pushes bundle artifacts to
       a container registry.
@@ -91,7 +92,13 @@ paths:
                     type: array
                     items:
                       type: string
-                    example: ["/v1/recipe", "/v1/bundle"]
+                    example:
+                      - /v1/recipe
+                      - /v1/query
+                      - /v1/bundle
+                      - /v2/recipe
+                      - /v2/query
+                      - /v2/bundle
 
   /v1/recipe:
     get:
@@ -187,7 +194,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RecipeResponse"
+                $ref: "#/components/schemas/LegacyRecipeResponse"
               examples:
                 basic:
                   summary: Basic recipe request
@@ -228,19 +235,21 @@ paths:
                         source: https://helm.ngc.nvidia.com/nvidia
                         chart: network-operator
                     constraints:
-                      driver:
-                        version: "580.82.07"
-                        cudaVersion: "13.1"
+                      - name: GPU.driver.version
+                        value: "580.82.07"
+                      - name: GPU.driver.cudaVersion
+                        value: "13.1"
         "400":
           description: >
-            Invalid request: malformed criteria, allowlist violation, or — new —
-            a stated criteria dimension not honored by any applicable recipe
-            overlay (uncovered dimension). Uncovered-dimension errors carry a
-            machine-readable `details.uncovered` array (dimension,
-            requestedValue, validCompletions). Snapshot-driven resolution
-            (CLI `--snapshot` / Go SDK) may additionally attach
-            `excludedOverlays` / `constraintWarnings`; this HTTP API resolves
-            from criteria only and never emits those fields.
+            Invalid request: malformed criteria, allowlist violation, a resolved
+            profile (which requires `/v2/recipe`), or a stated criteria dimension
+            not honored by any applicable recipe overlay (uncovered dimension).
+            Uncovered-dimension errors carry a machine-readable
+            `details.uncovered` array (dimension, requestedValue,
+            validCompletions). Snapshot-driven resolution (CLI `--snapshot` / Go
+            SDK) may additionally attach `excludedOverlays` /
+            `constraintWarnings`; this HTTP API resolves from criteria only and
+            never emits those fields.
           headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestIdResponse"
@@ -417,17 +426,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RecipeResponse"
+                $ref: "#/components/schemas/LegacyRecipeResponse"
         "400":
           description: >
-            Invalid request: malformed criteria, allowlist violation, or — new —
-            a stated criteria dimension not honored by any applicable recipe
-            overlay (uncovered dimension). Uncovered-dimension errors carry a
-            machine-readable `details.uncovered` array (dimension,
-            requestedValue, validCompletions). Snapshot-driven resolution
-            (CLI `--snapshot` / Go SDK) may additionally attach
-            `excludedOverlays` / `constraintWarnings`; this HTTP API resolves
-            from criteria only and never emits those fields.
+            Invalid request: malformed criteria, allowlist violation, a resolved
+            profile (which requires `/v2/recipe`), or a stated criteria dimension
+            not honored by any applicable recipe overlay (uncovered dimension).
+            Uncovered-dimension errors carry a machine-readable
+            `details.uncovered` array (dimension, requestedValue,
+            validCompletions). Snapshot-driven resolution (CLI `--snapshot` / Go
+            SDK) may additionally attach `excludedOverlays` /
+            `constraintWarnings`; this HTTP API resolves from criteria only and
+            never emits those fields.
           headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestIdResponse"
@@ -636,14 +646,15 @@ paths:
                     useOpenKernelModules: true
         "400":
           description: >
-            Invalid request: malformed criteria, allowlist violation, or — new —
-            a stated criteria dimension not honored by any applicable recipe
-            overlay (uncovered dimension). Uncovered-dimension errors carry a
-            machine-readable `details.uncovered` array (dimension,
-            requestedValue, validCompletions). Snapshot-driven resolution
-            (CLI `--snapshot` / Go SDK) may additionally attach
-            `excludedOverlays` / `constraintWarnings`; this HTTP API resolves
-            from criteria only and never emits those fields.
+            Invalid request: malformed criteria, allowlist violation, a resolved
+            profile (which requires `/v2/query`), or a stated criteria dimension
+            not honored by any applicable recipe overlay (uncovered dimension).
+            Uncovered-dimension errors carry a machine-readable
+            `details.uncovered` array (dimension, requestedValue,
+            validCompletions). Snapshot-driven resolution (CLI `--snapshot` / Go
+            SDK) may additionally attach `excludedOverlays` /
+            `constraintWarnings`; this HTTP API resolves from criteria only and
+            never emits those fields.
           headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestIdResponse"
@@ -770,14 +781,15 @@ paths:
                 description: The value at the selector path (scalar, object, or array)
         "400":
           description: >
-            Invalid request: malformed criteria, allowlist violation, or — new —
-            a stated criteria dimension not honored by any applicable recipe
-            overlay (uncovered dimension). Uncovered-dimension errors carry a
-            machine-readable `details.uncovered` array (dimension,
-            requestedValue, validCompletions). Snapshot-driven resolution
-            (CLI `--snapshot` / Go SDK) may additionally attach
-            `excludedOverlays` / `constraintWarnings`; this HTTP API resolves
-            from criteria only and never emits those fields.
+            Invalid request: malformed criteria, allowlist violation, a resolved
+            profile (which requires `/v2/query`), or a stated criteria dimension
+            not honored by any applicable recipe overlay (uncovered dimension).
+            Uncovered-dimension errors carry a machine-readable
+            `details.uncovered` array (dimension, requestedValue,
+            validCompletions). Snapshot-driven resolution (CLI `--snapshot` / Go
+            SDK) may additionally attach `excludedOverlays` /
+            `constraintWarnings`; this HTTP API resolves from criteria only and
+            never emits those fields.
           headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestIdResponse"
@@ -829,6 +841,529 @@ paths:
               schema:
                 type: integer
               description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v2/recipe:
+    get:
+      tags: [Recipes]
+      summary: Resolve a profile-aware recipe
+      operationId: getRecipeV2
+      description: >
+        Resolves criteria with an optional name=value profile selection. An
+        omitted profile applies the declaration's required default. Unknown
+        query parameters and conflicting repeated profile values are rejected.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/Service"
+        - $ref: "#/components/parameters/Accelerator"
+        - $ref: "#/components/parameters/GPUAlias"
+        - $ref: "#/components/parameters/Intent"
+        - $ref: "#/components/parameters/OS"
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Nodes"
+        - $ref: "#/components/parameters/ProfileSelection"
+      responses:
+        "200":
+          description: Resolved legacy or profile-bearing recipe
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecipeResponse"
+        "400":
+          description: Invalid criteria, profile selection, or query parameter
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags: [Recipes]
+      summary: Resolve a profile-aware recipe from a strict envelope
+      operationId: createRecipeV2
+      description: >
+        Accepts a strict criteria/profile envelope and an optional profile
+        query parameter. Matching query and envelope selections are accepted;
+        conflicting selections, unknown fields, unknown query parameters, and
+        trailing JSON or YAML documents are rejected. Content-Type must be
+        application/json or application/x-yaml.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/ProfileSelection"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecipeV2Request"
+          application/x-yaml:
+            schema:
+              $ref: "#/components/schemas/RecipeV2Request"
+      responses:
+        "200":
+          description: Resolved legacy or profile-bearing recipe
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecipeResponse"
+        "400":
+          description: Invalid request envelope, criteria, or profile selection
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body exceeds the maximum allowed size
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v2/query:
+    get:
+      tags: [Recipes]
+      summary: Query a profile-aware hydrated recipe
+      operationId: getQueryV2
+      description: >
+        Resolves criteria and an optional profile, hydrates the recipe, and
+        returns the value at selector. Unknown query parameters are rejected.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/Service"
+        - $ref: "#/components/parameters/Accelerator"
+        - $ref: "#/components/parameters/GPUAlias"
+        - $ref: "#/components/parameters/Intent"
+        - $ref: "#/components/parameters/OS"
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Nodes"
+        - $ref: "#/components/parameters/ProfileSelection"
+        - $ref: "#/components/parameters/Selector"
+      responses:
+        "200":
+          description: Selected scalar, object, or array
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                description: The value at the selector path
+        "400":
+          description: Invalid criteria, profile selection, or query parameter
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Selector path not found
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags: [Recipes]
+      summary: Query a profile-aware recipe from a strict envelope
+      operationId: createQueryV2
+      description: >
+        Accepts a strict criteria/profile/selector envelope and an optional
+        profile query parameter. Matching query and envelope selections are
+        accepted; conflicting selections, unknown fields, unknown query
+        parameters, and trailing JSON or YAML documents are rejected.
+        Content-Type must be application/json or application/x-yaml.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/ProfileSelection"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueryV2Request"
+          application/x-yaml:
+            schema:
+              $ref: "#/components/schemas/QueryV2Request"
+      responses:
+        "200":
+          description: Selected scalar, object, or array
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                description: The value at the selector path
+        "400":
+          description: Invalid request envelope, criteria, or profile selection
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body exceeds the maximum allowed size
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Selector path not found
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v2/bundle:
+    post:
+      tags: [Bundles]
+      summary: Generate a bundle from a legacy or profiled recipe
+      operationId: createBundleV2
+      description: >
+        Uses the same query parameters and ZIP response as POST /v1/bundle.
+        The body is an already-selected RecipeResult, so this route has no
+        profile-selection field. Legacy recipes stamped aicr.run/v1alpha2 or
+        omitting apiVersion are accepted; v1alpha3 profile recipes are decoded
+        strictly. Content-Type must be application/json or application/x-yaml.
+        Query parameter details are documented on POST /v1/bundle.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/BundleComponents"
+        - $ref: "#/components/parameters/BundleSet"
+        - $ref: "#/components/parameters/BundleDynamic"
+        - $ref: "#/components/parameters/SystemNodeSelector"
+        - $ref: "#/components/parameters/SystemNodeToleration"
+        - $ref: "#/components/parameters/AcceleratedNodeSelector"
+        - $ref: "#/components/parameters/AcceleratedNodeToleration"
+        - $ref: "#/components/parameters/BundleDeployer"
+        - $ref: "#/components/parameters/BundleRepo"
+        - $ref: "#/components/parameters/WorkloadGate"
+        - $ref: "#/components/parameters/WorkloadSelector"
+        - $ref: "#/components/parameters/BundleNodes"
+        - $ref: "#/components/parameters/VendorCharts"
+        - $ref: "#/components/parameters/Serial"
+        - $ref: "#/components/parameters/AppName"
+        - $ref: "#/components/parameters/Attest"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BundleRecipeV2Request"
+          application/x-yaml:
+            schema:
+              $ref: "#/components/schemas/BundleRecipeV2Request"
+      responses:
+        "200":
+          description: ZIP archive containing generated bundle artifacts
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Content-Disposition:
+              schema:
+                type: string
+                example: 'attachment; filename="bundles.zip"'
+              description: Indicates the response should be downloaded as a file
+            X-Bundle-Files:
+              schema:
+                type: integer
+              description: Total number of files in the bundle
+              example: 12
+            X-Bundle-Size:
+              schema:
+                type: integer
+              description: Total size of all files in bytes (uncompressed)
+              example: 45678
+            X-Bundle-Duration:
+              schema:
+                type: string
+              description: Time taken to generate bundles
+              example: "1.234s"
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: Invalid Content-Type, recipe, profile lock violation, or bundle option
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication failed while pulling a vendored chart
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: A requested vendored chart was not found
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body exceeds the maximum allowed size
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: A required bundling dependency or upstream service is unavailable
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Bundle generation or an upstream operation timed out
+          headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestIdResponse"
           content:
@@ -1385,6 +1920,249 @@ components:
       description: Unix timestamp when quota resets
       example: 1705318200
 
+  parameters:
+    RequestId:
+      name: X-Request-Id
+      in: header
+      required: false
+      description: Client-provided request ID for tracing.
+      schema:
+        type: string
+        format: uuid
+    Service:
+      name: service
+      in: query
+      required: false
+      description: Kubernetes service/environment type.
+      schema:
+        type: string
+        enum: [eks, gke, aks, oke, ocp, kind, lke, bcm, metal3, any]
+        default: any
+    Accelerator:
+      name: accelerator
+      in: query
+      required: false
+      description: GPU/accelerator type.
+      schema:
+        type: string
+        enum: [h100, h200, gb200, gb300, b200, a100, l40, l40s, rtx-pro-6000, any]
+        default: any
+    GPUAlias:
+      name: gpu
+      in: query
+      required: false
+      description: Backward-compatible alias for accelerator.
+      schema:
+        type: string
+        enum: [h100, h200, gb200, gb300, b200, a100, l40, l40s, rtx-pro-6000, any]
+        default: any
+    Intent:
+      name: intent
+      in: query
+      required: false
+      description: Workload intent.
+      schema:
+        type: string
+        enum: [training, inference, any]
+        default: any
+    OS:
+      name: os
+      in: query
+      required: false
+      description: GPU node operating system.
+      schema:
+        type: string
+        enum: [ubuntu, rhel, cos, amazonlinux, ol, talos, any]
+        default: any
+    Platform:
+      name: platform
+      in: query
+      required: false
+      description: Platform/framework type.
+      schema:
+        type: string
+        enum: [dynamo, kubeflow, nim, runai, slurm, any]
+        default: any
+    Nodes:
+      name: nodes
+      in: query
+      required: false
+      description: Number of GPU nodes (0 means unspecified).
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    ProfileSelection:
+      name: profile
+      in: query
+      required: false
+      description: >
+        Configuration profile selection in exact name=value form. Omission
+        applies the declaration's required default.
+      schema:
+        type: string
+        pattern: "^$|^[A-Za-z0-9._-]+=[A-Za-z0-9._-]+$"
+    Selector:
+      name: selector
+      in: query
+      required: true
+      description: Dot-delimited path; empty returns the hydrated recipe.
+      schema:
+        type: string
+    BundleComponents:
+      name: bundlers
+      in: query
+      required: false
+      description: Comma-delimited enabled component names to include.
+      schema:
+        type: string
+    BundleSet:
+      name: set
+      in: query
+      required: false
+      description: Repeatable component:path=value override.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    BundleDynamic:
+      name: dynamic
+      in: query
+      required: false
+      description: Repeatable install-time component:path declaration.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    SystemNodeSelector:
+      name: system-node-selector
+      in: query
+      required: false
+      description: Repeatable key=value selector for system components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    SystemNodeToleration:
+      name: system-node-toleration
+      in: query
+      required: false
+      description: Repeatable key=value:effect toleration for system components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    AcceleratedNodeSelector:
+      name: accelerated-node-selector
+      in: query
+      required: false
+      description: Repeatable key=value selector for accelerated components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    AcceleratedNodeToleration:
+      name: accelerated-node-toleration
+      in: query
+      required: false
+      description: Repeatable key=value:effect toleration for accelerated components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    BundleDeployer:
+      name: deployer
+      in: query
+      required: false
+      description: Bundle deployment method.
+      schema:
+        type: string
+        enum: [helm, argocd, argocd-helm, flux, helmfile]
+        default: helm
+    BundleRepo:
+      name: repo
+      in: query
+      required: false
+      description: Git repository URL for supported GitOps deployers.
+      schema:
+        type: string
+        format: uri
+    WorkloadGate:
+      name: workload-gate
+      in: query
+      required: false
+      description: >
+        Taint for nodewright-operator workload gating (format:
+        key=value:effect or key:effect).
+      schema:
+        type: string
+      example: "skyhook.nvidia.com/runtime=required:NoSchedule"
+    WorkloadSelector:
+      name: workload-selector
+      in: query
+      required: false
+      description: Repeatable key=value selector for workload-gate classification.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    BundleNodes:
+      name: nodes
+      in: query
+      required: false
+      description: Estimated GPU node count for bundle-time injections.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    VendorCharts:
+      name: vendor-charts
+      in: query
+      required: false
+      description: Include upstream chart bytes in the generated bundle.
+      schema:
+        type: boolean
+        default: false
+    Serial:
+      name: serial
+      in: query
+      required: false
+      description: Sequence components strictly in deployment order.
+      schema:
+        type: boolean
+        default: false
+    AppName:
+      name: app-name
+      in: query
+      required: false
+      description: Parent Argo CD Application name.
+      schema:
+        type: string
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+        maxLength: 253
+    Attest:
+      name: attest
+      in: query
+      required: false
+      description: Return a server-signed bundle.
+      schema:
+        type: boolean
+        default: false
+
   schemas:
     Error:
       type: object
@@ -1449,6 +2227,42 @@ components:
     Criteria:
       type: object
       description: Recipe criteria specification
+      properties:
+        service:
+          type: string
+          description: Kubernetes service type
+          enum: [eks, gke, aks, oke, ocp, kind, lke, bcm, metal3, any]
+          example: eks
+        accelerator:
+          type: string
+          description: GPU/accelerator type
+          enum: [h100, h200, gb200, gb300, b200, a100, l40, l40s, rtx-pro-6000, any]
+          example: h100
+        intent:
+          type: string
+          description: Workload intent
+          enum: [training, inference, any]
+          example: training
+        os:
+          type: string
+          description: Operating system family
+          enum: [ubuntu, rhel, cos, amazonlinux, ol, talos, any]
+          example: ubuntu
+        platform:
+          type: string
+          description: Platform/framework type
+          enum: [dynamo, kubeflow, nim, runai, slurm, any]
+          example: kubeflow
+        nodes:
+          type: integer
+          description: Number of GPU nodes (0 = any)
+          minimum: 0
+          default: 0
+
+    CriteriaV2:
+      type: object
+      description: Strict recipe criteria specification for v2 request bodies
+      additionalProperties: false
       properties:
         service:
           type: string
@@ -1567,6 +2381,39 @@ components:
             $ref: "#/components/schemas/Subtype"
           description: List of configuration subtypes within this measurement
 
+    RecipeV2Request:
+      type: object
+      description: >
+        Strict profile-aware recipe-resolution envelope. Unknown fields are
+        rejected both at this envelope level and inside criteria.
+      required: [criteria]
+      additionalProperties: false
+      properties:
+        criteria:
+          $ref: "#/components/schemas/CriteriaV2"
+        profile:
+          type: string
+          description: Optional configuration profile selection in name=value form
+          pattern: "^$|^[A-Za-z0-9._-]+=[A-Za-z0-9._-]+$"
+
+    QueryV2Request:
+      type: object
+      description: >
+        Strict profile-aware query envelope. Unknown fields are rejected both
+        at this envelope level and inside criteria.
+      required: [criteria, selector]
+      additionalProperties: false
+      properties:
+        criteria:
+          $ref: "#/components/schemas/CriteriaV2"
+        profile:
+          type: string
+          description: Optional configuration profile selection in name=value form
+          pattern: "^$|^[A-Za-z0-9._-]+=[A-Za-z0-9._-]+$"
+        selector:
+          type: string
+          description: Dot-delimited path; empty returns the hydrated recipe
+
     RecipeResponseBase:
       type: object
       description: >
@@ -1604,19 +2451,23 @@ components:
               type: array
               description: Optional list of matching overlays excluded from the final recipe
               items:
-                type: object
-                required: [name]
-                properties:
-                  name:
-                    type: string
-                    description: Name of the excluded overlay
-                  reason:
-                    type: string
-                    description: >
-                      Machine-readable reason for exclusion. API-generated responses
-                      populate this field; legacy stored recipes accepted for backward
-                      compatibility may omit it when deserialized.
-                    enum: [constraint-failed, mixin-constraint-failed]
+                oneOf:
+                  - type: string
+                    description: Legacy excluded-overlay name
+                  - type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                        description: Name of the excluded overlay
+                      reason:
+                        type: string
+                        description: >
+                          Machine-readable reason for exclusion. API-generated responses
+                          populate this field; legacy stored recipes accepted for backward
+                          compatibility may omit it when deserialized.
+                        enum: [constraint-failed, mixin-constraint-failed]
             constraintWarnings:
               type: array
               description: Optional details about failed constraint evaluations for excluded overlays
@@ -1648,6 +2499,38 @@ components:
                 snapshot was provided). Consumed by the bundle-time
                 CheckDriverOwnershipCoherence validation.
               enum: [preinstalled, absent]
+            selectedProfile:
+              type: object
+              description: >
+                Selected profile identity and declaration-wide lock surface.
+                Present only when apiVersion is aicr.run/v1alpha3.
+              not:
+                required: [advertiser]
+              required: [name, value, ownedPaths]
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+                  pattern: "^[A-Za-z0-9._-]+$"
+                value:
+                  type: string
+                  pattern: "^[A-Za-z0-9._-]+$"
+                advertiser:
+                  type: string
+                  enum: [external]
+                  description: >
+                    Reserved for the future GKE allocation-policy extension.
+                    This field must be absent in the current version; any
+                    non-empty value, including external, is rejected.
+                ownedPaths:
+                  type: object
+                  description: >
+                    Canonical component names mapped to sorted owned dotted
+                    paths. Every listed component includes synthetic "enabled".
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
         criteria:
           $ref: "#/components/schemas/Criteria"
           description: Original criteria parameters
@@ -1664,6 +2547,9 @@ components:
                   both enabled and disabled refs) when non-empty; a duplicate
                   non-empty name is rejected with 400. Refs with an empty
                   name are exempt from the uniqueness check.
+              namespace:
+                type: string
+                description: Kubernetes namespace for the component
               type:
                 type: string
                 enum: [Helm, Kustomize]
@@ -1719,6 +2605,13 @@ components:
                   on a source-backed ref. Values with surrounding whitespace
                   are rejected with 400. A chart without a source is rejected
                   (nothing to pull from).
+              valuesFile:
+                type: string
+                description: Path to component values relative to the data directory
+              overrides:
+                type: object
+                description: Inline component values, merged after valuesFile
+                additionalProperties: true
               path:
                 type: string
                 description: Path within the source to the kustomization (Kustomize)
@@ -1751,6 +2644,33 @@ components:
                   an enabled ref that sets `patches` is rejected with 400 rather
                   than silently producing an unpatched bundle. Do not set. See
                   issue #1588.
+              dependencyRefs:
+                type: array
+                items:
+                  type: string
+                description: Component names that must be deployed first
+              cleanup:
+                type: boolean
+                description: Whether validation infrastructure is removed after use
+              expectedResources:
+                type: array
+                description: Kubernetes resources expected after deployment
+                items:
+                  type: object
+                  required: [kind, name]
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+              healthCheckAsserts:
+                type: string
+                description: Hydrated Chainsaw-style health-check assertions
+              healthCheckSkip:
+                type: boolean
+                description: Whether registry health-check assertion hydration is skipped
           description: >-
             List of component references. Deployment order is not per-ref; it is
             the top-level `deploymentOrder` array.
@@ -1763,12 +2683,27 @@ components:
             Preserve this on a GET→POST round trip (POST /v1/bundle accepts this
             same shape) — dropping it changes deployment sequencing.
         constraints:
-          type: object
-          description: Deployment constraints (driver versions, etc.)
-          additionalProperties: true
+          type: array
+          description: Deployment constraints and assumptions
+          items:
+            type: object
+            required: [name, value]
+            properties:
+              name:
+                type: string
+              value:
+                type: string
+              severity:
+                type: string
+              remediation:
+                type: string
+              unit:
+                type: string
 
     RecipeResponse:
-      description: Complete recipe response with metadata and component references
+      description: >
+        Complete legacy or profile-aware recipe response with metadata and
+        component references.
       allOf:
         - $ref: "#/components/schemas/RecipeResponseBase"
         - type: object
@@ -1776,20 +2711,221 @@ components:
           properties:
             apiVersion:
               type: string
-              enum: [aicr.run/v1alpha2]
+              enum: [aicr.run/v1alpha2, aicr.run/v1alpha3]
               example: aicr.run/v1alpha2
             kind:
               type: string
               enum: [RecipeResult]
               example: RecipeResult
 
+    ProfileRecipeResponse:
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponse"
+        - type: object
+          description: >
+            Closed aicr.run/v1alpha3 RecipeResult shape. Unknown fields are
+            rejected at its typed object boundaries.
+          required: [metadata, componentRefs]
+          additionalProperties: false
+          properties:
+            apiVersion:
+              type: string
+              enum: [aicr.run/v1alpha3]
+            kind:
+              type: string
+              enum: [RecipeResult]
+            metadata:
+              type: object
+              required: [selectedProfile]
+              propertyNames:
+                enum:
+                  - version
+                  - appliedOverlays
+                  - excludedOverlays
+                  - constraintWarnings
+                  - gpuDriverState
+                  - selectedProfile
+              properties:
+                excludedOverlays:
+                  type: array
+                  items:
+                    type: object
+                    required: [name]
+                    propertyNames:
+                      enum: [name, reason]
+                constraintWarnings:
+                  type: array
+                  items:
+                    type: object
+                    required: [overlay, constraint, expected, reason]
+                    propertyNames:
+                      enum: [overlay, constraint, expected, actual, reason]
+                selectedProfile:
+                  type: object
+                  not:
+                    required: [advertiser]
+            criteria:
+              $ref: "#/components/schemas/CriteriaV2"
+            constraints:
+              type: array
+              items:
+                type: object
+                required: [name, value]
+                propertyNames:
+                  enum: [name, value, severity, remediation, unit]
+            componentRefs:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                required: [name]
+                propertyNames:
+                  enum:
+                    - name
+                    - namespace
+                    - chart
+                    - type
+                    - source
+                    - version
+                    - tag
+                    - valuesFile
+                    - overrides
+                    - patches
+                    - dependencyRefs
+                    - manifestFiles
+                    - preManifestFiles
+                    - path
+                    - cleanup
+                    - expectedResources
+                    - healthCheckAsserts
+                    - healthCheckSkip
+                properties:
+                  expectedResources:
+                    type: array
+                    items:
+                      type: object
+                      required: [kind, name]
+                      additionalProperties: false
+                      properties:
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+            deploymentOrder:
+              type: array
+              items:
+                type: string
+            validation:
+              type: object
+              propertyNames:
+                enum: [readiness, deployment, performance, conformance]
+              additionalProperties:
+                type: object
+                propertyNames:
+                  enum: [timeout, constraints, checks, nodeSelection, infrastructure]
+                properties:
+                  timeout:
+                    type: string
+                  constraints:
+                    type: array
+                    items:
+                      type: object
+                      required: [name, value]
+                      propertyNames:
+                        enum: [name, value, severity, remediation, unit]
+                  checks:
+                    type: array
+                    items:
+                      type: string
+                  nodeSelection:
+                    type: object
+                    propertyNames:
+                      enum: [selector, maxNodes, excludeNodes]
+                    properties:
+                      selector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      maxNodes:
+                        type: integer
+                      excludeNodes:
+                        type: array
+                        items:
+                          type: string
+                  infrastructure:
+                    type: string
+
+    LegacyRecipeResponse:
+      description: >
+        Additive legacy recipe shape. Unknown fields remain accepted for
+        compatibility, but metadata.selectedProfile is reserved for v1alpha3.
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponse"
+        - type: object
+          properties:
+            apiVersion:
+              type: string
+              enum: [aicr.run/v1alpha2]
+            metadata:
+              type: object
+              not:
+                required: [selectedProfile]
+
+    LegacyBundleRecipeV2Request:
+      description: >
+        Additive legacy RecipeResult accepted by POST /v2/bundle: any
+        combination of apiVersion absent, empty, or aicr.run/v1alpha2 with
+        kind absent, empty, or RecipeResult. One branch covers the whole
+        legacy square because DecodeRecipeResult accepts every cell of it —
+        kind is enforced only when non-empty, and only v1alpha3 requires it —
+        and /v1/bundle's BundleRecipeRequest admits the same shapes, so any
+        narrower branch leaves /v2/bundle stricter than its own server
+        (previously true for the empty-header round trip, then again for
+        apiVersion v1alpha2 with kind absent). The legacy kind Recipe is
+        v1-only: the strict v2 decode path rejects it.
+        metadata.selectedProfile remains reserved for v1alpha3.
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponseBase"
+        - type: object
+          properties:
+            apiVersion:
+              type: string
+              description: >
+                aicr.run/v1alpha2, absent, or empty after a legacy struct
+                round trip
+              enum: ["", aicr.run/v1alpha2]
+            kind:
+              type: string
+              description: >
+                RecipeResult, absent, or empty for a round-tripped artifact
+              enum: ["", RecipeResult]
+              example: RecipeResult
+            metadata:
+              type: object
+              not:
+                required: [selectedProfile]
+    BundleRecipeV2Request:
+      description: >
+        Version-partitioned RecipeResult accepted by POST /v2/bundle.
+        Legacy input with apiVersion aicr.run/v1alpha2 or no apiVersion remains
+        additive; v1alpha3 input is closed and requires
+        metadata.selectedProfile. The branches are disjoint on apiVersion:
+        the legacy branch admits only absent/empty/v1alpha2 and prohibits
+        selectedProfile, while the profile branch requires v1alpha3.
+      oneOf:
+        - $ref: "#/components/schemas/LegacyBundleRecipeV2Request"
+        - $ref: "#/components/schemas/ProfileRecipeResponse"
+
     BundleRecipeRequest:
       description: >
         RecipeResult accepted by POST /v1/bundle. Current aicr.run/v1alpha2
         artifacts and legacy artifacts with absent or empty header fields are
         accepted. The kind value Recipe is also accepted: it was the value this
-        contract published through v0.18.0, and the handler performs no header
+        contract published through v0.18.0, and the handler performs no kind
         validation, so clients written against that spec must keep working.
+        apiVersion is the one validated header field — see below.
 
         A legacy kind is echoed into the generated bundle's recipe.yaml rather
         than normalized, and the CLI file loader accepts an absent or empty kind
@@ -1800,10 +2936,14 @@ components:
         apiVersion deliberately has no equivalent legacy window. The artifact
         group/version bump is a hard break with no transition period (see
         docs/design/011-artifact-apiversion-policy.md), so an artifact stamped
-        with a prior group/version should be regenerated rather than sent. That
-        is a client-contract rule rather than an enforced one: this endpoint
-        validates no header field, so a prior apiVersion is ignored rather than
-        rejected. The CLI file-load path does enforce it.
+        with a prior group/version must be regenerated rather than sent. This
+        rule is enforced: the shared artifact gate rejects any apiVersion
+        outside aicr.run/v1alpha2 and aicr.run/v1alpha3 with a 400, here and on
+        the CLI file-load path alike. An absent or empty apiVersion is still
+        admitted as the legacy shape.
+
+        metadata.selectedProfile remains reserved for aicr.run/v1alpha3 and
+        is rejected on this route.
       allOf:
         - $ref: "#/components/schemas/RecipeResponseBase"
         - type: object
@@ -1821,6 +2961,10 @@ components:
                 RecipeResult, the legacy Recipe value published through
                 v0.18.0, or empty for a legacy artifact
               enum: ["", Recipe, RecipeResult]
+            metadata:
+              type: object
+              not:
+                required: [selectedProfile]
 
     QueryRequest:
       type: object

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -29,12 +29,12 @@ All server code lives in [`pkg/server`](https://github.com/NVIDIA/aicr/tree/main
 
 | File | Responsibility |
 |------|----------------|
-| `serve.go` | Entry point. Parses env allowlists, constructs `aicr.Client`, wires `/v1/recipe`, `/v1/query`, `/v1/bundle`, runs `Server.Run` |
+| `serve.go` | Entry point. Parses env allowlists, constructs `aicr.Client`, wires the v1 and v2 recipe, query, and bundle routes, runs `Server.Run` |
 | `server.go` | `Server` struct, options, route mux, lifecycle (`Start`, `Shutdown`, `Run`) |
 | `config.go` | `config` struct and env-var overrides (`PORT`, `SHUTDOWN_TIMEOUT_SECONDS`) |
 | `middleware.go` | 8-layer middleware chain; ordering rationale lives in source comments |
-| `recipe_handler.go` | `GET\|POST /v1/recipe` and `/v1/query` adapter over `Client.ResolveRecipeFromCriteria` |
-| `bundle_handler.go` | `POST /v1/bundle` adapter over `Client.AdoptRecipe` + `Client.MakeBundle` |
+| `recipe_handler.go` | `GET\|POST /v1/recipe`, `/v1/query`, `/v2/recipe`, and `/v2/query` adapter over the profile-aware `Client` resolution methods |
+| `bundle_handler.go` | `POST /v1/bundle` and `/v2/bundle` adapter over `Client.AdoptRecipe` + `Client.MakeBundle` |
 | `health.go` | `GET /health` and `GET /ready` |
 | `metrics.go` | Prometheus collectors (requests, duration, in-flight, rate-limit rejects, panic recoveries) |
 | `version.go` | `X-API-Version` header negotiation from `Accept: application/vnd.nvidia.aicr.v1+json` |
@@ -155,6 +155,9 @@ field is wired in one place.
 | `/v1/recipe` | GET, POST | Resolve recipe from criteria → `RecipeResult` JSON |
 | `/v1/query` | GET, POST | Resolve recipe, hydrate values, return value at `?selector=path` |
 | `/v1/bundle` | POST | Adopt `RecipeResult` body, generate bundle, stream zip |
+| `/v2/recipe` | GET, POST | Resolve a profile-aware recipe from criteria → strict `RecipeResult` JSON |
+| `/v2/query` | GET, POST | Resolve a profile-aware recipe, hydrate values, and return the required selector path |
+| `/v2/bundle` | POST | Strictly decode a profile-aware `RecipeResult`, generate a bundle, and stream zip |
 
 Schemas, query parameters, and example payloads live in
 [docs/user/api-reference.md](../user/api-reference.md) and

--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -198,6 +198,56 @@ to walking from the root spec down to this node. Leaf is a role, not a
 distinct `kind` — every overlay is a `RecipeMetadata`; "leaf" just
 names the ones at the end of a chain.
 
+### Configuration Profile Contract
+
+`RecipeMetadata.Spec.Profile` declares one overlay-scoped enum for qualified
+configuration ownership modes. A declaration requires recipe apiVersion
+`aicr.run/v1alpha3`; that version without a declaration, or a declaration on
+the legacy version, is rejected. Profile-version metadata and recipe
+artifacts are strictly decoded so an unknown field cannot silently disappear.
+
+The core `ProfileValue` contract is closed to `constraints` and
+`componentRefs{name,overrides}`. It rejects `valuesFile`, component
+identity/deployment fields, root `overrides.enabled`, literal dotted keys,
+nested empty maps, and allocation-policy selector paths. The `advertiser`
+wire field is reserved for the later GKE extension and is rejected by the
+core validator. Value-bearing ownership is limited to Helm components;
+Kustomize components do not consume values overrides and support only a
+valueless reference for presence locking.
+
+Resolution enforces these invariants:
+
+1. Before snapshot filtering, collect declarations from every matching
+   candidate chain. Deduplicate one declaring source reached through multiple
+   chains; reject independently authored declarations.
+2. Snapshot filtering may not remove the declaring source and fall back to an
+   unprofiled composition.
+3. Apply an explicit `name=value` selection or the required default after
+   overlays and mixins. Every referenced component across all values must
+   already be enabled in the surviving composition.
+4. Every value has the same flattened override-path set. Apply the selected
+   fragment at the highest recipe precedence and reject constraint-name
+   collisions.
+5. Evaluate selected profile constraints fail closed. A missing reading has a
+   distinct invalid-request diagnostic; other evaluator failures propagate.
+6. Stamp the result `aicr.run/v1alpha3` and persist
+   `metadata.selectedProfile`. Its sorted `ownedPaths` is the
+   declaration-wide path union plus synthetic `enabled` for each referenced
+   component.
+
+The shared raw-artifact gate checks version/profile coupling and hydrates
+profile-owned values. Bundle and mirror compare final candidate state with the
+hydrated recipe before creating output. Exact, ancestor, or descendant dynamic
+paths reject unconditionally; static writes reject only when the effective
+three-state observation (present bytes, absent, or blocked) diverges.
+Argocd-helm emits the corresponding structural template-time guard. Other
+deployers have no supported install-time value surface.
+
+Unprofiled compositions retain the legacy apiVersion and byte shape.
+Generation-side driver auto-detection skips a path owned by the selected
+profile. Evidence projection also rejects profiled artifacts until generic
+per-value evidence support lands with the first adopter.
+
 ## Mixin Composition
 
 Inheritance is single-parent, which means cross-cutting concerns (OS
@@ -308,7 +358,7 @@ The resolver lives in `pkg/recipe/metadata_store.go`. The merge
 proceeds in this temporal order:
 
 ```text
-base chain (root → leaf) → mixins → registry defaults → CLI/API --set
+base chain (root → leaf) → mixins → selected profile → registry defaults → CLI/API --set
 ```
 
 The base inheritance chain is merged first (root → leaf, later
@@ -335,12 +385,16 @@ Implementation notes:
    the leaf, loads each from `recipes/mixins/`, and appends.
    `mixinComponentRefSafeForMerge` rejects mixin componentRefs that
    touch identity/sourcing fields.
-4. **Registry defaults.** `applyRegistryDefaults(provider, refs)`
+4. **Profile specialization.** When the pre-filter composition found one
+   declaration and that source survived filtering, apply the selected value
+   after the chain and mixins. The fragment supersedes earlier assignments
+   only on its closed override surface. Unprofiled resolution skips this step.
+5. **Registry defaults.** `applyRegistryDefaults(provider, refs)`
    fills in chart/version/namespace/source/tag/path defaults for any
    `ComponentRef` field still empty after the chain merge. Failure to
    load the registry is propagated, not swallowed — partial refs
    would fail downstream far from the root cause.
-5. **Topological sort.** `TopologicalSort()` orders components by
+6. **Topological sort.** `TopologicalSort()` orders components by
    `dependencyRefs` for the final `DeploymentOrder`. Cycles produce
    `ErrCodeInvalidRequest`. Components disabled via
    `overrides.enabled: false` (`ComponentRef.IsEnabled()`) are excluded

--- a/docs/design/015-recipe-configuration-profiles.md
+++ b/docs/design/015-recipe-configuration-profiles.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-**Accepted** — 2026-07-21 (proposed 2026-07-14).
+**Accepted** — 2026-07-21 (proposed 2026-07-14). Amended
+2026-07-27 to stage the service-agnostic mechanism through an AKS-first,
+GKE-second rollout.
 
 Originated from an internal GKE device-plugin ownership discussion
 (2026-07-14) and
@@ -22,9 +24,10 @@ stack — the cloud service or the GPU Operator**:
   with `--gpu-driver none` (operator installs driver + toolkit) vs. the AKS
   **"Driver only"** install profile with driver and toolkit preinstalled
   (gpu-operator needs `driver.enabled=false`, `toolkit.enabled=false`,
-  `operator.runtimeClass=nvidia-container-runtime`, all three together —
-  mixing modes leaves containerd without a working `nvidia` runtime
-  handler). Fully AKS-managed GPU node pools (`--enable-managed-gpu=true`,
+  `operator.runtimeClass=nvidia-container-runtime`, and DRA needs
+  `nvidiaDriverRoot=/`, all four together — mixing modes leaves containerd
+  without a working `nvidia` runtime handler or DRA without the driver
+  userspace). Fully AKS-managed GPU node pools (`--enable-managed-gpu=true`,
   preview) additionally own the device plugin, DCGM exporter, and health
   tooling; that mode conflicts with the operands AICR deploys and stays
   **out of scope** here, as the AKS guide already states.
@@ -122,13 +125,17 @@ ownership record.
 A profile value's effect is a **recipe fragment reusing existing syntax**
 (`componentRefs[].overrides` and `constraints`) — exactly mixin-shaped,
 kept as a distinct profile fragment so existing component merge, registry
-defaulting, and dependency validation apply unchanged. The one
-profile-specific field not inherited from existing fragment syntax is
-`advertiser` (see the #1327 amendment below): a value that hands
-`nvidia.com/gpu` advertisement to a provider-managed plugin declares
-`advertiser: external`. It is optional and `external` is its only value —
-operator ownership is never declared, it is read from the effective
-values (`devicePlugin.enabled`) as today. Two consumers, same shape:
+defaulting, and dependency validation apply unchanged.
+
+The first roll-in accepts only those two fragment fields. The GKE adoption
+extends the closed fragment with `advertiser` (see the #1327 amendment
+below): a value that hands `nvidia.com/gpu` advertisement to a
+provider-managed plugin declares `advertiser: external`. The core wire type
+reserves that field, but its validator rejects it until the GKE extension
+lands. This stages the policy-specific machinery without making the ADR or
+the profile mechanism AKS-specific.
+
+Two consumers, same shape:
 
 ```yaml
 # recipes/overlays/aks.yaml — driver/toolkit ownership (unmanaged pools only;
@@ -137,7 +144,7 @@ spec:
   profile:
     name: gpuStack
     description: Who installs the GPU driver and container toolkit.
-    default: operator
+    default: driver-only
     values:
       operator:            # node pools created with --gpu-driver none
         componentRefs:
@@ -145,8 +152,11 @@ spec:
             overrides:
               driver:  {enabled: true}
               toolkit: {enabled: true}
-              operator: {runtimeClass: null}   # authored absence — union
-                                               # totality, see below
+              operator: {runtimeClass: nvidia}
+          - name: nvidia-dra-driver-gpu
+            overrides:
+              nvidiaDriverRoot: /run/nvidia/driver
+        # PR 2 adds the symmetric gpuProfile.driver=None constraint.
       driver-only:         # AKS "Driver only" install profile:
                            # driver + toolkit preinstalled on the node
         componentRefs:
@@ -155,33 +165,40 @@ spec:
               driver:  {enabled: false}
               toolkit: {enabled: false}
               operator: {runtimeClass: nvidia-container-runtime}
-        # constraints: TBD — see note below; no snapshot signal exists yet.
+          - name: nvidia-dra-driver-gpu
+            overrides:
+              nvidiaDriverRoot: /
+        # PR 2 adds the symmetric gpuProfile.driver=Install constraint.
 ```
 
-The `driver-only` value deliberately shows no constraint: AICR's GPU
-collector is driver-free by design, and the only driver signal it
-captures is a
-`GPU.hardware.driver-loaded` boolean (`pkg/collector/gpu`), which proves
-driver *presence*, not which mode owns it. No *node-level
-installed-driver* or node-pool-mode reading exists in snapshots today —
-the snapshot's `K8s.policy.driver.version` is the ClusterPolicy-
-*configured* value, post-deployment intent rather than node state.
+AKS is the first consumer because its current recipe already defaults to
+the four-path `driver-only` tuple shown above. The alternative override
+documented by the merged AKS change flips all four paths together.
+Moving that existing qualified split behind a profile removes the
+bundle-time flag tuple without requiring the GKE-only advertiser model.
+
+AICR's existing GPU collector is driver-free by design, and its
+`GPU.hardware.driver-loaded` boolean proves driver *presence*, not which
+mode owns it. The AKS adoption therefore adds a provider reading projected
+from each GPU agent pool's durable
+[`gpuProfile.driver`](https://learn.microsoft.com/en-us/rest/api/aks/agent-pools/get?view=rest-aks-2026-04-01)
+property:
+`Install` selects `driver-only`, while `None` selects `operator`. An
+unavailable provider reading, an unknown value, or mixed GPU-pool values
+fails closed. Both profile values carry symmetric constraints over that
+reading.
 
 The shipped `gpuDriverState` heuristic is a legacy value-level
 optimization on unprofiled compositions, never profile selection, and
 not the authoritative signal this value needs — it samples a single
 node and is ambiguous once any installer has run.
 
-The *authoritative*
-node-pool-mode signal (an AKS-set node label, the `gpuProfile` surface, or
-a new collector reading) must be identified and documented before this
-profile value ships. The rule, precisely: a profile value must carry a
-validation signal that **distinguishes its configuration from every
-sibling value's** — a value without one (no signal at all, or
-constraints identical to a sibling's) does not satisfy this ADR's
-"validated against deployed config" claim and must not be declared.
-Values shown in this document without such a signal are target state,
-gated by this rule.
+The rule remains general: a profile value must carry a validation signal
+that **distinguishes its configuration from every sibling value's**. A
+value without one (no signal at all, or constraints identical to a
+sibling's) does not satisfy this ADR's "validated against deployed config"
+claim and must not be declared. Values shown without such a signal are
+target state, gated by this rule.
 
 ```yaml
 # recipes/overlays/gke-cos.yaml — device-plugin ownership
@@ -262,6 +279,13 @@ the surviving composition is known (catalog load cannot see snapshot
 exclusions). A profile changes how existing components are configured,
 never the component set — in either direction.
 
+A value-bearing fragment may reference only a **Helm** component.
+Kustomize deployment consumes source, path, and tag rather than Helm
+values, so accepting an override there would record a selected profile
+without changing the generated manifests. A Kustomize component may
+appear only as a valueless reference when the declaration needs the
+synthetic `enabled` presence lock.
+
 A fragment override therefore must not set the root `enabled` key
 (rejected at catalog load): the component model reads
 `overrides.enabled: false` as component removal, which would mutate
@@ -291,10 +315,12 @@ once conditional installation is values-gated, and admitting it would
 pull addition and ordering-declaration semantics into the fragment
 schema ahead of any user.
 
-**The fragment schema is closed: a profile value permits `advertiser`,
-`constraints`, and `componentRefs` only, and each `componentRef`
-permits only `name` and `overrides` — every other `ComponentRef` field
-is rejected at catalog load** (full field inventory in #1761).
+**The fragment schema is closed.** The core roll-in permits
+`constraints` and `componentRefs` only, and each `componentRef` permits
+only `name` and `overrides`. Every other `ComponentRef` field is rejected
+at catalog load. The GKE extension admits only the already-reserved
+`advertiser` field in addition to that core shape (full field inventory in
+[#1761](https://github.com/NVIDIA/aicr/issues/1761)).
 
 The operative criterion: a fragment field is permitted only when its
 effect is either representable in `ownedPaths` (value paths plus the
@@ -367,9 +393,11 @@ once, inherited by accelerator/intent leaves.
   name must name the precise
   ownership split it encodes (see Consequences), and only qualified,
   validatable configurations may be declared.
-- The single piece of **reserved vocabulary** is `advertiser`: an
-  optional marker whose only value is `external`, feeding #1327 policy
-  resolution and rejected at every boundary when unknown.
+- The single piece of **reserved vocabulary** is `advertiser`: the GKE
+  extension's optional marker whose only value is `external`, feeding
+  #1327 policy resolution. The core roll-in rejects the field even when
+  its value is `external`; after the extension lands, every unknown value
+  remains rejected at every boundary.
 
 ### Resolution algorithm
 
@@ -516,7 +544,10 @@ to the surviving composition:
   artifact** (the generate-first workflow). **Direct overlay hydration
   (`aicr bundle -r <overlay.yaml>`) deliberately exposes no selection
   surface and applies the declared default** — selecting a non-default
-  value means generating the recipe first.
+  value means generating the recipe first. Hydration resolves the file's
+  criteria against the active catalog and fails closed unless the effective
+  declaration structurally matches the file's declaration after JSON
+  normalization; the overlay name itself need not match.
 - Discovery surfaces the **effective declaration after inheritance and
   co-match resolution** — the declaration typically lives on an
   ancestor (`gke-cos`), so a criteria-filtered listing of leaves must
@@ -539,11 +570,19 @@ to the surviving composition:
   recorded selection — a single selection-less hydration matches only
   the declared default (wiring in #1761).
 
+  The core roll-in does not publish or project profiled evidence. Those
+  boundaries strictly decode the new artifact and reject it rather than
+  dropping profile identity. Generic per-value evidence partitioning and
+  the new predicate type land with the first consumer. The
+  canonical-descriptor identity and currentness expansion described below
+  are GKE-only policy work and land with GKE.
+
 ### Override locking
 
-Profile-owned paths are locked. At bundle time the **effective lock set**
-is `selectedProfile.ownedPaths` **plus the recomputed canonical #1327
-closure** when the closure trigger applies (see the amendment below).
+Profile-owned paths are locked. In the core roll-in, the **effective lock
+set** is `selectedProfile.ownedPaths`. The GKE extension adds the
+recomputed canonical #1327 closure when its trigger applies (see the
+amendment below).
 `aicr bundle` **rejects** (`ErrCodeInvalidRequest`) any override —
 static `--set`/`--set-json`/`--set-file` or config-file — whose result
 **diverges from the selected recipe at a locked path** (a redundant
@@ -696,7 +735,8 @@ matcher semantics for zero enforcement weight — **schema validation is
 skippable, templates always render**; the chart's existing
 `deployer.*` schema is unchanged (guard mechanics in #1761).
 
-**Descriptor expansion and frozen outputs.** One boundary caveat: the
+**Descriptor expansion and frozen outputs.** This subsection applies when
+the GKE extension activates the canonical closure. One boundary caveat: the
 emitted guard **freezes the generation-time closure** — a rendered
 chart is not a boundary where an AICR binary can recompute it. After a
 canonical-descriptor expansion, an existing authentic argocd-helm
@@ -792,7 +832,13 @@ locking defends against flag misuse, not artifact forgery — the digest
 makes an edit observable, and a signature or evidence record anchored to
 the expected digest detects it.
 
-### Amendment to the #1327 allocation-policy model
+### GKE amendment to the #1327 allocation-policy model
+
+This amendment is part of the accepted service-agnostic design, but not the
+core roll-in. The core validator rejects `advertiser` and explicit
+allocation-policy selector paths in profile fragments. GKE adoption enables
+them only after the canonical descriptor, shared evaluator, and evidence
+currentness work in this section lands together.
 
 The #1327 resolver (`pkg/validator/v1/allocation_policy.go`) currently
 treats externally managed advertisers as an explicit non-goal: with
@@ -1029,7 +1075,9 @@ profile: gpuStack=csp-managed   # optional
 GET carries the same string in the `profile` parameter.
 `/v2` requests are **strict**: an unknown query parameter or envelope
 field is rejected (`ErrCodeInvalidRequest`) — a typo (`?profie=…`)
-must not silently select the default. `/v1` keeps its lenient parsing
+must not silently select the default. POST envelopes require
+`Content-Type: application/json` or `Content-Type: application/x-yaml`;
+missing or unsupported media types are rejected. `/v1` keeps its lenient parsing
 for unknown inputs, with one reserved exception: new servers **reject
 explicit profile input on `/v1`** — a `profile` GET parameter or
 top-level POST field on `/v1/recipe` and `/v1/query`, regardless of
@@ -1210,21 +1258,20 @@ recurrence — the shape the Problem section expects.
   family-wide `/v1` rejection of ordinary criteria requests, evidence
   re-signing — is deferred to a family's explicit conversion (below),
   never triggered by the mechanism landing.
-- One-time feature cost: declaration/resolution in `pkg/recipe`, the
+- The core feature cost is declaration/resolution in `pkg/recipe`, the
   ownership record and new artifact apiVersion, selection plumbing and
-  the `/v2` endpoints, override locking across bundle/mirror/argocd-helm,
-  and docs. After this lands, new configurations are per-overlay edits.
-  The full implementation inventory and acceptance criteria live in
-  [#1761](https://github.com/NVIDIA/aicr/issues/1761).
-- Validation needs the constraint forms the fragments reference: the
-  GKE consumer depends on the node-set label check from
-  [#1755](https://github.com/NVIDIA/aicr/issues/1755) — a new
-  reading/evaluator capability, scope confirmation is Deferred
-  Decision 2 — **and** on the #1327 amendment above; part of the
-  mechanism cost, not an optional follow-up. The AKS
-  consumer's authoritative node-pool-mode signal must be identified and
-  documented first; whether it needs new collector or evaluator machinery
-  depends on that signal (see Declaration).
+  the `/v2` endpoints, override locking across
+  bundle/mirror/argocd-helm, and docs. It deliberately has no adopter.
+  `advertiser`, allocation-policy profile paths, and profiled evidence
+  publication fail closed at this stage.
+
+  Consumer-specific capabilities land with the consumer that needs them.
+  AKS adds the `gpuProfile.driver` provider reading and generic per-value
+  evidence support. GKE then adds the node-set label check from
+  [#1755](https://github.com/NVIDIA/aicr/issues/1755), the #1327
+  advertiser/canonical-descriptor extension, and descriptor-bound evidence
+  currentness. The full implementation inventory and acceptance criteria
+  live in [#1761](https://github.com/NVIDIA/aicr/issues/1761).
 - Every declared profile value is a supported configuration and must be
   qualified (KWOK lanes / UAT coverage where feasible); values we cannot
   test — or cannot validate against the cluster — do not get declared
@@ -1277,11 +1324,13 @@ recurrence — the shape the Problem section expects.
   policy keys are GPU *advertisement* keys (`devicePlugin.enabled`, DRA
   `resources.gpus.enabled` / `gpuResourcesEnabledOverride`, component
   `enabled`) — not
-  `driver.enabled`/`toolkit.enabled`/`operator.runtimeClass`. Profile
-  locking therefore changes AKS driver paths from allowed/silent to
-  rejected; it does not interact with the allocation-policy WARN. Where a
-  profile triggers the policy closure, all #1327 policy paths join the
-  lock (see the amendment). Graduating the
+  `driver.enabled`/`toolkit.enabled`/`operator.runtimeClass`/
+  `nvidiaDriverRoot`. Profile locking therefore changes all four
+  coordinated AKS driver-ownership paths from allowed/silent to rejected
+  when a write would diverge. A redundant same-value write remains
+  accepted. This does not interact with the allocation-policy WARN. Where
+  a GKE profile triggers the policy closure, all #1327 policy paths join
+  the lock (see the amendment). Graduating the
   allocation-policy static-override WARN to REJECT globally remains a
   **separate decision** outside this ADR.
 - Rule of thumb, to keep profiles from sprawling: a profile value encodes
@@ -1295,45 +1344,52 @@ recurrence — the shape the Problem section expects.
 
 1. Land the profile mechanism (declaration, composition-wide uniqueness,
    resolution ordering, ownership-record + apiVersion stamping, override
-   locking) + docs.
-2. First consumer: GKE `gpuStack: [operator (default), csp-managed,
+   locking) and docs, with no adopter. The accepted core fragment is
+   `constraints` plus `componentRefs{name,overrides}`. The core rejects
+   `advertiser`, allocation-policy selector paths, and profiled evidence
+   projection until their consumer stage.
+2. First consumer: AKS
+   `gpuStack: [driver-only (default), operator]` for unmanaged pools.
+   It moves the existing qualified four-path tuple
+   (`driver.enabled`, `toolkit.enabled`, `operator.runtimeClass`, and
+   `nvidiaDriverRoot`) behind profile selection and removes the documented
+   bundle-time override workflow, including the air-gap mirror guidance.
+   This step adds the `gpuProfile.driver` provider reading, symmetric
+   constraints for `Install` and `None`, and generic per-value evidence
+   partitioning. An unavailable provider reading, an unknown value, or
+   mixed GPU-pool ownership values fails closed. Fully AKS-managed pools
+   remain out of scope.
+3. Second consumer: GKE
+   `gpuStack: [operator (default), csp-managed,
    operator-selfdriver]` — device-plugin and driver-provisioning
    ownership, gated on the #1755 label check and the #1327
-   external-advertiser amendment. The `operator-selfdriver` value
-   additionally requires the `gcp-driver-installer` component
-   (values-gated chart, new public registry entry) and is declared only
-   once its durable ownership-mode distinguishing signal is identified
-   (Deferred Decision 5) — the other two values do not wait on it. The
-   dormant component and the third value land **together**, in one
-   event: declaring the value later is an ownership-surface expansion
-   (`install` joins the union and the installer's synthetic `enabled`
-   joins `ownedPaths`), which is a family-wide
-   re-qualification and evidence re-signing event by the
-   Recording rules — budget for it when DD5 resolves. Any dcgm-exporter GPU-ID-mapping
-   adjustment for `csp-managed` is an external GKE behavior not
-   verifiable from this repository — it is verified and added during
-   this step if required, with the upstream citations (NVIDIA GPU
-   Operator GKE guidance; GKE device-plugin documentation) recorded in
-   that step's PR. GKE goes first because it exercises the full
-   mechanism end-to-end: effects, opposite constraints, policy amendment,
-   locking, and evidence. Because conversion rejects the family's
-   ordinary criteria requests on `/v1` (see the compatibility gate),
-   this step also checks the family's `/v1` usage — or announces a
-   deprecation window — **before** converting, so clients do not
-   discover the rejection at cut-over.
-3. Second consumer: AKS `gpuStack: [operator (default), driver-only]` —
-   driver/toolkit ownership on unmanaged pools, replacing the documented
-   `--set` guidance **including the air-gap mirror guidance**
-   (`docs/user/air-gap-mirror.md` recommends
-   `--set gpuoperator:driver.enabled=false`, which migrates to profile
-   selection); gated on identifying and documenting the authoritative
-   node-pool-mode validation signal. Fully AKS-managed pools remain out
-   of scope.
-4. Internal recipes (DGXC/NKX): once `operator-selfdriver` is declared,
-   the internal cos-gpu-installer arrangement (internal MR #27)
-   migrates to the public value — the values-gated
+   external-advertiser amendment. This step activates the reserved
+   `advertiser` field, canonical descriptor/evaluator, and
+   descriptor-bound evidence currentness together.
+
+   The `operator-selfdriver` value additionally requires the
+   `gcp-driver-installer` component (values-gated chart, new public
+   registry entry) and is declared only once its durable ownership-mode
+   distinguishing signal is identified (Deferred Decision 5). The other
+   two values do not wait on it. The dormant component and the third value
+   land **together**, in one event: declaring the value later is an
+   ownership-surface expansion (`install` joins the union and the
+   installer's synthetic `enabled` joins `ownedPaths`), which is a
+   family-wide re-qualification and evidence re-signing event.
+
+   Any dcgm-exporter GPU-ID-mapping adjustment for `csp-managed` is an
+   external GKE behavior not verifiable from this repository. It is
+   verified and added during this step if required, with upstream
+   citations recorded in that PR. Before conversion, this step also
+   checks the family's `/v1` usage or announces a deprecation window so
+   clients do not discover the `/v1` rejection at cut-over.
+4. Other consumers: once `operator-selfdriver` is declared, internal
+   recipes (DGXC/NKX) migrate the cos-gpu-installer arrangement
+   (internal MR #27) to the public value. The values-gated
    `gcp-driver-installer` component makes the case expressible without
-   an internal-only component or a component-addition amendment.
+   an internal-only component or a component-addition amendment. Other
+   services adopt the mechanism only when a qualified, distinguishable
+   ownership mode appears.
 
 ## Deferred Adoption Decisions
 
@@ -1351,16 +1407,15 @@ work that resolves it.
 2. **#1755 scope confirmation.** This ADR reads #1755 as delivering the
    node-set constraint *form* (every GPU node has label X, including
    the negated form) — a new reading/evaluator capability. **Proposed:
-   confirm on the issue before implementation; the GKE consumer is
-   gated on it.**
-3. **AKS node-pool-mode signal** — an AKS-set node label, the
-   `gpuProfile` surface, or a new collector reading? Gates declaring
-   the `driver-only` value at all. Like DD5, the signal must be a
-   **durable ownership-mode marker** — profile constraints are
-   re-evaluated post-deployment. When identified, it lands as
-   symmetric constraints on both values — `operator` asserts the
-   opposite of `driver-only` — not on `driver-only` alone. **Proposed:
-   resolve during adoption step 3; nothing else waits on it.**
+   confirm during GKE adoption; the GKE consumer is gated on it.**
+3. **AKS node-pool-mode signal — resolved by the 2026-07-27 amendment.**
+   The provider-facing AgentPool `gpuProfile.driver` property is the
+   durable ownership marker. AKS adoption projects it into a snapshot
+   reading across GPU pools: `Install` maps to `driver-only`, `None` maps
+   to `operator`, and an absent field in a successful supported API response
+   follows the provider's documented `Install` default. Unavailable API
+   data, mixed values, and unknown values fail closed. Both profile values
+   receive symmetric constraints over the projection.
 4. **Catalog compatibility follow-up.** A general catalog compatibility
    contract (the `--data` path has no apiVersion gate) is deferred.
    **Filed as

--- a/docs/integrator/data-flow.md
+++ b/docs/integrator/data-flow.md
@@ -246,21 +246,30 @@ When a query matches a leaf recipe with a `spec.base` reference, the builder:
 3. **Merges in order**, later overlays overriding earlier ones.
 4. **Applies mixins** (`spec.mixins`): appends their constraints and
    `componentRefs`, evaluating mixin constraints when a snapshot is provided.
-5. **Strips context** maps from subtypes unless context output is requested.
+5. **Applies the selected profile** after overlay and mixin composition. An
+   explicit `name=value` selection wins; otherwise the declaration's default
+   is used. Its overrides merge before finalization and registry defaults.
+6. **Strips context** maps from subtypes unless context output is requested.
 
 For the resolver internals (specificity scoring, deep-merge semantics) see
 [Recipe architecture](../contributor/recipe.md).
 
 ### Recipe Data Structure
 
-```
+Unprofiled recipe results retain `aicr.run/v1alpha2`. Selecting a configuration
+profile produces `aicr.run/v1alpha3` and records the selected profile and its
+owned value paths in result metadata.
+
+```text
 ┌─────────────────────────────────────────────────────────┐
-│ RecipeResult (aicr.run/v1alpha2)                          │
+│ RecipeResult                                            │
 ├─────────────────────────────────────────────────────────┤
 │ metadata:                                               │
 │   version: CLI version that generated the recipe        │
 │   appliedOverlays: inheritance chain (root to leaf)     │
 │   excludedOverlays: matched-but-excluded overlays       │
+│   selectedProfile: name, value, and ownedPaths          │
+│                    (v1alpha3 only)                      │
 │                                                         │
 │ criteria: Criteria (6 dimensions — see mapping above)   │
 │                                                         │

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -76,6 +76,7 @@ func main() {
 		OS:          "ubuntu", // REQUIRED to reach the OS-pinned kubeflow overlay; see "Recipe sources" below
 		Intent:      "training",
 		Platform:    "kubeflow",
+		// Profile:  "gpuStack=driver-installed", // only when the composition declares it
 	})
 	if err != nil {
 		log.Fatalf("resolve recipe: %v", err)
@@ -169,7 +170,11 @@ if err != nil {
 Client's own data provider and returns a Client-owned `*RecipeResult`
 ready for `ValidateState` / `BundleComponents` — it passes the same
 ownership check as a `ResolveRecipe` result. An already-hydrated
-`RecipeResult` file is returned with its provider bound to the Client.
+`RecipeResult` file is returned with its provider bound to the Client. For a
+profile-bearing overlay, the effective declaration resolved from that provider
+must structurally match the file's declaration after JSON normalization;
+otherwise loading fails rather than returning a recipe selected from a
+different profile contract.
 Note that bundle generation runs blocking preflight validations (for
 example `CheckDriverOwnershipCoherence`, which rejects a recipe whose
 snapshot recorded `gpuDriverState: absent` under a preinstalled-driver
@@ -248,13 +253,20 @@ identifiers. When you already hold a `pkg/recipe.AllowLists`, use
 
 `ResolveRecipe` takes the stable `RecipeRequest` shape and returns the
 facade `RecipeResult` — a deliberately small struct exposing the
-`Name`, `Version`, and `Components` of the resolved recipe. `Components`
-lists enabled (deployable) components only; disabled refs remain visible
-via `Resolved().ComponentRefs`. When you
+`Name`, `Version`, `Components`, and optional `SelectedProfile` of the
+resolved recipe. Set `RecipeRequest.Profile` to the exact `name=value`
+selection when the resolved composition declares a profile. Empty applies
+the declaration's required default; a nonempty selection against an
+unprofiled composition fails closed.
+
+`Components` lists enabled (deployable) components only; disabled refs remain
+visible via `Resolved().ComponentRefs`. When you
 already hold an `*aicr.Criteria` value — for example, a REST handler
 that parsed criteria from an incoming HTTP request and wrapped them with
-`aicr.WrapCriteria` — use `ResolveRecipeFromCriteria`. It returns the
-same facade `*RecipeResult`; call `result.Resolved()` when you need the
+`aicr.WrapCriteria` — use `ResolveRecipeFromCriteria`. Use
+`ResolveRecipeFromCriteriaWithProfile` for an explicit selection and
+`ResolveRecipeFromSnapshotWithProfile` for snapshot-filtered resolution.
+These return the same facade `*RecipeResult`; call `result.Resolved()` when you need the
 complete underlying `*pkg/recipe.RecipeResult` (constraints, deployment
 order, validation config, metadata):
 
@@ -266,6 +278,9 @@ if err != nil {
 
 // Facade surface — Name, Version, Components.
 log.Printf("recipe %s components: %d", rec.Name, len(rec.Components))
+if rec.SelectedProfile != nil {
+	log.Printf("profile %s=%s", rec.SelectedProfile.Name, rec.SelectedProfile.Value)
+}
 
 // Full upstream shape, when needed.
 resolved := rec.Resolved()
@@ -276,6 +291,8 @@ The returned `*RecipeResult` carries:
 
 - `Name`, `Version`, `TranslatedAt` — stable identity
 - `Components` — `[]ComponentRef` (Name, Kind, Version, Source, Chart, Namespace)
+- `SelectedProfile` — selected name/value and declaration-wide `OwnedPaths`;
+  nil for legacy recipes
 - `Resolved()` — the upstream `*pkg/recipe.RecipeResult` for callers that
   need constraints, deployment order, validation config, or metadata
   (e.g., evidence emission). Do not mutate; do not retain past the
@@ -290,6 +307,11 @@ identifiers. Construct one directly or wrap an upstream
 `nil` Client, `nil` context, or `nil` criteria each return
 `ErrCodeInvalidRequest`, and the same facade-level timeout bounds the
 resolve.
+
+`ListCatalog` projects the effective inherited profile declaration on each
+entry as `CatalogEntry.Profile`. The summary contains its name, description,
+required default, and sorted value names; it is nil when the composition is
+unprofiled.
 
 To extract a single value from a resolved recipe, use
 `SelectFromRecipe` with a dot-path selector. It hydrates the recipe's

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -420,7 +420,159 @@ Base → ValuesFile → Overrides → CLI --set flags
 # Result: driver.version="580.13.01", driver.repository="nvcr.io/nvidia" (preserved)
 ```
 
-**Snapshot-driven override — `gpu-operator.driver.enabled`.** When a recipe is resolved from a snapshot (via `aicr recipe --snapshot` or `ResolveRecipeFromSnapshot`), AICR reads the sampled GPU node's `driver-loaded` measurement and injects `gpu-operator.overrides.driver.enabled=false` when the NVIDIA kernel module is already loaded on the node — as an Overrides entry, so it wins over base and provider values files. Explicit `--set` flags at bundle generation (`aicr bundle --set gpuoperator:driver.enabled=true`) retain higher precedence and can supersede the injection — `--set` is a bundle-time flag, not an `aicr recipe` flag. The gate: injection only fires when the resolved overlay already declares the coordinated preinstalled-driver profile (`gpu-operator.driver.enabled=false` in the merged base+valuesFile) — that scopes auto-detect to overlays like AKS, GKE-COS, and OKE, and skips bare EKS with a warning instead of leaving the Operator half-configured. Policy is only-false (never forces `true`), so recipes resolved without a snapshot fall back to today's static defaults. Capture the snapshot **before** deploying the GPU Operator: a snapshot taken after a prior AICR-managed driver install still reports `driver-loaded=true` and would flip a re-deploy toward driverless nodes; AICR emits a warning when both `driver-loaded=true` and a gpu-operator ClusterPolicy are present in the snapshot. See [Component Catalog › GPU Operator Driver Auto-Detect](../user/component-catalog.md#gpu-operator-driver-auto-detect).
+### Configuration Profiles
+
+A service or OS overlay may declare one configuration profile when the same
+criteria combination has multiple qualified ownership modes. The core
+mechanism ships without an embedded adopter; its first declaration is planned
+for AKS in a separate rollout.
+
+A declaring overlay uses recipe apiVersion `aicr.run/v1alpha3`:
+
+```yaml
+kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha3
+metadata:
+  name: example-service
+spec:
+  criteria:
+    service: example
+  profile:
+    name: gpuStack
+    description: Who installs the GPU driver.
+    default: driver-installed
+    values:
+      # SHAPE ONLY — not a shippable declaration. Neither value carries
+      # the distinguishing constraint ADR-015 requires (see below).
+      driver-installed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: false
+      operator-managed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: true
+```
+
+**Every value must carry a distinguishing constraint.** ADR-015 requires each
+value to declare a validation signal that distinguishes its configuration from
+every sibling value's. A value with no constraints at all — or with constraints
+identical to a sibling's — does not support the "validated against deployed
+config" claim and must not be declared. The snippet above shows the declaration
+shape only; it is not a declaration you should copy into an overlay.
+
+**Constraint names must be measurement paths a collector actually emits**, in
+`{Type}.{Subtype}.{Key}` form. The type must be one the snapshot carries —
+`K8s`, `GPU`, `OS`, `SystemD`, `NodeTopology`, or `NetworkTopology` —
+so `K8s.server.version` resolves while an unknown type is rejected outright as
+an invalid measurement type. Constraints are evaluated against the snapshot
+when one is supplied, and a name whose subtype nothing produces fails closed
+with `subtype not found`. Either way a fabricated path makes the whole value
+unselectable rather than unconstrained.
+
+Do not borrow paths from `validation.deployment.constraints`, such as
+`Deployment.gpu-operator.version`. Those are deployment-phase validator keys
+evaluated against a live cluster, not snapshot readings, and `Deployment` is
+not a measurement type.
+
+**Which signal qualifies a driver-ownership profile depends on the service.**
+The example above names none, which is why it is shape only. `GPU.hardware`
+readings do not settle it: `driver-loaded` proves a driver is *present*, not
+which mode installed it.
+
+**AKS** projects each GPU agent pool's durable `gpuProfile.driver` property
+into a snapshot reading — `Install` selects the preinstalled value, `None`
+selects the operator-managed one. Unavailable, unknown, or mixed pool values
+fail closed. ADR-015 resolves this signal, and AKS is the first planned
+adopter.
+
+No equivalent reading exists for other services yet. Declare a
+driver-ownership profile only once the signal for that service exists, and
+give both values symmetric constraints over it. Do not substitute a signal
+that reports something adjacent: GKE's
+`gke-no-default-nvidia-gpu-device-plugin` label, for instance, governs
+device-plugin advertisement rather than driver provisioning
+([#1755](https://github.com/NVIDIA/aicr/issues/1755) keeps the two
+deliberately separate), so selecting driver modes with it can pick the wrong
+configuration on a supported cluster.
+
+Nothing in core admission blocks a constraint-free declaration — the
+distinguishability rule is enforced during catalog review. A value without
+constraints still resolves, still returns `metadata.selectedProfile`, and still
+locks its `ownedPaths`, so shipping one produces a recipe that attests an
+unqualified configuration.
+
+Profile declarations are intentionally narrow:
+
+- One declaration may influence a resolved composition. Put it on a shared
+  overlay ancestor; mixins cannot declare profiles.
+- `default` is required. Profile and value identifiers use
+  `[A-Za-z0-9._-]+`.
+- A value permits only `constraints` and
+  `componentRefs{name,overrides}` in the core mechanism. `valuesFile`,
+  component identity/deployment fields, literal dotted keys, nested empty
+  maps, and root `overrides.enabled` are rejected.
+- Override leaves must be JSON/YAML scalar values. Finite numbers and YAML
+  timestamps are supported; non-finite `.nan`/`.inf` values are rejected
+  because every resolved recipe must remain JSON-serializable. Integers must
+  remain within the JSON round-trip-safe range, from -9007199254740991 through
+  9007199254740991.
+- Every value must assign the same flattened override paths. A profile may
+  configure only components already enabled in the surviving composition.
+- Profile values may assign overrides only to Helm components. Kustomize
+  components do not consume values overrides, so they may be referenced only
+  without overrides for presence locking.
+- Profile constraints must distinguish sibling modes. They are evaluated
+  fail closed during snapshot resolution and remain in the hydrated recipe
+  for later validation. This qualification rule is enforced during catalog
+  review; core admission does not infer whether arbitrary readings
+  semantically distinguish two modes.
+- The GKE-only `advertiser` and allocation-policy selector paths are reserved
+  but rejected until the GKE extension lands.
+
+Select with `aicr recipe --profile name=value`; omission uses the declared
+default. A profiled result uses `aicr.run/v1alpha3` and records
+`metadata.selectedProfile`, including declaration-wide `ownedPaths`.
+Divergent static overrides, all intersecting dynamic paths, removal of an
+owned component, and argocd-helm install-time values on owned paths fail
+closed. A redundant override that resolves to the selected value is allowed.
+
+**Snapshot-driven override — `gpu-operator.driver.enabled`.** When a recipe is
+resolved from a snapshot (via `aicr recipe --snapshot` or
+`ResolveRecipeFromSnapshot`), AICR reads the sampled GPU node's `driver-loaded`
+measurement. When the NVIDIA kernel module is already loaded, AICR injects
+`gpu-operator.overrides.driver.enabled=false` as an Overrides entry, so it wins
+over base and provider values files.
+
+Explicit `--set` flags at bundle generation, such as
+`aicr bundle --set gpuoperator:driver.enabled=true`, retain higher precedence
+and can supersede the injection unless the path is profile-owned. Divergent
+overrides of profile-owned paths fail closed. `--set` is a bundle-time flag,
+not an `aicr recipe` flag.
+
+**Profile ownership.** When a selected profile owns
+`gpu-operator.driver.enabled`, auto-detection does not mutate that path. The
+selected profile remains authoritative.
+
+**Static activation gate.** Otherwise, injection fires only when the resolved
+component values already set `gpu-operator.driver.enabled=false` and carry the
+coordinated preinstalled-driver configuration. This prerequisite is independent
+of whether the recipe declares an ADR-015 profile. It scopes auto-detection to
+statically prepared overlays such as AKS, GKE-COS, and OKE. Bare EKS is skipped
+with a warning instead of leaving the Operator half-configured. The policy is
+only-false and never forces `true`, so recipes resolved without a snapshot use
+their static defaults.
+
+**Snapshot timing.** Capture the snapshot **before** deploying the GPU
+Operator. A snapshot taken after an earlier AICR-managed driver install still
+reports `driver-loaded=true` and could flip a re-deployment toward driverless
+nodes. AICR warns when both `driver-loaded=true` and a gpu-operator
+ClusterPolicy are present in the snapshot. See
+[Component Catalog › GPU Operator Driver Auto-Detect](../user/component-catalog.md#gpu-operator-driver-auto-detect).
 
 ## Disable a Component in an Overlay
 

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -26,10 +26,10 @@ The AICR API Server provides HTTP REST access to recipe generation and bundle cr
 
 | Feature | API | CLI |
 |---------|-----|-----|
-| Recipe generation | ✅ GET /v1/recipe | ✅ `aicr recipe` |
-| Value query | ✅ GET /v1/query | ✅ `aicr query` |
-| Bundle creation | ✅ POST /v1/bundle | ✅ `aicr bundle` |
-| Bundle attestation | ✅ POST /v1/bundle?attest=true (server signs as itself) | ✅ `aicr bundle --attest` (interactive or ambient OIDC) |
+| Recipe generation | ✅ GET `/v1/recipe`; profile-aware GET/POST `/v2/recipe` | ✅ `aicr recipe` |
+| Value query | ✅ GET `/v1/query`; profile-aware GET/POST `/v2/query` | ✅ `aicr query` |
+| Bundle creation | ✅ POST `/v1/bundle`; profile-aware POST `/v2/bundle` | ✅ `aicr bundle` |
+| Bundle attestation | ✅ POST `/v1/bundle?attest=true`; profile-aware POST `/v2/bundle?attest=true` (server signs as itself) | ✅ `aicr bundle --attest` (interactive or ambient OIDC) |
 | Snapshot capture | ❌ Use CLI | ✅ `aicr snapshot` |
 | ConfigMap I/O | ❌ Use CLI | ✅ `cm://` URIs |
 | Agent deployment | ❌ Use CLI | ✅ `aicr snapshot` |
@@ -110,7 +110,10 @@ curl "http://localhost:8080/"
 {
   "service": "aicrd",
   "version": "v0.14.0",
-  "routes": ["/v1/recipe", "/v1/query", "/v1/bundle"]
+  "routes": [
+    "/v1/recipe", "/v1/query", "/v1/bundle",
+    "/v2/recipe", "/v2/query", "/v2/bundle"
+  ]
 }
 ```
 
@@ -391,6 +394,92 @@ The response format matches `GET /v1/query`: scalar values are returned as plain
 
 ---
 
+### Profile-aware v2 endpoints
+
+`v2` in the route and `apiVersion` in a recipe document are independent
+version axes. The route segment versions the transient HTTP contract;
+`aicr.run/v1alpha2` and `aicr.run/v1alpha3` identify persisted recipe schemas.
+Therefore, `/v2/recipe` can return either artifact version and `/v2/bundle`
+accepts both, plus versionless legacy artifacts. Whether resolution selects a
+profile explicitly or through a declared default—not the route number—
+determines whether the artifact uses `v1alpha3`.
+
+`/v2/recipe`, `/v2/query`, and `/v2/bundle` expose the profile-aware HTTP
+contract. The core mechanism exposes these routes before any embedded cloud
+recipe declares a profile, so existing `/v1` workflows remain unchanged.
+
+**GET `/v2/recipe`.** Accepts the `/v1/recipe` criteria parameters plus
+optional `profile=name=value`. Omission applies the resolved declaration's
+required default. The v2 route rejects unknown query parameters and
+conflicting repeated profile values.
+
+```shell
+# Contract example; substitute a family after its profile adopter lands.
+curl "http://localhost:8080/v2/recipe?service=SERVICE&profile=NAME=VALUE"
+```
+
+**POST `/v2/recipe`.** Accepts a strict JSON or YAML envelope. `criteria` is
+the plain criteria object, not a `RecipeCriteria` resource. Profile selection
+may be supplied in the envelope, as the `profile` query parameter, or in both
+places when the values agree. Conflicting selections are rejected:
+
+```yaml
+criteria:
+  service: aks
+  accelerator: h100
+  intent: training
+profile: gpuStack=driver-only
+```
+
+Unknown fields, duplicate or trailing documents, malformed selections, and
+selections against an unprofiled composition fail with `400
+INVALID_REQUEST`. POST envelopes require `Content-Type: application/json` or
+`Content-Type: application/x-yaml`; missing, aliased, or unsupported media
+types are rejected.
+
+**GET and POST `/v2/query`.** GET accepts the v2 recipe parameters plus
+`selector`. POST accepts the same strict envelope with a required selector.
+POST profile selection follows the same query/envelope agreement rule as
+`/v2/recipe`:
+
+```yaml
+criteria:
+  service: aks
+  accelerator: h100
+profile: gpuStack=driver-only
+selector: metadata.selectedProfile
+```
+
+**POST `/v2/bundle`.** Uses the same query parameters and ZIP response as
+`POST /v1/bundle`. It carries no profile-selection field because its body is
+an already-selected `RecipeResult`. It accepts legacy
+`aicr.run/v1alpha2` recipes, including older artifacts that omit
+`apiVersion`, and strictly decodes profiled `aicr.run/v1alpha3` recipes. The
+request requires `Content-Type: application/json` or `Content-Type:
+application/x-yaml`; missing, aliased, or unsupported media types are
+rejected.
+
+```shell
+# Contract example; substitute a family after its profile adopter lands.
+curl -s \
+  "http://localhost:8080/v2/recipe?service=SERVICE&profile=NAME=VALUE" |
+  curl -X POST "http://localhost:8080/v2/bundle" \
+    -H "Content-Type: application/json" -d @- -o bundles.zip
+```
+
+Profile-bearing responses record `metadata.selectedProfile` and use recipe
+apiVersion `aicr.run/v1alpha3`. Their owned paths are immutable across AICR's
+supported override surfaces: divergent static values, intersecting dynamic
+paths, owned-component removal, and argocd-helm install-time values fail
+closed before output.
+
+The `/v1` routes remain the legacy contract. Explicit profile input is
+rejected, `/v1/recipe` and `/v1/query` reject a composition after it adopts a
+profile even when the request omits selection, and `/v1/bundle` rejects a
+profile-bearing body. Migrate a converted recipe family to v2 as one cut-over.
+
+---
+
 ### POST /v1/bundle
 
 Generate deployment bundles from a recipe.
@@ -426,17 +515,18 @@ For backward compatibility, the endpoint also accepts:
   strings after a decode/remarshal round trip.
 - The `kind: Recipe` value this contract published through v0.18.0.
 
-The handler does not validate these header fields, so all three shapes reach the
-bundler identically.
+The handler does not validate `kind`, so all three shapes reach the bundler
+identically. `apiVersion` is the exception, validated as described next.
 
 `apiVersion` has no equivalent legacy window on purpose. An artifact
 group/version bump is a hard break with no transition period, so a recipe
 stamped with a prior group/version should be regenerated rather than sent.
 
-That is a client-contract rule, not an enforced one. As above, this endpoint
-validates no header field: a prior `apiVersion` is ignored rather than rejected,
-so such a request still succeeds. The CLI file-load path does enforce it and
-rejects an unsupported `apiVersion` outright.
+This one is enforced. The shared artifact gate rejects any `apiVersion` outside
+`aicr.run/v1alpha2` and `aicr.run/v1alpha3` with a 400, on this endpoint as well
+as on the CLI file-load path, so a prior group/version fails rather than being
+silently accepted. An absent or empty `apiVersion` is still admitted as the
+legacy shape.
 
 **Round-trip caveat for `kind: Recipe`.** The header is copied into the
 generated bundle's `recipe.yaml` rather than normalized. The CLI file loader
@@ -444,6 +534,11 @@ tolerates an absent or empty `kind` but rejects `Recipe`, so a bundle generated
 from a `kind: Recipe` body cannot be fed back through `aicr bundle -r` or
 `aicr validate -r`. Send `kind: RecipeResult` if you need the emitted artifact
 to remain reloadable.
+
+The same limit reaches the tooling that reads a bundle's `recipe.yaml`, so
+TestGrid publication and evidence synthesis also reject such a bundle. Only
+bundles generated from a `kind: Recipe` HTTP body are affected; the CLI always
+writes `RecipeResult`.
 
 #### Components
 
@@ -848,7 +943,9 @@ Allowlists are configured via environment variables when starting the server:
 - If an environment variable is **not set**, all values for that criteria are allowed
 - If an environment variable is **set**, only the specified values are permitted
 - The `any` value is always allowed regardless of allowlist configuration
-- Allowlists apply to both `/v1/recipe` and `/v1/bundle` endpoints
+- Allowlists apply to the recipe, query, and bundle endpoints on both routes —
+  `/v1/recipe`, `/v1/query`, `/v1/bundle`, `/v2/recipe`, `/v2/query`, and
+  `/v2/bundle`
 
 ### Example Configuration
 

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -106,6 +106,7 @@ spec:
       os: ubuntu
       platform: kubeflow
       nodes: 2
+    profile: ""                      # optional name=value; empty uses the declared default
     # input:
     #   snapshot: snapshot.yaml      # derive criteria from a snapshot instead
     output:
@@ -211,6 +212,7 @@ exclusive** — query by criteria or derive from a snapshot, not both.
 |-------|------|-------|
 | `criteria.service` / `.accelerator` / `.intent` / `.os` / `.platform` | string | Same names and values as the CLI flags |
 | `criteria.nodes` | int | Target GPU node count |
+| `profile` | string | Optional configuration profile selection in `name=value` form. Empty applies the resolved declaration's default. |
 | `input.snapshot` | string | Snapshot path to derive the recipe from |
 | `output.path` | string | Recipe output path |
 | `output.format` | string | `yaml` \| `json` \| `table` |

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -333,6 +333,17 @@ aicr recipe   -s cm://default/snapshot --intent training
 
 When both a snapshot and explicit criteria are given, the explicit values win (e.g. `--snapshot … --service gke` overrides the detected service).
 
+**Configuration profiles:** an overlay composition may declare one named
+configuration choice. Select a non-default value with
+`--profile name=value`; omitting the flag applies the declaration's required
+default. A selection against a composition with no declaration, a wrong name,
+or an unknown value fails closed. Profile-bearing output records
+`metadata.selectedProfile`, uses recipe apiVersion `aicr.run/v1alpha3`, and
+locks every declared owned path against divergent bundle, mirror, and
+argocd-helm install-time overrides. The core mechanism ships without an
+embedded cloud adopter; a profile can initially be exercised through a
+versioned external overlay.
+
 **Every stated criteria dimension must be honored:** for `service`, `accelerator`, `intent`, `os`, and `platform`, resolution now enforces a coverage post-condition — if you state a value for one of these dimensions, at least one applied overlay must carry that exact value, or the request fails with an actionable `INVALID_REQUEST` error instead of silently returning a recipe that ignores what you asked for. The error names the uncovered dimension and, where possible, the additional criteria that would make the request resolvable (e.g. `platform 'kubeflow' ... requires os (valid: ubuntu)`). `--nodes` is exempt from this check — it is advisory only, since no overlay gates on node count, and stating it never requires matching node-count-specific recipe content to exist.
 
 **Snapshot-detected dimensions are advisory, not strict:** on the `--snapshot` path, `service`, `accelerator`, and `os` can be auto-detected from the cluster fingerprint rather than stated by you. If the coverage post-condition above fails and every uncovered dimension came from that detection (none of them were set via a CLI flag or `--config`), AICR relaxes those dimensions back to unstated and retries resolution once, logging a warning that names each relaxed dimension and its detected value — this handles overlay trees that are deliberately agnostic to a dimension the snapshot still reports (e.g. an OS-agnostic Kind overlay tree observing `os=ubuntu` on the node). Dimensions you passed explicitly via a flag are never relaxed: if any uncovered dimension was explicitly stated, the error still fails the request.
@@ -372,6 +383,15 @@ spec:
 
 Individual CLI flags always override config file values. For slice/map flags, presence on the CLI replaces the file's value (no append).
 
+For a composition that declares a profile, the equivalent config field is
+`spec.recipe.profile`. The CLI flag takes precedence:
+
+```yaml
+spec:
+  recipe:
+    profile: gpuStack=driver-installed
+```
+
 ```shell
 # Load criteria from config file
 aicr recipe --config config.yaml
@@ -400,6 +420,7 @@ Generate recipes using direct system parameters:
 | `--intent` | | string | Workload intent: training, inference |
 | `--os` | | string | OS family: ubuntu, rhel, cos, amazonlinux, ol, talos |
 | `--platform` | | string | Platform/framework type: dynamo, kubeflow, nim, runai, slurm |
+| `--profile` | | string | Profile selection in exact `name=value` form; omit to use the declaration's default |
 | `--nodes` | | int | Number of GPU nodes in the cluster |
 | `--output` | `-o` | string | Output file (default: stdout) |
 | `--format` | `-t` | string | Format: json, yaml, table (default: yaml) |
@@ -455,6 +476,7 @@ compatible.
 | `--snapshot` | `-s` | string | Path/URI to snapshot (file path, URL, or cm://namespace/name) |
 | `--intent` | | string | Workload intent: training, inference |
 | `--platform` | | string | Explicit platform/framework type, including slurm |
+| `--profile` | | string | Profile selection in exact `name=value` form; omit to use the declaration's default |
 | `--output` | `-o` | string | Output destination (file, ConfigMap URI, or stdout) |
 | `--format` | `-t` | string | Format: json, yaml, table (default: yaml) |
 | `--kubeconfig` | `-k` | string | Path to kubeconfig file (used when `--snapshot` or `--output` is a ConfigMap URI; overrides KUBECONFIG env) |
@@ -524,6 +546,24 @@ constraints:
     value: "<cuda-version>"       # illustrative
 ```
 
+A profiled result applies the selected value's constraints and component
+overrides to the normal recipe fields. It also uses a profile-aware recipe
+apiVersion and records the selected identity and declaration-wide lock
+surface:
+
+```yaml
+apiVersion: aicr.run/v1alpha3
+kind: RecipeResult
+metadata:
+  selectedProfile:
+    name: gpuStack
+    value: driver-installed
+    ownedPaths:
+      gpu-operator:
+        - driver.enabled
+        - enabled
+```
+
 ---
 
 ### aicr recipe list
@@ -567,6 +607,7 @@ with AND.
 | `criteria` | The full criteria dimensions the overlay targets |
 | `is_leaf` | `true` when the overlay is a leaf — no other overlay inherits from it |
 | `source` | Data provenance: `embedded` (built-in) or `external` (from `--data`) |
+| `profile` | Effective inherited profile summary (`name`, `description`, `default`, sorted `values`); structured output only and omitted when none is declared |
 | `health.status` | Rolled-up structural verdict for the leaf overlay: `pass`, `warn`, `fail`, or `unknown` (omitted for non-leaf overlays) |
 | `health.dimensions` | Per-dimension status map (e.g. `resolves`, `chart_pinned`) feeding the rollup |
 | `health.coverage` | Declared validation coverage per phase (`readiness`, `deployment`, `performance`, `conformance`): the named checks and phase-level constraint count each declares |
@@ -733,6 +774,7 @@ Uses dot-delimited paths consistent with Helm `--set` and `yq`:
 | `components.<name>.chart` | Component metadata field |
 | `components.<name>` | Entire hydrated component block |
 | `criteria.<field>` | Recipe criteria field |
+| `metadata.selectedProfile` | Selected profile identity and lock surface; present only on profiled recipes |
 | `deploymentOrder` | Component deployment order list |
 | `constraints` | Merged constraint list |
 | `.` or empty | Entire hydrated recipe |
@@ -894,7 +936,7 @@ Validation can be run in different phases to validate different aspects of the d
 >
 > **Version skew:** Snapshots and recipes record the `aicr` version that produced them. When the recipe, the snapshot, and the running binary report different release versions, `validate` logs a single advisory warning (`version skew detected across validate inputs`) naming all three. This is a debugging breadcrumb — mixing artifacts from different versions can surface as confusing failures — and does **not** fail the command. Dev (`dev`) and pre-release (`-next`) builds are ignored to avoid noise.
 >
-> **apiVersion gate:** Snapshots and recipes also carry a schema `apiVersion` (currently `aicr.run/v1alpha2`). Loading an artifact stamped with an `apiVersion` this build does not support fails fast with an `invalid apiVersion` error; regenerate or recapture the artifact with a matching `aicr` version. An empty `apiVersion` (older artifacts that predate the field) is still accepted. See [ADR-011](../design/011-artifact-apiversion-policy.md) for the evolution policy.
+> **apiVersion gate:** Snapshots and legacy recipe results use `aicr.run/v1alpha2`. Recipe results with a selected configuration profile use `aicr.run/v1alpha3`. Loading an artifact stamped with an `apiVersion` this build does not support fails fast with an `invalid apiVersion` error; regenerate or recapture the artifact with a matching `aicr` version. An empty `apiVersion` (older artifacts that predate the field) is still accepted. See [ADR-011](../design/011-artifact-apiversion-policy.md) for the evolution policy.
 
 Phases run sequentially with `--phase all` and all phases run by default, producing results regardless of earlier failures; use `--fail-fast` to stop after the first failing phase. For what each phase actually checks (deployment-phase readiness signals, graceful-skip semantics, RBAC, Day-N re-verification, and evidence), see [Validation](validation.md).
 
@@ -1457,11 +1499,11 @@ The `--deployer` flag controls how deployment artifacts are generated:
 |--------|-------------|
 | `helm` | (Default) Generates Helm charts with values for deployment. Supports `--dynamic`. |
 | `argocd` | Generates Argo CD Application manifests for GitOps deployment. Does **not** support `--dynamic`. |
-| `argocd-helm` | Generates a Helm chart app-of-apps for Argo CD. All values overridable at install time via `helm --set`. Use `--dynamic` to pre-populate specific paths. |
+| `argocd-helm` | Generates a Helm chart app-of-apps for Argo CD. All non-profile-owned values overridable at install time via `helm --set`; a profiled recipe ships a lock template that rejects overrides on profile-owned paths. Use `--dynamic` to pre-populate specific paths. |
 | `flux` | Generates Flux HelmRelease manifests for GitOps deployment. Supports `--dynamic` via ConfigMap `valuesFrom`. |
 | `helmfile` | Generates a `helmfile.yaml` release graph driven by the upstream [helmfile](https://helmfile.readthedocs.io/) CLI (`helmfile apply` / `diff` / `destroy`). Supports `--dynamic` via per-release `cluster-values.yaml`. Requires the `helmfile` binary at deploy time. |
 
-> **Note:** `--dynamic` is not supported with `--deployer argocd`. Use `--deployer argocd-helm` instead, which produces a Helm chart where all values are overridable at install time.
+> **Note:** `--dynamic` is not supported with `--deployer argocd`. Use `--deployer argocd-helm` instead, which produces a Helm chart where all non-profile-owned values are overridable at install time (a profiled recipe ships a lock template that rejects install-time values on profile-owned paths).
 
 > **Note:** `--dynamic` declarations targeting the GPU allocation-policy keys (`nvidia-dra-driver-gpu` `resources.gpus.enabled` / `gpuResourcesEnabledOverride`, `gpu-operator`(`-ocp`) `devicePlugin.enabled`, or those components' `enabled` toggle) are rejected: validators verify the recipe-resolved allocation policy, so its value cannot be deferred to install time. See [Configured GPU allocation policy](validation.md#configured-gpu-allocation-policy).
 
@@ -1491,6 +1533,12 @@ Override any value in the generated bundle files using dot notation:
 
 **Behavior:**
 - **Duplicate keys**: When the same `bundler:path` is specified multiple times, the **last value wins**
+- **Overlapping scalar paths**: Scalar paths are applied shallowest-first. If
+  one `--set` assigns a non-map parent and another assigns one of its
+  descendants (for example, `comp:driver=true` plus
+  `comp:driver.enabled=false`), the request is rejected regardless of flag
+  order. Use one coherent object through `--set-json` / `--set-file` when a
+  parent and its nested keys must be supplied together.
 - **Array values**: Individual array elements cannot be overridden (no `[0]` index syntax). `--set` is **scalar-only** — pointing it at a list/object field writes a bare string and produces type-invalid output. To replace an entire array or object from the CLI, use [`--set-json` / `--set-file`](#list-and-object-value-overrides); recipe-level overrides in `componentRefs[].overrides` are the alternative.
 - **Type conversion**: String values are automatically converted to appropriate types (`true`/`false` → bool, numeric strings → numbers)
 - **Component enable/disable**: The special `enabled` key controls whether a component is included in the bundle. `--set <component>:enabled=false` excludes a component the recipe enabled. A component the recipe **disabled** (`overrides.enabled: false`) cannot be re-enabled this way — `--set <component>:enabled=true` on such a component is rejected, since re-enabling a platform-provided component would install a conflicting second copy. The `enabled` key is consumed by the bundler and not passed to Helm chart values.
@@ -1844,7 +1892,7 @@ Before deploying, fill in `cluster-values.yaml` with cluster-specific values.
 
 **Argo CD deployer behavior:**
 
-The `--deployer argocd-helm` generates a Helm chart app-of-apps where all values are overridable at install time. Static values are baked into the chart as files; dynamic overrides are merged on top at render time. Use `--dynamic` to pre-populate specific paths in the root `values.yaml`:
+The `--deployer argocd-helm` generates a Helm chart app-of-apps where all non-profile-owned values are overridable at install time. When the recipe carries a selected profile, `templates/aicr-profile-lock.yaml` fails the install if a value is supplied for a profile-owned path. Static values are baked into the chart as files; dynamic overrides are merged on top at render time. Use `--dynamic` to pre-populate specific paths in the root `values.yaml`:
 
 ```shell
 helm install aicr-bundle ./bundle \
@@ -1871,13 +1919,13 @@ aicr bundle -r recipe.yaml \
   --dynamic alloy:clusterName \
   -o ./bundles
 
-# Argo CD Helm chart: all values overridable, --dynamic pre-populates specific paths
+# Argo CD Helm chart: all non-profile-owned values overridable, --dynamic pre-populates specific paths
 aicr bundle -r recipe.yaml \
   --deployer argocd-helm \
   --dynamic alloy:clusterName \
   -o ./bundles
 
-# Argo CD Helm chart: without --dynamic, still fully overridable via helm --set
+# Argo CD Helm chart: without --dynamic, non-profile-owned values still overridable via helm --set
 aicr bundle -r recipe.yaml \
   --deployer argocd-helm \
   -o ./bundles
@@ -2648,6 +2696,7 @@ aicr mirror list [flags]
 | `--intent` | | string | | Workload intent (`training` or `inference`). Alternative to `--recipe`. |
 | `--os` | | string | | Operating system (e.g., `ubuntu`). Alternative to `--recipe`. |
 | `--platform` | | string | | Optional platform specialization (e.g., `kubeflow`). |
+| `--profile` | | string | | Profile selection in exact `name=value` form when resolving from criteria. Cannot be combined with `--recipe`. |
 | `--set` | | string[] | | Override values that affect image discovery (format: `component:path.to.field=value`). Repeatable. |
 | `--data` | | string | | External data directory to overlay on embedded data. Overlay-provided component values and manifests both feed image discovery (see [External Data](#external-data-directory)). |
 | `--format` | `-f` | string | `yaml` | Output format: `yaml`, `json`, `hauler`, `zarf` |

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -246,6 +246,14 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 			"recipe must contain at least one component reference")
 	}
 
+	// New initializes Config for every supported construction path. Fail
+	// closed when a caller bypasses it with a zero-value or struct-literal
+	// bundler instead of panicking on the first configuration lookup.
+	if b.Config == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"bundler config is required; construct the bundler with New")
+	}
+
 	// Reject incoherent component refs (e.g. a Helm ref that also carries a
 	// Kustomize tag/path, which the deployers silently build as Kustomize)
 	// before generating anything. DefaultBundler.Make is a public entry point
@@ -256,10 +264,11 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	// canonicalization from mutating the caller's RecipeResult. See #1584.
 	validated := *recipeResult
 	validated.ComponentRefs = append([]recipe.ComponentRef(nil), recipeResult.ComponentRefs...)
-	if err := validated.PrepareAndValidate(); err != nil {
+	if err := validated.PrepareAndValidateWithContext(ctx); err != nil {
 		return nil, err
 	}
 	recipeResult = &validated
+	profileBaseline := recipeResult
 
 	enabledRefs, filteredOrder, filterErr := b.filterEnabledComponents(recipeResult)
 	if filterErr != nil {
@@ -271,22 +280,6 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 	filtered.ComponentRefs = enabledRefs
 	filtered.DeploymentOrder = filteredOrder
 	recipeResult = &filtered
-
-	// Set default output directory
-	if dir == "" {
-		dir = "."
-	}
-
-	// Create output directory
-	if dir != "." {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal,
-				"failed to create output directory", err)
-		}
-	}
-	if err := checksum.ValidateOutputRoot(ctx, dir); err != nil {
-		return nil, err
-	}
 
 	// Bundle-time override policy for GPU allocation-policy keys (#1327):
 	// reject --dynamic declarations, warn on static overrides. Runs after
@@ -321,9 +314,34 @@ func (b *DefaultBundler) Make(ctx context.Context, recipeResult *recipe.RecipeRe
 		return nil, exposureErr
 	}
 
+	dynamicValues, err := b.buildDynamicValuesMap(recipeResult.DataProvider())
+	if err != nil {
+		return nil, err
+	}
+	if lockErr := profileBaseline.ValidateProfileLock(
+		ctx, recipeResult.ComponentRefs, componentValues, dynamicValues,
+	); lockErr != nil {
+		return nil, lockErr
+	}
+
 	// Run component-specific validations
 	if validationErr := b.runComponentValidations(ctx, recipeResult); validationErr != nil {
 		return nil, componentValidationError(validationErr)
+	}
+
+	// No filesystem output is created until the final candidate has passed the
+	// profile state and mutability invariant above.
+	if dir == "" {
+		dir = "."
+	}
+	if dir != "." {
+		if mkdirErr := os.MkdirAll(dir, 0755); mkdirErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal,
+				"failed to create output directory", mkdirErr)
+		}
+	}
+	if rootErr := checksum.ValidateOutputRoot(ctx, dir); rootErr != nil {
+		return nil, rootErr
 	}
 
 	// Copy external data files before deployer construction so the file list

--- a/pkg/bundler/bundler_test.go
+++ b/pkg/bundler/bundler_test.go
@@ -688,6 +688,21 @@ func TestMake_EmptyComponentRefs(t *testing.T) {
 	}
 }
 
+func TestMake_NilConfigFailsClosed(t *testing.T) {
+	bundler := &DefaultBundler{}
+	recipeResult := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{{Name: "gpu-operator"}},
+	}
+
+	_, err := bundler.Make(t.Context(), recipeResult, t.TempDir())
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("Make() error = %v, want ErrCodeInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "construct the bundler with New") {
+		t.Fatalf("Make() error = %v, want constructor guidance", err)
+	}
+}
+
 func TestMake_Success(t *testing.T) {
 	bundler, err := New()
 	if err != nil {
@@ -763,6 +778,111 @@ func TestMake_Success(t *testing.T) {
 	if output.TotalFiles < 7 {
 		t.Errorf("expected at least 7 files, got %d", output.TotalFiles)
 	}
+}
+
+func TestMake_ProfileLockBeforeOutput(t *testing.T) {
+	newRecipe := func() *recipe.RecipeResult {
+		result := &recipe.RecipeResult{
+			APIVersion: recipe.RecipeProfileAPIVersion,
+			Kind:       recipe.RecipeResultKind,
+			Criteria: &recipe.Criteria{
+				Service:     recipe.CriteriaServiceAKS,
+				Accelerator: recipe.CriteriaAcceleratorH100,
+				Intent:      recipe.CriteriaIntentTraining,
+			},
+			ComponentRefs: []recipe.ComponentRef{
+				{
+					Name:    "gpu-operator",
+					Version: "v25.3.3",
+					Type:    recipe.ComponentTypeHelm,
+					Source:  "https://helm.ngc.nvidia.com/nvidia",
+					Chart:   "gpu-operator",
+					Overrides: map[string]any{
+						"driver": map[string]any{"enabled": false},
+					},
+				},
+				{
+					Name:    "cert-manager",
+					Version: "v1.20.0",
+					Type:    recipe.ComponentTypeHelm,
+					Source:  "https://charts.jetstack.io",
+					Chart:   "cert-manager",
+				},
+			},
+			DeploymentOrder: []string{"cert-manager", "gpu-operator"},
+		}
+		result.Metadata.SelectedProfile = &recipe.SelectedProfile{
+			Name:  "gpuStack",
+			Value: "driver-installed",
+			OwnedPaths: map[string][]string{
+				"gpu-operator": {"driver.enabled", "enabled"},
+			},
+		}
+		return result
+	}
+
+	tests := []struct {
+		name    string
+		options []config.Option
+		wantErr string
+	}{
+		{
+			name: "divergent set",
+			options: []config.Option{config.WithValueOverrides(map[string]map[string]string{
+				"gpuoperator": {"driver.enabled": "true"},
+			})},
+			wantErr: "driver.enabled diverged",
+		},
+		{
+			name: "dynamic owned path",
+			options: []config.Option{config.WithDynamicValues(map[string][]string{
+				"gpuoperator": {"driver.enabled"},
+			})},
+			wantErr: "intersects profile-owned",
+		},
+		{
+			name: "subset omits owned component",
+			options: []config.Option{config.WithBundlers([]string{
+				"cert-manager",
+			})},
+			wantErr: "absent or disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundler, err := New(WithConfig(config.NewConfig(tt.options...)))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			outputDir := filepath.Join(t.TempDir(), "not-created")
+			_, err = bundler.Make(t.Context(), newRecipe(), outputDir)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Make() error = %v, want containing %q", err, tt.wantErr)
+			}
+			if _, statErr := os.Stat(outputDir); !os.IsNotExist(statErr) {
+				t.Fatalf("output directory exists before profile rejection: %v", statErr)
+			}
+		})
+	}
+
+	t.Run("redundant set succeeds", func(t *testing.T) {
+		bundler, err := New(WithConfig(config.NewConfig(
+			config.WithValueOverrides(map[string]map[string]string{
+				"gpuoperator": {"driver.enabled": "false"},
+			}),
+		)))
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		outputDir := filepath.Join(t.TempDir(), "bundle")
+		if _, err := bundler.Make(t.Context(), newRecipe(), outputDir); err != nil {
+			t.Fatalf("Make() error = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(outputDir, "recipe.yaml")); err != nil {
+			t.Fatalf("profile bundle recipe.yaml: %v", err)
+		}
+	})
 }
 
 // TestMake_RecipeCoveredByChecksums verifies the resolved recipe participates

--- a/pkg/bundler/config/config.go
+++ b/pkg/bundler/config/config.go
@@ -41,7 +41,8 @@ const (
 	// DeployerArgoCD generates Argo CD App of Apps manifests.
 	DeployerArgoCD DeployerType = "argocd"
 	// DeployerArgoCDHelm generates a Helm chart app-of-apps for Argo CD.
-	// All values are overridable at install time via helm --set.
+	// All non-profile-owned values are overridable at install time via helm
+	// --set; a profiled recipe's lock template rejects profile-owned paths.
 	// Use --dynamic to pre-populate specific paths in root values.yaml.
 	DeployerArgoCDHelm DeployerType = "argocd-helm"
 	// DeployerFlux generates Flux HelmRelease manifests.

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -41,7 +41,11 @@
 //  3. Build a root values.yaml with ONLY dynamic paths (recipe defaults when
 //     available, empty strings otherwise). Static values stay in chart files.
 //  4. Write Chart.yaml + templates/ + values.yaml as a valid Helm chart,
-//     plus static/ when any component contributes a values file to it.
+//     plus static/ when any component contributes a values file to it, and
+//     templates/aicr-profile-lock.yaml when the recipe carries a selected
+//     profile. That template fails the install if a value is supplied for a
+//     profile-owned path, so the lock survives helm install/upgrade rather
+//     than holding only at bundle generation.
 //
 // This approach means changes to the Argo CD deployer (new component types,
 // sync policies, etc.) automatically flow through without duplication.
@@ -50,7 +54,9 @@
 //
 // The bundler routes here when --deployer argocd-helm is specified.
 // The --dynamic flag is optional — it pre-populates specific paths in the
-// root values.yaml, but all values are overridable regardless.
+// root values.yaml, but all non-profile-owned values are overridable
+// regardless. Profile-owned paths are the exception: the lock template
+// above rejects install-time values for them.
 //
 // # Deployment requires a chart-source backend (git or OCI)
 //
@@ -75,7 +81,9 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -96,10 +104,18 @@ import (
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
-// yamlStringTag is the YAML resolved-tag for explicit scalar strings, used
-// when emitting nodes that must serialize as quoted strings (e.g. Helm
-// template placeholders that would otherwise be misparsed).
-const yamlStringTag = "!!str"
+const (
+	// yamlStringTag is the YAML resolved-tag for explicit scalar strings, used
+	// when emitting nodes that must serialize as quoted strings (e.g. Helm
+	// template placeholders that would otherwise be misparsed).
+	yamlStringTag = "!!str"
+
+	// profileLockTemplateName is reserved only when a profiled recipe emits
+	// the deployer-owned install-time guard of the same name.
+	profileLockTemplateName = "aicr-profile-lock"
+
+	profileLockTemplateHeader = "{{- /* AICR profile install-time ownership guard. */ -}}\n"
+)
 
 // DefaultChartName is the Helm chart name used when ChartName is not set
 // (typically when --output is a local directory). When --output is an OCI
@@ -389,6 +405,14 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	if mkdirErr := os.MkdirAll(templatesDir, 0755); mkdirErr != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create templates directory", mkdirErr)
 	}
+	lockPath, lockSize, lockErr := g.writeProfileLockTemplate(templatesDir)
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	if lockPath != "" {
+		output.Files = append(output.Files, lockPath)
+		output.TotalSize += lockSize
+	}
 
 	if processErr := g.processFolders(ctx, tmpDir, outputDir, templatesDir, output); processErr != nil {
 		return nil, processErr
@@ -432,6 +456,155 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 	)
 
 	return output, nil
+}
+
+// writeProfileLockTemplate emits a Helm-render-time guard for profiled
+// bundles. ArgoCD-Helm deliberately exposes component values through the
+// parent chart's .Values; the guard rejects any install-time key whose path
+// equals, contains, or is contained by a profile-owned path. Key existence is
+// used throughout, so false, null, empty maps, and empty lists cannot bypass
+// the lock. Unprofiled bundles emit no file and remain byte-identical.
+func (g *Generator) writeProfileLockTemplate(templatesDir string) (string, int64, error) {
+	if g.RecipeResult == nil || g.RecipeResult.Metadata.SelectedProfile == nil {
+		if err := removeGeneratedProfileLockTemplate(templatesDir); err != nil {
+			return "", 0, err
+		}
+		return "", 0, nil
+	}
+
+	components := make([]string, 0, len(g.RecipeResult.Metadata.SelectedProfile.OwnedPaths))
+	for component := range g.RecipeResult.Metadata.SelectedProfile.OwnedPaths {
+		components = append(components, component)
+	}
+	sort.Strings(components)
+
+	var buf strings.Builder
+	buf.WriteString(profileLockTemplateHeader)
+	for componentIndex, componentName := range components {
+		overrideKey, err := resolveOverrideKey(componentName, g.RecipeResult.DataProvider())
+		if err != nil {
+			return "", 0, err
+		}
+		for pathIndex, lockedPath := range g.RecipeResult.Metadata.SelectedProfile.OwnedPaths[componentName] {
+			segments := strings.Split(lockedPath, ".")
+			writeProfilePathGuard(
+				&buf,
+				".Values",
+				append([]string{overrideKey}, segments...),
+				fmt.Sprintf("aicrProfile%d_%d", componentIndex, pathIndex),
+				componentName+"."+lockedPath,
+			)
+		}
+	}
+
+	outputPath, err := deployer.SafeJoin(templatesDir, profileLockTemplateName+".yaml")
+	if err != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			"failed to resolve profile lock template path", err)
+	}
+	exists, generated, err := inspectProfileLockTemplate(outputPath)
+	if err != nil {
+		return "", 0, err
+	}
+	if exists && !generated {
+		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("refusing to overwrite non-AICR profile lock template %q", outputPath))
+	}
+	content := []byte(buf.String())
+	if err := os.WriteFile(outputPath, content, 0600); err != nil {
+		return "", 0, errors.Wrap(errors.ErrCodeInternal,
+			"failed to write profile lock template", err)
+	}
+	return outputPath, int64(len(content)), nil
+}
+
+// removeGeneratedProfileLockTemplate removes only a guard recognizable as
+// AICR-owned output from a prior profiled generation. An unrelated preexisting
+// file with the same name is left untouched so unprofiled generation retains
+// its legacy collision behavior.
+func removeGeneratedProfileLockTemplate(templatesDir string) error {
+	outputPath, err := deployer.SafeJoin(templatesDir, profileLockTemplateName+".yaml")
+	if err != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to resolve stale profile lock template path", err)
+	}
+	exists, generated, err := inspectProfileLockTemplate(outputPath)
+	if err != nil {
+		return err
+	}
+	if !exists || !generated {
+		return nil
+	}
+	if err := os.Remove(outputPath); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to remove stale profile lock template", err)
+	}
+	return nil
+}
+
+func inspectProfileLockTemplate(outputPath string) (bool, bool, error) {
+	file, err := os.Open(outputPath)
+	if os.IsNotExist(err) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, errors.Wrap(errors.ErrCodeInternal,
+			"failed to inspect profile lock template", err)
+	}
+	generated, inspectErr := hasGeneratedProfileLockHeader(file)
+	closeErr := file.Close()
+	if inspectErr != nil {
+		return false, false, errors.Wrap(errors.ErrCodeInternal,
+			"failed to inspect profile lock template", inspectErr)
+	}
+	if closeErr != nil {
+		return false, false, errors.Wrap(errors.ErrCodeInternal,
+			"failed to close profile lock template", closeErr)
+	}
+	return true, generated, nil
+}
+
+func hasGeneratedProfileLockHeader(reader io.Reader) (bool, error) {
+	prefix := make([]byte, len(profileLockTemplateHeader))
+	n, err := io.ReadFull(reader, prefix)
+	if err != nil {
+		if stderrors.Is(err, io.EOF) || stderrors.Is(err, io.ErrUnexpectedEOF) {
+			return false, nil
+		}
+		return false, err
+	}
+	return n == len(prefix) && string(prefix) == profileLockTemplateHeader, nil
+}
+
+func writeProfilePathGuard(
+	buf *strings.Builder,
+	parent string,
+	segments []string,
+	varPrefix string,
+	displayPath string,
+) {
+
+	if len(segments) == 0 {
+		return
+	}
+	key := segments[0]
+	fmt.Fprintf(buf, "{{- if hasKey %s %q -}}\n", parent, key)
+	if len(segments) == 1 {
+		fmt.Fprintf(buf, "{{- fail %q -}}\n",
+			"install-time value intersects profile-owned path "+displayPath)
+		buf.WriteString("{{- end -}}\n")
+		return
+	}
+
+	current := fmt.Sprintf("$%s_%d", varPrefix, len(segments))
+	fmt.Fprintf(buf, "{{- %s := index %s %q -}}\n", current, parent, key)
+	fmt.Fprintf(buf, "{{- if kindIs \"map\" %s -}}\n", current)
+	writeProfilePathGuard(buf, current, segments[1:], varPrefix, displayPath)
+	buf.WriteString("{{- else -}}\n")
+	fmt.Fprintf(buf, "{{- fail %q -}}\n",
+		"install-time value intersects profile-owned path "+displayPath)
+	buf.WriteString("{{- end -}}\n")
+	buf.WriteString("{{- end -}}\n")
 }
 
 // writeValuesFiles writes the chart's value surfaces: per-component
@@ -1053,6 +1226,8 @@ func (g *Generator) processFolders(ctx context.Context, tmpDir, outputDir, templ
 	if readErr != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to list argocd output", readErr)
 	}
+	profileLockReserved := g.RecipeResult != nil &&
+		g.RecipeResult.Metadata.SelectedProfile != nil
 	for _, e := range folderEntries {
 		select {
 		case <-ctx.Done():
@@ -1143,7 +1318,9 @@ func (g *Generator) processFolders(ctx context.Context, tmpDir, outputDir, templ
 		if keyErr != nil {
 			return keyErr
 		}
-		tmplPath, tmplSize, transformErr := transformApplication(tmpDir, templatesDir, folderName, folderComponent, overrideKey)
+		tmplPath, tmplSize, transformErr := transformApplication(
+			tmpDir, templatesDir, folderName, folderComponent, overrideKey, profileLockReserved,
+		)
 		if transformErr != nil {
 			return transformErr
 		}
@@ -1164,7 +1341,11 @@ func (g *Generator) processFolders(ctx context.Context, tmpDir, outputDir, templ
 //   - spec.source (single-source path-based): inject helm.values that exposes
 //     just the dynamic .Values.<overrideKey> overrides; the wrapped chart at
 //     the path provides its own values.yaml as the static layer.
-func transformApplication(srcDir, templatesDir, folderName, componentName, overrideKey string) (string, int64, error) {
+func transformApplication(
+	srcDir, templatesDir, folderName, componentName, overrideKey string,
+	profileLockReserved bool,
+) (string, int64, error) {
+
 	if !deployer.IsSafePathComponent(componentName) {
 		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid component name %q: must not contain path separators or parent directory references", componentName))
@@ -1172,6 +1353,10 @@ func transformApplication(srcDir, templatesDir, folderName, componentName, overr
 	if !deployer.IsSafePathComponent(folderName) {
 		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid folder name %q: must not contain path separators or parent directory references", folderName))
+	}
+	if profileLockReserved && componentName == profileLockTemplateName {
+		return "", 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("component %q template collides with a deployer-owned template", componentName))
 	}
 	componentDir, joinErr := deployer.SafeJoin(srcDir, folderName)
 	if joinErr != nil {
@@ -1561,8 +1746,9 @@ func copyFolderContent(srcDir, outputDir, folderName string, skip ...string) ([]
 // replacing the multi-source "sources" block with a single "source" that
 // loads static values from a chart file and merges dynamic overrides.
 //
-// All Helm components use the merge pattern — every value is overridable
-// at install time via --set, not just paths declared with --dynamic.
+// All Helm components use the merge pattern — every non-profile-owned value
+// is overridable at install time via --set, not just paths declared with
+// --dynamic. Profile-owned paths are rejected by the lock template, not here.
 func convertToSingleSourceWithValues(app map[string]any, componentName, overrideKey string) error {
 	spec, ok := app["spec"].(map[string]any)
 	if !ok {

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -256,6 +257,270 @@ func TestGenerate(t *testing.T) {
 				tt.assert(t, outputDir, output)
 			}
 		})
+	}
+}
+
+func TestGenerate_ProfileLockTemplate(t *testing.T) {
+	t.Run("unprofiled bundle emits no guard", func(t *testing.T) {
+		outputDir := t.TempDir()
+		g := &Generator{
+			RecipeResult: newRecipeResult("v1.0.0", []recipe.ComponentRef{{
+				Name: "gpu-operator", Namespace: "gpu-operator", Chart: "gpu-operator",
+				Version: "v25.3.3", Type: recipe.ComponentTypeHelm,
+				Source: "https://helm.ngc.nvidia.com/nvidia",
+			}}),
+			ComponentValues: map[string]map[string]any{"gpu-operator": {}},
+			Version:         "v0.0.0-test",
+		}
+		if _, err := g.Generate(t.Context(), outputDir); err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(outputDir, "templates", "aicr-profile-lock.yaml")); !os.IsNotExist(err) {
+			t.Fatalf("unprofiled guard stat error = %v, want not-exist", err)
+		}
+	})
+
+	t.Run("profiled guard rejects structural intersections", func(t *testing.T) {
+		requireHelm(t)
+
+		outputDir := t.TempDir()
+		result := newRecipeResult("v1.0.0", []recipe.ComponentRef{{
+			Name: "gpu-operator", Namespace: "gpu-operator", Chart: "gpu-operator",
+			Version: "v25.3.3", Type: recipe.ComponentTypeHelm,
+			Source: "https://helm.ngc.nvidia.com/nvidia",
+		}})
+		result.APIVersion = recipe.RecipeProfileAPIVersion
+		result.Metadata.SelectedProfile = &recipe.SelectedProfile{
+			Name:  "gpuStack",
+			Value: "driver-installed",
+			OwnedPaths: map[string][]string{
+				"gpu-operator": {"driver.enabled", "enabled"},
+			},
+		}
+		g := &Generator{
+			RecipeResult: result,
+			ComponentValues: map[string]map[string]any{
+				"gpu-operator": {"driver": map[string]any{"enabled": false}},
+			},
+			Version: "v0.0.0-test",
+		}
+		if _, err := g.Generate(t.Context(), outputDir); err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if _, err := g.Generate(t.Context(), outputDir); err != nil {
+			t.Fatalf("second Generate() into the same output directory error = %v", err)
+		}
+		guardPath := filepath.Join(outputDir, "templates", "aicr-profile-lock.yaml")
+		guard, err := os.ReadFile(guardPath)
+		if err != nil {
+			t.Fatalf("read profile lock guard: %v", err)
+		}
+		if !strings.Contains(string(guard), "gpu-operator.driver.enabled") {
+			t.Fatalf("profile lock guard does not name owned path:\n%s", guard)
+		}
+
+		tests := []struct {
+			name      string
+			extraArgs []string
+			wantErr   bool
+		}{
+			{name: "no component override"},
+			{
+				name:      "unrelated sibling",
+				extraArgs: []string{"--set", "gpuoperator.driver.version=580"},
+			},
+			{
+				name:      "exact false still intersects",
+				extraArgs: []string{"--set", "gpuoperator.driver.enabled=false"},
+				wantErr:   true,
+			},
+			{
+				name:      "explicit null still intersects",
+				extraArgs: []string{"--set-json", "gpuoperator.driver.enabled=null"},
+				wantErr:   true,
+			},
+			{
+				name:      "empty list still intersects",
+				extraArgs: []string{"--set-json", "gpuoperator.driver.enabled=[]"},
+				wantErr:   true,
+			},
+			{
+				name:      "non-map ancestor intersects",
+				extraArgs: []string{"--set-string", "gpuoperator.driver=blocked"},
+				wantErr:   true,
+			},
+			{
+				name:      "synthetic presence intersects",
+				extraArgs: []string{"--set", "gpuoperator.enabled=true"},
+				wantErr:   true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cmdCtx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+				defer cancel()
+				args := []string{
+					"template", "test-release", outputDir,
+					"--set", "repoURL=oci://example.test/aicr",
+				}
+				args = append(args, tt.extraArgs...)
+				cmd := exec.CommandContext(cmdCtx, "helm", args...) //nolint:gosec // controlled test arguments
+				out, err := cmd.CombinedOutput()
+				if (err != nil) != tt.wantErr {
+					t.Fatalf("helm template error = %v, wantErr %v\noutput:\n%s", err, tt.wantErr, out)
+				}
+				if tt.wantErr && !strings.Contains(string(out), "intersects profile-owned path") {
+					t.Fatalf("helm template error does not name profile intersection:\n%s", out)
+				}
+			})
+		}
+	})
+
+	t.Run("profiled to unprofiled regeneration removes guard", func(t *testing.T) {
+		outputDir := t.TempDir()
+		result := newRecipeResult("v1.0.0", []recipe.ComponentRef{{
+			Name: "gpu-operator", Namespace: "gpu-operator", Chart: "gpu-operator",
+			Version: "v25.3.3", Type: recipe.ComponentTypeHelm,
+			Source: "https://helm.ngc.nvidia.com/nvidia",
+		}})
+		result.APIVersion = recipe.RecipeProfileAPIVersion
+		result.Metadata.SelectedProfile = &recipe.SelectedProfile{
+			Name:  "gpuStack",
+			Value: "driver-installed",
+			OwnedPaths: map[string][]string{
+				"gpu-operator": {"driver.enabled", "enabled"},
+			},
+		}
+		g := &Generator{
+			RecipeResult: result,
+			ComponentValues: map[string]map[string]any{
+				"gpu-operator": {"driver": map[string]any{"enabled": false}},
+			},
+			Version: "v0.0.0-test",
+		}
+		if _, err := g.Generate(t.Context(), outputDir); err != nil {
+			t.Fatalf("profiled Generate() error = %v", err)
+		}
+		guardPath := filepath.Join(outputDir, "templates", "aicr-profile-lock.yaml")
+		if _, err := os.Stat(guardPath); err != nil {
+			t.Fatalf("profile guard stat error = %v", err)
+		}
+
+		result.APIVersion = recipe.RecipeAPIVersion
+		result.Metadata.SelectedProfile = nil
+		if _, err := g.Generate(t.Context(), outputDir); err != nil {
+			t.Fatalf("unprofiled regeneration error = %v", err)
+		}
+		if _, err := os.Stat(guardPath); !os.IsNotExist(err) {
+			t.Fatalf("stale profile guard stat error = %v, want not-exist", err)
+		}
+	})
+}
+
+func TestHasGeneratedProfileLockHeader_BoundedRead(t *testing.T) {
+	readPastHeader := errors.New("read past profile lock header")
+	reader := io.MultiReader(
+		strings.NewReader(profileLockTemplateHeader),
+		iotest.ErrReader(readPastHeader),
+	)
+
+	generated, err := hasGeneratedProfileLockHeader(reader)
+	if err != nil {
+		t.Fatalf("hasGeneratedProfileLockHeader() error = %v", err)
+	}
+	if !generated {
+		t.Fatal("hasGeneratedProfileLockHeader() = false, want true")
+	}
+}
+
+func TestWriteProfileLockTemplateRejectsUnownedExistingFile(t *testing.T) {
+	templatesDir := t.TempDir()
+	guardPath := filepath.Join(templatesDir, profileLockTemplateName+".yaml")
+	const sentinel = "user-owned template\n"
+	if err := os.WriteFile(guardPath, []byte(sentinel), 0o600); err != nil {
+		t.Fatalf("write user-owned profile lock template: %v", err)
+	}
+
+	g := &Generator{RecipeResult: &recipe.RecipeResult{
+		Metadata: recipe.RecipeResultMetadata{
+			SelectedProfile: &recipe.SelectedProfile{
+				Name:  "gpuStack",
+				Value: "driver-installed",
+				OwnedPaths: map[string][]string{
+					"gpu-operator": {"driver.enabled", "enabled"},
+				},
+			},
+		},
+	}}
+	_, _, err := g.writeProfileLockTemplate(templatesDir)
+	if err == nil {
+		t.Fatal("writeProfileLockTemplate() accepted a user-owned template collision")
+	}
+	if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("writeProfileLockTemplate() error = %v, want ErrCodeInvalidRequest", err)
+	}
+	got, readErr := os.ReadFile(guardPath)
+	if readErr != nil {
+		t.Fatalf("read user-owned profile lock template: %v", readErr)
+	}
+	if string(got) != sentinel {
+		t.Fatalf("user-owned profile lock template = %q, want unchanged %q", got, sentinel)
+	}
+}
+
+func TestTransformApplicationRejectsDeployerTemplateCollision(t *testing.T) {
+	srcDir := t.TempDir()
+	templatesDir := t.TempDir()
+	const (
+		folderName    = "001-aicr-profile-lock"
+		componentName = "aicr-profile-lock"
+		sentinel      = "profile lock must survive"
+	)
+
+	componentDir := filepath.Join(srcDir, folderName)
+	if err := os.MkdirAll(componentDir, 0o755); err != nil {
+		t.Fatalf("create component directory: %v", err)
+	}
+	app := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aicr-profile-lock
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://example.test/repository
+    path: 001-aicr-profile-lock
+    targetRevision: main
+`
+	if err := os.WriteFile(filepath.Join(componentDir, "application.yaml"), []byte(app), 0o600); err != nil {
+		t.Fatalf("write source application: %v", err)
+	}
+
+	lockPath := filepath.Join(templatesDir, componentName+".yaml")
+	if err := os.WriteFile(lockPath, []byte(sentinel), 0o600); err != nil {
+		t.Fatalf("write deployer-owned template: %v", err)
+	}
+
+	_, _, err := transformApplication(
+		srcDir, templatesDir, folderName, componentName, "profilelock", true,
+	)
+	if err == nil {
+		t.Fatal("transformApplication() error = nil, want collision rejection")
+	}
+	if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("error code = %v, want ErrCodeInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "collides with a deployer-owned template") {
+		t.Fatalf("error = %v, want collision message", err)
+	}
+	got, readErr := os.ReadFile(lockPath)
+	if readErr != nil {
+		t.Fatalf("read deployer-owned template: %v", readErr)
+	}
+	if string(got) != sentinel {
+		t.Fatalf("deployer-owned template was overwritten: %q", got)
 	}
 }
 

--- a/pkg/bundler/handler.go
+++ b/pkg/bundler/handler.go
@@ -20,6 +20,7 @@ import (
 	stderrors "errors"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"strconv"
@@ -37,9 +38,51 @@ import (
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
 
-const zipCopyBufferSize = 32 * 1024
+const (
+	zipCopyBufferSize = 32 * 1024
+
+	bundleQueryAcceleratedNodeSelector   = "accelerated-node-selector"
+	bundleQueryAcceleratedNodeToleration = "accelerated-node-toleration"
+	bundleQueryAppName                   = "app-name"
+	bundleQueryBundlers                  = "bundlers"
+	bundleQueryDeployer                  = "deployer"
+	bundleQueryDynamic                   = "dynamic"
+	bundleQueryNodes                     = "nodes"
+	bundleQueryRepo                      = "repo"
+	bundleQuerySerial                    = "serial"
+	bundleQuerySet                       = "set"
+	bundleQuerySystemNodeSelector        = "system-node-selector"
+	bundleQuerySystemNodeToleration      = "system-node-toleration"
+	bundleQueryVendorCharts              = "vendor-charts"
+	bundleQueryWorkloadGate              = "workload-gate"
+	bundleQueryWorkloadSelector          = "workload-selector"
+)
 
 var canonicalZipModifiedTime = time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+var supportedBundleQueryParameters = map[string]struct{}{
+	bundleQueryAcceleratedNodeSelector:   {},
+	bundleQueryAcceleratedNodeToleration: {},
+	bundleQueryAppName:                   {},
+	bundleQueryBundlers:                  {},
+	bundleQueryDeployer:                  {},
+	bundleQueryDynamic:                   {},
+	bundleQueryNodes:                     {},
+	bundleQueryRepo:                      {},
+	bundleQuerySerial:                    {},
+	bundleQuerySet:                       {},
+	bundleQuerySystemNodeSelector:        {},
+	bundleQuerySystemNodeToleration:      {},
+	bundleQueryVendorCharts:              {},
+	bundleQueryWorkloadGate:              {},
+	bundleQueryWorkloadSelector:          {},
+}
+
+// SupportedBundleQueryParameters returns the query parameter names recognized
+// by ParseBundleConfig. The returned map is a defensive copy.
+func SupportedBundleQueryParameters() map[string]struct{} {
+	return maps.Clone(supportedBundleQueryParameters)
+}
 
 // ParseBundleConfig parses the /v1/bundle query parameters from r and
 // returns the bundler *config.Config they describe. It is the exported
@@ -301,43 +344,43 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 	var err error
 
 	// Parse value overrides
-	params.valueOverrides, err = config.ParseValueOverrides(query["set"])
+	params.valueOverrides, err = config.ParseValueOverrides(query[bundleQuerySet])
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "Invalid set parameter", err)
 	}
 
 	// Parse dynamic value declarations
-	params.dynamicValues, err = config.ParseDynamicValues(query["dynamic"])
+	params.dynamicValues, err = config.ParseDynamicValues(query[bundleQueryDynamic])
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "Invalid dynamic parameter", err)
 	}
 
 	// Parse system node selectors
-	params.systemNodeSelector, err = snapshotter.ParseNodeSelectors(query["system-node-selector"])
+	params.systemNodeSelector, err = snapshotter.ParseNodeSelectors(query[bundleQuerySystemNodeSelector])
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "Invalid system-node-selector", err)
 	}
 
 	// Parse accelerated node selectors
-	params.acceleratedNodeSelector, err = snapshotter.ParseNodeSelectors(query["accelerated-node-selector"])
+	params.acceleratedNodeSelector, err = snapshotter.ParseNodeSelectors(query[bundleQueryAcceleratedNodeSelector])
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "Invalid accelerated-node-selector", err)
 	}
 
 	// Parse system node tolerations
-	params.systemNodeTolerations, err = snapshotter.ParseTolerations(query["system-node-toleration"])
+	params.systemNodeTolerations, err = snapshotter.ParseTolerations(query[bundleQuerySystemNodeToleration])
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "Invalid system-node-toleration", err)
 	}
 
 	// Parse accelerated node tolerations
-	params.acceleratedNodeTolerations, err = snapshotter.ParseTolerations(query["accelerated-node-toleration"])
+	params.acceleratedNodeTolerations, err = snapshotter.ParseTolerations(query[bundleQueryAcceleratedNodeToleration])
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "Invalid accelerated-node-toleration", err)
 	}
 
 	// Parse deployer type (helm, argocd)
-	deployerStr := query.Get("deployer")
+	deployerStr := query.Get(bundleQueryDeployer)
 	if deployerStr == "" {
 		params.deployer = config.DeployerHelm // default
 	} else {
@@ -348,10 +391,10 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 	}
 
 	// Parse repo URL (for Argo CD deployer)
-	params.repoURL = query.Get("repo")
+	params.repoURL = query.Get(bundleQueryRepo)
 
 	// Parse workload-gate taint
-	workloadGateStr := query.Get("workload-gate")
+	workloadGateStr := query.Get(bundleQueryWorkloadGate)
 	if workloadGateStr != "" {
 		params.workloadGateTaint, err = snapshotter.ParseTaint(workloadGateStr)
 		if err != nil {
@@ -360,13 +403,13 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 	}
 
 	// Parse workload-selector
-	params.workloadSelector, err = snapshotter.ParseNodeSelectors(query["workload-selector"])
+	params.workloadSelector, err = snapshotter.ParseNodeSelectors(query[bundleQueryWorkloadSelector])
 	if err != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "Invalid workload-selector parameter", err)
 	}
 
 	// Parse nodes (estimated node count; 0 = unset)
-	if nodesStr := query.Get("nodes"); nodesStr != "" {
+	if nodesStr := query.Get(bundleQueryNodes); nodesStr != "" {
 		n, parseErr := strconv.Atoi(nodesStr)
 		if parseErr != nil || n < 0 {
 			return nil, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "nodes must be a non-negative integer")
@@ -375,7 +418,7 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 	}
 
 	// Parse vendor-charts (opt-in air-gap vendoring)
-	if v := query.Get("vendor-charts"); v != "" {
+	if v := query.Get(bundleQueryVendorCharts); v != "" {
 		b, parseErr := strconv.ParseBool(v)
 		if parseErr != nil {
 			return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
@@ -386,7 +429,7 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 
 	// Parse serial (deploy components one at a time instead of parallelizing
 	// independent ones; the API counterpart of the --serial CLI flag).
-	if v := query.Get("serial"); v != "" {
+	if v := query.Get(bundleQuerySerial); v != "" {
 		b, parseErr := strconv.ParseBool(v)
 		if parseErr != nil {
 			return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
@@ -398,7 +441,7 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 	// Parse app-name (parent Argo Application name for argocd / argocd-helm).
 	// Reject on other deployers so a typo on a helm-deployer request fails
 	// loudly rather than being silently ignored.
-	if v := query.Get("app-name"); v != "" {
+	if v := query.Get(bundleQueryAppName); v != "" {
 		if params.deployer != config.DeployerArgoCD && params.deployer != config.DeployerArgoCDHelm {
 			return nil, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
 				"app-name is only valid with deployer=argocd or deployer=argocd-helm")
@@ -415,7 +458,7 @@ func parseQueryParams(r *http.Request) (*bundleParams, error) {
 	// keyed on the query map, not query.Get, so an explicit empty value
 	// ("bundlers=" or "bundlers=,,") is rejected rather than silently
 	// bundling everything — only an ABSENT parameter means no filter. See #1531.
-	if values, ok := query["bundlers"]; ok {
+	if values, ok := query[bundleQueryBundlers]; ok {
 		for _, v := range values {
 			for _, name := range strings.Split(v, ",") {
 				if name = strings.TrimSpace(name); name != "" {

--- a/pkg/bundler/handler_test.go
+++ b/pkg/bundler/handler_test.go
@@ -211,6 +211,17 @@ func TestParseBundleConfig_Serial(t *testing.T) {
 	}
 }
 
+func TestSupportedBundleQueryParametersReturnsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	parameters := SupportedBundleQueryParameters()
+	delete(parameters, bundleQuerySet)
+
+	if _, ok := SupportedBundleQueryParameters()[bundleQuerySet]; !ok {
+		t.Errorf("deleting %q from returned map mutated the supported parameter set", bundleQuerySet)
+	}
+}
+
 func TestStreamZipResponseContext_VerifiedInventory(t *testing.T) {
 	dir, inventory := writeVerifiedZipBundle(t, true)
 	output := &result.Output{

--- a/pkg/bundler/validations/checks.go
+++ b/pkg/bundler/validations/checks.go
@@ -528,18 +528,12 @@ func componentDisabled(ref *recipe.ComponentRef, bundlerConfig *config.Config, k
 // so a bundle whose values cannot be resolved is never emitted by either
 // path.
 //
-// Override-apply failures (--set / --set-json / --set-file) are blocking
-// too. extractComponentValues usually rejects them with
-// ErrCodeInvalidRequest before validations run, but not reliably:
-// ApplyMapOverrides applies scalar --set paths in Go's randomized
-// map-iteration order, so an overlapping pair (e.g. gpuoperator:a.b=1
-// alongside gpuoperator:a=2) can apply cleanly child-first during
-// extraction yet fail parent-first here on a fresh iteration order.
-// Skipping on that failure would disarm the gate for exactly the
-// override sets whose effective values it cannot reconstruct — with
-// gpuDriverState=absent that lets a driverless bundle through — so the
-// gate fails closed instead. When extraction already failed, validations
-// never run, so this cannot duplicate the bundler's own rejection.
+// Override-apply failures (--set / --set-json / --set-file) are blocking too.
+// Bundle generation normally rejects them during value extraction before
+// validations run, but this helper is also usable directly. Skipping an
+// override it cannot reconstruct would disarm the gate for that candidate —
+// with gpuDriverState=absent that could let a driverless configuration pass —
+// so the gate independently fails closed.
 func effectiveComponentValues(ctx context.Context, recipeResult *recipe.RecipeResult, bundlerConfig *config.Config, componentName string, keys []string) (map[string]any, error) {
 	values, err := recipeResult.GetValuesForComponentWithContext(ctx, componentName)
 	if err != nil {

--- a/pkg/bundler/validations/checks_test.go
+++ b/pkg/bundler/validations/checks_test.go
@@ -1011,10 +1011,9 @@ func TestCheckDriverOwnershipCoherence(t *testing.T) {
 			wantContains: []string{"driverless", "regenerate the recipe"},
 		},
 		{
-			// Fail closed: the bundler's extractComponentValues only warns
-			// on a recipe-side resolution failure and renders from an EMPTY
-			// map, so a skip here would let an unverifiable recipe bypass
-			// the gate entirely and still bundle.
+			// Fail closed within validation itself. Normal bundle value
+			// extraction also rejects this input, but direct validation
+			// callers must not treat an unverifiable recipe as a skip.
 			name: "unresolvable gpu-operator values → blocking error, not skip",
 			recipeResult: result(recipe.GPUDriverStateAbsent, aks, recipe.ComponentRef{
 				Name:       "gpu-operator",
@@ -1035,12 +1034,10 @@ func TestCheckDriverOwnershipCoherence(t *testing.T) {
 			wantErrContains: []string{"driver-ownership coherence", "nvidia-dra-driver-gpu"},
 		},
 		{
-			// Fail closed on override REAPPLICATION too: ApplyMapOverrides
-			// iterates scalar --set paths in randomized map order, so an
-			// overlapping pair can pass extraction yet fail here — a silent
-			// skip would disarm the gate for exactly the override sets whose
-			// effective values it cannot reconstruct. (driver.enabled is a
-			// boolean, so the deeper path fails traversal deterministically.)
+			// Fail closed on override reapplication too. This direct
+			// validation call must surface an override set whose effective
+			// values it cannot reconstruct. (driver.enabled is a boolean, so
+			// the deeper path fails traversal deterministically.)
 			name:         "--set override that cannot be reapplied → blocking error, not skip",
 			recipeResult: result(recipe.GPUDriverStateAbsent, aks, gpuOpRef(driverOff())),
 			bundlerConfig: config.NewConfig(config.WithValueOverrides(map[string]map[string]string{

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -35,6 +35,7 @@ const (
 	flagIntent      = "intent"
 	flagOS          = "os"
 	flagPlatform    = "platform"
+	flagProfile     = "profile"
 	flagNoHealth    = "no-health"
 )
 

--- a/pkg/cli/mirror.go
+++ b/pkg/cli/mirror.go
@@ -145,7 +145,7 @@ func flagMatchesName(f cli.Flag, name string) bool {
 //nolint:gocyclo // linear option resolution
 func runMirrorListCmd(ctx context.Context, cmd *cli.Command) (err error) {
 	if validErr := validateSingleValueFlags(cmd, "recipe", "service", "accelerator",
-		"intent", "os", "platform", "snapshot", "config", "format", "output"); validErr != nil {
+		"intent", "os", "platform", flagProfile, "snapshot", "config", "format", "output"); validErr != nil {
 		return validErr
 	}
 
@@ -237,6 +237,10 @@ func runMirrorListCmd(ctx context.Context, cmd *cli.Command) (err error) {
 func resolveRecipeForMirror(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig, client *aicr.Client) (*recipe.RecipeResult, error) {
 	recipePath := cmd.String("recipe")
 	if recipePath != "" {
+		if cmd.IsSet(flagProfile) || cfg.Recipe().ProfileSelection() != "" {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				"--profile/spec.recipe.profile selects during criteria resolution and cannot be combined with --recipe")
+		}
 		slog.Info("loading recipe from file", "path", recipePath)
 
 		loaded, err := client.LoadRecipe(ctx, recipePath, cmd.String("kubeconfig"))

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -97,7 +97,7 @@ Use in shell scripts:
     --selector components.gpu-operator.values.driver.version)`,
 		Flags: queryCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform", "snapshot", "config", "format", "selector"); err != nil {
+			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform", flagProfile, "snapshot", "config", "format", "selector"); err != nil {
 				return err
 			}
 
@@ -166,6 +166,7 @@ Use in shell scripts:
 // is seeded.
 func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig, client *aicr.Client) (*aicr.RecipeResult, error) {
 	reg := client.CriteriaRegistry()
+	profile := stringFlagOrConfig(cmd, flagProfile, cfg.Recipe().ProfileSelection())
 
 	snapFilePath := stringFlagOrConfig(cmd, "snapshot", cfg.Recipe().SnapshotPath())
 
@@ -208,7 +209,9 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 		// ResolveRecipeFromSnapshot builds the constraint evaluator
 		// internally (constraints.Evaluate against snap), mirroring the
 		// pre-facade BuildFromCriteriaWithEvaluator path.
-		result, err := client.ResolveRecipeFromSnapshot(ctx, aicr.WrapCriteria(criteria), aicr.WrapSnapshot(snap))
+		result, err := client.ResolveRecipeFromSnapshotWithProfile(
+			ctx, aicr.WrapCriteria(criteria), aicr.WrapSnapshot(snap), profile,
+		)
 		if err == nil {
 			return result, nil
 		}
@@ -219,7 +222,9 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 		}
 
 		slog.Info("retrying recipe resolution with snapshot-derived criteria relaxed", "criteria", relaxed.String())
-		return client.ResolveRecipeFromSnapshot(ctx, aicr.WrapCriteria(relaxed), aicr.WrapSnapshot(snap))
+		return client.ResolveRecipeFromSnapshotWithProfile(
+			ctx, aicr.WrapCriteria(relaxed), aicr.WrapSnapshot(snap), profile,
+		)
 	}
 
 	criteria, err := mergeCriteriaFromCmdAndConfig(cmd, cfg, reg)
@@ -233,7 +238,7 @@ func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *ap
 	}
 
 	slog.Info("building recipe from criteria", "criteria", criteria.String())
-	return client.ResolveRecipeFromCriteria(ctx, aicr.WrapCriteria(criteria))
+	return client.ResolveRecipeFromCriteriaWithProfile(ctx, aicr.WrapCriteria(criteria), profile)
 }
 
 // relaxSnapshotDerivedCoverage inspects a recipe-resolution error for the

--- a/pkg/cli/query_test.go
+++ b/pkg/cli/query_test.go
@@ -127,16 +127,16 @@ func TestQueryCmdFlagsExcludesOutput(t *testing.T) {
 
 func TestQueryCmdFlagsIncludesSelector(t *testing.T) {
 	flags := queryCmdFlags()
-	found := false
+	found := map[string]bool{}
 	for _, f := range flags {
 		names := f.Names()
 		for _, n := range names {
-			if n == "selector" {
-				found = true
-			}
+			found[n] = true
 		}
 	}
-	if !found {
-		t.Error("queryCmdFlags must include --selector flag")
+	for _, name := range []string{"selector", "profile"} {
+		if !found[name] {
+			t.Errorf("queryCmdFlags must include --%s flag", name)
+		}
 	}
 }

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -65,6 +65,11 @@ func recipeCmdFlags() []cli.Flag {
 			Usage:    fmt.Sprintf("Platform/framework type to include in the runtime (e.g. %s)", strings.Join(recipe.GetCriteriaPlatformTypes(), ", ")),
 			Category: catQueryParameters,
 		}, recipe.GetCriteriaPlatformTypes),
+		&cli.StringFlag{
+			Name:     flagProfile,
+			Usage:    "Configuration profile selection in name=value form",
+			Category: catQueryParameters,
+		},
 		&cli.IntFlag{
 			Name:     "nodes",
 			Usage:    "Number of worker/GPU nodes in the cluster",
@@ -137,7 +142,7 @@ Override snapshot-detected criteria:
 		},
 		Flags: recipeCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if err := validateSingleValueFlags(cmd, flagService, flagAccelerator, flagIntent, flagOS, flagPlatform, "snapshot", "config", flagOutput, flagFormat); err != nil {
+			if err := validateSingleValueFlags(cmd, flagService, flagAccelerator, flagIntent, flagOS, flagPlatform, flagProfile, "snapshot", "config", flagOutput, flagFormat); err != nil {
 				return err
 			}
 

--- a/pkg/cli/recipe_test.go
+++ b/pkg/cli/recipe_test.go
@@ -656,7 +656,10 @@ func TestRecipeCmd_CommandStructure(t *testing.T) {
 		t.Error("Description should not be empty")
 	}
 
-	requiredFlags := []string{"service", "accelerator", "intent", "os", "nodes", "snapshot", "output", "format"}
+	requiredFlags := []string{
+		"service", "accelerator", "intent", "os", "profile",
+		"nodes", "snapshot", "output", "format",
+	}
 	for _, flagName := range requiredFlags {
 		found := false
 		for _, flag := range cmd.Flags {

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -322,15 +322,21 @@ func (c *Client) LoadCatalog(ctx context.Context) error {
 // catalog is fully populated before calling this.
 //
 // Each entry carries the overlay name, its criteria, whether it is a leaf
-// (IsLeaf=true means no other overlay inherits from it), and its data
-// provenance ("embedded" or "external"). Entries are returned in ascending
-// name order for deterministic output.
+// (IsLeaf=true means no other overlay inherits from it), its data provenance
+// ("embedded" or "external"), and its effective configuration profile — the
+// declaration reachable from that overlay after inheritance and co-match
+// resolution, nil when the overlay reaches none. Entries are returned in
+// ascending name order for deterministic output.
 //
 // When filter is non-nil, only overlays whose criteria carry the exact values
 // specified in each non-empty/non-"any" filter dimension are returned. Setting
 // a filter dimension to "" or "any" places no constraint on that dimension.
 //
-// Returns ErrCodeInvalidRequest on a nil or closed Client, and propagates
+// Returns ErrCodeInvalidRequest on a nil or closed Client, or when an overlay
+// reachable from the filtered set declares an invalid profile — profile
+// declarations are validated during projection, so a malformed declaration
+// fails the whole call rather than yielding a partial catalog. Returns
+// ErrCodeTimeout if ctx is canceled during projection, and propagates
 // ErrCodeInternal if the underlying metadata store cannot be loaded.
 func (c *Client) ListCatalog(ctx context.Context, filter *Criteria) ([]CatalogEntry, error) {
 	if c == nil {
@@ -358,9 +364,15 @@ func (c *Client) ListCatalog(ctx context.Context, filter *Criteria) ([]CatalogEn
 		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to load recipe catalog")
 	}
 
-	raw := store.ListCatalog(toInternalCriteria(filter))
+	raw, err := store.ListCatalogWithProfiles(ctx, toInternalCriteria(filter))
+	if err != nil {
+		return nil, err
+	}
 	entries := make([]CatalogEntry, len(raw))
 	for i, e := range raw {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeTimeout, "catalog response conversion canceled", ctxErr)
+		}
 		var crit Criteria
 		if wrapped := WrapCriteria(e.Criteria); wrapped != nil {
 			crit = *wrapped
@@ -371,6 +383,17 @@ func (c *Client) ListCatalog(ctx context.Context, filter *Criteria) ([]CatalogEn
 			IsLeaf:   e.IsLeaf,
 			Source:   e.Source,
 		}
+		if e.Profile != nil {
+			entries[i].Profile = &ProfileSummary{
+				Name:        e.Profile.Name,
+				Description: e.Profile.Description,
+				Default:     e.Profile.Default,
+				Values:      append([]string(nil), e.Profile.Values...),
+			}
+		}
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, errors.Wrap(errors.ErrCodeTimeout, "catalog response conversion canceled", ctxErr)
 	}
 	return entries, nil
 }
@@ -500,7 +523,7 @@ func (c *Client) ResolveRecipe(ctx context.Context, req RecipeRequest) (*RecipeR
 		return nil, err
 	}
 
-	internal, err := c.resolveCriteria(ctx, builder, criteria)
+	internal, err := c.resolveCriteria(ctx, builder, criteria, req.Profile)
 	if err != nil {
 		// Don't re-wrap with ErrCodeInternal — the builder already
 		// returns a structured error with the appropriate code
@@ -529,11 +552,17 @@ func (c *Client) ResolveRecipe(ctx context.Context, req RecipeRequest) (*RecipeR
 // vs-lossless projection and owner stamping. The criteria parameter is the
 // upstream pkg/recipe.Criteria shape — facade entry points translate via
 // toInternalCriteria before reaching here.
-func (c *Client) resolveCriteria(ctx context.Context, builder *recipe.Builder, criteria *recipe.Criteria) (*recipe.RecipeResult, error) {
+func (c *Client) resolveCriteria(
+	ctx context.Context,
+	builder *recipe.Builder,
+	criteria *recipe.Criteria,
+	profile string,
+) (*recipe.RecipeResult, error) {
+
 	if err := c.enforceAllowLists(criteria); err != nil {
 		return nil, err
 	}
-	return builder.BuildFromCriteria(ctx, criteria)
+	return builder.BuildFromCriteriaWithProfile(ctx, criteria, profile)
 }
 
 // ResolveRecipeFromCriteria resolves a facade Criteria into a facade
@@ -553,6 +582,17 @@ func (c *Client) resolveCriteria(ctx context.Context, builder *recipe.Builder, c
 // nil context, and nil criteria are rejected with ErrCodeInvalidRequest; a
 // closed Client is rejected; a facade-level timeout bounds the resolve.
 func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criteria) (*RecipeResult, error) {
+	return c.ResolveRecipeFromCriteriaWithProfile(ctx, criteria, "")
+}
+
+// ResolveRecipeFromCriteriaWithProfile resolves criteria with an optional
+// name=value profile selection.
+func (c *Client) ResolveRecipeFromCriteriaWithProfile(
+	ctx context.Context,
+	criteria *Criteria,
+	profile string,
+) (*RecipeResult, error) {
+
 	if c == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
 	}
@@ -579,7 +619,7 @@ func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criter
 	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
 	defer cancel()
 
-	internal, err := c.resolveCriteria(ctx, builder, toInternalCriteria(criteria))
+	internal, err := c.resolveCriteria(ctx, builder, toInternalCriteria(criteria), profile)
 	if err != nil {
 		return nil, err
 	}
@@ -626,6 +666,18 @@ func (c *Client) ResolveRecipeFromCriteria(ctx context.Context, criteria *Criter
 // bounds the resolve. Builder errors propagate as-is (they already carry the
 // appropriate pkg/errors code) rather than being re-wrapped.
 func (c *Client) ResolveRecipeFromSnapshot(ctx context.Context, criteria *Criteria, snap *Snapshot) (*RecipeResult, error) {
+	return c.ResolveRecipeFromSnapshotWithProfile(ctx, criteria, snap, "")
+}
+
+// ResolveRecipeFromSnapshotWithProfile is the snapshot-filtered profile
+// resolution path.
+func (c *Client) ResolveRecipeFromSnapshotWithProfile(
+	ctx context.Context,
+	criteria *Criteria,
+	snap *Snapshot,
+	profile string,
+) (*RecipeResult, error) {
+
 	if c == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")
 	}
@@ -688,7 +740,7 @@ func (c *Client) ResolveRecipeFromSnapshot(ctx context.Context, criteria *Criter
 	// Don't re-wrap the builder's error — it already returns a structured
 	// error with the appropriate code (ErrCodeInvalidRequest for bad
 	// criteria, ErrCodeTimeout for context expiry, etc.).
-	internal, err := builder.BuildFromCriteriaWithEvaluator(ctx, internalCriteria, evaluator)
+	internal, err := builder.BuildFromCriteriaWithEvaluatorAndProfile(ctx, internalCriteria, evaluator, profile)
 	if err != nil {
 		return nil, err
 	}
@@ -855,6 +907,17 @@ func facadeResultFromInternal(r *recipe.RecipeResult, name string) *RecipeResult
 		Version:      r.Metadata.Version,
 		TranslatedAt: time.Now(),
 		internal:     r,
+	}
+	if r.Metadata.SelectedProfile != nil {
+		out.SelectedProfile = &SelectedProfile{
+			Name:       r.Metadata.SelectedProfile.Name,
+			Value:      r.Metadata.SelectedProfile.Value,
+			Advertiser: r.Metadata.SelectedProfile.Advertiser,
+			OwnedPaths: make(map[string][]string, len(r.Metadata.SelectedProfile.OwnedPaths)),
+		}
+		for component, paths := range r.Metadata.SelectedProfile.OwnedPaths {
+			out.SelectedProfile.OwnedPaths[component] = append([]string(nil), paths...)
+		}
 	}
 	for _, c := range r.ComponentRefs {
 		if !c.IsEnabled() {

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -948,6 +949,41 @@ func TestAdoptRecipe_DeepCopiesForClientIsolation(t *testing.T) {
 	}
 }
 
+func TestAdoptRecipe_RejectsCyclicProfileOverridesBeforeDeepCopy(t *testing.T) {
+	client := newClientForBundleTest(t)
+	overrides := map[string]any{}
+	overrides["driver"] = overrides
+	input := &recipe.RecipeResult{
+		Kind:       recipe.RecipeResultKind,
+		APIVersion: recipe.RecipeProfileAPIVersion,
+		ComponentRefs: []recipe.ComponentRef{{
+			Name:      "gpu-operator",
+			Type:      recipe.ComponentTypeHelm,
+			Source:    "https://charts.example.com",
+			Chart:     "gpu-operator",
+			Version:   "1.0.0",
+			Overrides: overrides,
+		}},
+		Metadata: recipe.RecipeResultMetadata{
+			SelectedProfile: &recipe.SelectedProfile{
+				Name:  "gpuStack",
+				Value: "driver-installed",
+				OwnedPaths: map[string][]string{
+					"gpu-operator": {"driver.enabled", "enabled"},
+				},
+			},
+		},
+	}
+
+	_, err := client.AdoptRecipe(t.Context(), input)
+	if err == nil || !strings.Contains(err.Error(), "cyclic reference") {
+		t.Fatalf("AdoptRecipe() error = %v, want cyclic-reference rejection", err)
+	}
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("AdoptRecipe() error = %v, want ErrCodeInvalidRequest", err)
+	}
+}
+
 // TestClient_CloseDrainsInflightResolve is the deterministic race
 // test for the inflight-drain pattern. Without the drain, this
 // sequence races storeCache repopulation against eviction:
@@ -1222,6 +1258,70 @@ func (b *blockingReadFileProvider) WalkDir(ctx context.Context, root string, fn 
 }
 
 func (b *blockingReadFileProvider) Source(path string) string { return b.underlying.Source(path) }
+
+type deadlineRequiredProvider struct {
+	underlying recipe.DataProvider
+	calls      atomic.Int64
+}
+
+func (d *deadlineRequiredProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	d.calls.Add(1)
+	if _, ok := ctx.Deadline(); !ok {
+		return nil, aicrerrors.New(
+			aicrerrors.ErrCodeInternal, "provider read did not receive a deadline")
+	}
+	return d.underlying.ReadFile(ctx, path)
+}
+
+func (d *deadlineRequiredProvider) WalkDir(
+	ctx context.Context,
+	root string,
+	fn fs.WalkDirFunc,
+) error {
+
+	d.calls.Add(1)
+	if _, ok := ctx.Deadline(); !ok {
+		return aicrerrors.New(
+			aicrerrors.ErrCodeInternal, "provider walk did not receive a deadline")
+	}
+	return d.underlying.WalkDir(ctx, root, fn)
+}
+
+func (d *deadlineRequiredProvider) Source(path string) string {
+	return d.underlying.Source(path)
+}
+
+func TestAdoptRecipe_BoundsProviderIO(t *testing.T) {
+	t.Parallel()
+
+	embedded := recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), ".")
+	dp := &deadlineRequiredProvider{underlying: embedded}
+	c := &Client{
+		builder: recipe.NewBuilder(recipe.WithDataProvider(dp)),
+		dp:      dp,
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err := c.AdoptRecipe(context.Background(), &recipe.RecipeResult{
+		Kind:       recipe.RecipeResultKind,
+		APIVersion: recipe.RecipeAPIVersion,
+		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "gpu-operator",
+				Source:  "https://charts.example.com",
+				Chart:   "gpu-operator",
+				Version: "v1",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AdoptRecipe(context.Background()) error = %v", err)
+	}
+	if dp.calls.Load() == 0 {
+		t.Fatal("AdoptRecipe() did not exercise provider I/O")
+	}
+}
 
 // TestClient_CloseDrainsInflightAdopt pins the inflight registration added for
 // adoptRecipe (issue #1584): PrepareAndValidate reads the component registry to

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -799,6 +799,99 @@ func TestResolveRecipeFromCriteriaLossless(t *testing.T) {
 	}
 }
 
+func TestResolveRecipeWithProfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "overlays"), 0o755); err != nil {
+		t.Fatalf("setup overlays directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"),
+		[]byte("components: []\n"), 0o600); err != nil {
+		t.Fatalf("setup registry.yaml: %v", err)
+	}
+	overlay := []byte(`apiVersion: aicr.run/v1alpha3
+kind: RecipeMetadata
+metadata:
+  name: profile-aks
+spec:
+  criteria:
+    service: aks
+  profile:
+    name: gpuStack
+    default: driver-installed
+    values:
+      driver-installed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: false
+      operator-managed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: true
+`)
+	if err := os.WriteFile(filepath.Join(dir, "overlays", "profile-aks.yaml"),
+		overlay, 0o600); err != nil {
+		t.Fatalf("setup profile overlay: %v", err)
+	}
+
+	client, err := aicr.NewClient(
+		aicr.WithRecipeSource(aicr.FilesystemSource(dir)),
+		aicr.WithVersion("v1.2.3"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	criteria, err := recipe.BuildCriteriaWithRegistry(client.CriteriaRegistry(),
+		recipe.WithServiceRegistry("aks"),
+		recipe.WithAcceleratorRegistry("h100"),
+		recipe.WithIntentRegistry("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteriaWithRegistry: %v", err)
+	}
+	result, err := client.ResolveRecipeFromCriteriaWithProfile(
+		t.Context(), aicr.WrapCriteria(criteria), "gpuStack=operator-managed",
+	)
+	if err != nil {
+		t.Fatalf("ResolveRecipeFromCriteriaWithProfile: %v", err)
+	}
+	if result.SelectedProfile == nil ||
+		result.SelectedProfile.Value != "operator-managed" ||
+		result.Resolved().APIVersion != recipe.RecipeProfileAPIVersion {
+
+		t.Fatalf("profile result = %#v, apiVersion=%q",
+			result.SelectedProfile, result.Resolved().APIVersion)
+	}
+	values, err := result.Resolved().GetValuesForComponentWithContext(t.Context(), "gpu-operator")
+	if err != nil {
+		t.Fatalf("GetValuesForComponentWithContext: %v", err)
+	}
+	if enabled := values["driver"].(map[string]any)["enabled"]; enabled != true {
+		t.Fatalf("driver.enabled = %v, want true", enabled)
+	}
+
+	entries, err := client.ListCatalog(t.Context(), &aicr.Criteria{Service: "aks"})
+	if err != nil {
+		t.Fatalf("ListCatalog: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name == "profile-aks" {
+			if entry.Profile == nil || entry.Profile.Default != "driver-installed" {
+				t.Fatalf("catalog profile = %#v", entry.Profile)
+			}
+			return
+		}
+	}
+	t.Fatal("profile-aks catalog entry not found")
+}
+
 // TestResolveRecipeFromSnapshot proves the snapshot-evaluator resolve path:
 // ResolveRecipeFromSnapshot builds a recipe from explicit Criteria while
 // evaluating its resolution constraints against an observed cluster Snapshot

--- a/pkg/client/v1/bundle.go
+++ b/pkg/client/v1/bundle.go
@@ -22,6 +22,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
@@ -139,6 +140,19 @@ func (c *Client) adoptRecipe(ctx context.Context, rec *recipe.RecipeResult) (*Re
 	c.mu.RUnlock()
 	defer c.inflight.Done()
 
+	// Profile-bearing artifacts hydrate their owned component values during
+	// adoption. Bound that provider-backed I/O even when an SDK caller passes
+	// context.Background; a tighter caller deadline remains authoritative.
+	ctx, cancel := context.WithTimeout(ctx, defaults.RecipeOperationTimeout)
+	defer cancel()
+
+	// Validate the no-I/O profile contract before DeepCopy. In particular,
+	// canonical inline maps and slices must be acyclic because DeepCopy
+	// recursively copies those containers.
+	if err := rec.ValidateProfileContract(); err != nil {
+		return nil, err
+	}
+
 	// Deep-copy the caller-supplied recipe BEFORE binding the provider.
 	// BindDataProvider mutates the receiver's unexported provider field, and
 	// the input is caller-owned: a caller reusing one recipe.RecipeResult
@@ -158,7 +172,7 @@ func (c *Client) adoptRecipe(ctx context.Context, rec *recipe.RecipeResult) (*Re
 	// back-fills missing types from the registry first (this boundary does not
 	// run ApplyRegistryDefaults) so a type-less registry ref — valid before
 	// #1584 — still resolves rather than being rejected. See issue #1584.
-	if err := cp.PrepareAndValidate(); err != nil {
+	if err := cp.PrepareAndValidateWithContext(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/client/v1/gpu_driver_state.go
+++ b/pkg/client/v1/gpu_driver_state.go
@@ -412,6 +412,10 @@ func hasPreinstalledDriverProfile(ctx context.Context, r *recipe.RecipeResult) b
 // a pre-installed driver on the sampled GPU node AND the resolved
 // overlay already declares the coordinated preinstalled-driver profile.
 //
+// When a selected configuration profile owns driver.enabled, the function
+// never mutates: an agreeing profile value makes the injection redundant and
+// a disagreeing one must win, so ownership short-circuits before any write.
+//
 // Policy is only-false: the function never forces driver.enabled=true.
 // The injection is a no-op on rendered Helm output for overlays that
 // already carry the profile (the resolved recipe records the override
@@ -485,6 +489,23 @@ func applyGPUDriverAutoOverride(ctx context.Context, r *recipe.RecipeResult, sna
 			"reason", "driver state is not preinstalled")
 		return
 	}
+	if r.OwnsProfilePath(gpuOperatorComponentName, "driver.enabled") {
+		driverEnabled, known := profileOwnedDriverEnabled(r)
+		if known && !driverEnabled {
+			slog.Debug("gpu-operator driver auto-detect: selected profile owns driver.enabled; skipping mutation",
+				"state", state.String(),
+				"component", gpuOperatorComponentName)
+		} else {
+			slog.Warn("gpu-operator driver auto-detect: selected profile owns driver.enabled; "+
+				"skipping mutation even though a pre-installed driver was observed. "+
+				"If the selected profile keeps driver.enabled=true, applying it may install "+
+				"a second driver. Select a preinstalled-driver profile or regenerate the recipe.",
+				"state", state.String(),
+				"component", gpuOperatorComponentName,
+				"profile", r.Metadata.SelectedProfile.Name+"="+r.Metadata.SelectedProfile.Value)
+		}
+		return
+	}
 	if !hasPreinstalledDriverProfile(ctx, r) {
 		slog.Warn("gpu-operator driver auto-detect: pre-installed driver observed on sampled node, "+
 			"but the resolved overlay is not a preinstalled-driver profile "+
@@ -537,4 +558,17 @@ func applyGPUDriverAutoOverride(ctx context.Context, r *recipe.RecipeResult, sna
 	}
 	slog.Debug("gpu-operator driver auto-detect: no gpu-operator component ref in resolved recipe",
 		"state", state.String())
+}
+
+func profileOwnedDriverEnabled(r *recipe.RecipeResult) (bool, bool) {
+	ref := r.GetComponentRef(gpuOperatorComponentName)
+	if ref == nil {
+		return false, false
+	}
+	driver, ok := ref.Overrides["driver"].(map[string]any)
+	if !ok {
+		return false, false
+	}
+	enabled, ok := driver["enabled"].(bool)
+	return enabled, ok
 }

--- a/pkg/client/v1/gpu_driver_state_test.go
+++ b/pkg/client/v1/gpu_driver_state_test.go
@@ -15,7 +15,10 @@
 package aicr
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/measurement"
@@ -472,6 +475,62 @@ func TestApplyGPUDriverAutoOverride_UnitCases(t *testing.T) {
 			}
 			if got != nil {
 				t.Errorf("driver.enabled = %v, want no injection", got)
+			}
+		})
+	}
+}
+
+func TestApplyGPUDriverAutoOverride_ProfileOwnedDriverConflictWarning(t *testing.T) {
+	preinstalledSnap := gpuHardwareSnapshotWith(func(b *measurement.SubtypeBuilder) {
+		b.SetBool(measurement.KeyGPUPresent, true).
+			SetInt(measurement.KeyGPUCount, 8).
+			SetBool(measurement.KeyGPUDriverLoaded, true)
+	})
+	tests := []struct {
+		name     string
+		enabled  bool
+		wantWarn bool
+	}{
+		{
+			name:     "operator-managed driver warns",
+			enabled:  true,
+			wantWarn: true,
+		},
+		{
+			name:    "preinstalled driver profile stays quiet",
+			enabled: false,
+		},
+	}
+
+	previousLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+				Level: slog.LevelWarn,
+			})))
+			result := &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{{
+					Name: gpuOperatorComponentName,
+					Overrides: map[string]any{
+						"driver": map[string]any{"enabled": tt.enabled},
+					},
+				}},
+			}
+			result.Metadata.SelectedProfile = &recipe.SelectedProfile{
+				Name:  "gpuStack",
+				Value: "selected",
+				OwnedPaths: map[string][]string{
+					gpuOperatorComponentName: {"driver.enabled", "enabled"},
+				},
+			}
+
+			applyGPUDriverAutoOverride(t.Context(), result, preinstalledSnap)
+
+			gotWarn := strings.Contains(logs.String(), "may install a second driver")
+			if gotWarn != tt.wantWarn {
+				t.Errorf("warning present = %t, want %t; logs: %s", gotWarn, tt.wantWarn, logs.String())
 			}
 		})
 	}

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -55,7 +55,8 @@ func TestStability_Client(t *testing.T) {
 func TestStability_RecipeResolution(t *testing.T) {
 	t.Parallel()
 
-	_ = aicr.RecipeRequest{}
+	var req aicr.RecipeRequest
+	_ = req.Profile
 
 	_ = func(c *aicr.Client, ctx context.Context, req aicr.RecipeRequest) (*aicr.RecipeResult, error) {
 		return c.ResolveRecipe(ctx, req)
@@ -63,8 +64,21 @@ func TestStability_RecipeResolution(t *testing.T) {
 	_ = func(c *aicr.Client, ctx context.Context, cr *aicr.Criteria) (*aicr.RecipeResult, error) {
 		return c.ResolveRecipeFromCriteria(ctx, cr)
 	}
+	_ = func(c *aicr.Client, ctx context.Context, cr *aicr.Criteria, profile string) (*aicr.RecipeResult, error) {
+		return c.ResolveRecipeFromCriteriaWithProfile(ctx, cr, profile)
+	}
 	_ = func(c *aicr.Client, ctx context.Context, cr *aicr.Criteria, s *aicr.Snapshot) (*aicr.RecipeResult, error) {
 		return c.ResolveRecipeFromSnapshot(ctx, cr, s)
+	}
+	_ = func(
+		c *aicr.Client,
+		ctx context.Context,
+		cr *aicr.Criteria,
+		s *aicr.Snapshot,
+		profile string,
+	) (*aicr.RecipeResult, error) {
+
+		return c.ResolveRecipeFromSnapshotWithProfile(ctx, cr, s, profile)
 	}
 	_ = func(c *aicr.Client, ctx context.Context, path, kubeconfig string) (*aicr.RecipeResult, error) {
 		return c.LoadRecipe(ctx, path, kubeconfig)
@@ -83,7 +97,31 @@ func TestStability_RecipeResult(t *testing.T) {
 	_ = r.Name
 	_ = r.Version
 	_ = r.Components
+	_ = r.SelectedProfile
 	_ = r.Resolved()
+}
+
+// TestStability_Profile pins the profile resolution and catalog projections.
+func TestStability_Profile(t *testing.T) {
+	t.Parallel()
+
+	var selected aicr.SelectedProfile
+	_ = selected.Name
+	_ = selected.Value
+	_ = selected.Advertiser
+	_ = selected.OwnedPaths
+
+	var summary aicr.ProfileSummary
+	_ = summary.Name
+	_ = summary.Description
+	_ = summary.Default
+	_ = summary.Values
+
+	var entry aicr.CatalogEntry
+	_ = entry.Profile
+	_ = func(c *aicr.Client, ctx context.Context, filter *aicr.Criteria) ([]aicr.CatalogEntry, error) {
+		return c.ListCatalog(ctx, filter)
+	}
 }
 
 // TestStability_Bundle pins the bundle surface: options shape, MakeBundle /

--- a/pkg/client/v1/types.go
+++ b/pkg/client/v1/types.go
@@ -240,6 +240,10 @@ type RecipeRequest struct {
 	// "kubeflow", "nim".
 	Platform string
 
+	// Profile is an optional name=value configuration profile selection.
+	// Empty applies the resolved declaration's mandatory default.
+	Profile string
+
 	// PinnedName reserves space for future pinned-recipe support.
 	// Currently rejected with ErrCodeUnavailable; set the criteria
 	// fields above instead.
@@ -273,6 +277,10 @@ type RecipeResult struct {
 	// the full underlying ComponentRefs (enabled and disabled).
 	Components []ComponentRef
 
+	// SelectedProfile is present when the resolved composition declares a
+	// configuration profile.
+	SelectedProfile *SelectedProfile
+
 	// internal holds the upstream pkg/recipe.RecipeResult so
 	// BundleComponents can call its GetValuesForComponent /
 	// component-ref helpers without re-resolving the recipe.
@@ -298,9 +306,35 @@ type RecipeResult struct {
 	owner *Client
 }
 
+// SelectedProfile is the stable facade projection of a recipe profile.
+// It is populated only for aicr.run/v1alpha3 results; an unprofiled
+// composition leaves it nil.
+type SelectedProfile struct {
+	// Name is the declaration this selection came from, e.g. "gpuStack".
+	Name string
+
+	// Value is the selected value within that declaration.
+	Value string
+
+	// Advertiser is reserved for the future GKE allocation-policy
+	// extension and is always empty in this version — a declaration
+	// carrying one is rejected at catalog load, so no result reaches a
+	// caller with it set. Do not branch on it.
+	Advertiser string
+
+	// OwnedPaths maps each locked component to its sorted dotted value
+	// paths, and is the union across every value of the declaration rather
+	// than only the selected one. Every listed component carries the
+	// synthetic "enabled" path recording that the profile owns its
+	// presence. Overriding any listed path is rejected at bundle time
+	// unless the override agrees with the selected value.
+	OwnedPaths map[string][]string
+}
+
 // Resolved returns the complete underlying recipe (the full
 // pkg/recipe.RecipeResult) that this result wraps. The facade RecipeResult
-// exposes only Name/Version/Components; callers that need constraints,
+// exposes only Name/Version/TranslatedAt/Components/SelectedProfile;
+// callers that need constraints,
 // validation config, deployment order, or metadata (e.g. evidence emission)
 // use this. Returns nil if the result was not produced by the Client.
 //
@@ -387,6 +421,18 @@ type CatalogEntry struct {
 
 	// Source is the data provenance: "embedded" or "external".
 	Source string `json:"source" yaml:"source"`
+
+	// Profile is the effective declaration after inheritance and co-match
+	// resolution. It is nil for an unprofiled catalog entry.
+	Profile *ProfileSummary `json:"profile,omitempty" yaml:"profile,omitempty"`
+}
+
+// ProfileSummary is the compact catalog discovery shape.
+type ProfileSummary struct {
+	Name        string   `json:"name" yaml:"name"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Default     string   `json:"default" yaml:"default"`
+	Values      []string `json:"values" yaml:"values"`
 }
 
 // ComponentRef identifies a deployable recipe component.

--- a/pkg/component/overrides.go
+++ b/pkg/component/overrides.go
@@ -26,9 +26,10 @@ import (
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
-// ApplyMapOverrides applies overrides to a map[string]any using dot-notation paths.
-// Handles nested maps by traversing the path segments and creating nested maps as needed.
-// Useful for applying --set flag overrides to values.yaml content.
+// ApplyMapOverrides applies overrides to a map[string]any using dot-notation
+// paths. Paths are applied shallowest-first, then lexicographically, so
+// overlapping inputs have a deterministic result. Intermediate maps are
+// created as needed; an existing non-map ancestor is rejected.
 func ApplyMapOverrides(target map[string]any, overrides map[string]string) error {
 	if target == nil {
 		return errors.New(errors.ErrCodeInvalidRequest, "target map cannot be nil")
@@ -39,7 +40,8 @@ func ApplyMapOverrides(target map[string]any, overrides map[string]string) error
 	}
 
 	var errs []string
-	for path, value := range overrides {
+	for _, path := range sortedOverridePaths(overrides) {
+		value := overrides[path]
 		if err := setMapValueByPath(target, path, value); err != nil {
 			errs = append(errs, fmt.Sprintf("%s=%s: %v", path, value, err))
 		}
@@ -93,9 +95,10 @@ func ApplyTypedOverrides(target map[string]any, overrides map[string]any) error 
 // sortedOverridePaths returns the override paths ordered shallowest-first by
 // dot-separated segment count, breaking ties lexicographically. A path that is
 // a strict dot-prefix of another always has fewer segments, so it is always
-// applied before the path that extends it — making overlapping-path merges
-// deterministic and letting the deeper override win.
-func sortedOverridePaths(overrides map[string]any) []string {
+// applied before the path that extends it. This makes overlapping-path merges
+// deterministic: compatible descendants apply last, while a non-map ancestor
+// consistently blocks them.
+func sortedOverridePaths[T any](overrides map[string]T) []string {
 	paths := make([]string, 0, len(overrides))
 	for path := range overrides {
 		paths = append(paths, path)

--- a/pkg/component/overrides_test.go
+++ b/pkg/component/overrides_test.go
@@ -623,6 +623,26 @@ func TestApplyMapOverrides(t *testing.T) {
 	}
 }
 
+func TestApplyMapOverrides_OverlappingPathsAreDeterministic(t *testing.T) {
+	const attempts = 50
+	overrides := map[string]string{
+		"driver":         "true",
+		"driver.enabled": "false",
+	}
+	for range attempts {
+		target := map[string]any{}
+		err := ApplyMapOverrides(target, overrides)
+		if err == nil || !strings.Contains(err.Error(), "driver.enabled=false") ||
+			!strings.Contains(err.Error(), "exists but is not a map") {
+
+			t.Fatalf("ApplyMapOverrides() error = %v, want deterministic blocked-child rejection", err)
+		}
+		if got := target["driver"]; got != true {
+			t.Fatalf("driver = %#v, want parent override true before child rejection", got)
+		}
+	}
+}
+
 func TestSetNodeSelectorAtPath(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/config/accessors.go
+++ b/pkg/config/accessors.go
@@ -89,6 +89,14 @@ func (r *RecipeSpec) DataDir() string {
 	return r.Data
 }
 
+// ProfileSelection returns spec.recipe.profile, or "" when unset.
+func (r *RecipeSpec) ProfileSelection() string {
+	if r == nil {
+		return ""
+	}
+	return r.Profile
+}
+
 // IsCriteriaStrict returns spec.recipe.criteriaStrict flattened to a
 // plain bool (false when unset). Mirrors the --criteria-strict CLI
 // flag. The pointer-to-bool shape on RecipeSpec lets the spec

--- a/pkg/config/accessors_test.go
+++ b/pkg/config/accessors_test.go
@@ -45,6 +45,9 @@ func TestAccessors_NilTolerant(t *testing.T) {
 	if got := nilRecipe.DataDir(); got != "" {
 		t.Errorf("nil RecipeSpec DataDir = %q, want empty", got)
 	}
+	if got := nilRecipe.ProfileSelection(); got != "" {
+		t.Errorf("nil RecipeSpec ProfileSelection = %q, want empty", got)
+	}
 	if got := nilRecipe.IsCriteriaStrict(); got {
 		t.Errorf("nil RecipeSpec IsCriteriaStrict = %v, want false", got)
 	}
@@ -94,9 +97,10 @@ func TestAccessors_PopulatedReturnsValues(t *testing.T) {
 	cfg := &config.AICRConfig{
 		Spec: config.Spec{
 			Recipe: &config.RecipeSpec{
-				Input:  &config.RecipeInputSpec{Snapshot: "snap.yaml"},
-				Output: &config.RecipeOutputSpec{Path: "out.yaml", Format: "json"},
-				Data:   "/data",
+				Input:   &config.RecipeInputSpec{Snapshot: "snap.yaml"},
+				Output:  &config.RecipeOutputSpec{Path: "out.yaml", Format: "json"},
+				Data:    "/data",
+				Profile: "gpuStack=operator",
 			},
 			Bundle: &config.BundleSpec{},
 		},
@@ -116,6 +120,9 @@ func TestAccessors_PopulatedReturnsValues(t *testing.T) {
 	}
 	if got := r.DataDir(); got != "/data" {
 		t.Errorf("DataDir = %q", got)
+	}
+	if got := r.ProfileSelection(); got != "gpuStack=operator" {
+		t.Errorf("ProfileSelection = %q", got)
 	}
 	if cfg.Bundle() == nil {
 		t.Fatal("Bundle() = nil")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,6 +105,7 @@ type RecipeSpec struct {
 	Input    *RecipeInputSpec  `yaml:"input,omitempty" json:"input,omitempty"`
 	Output   *RecipeOutputSpec `yaml:"output,omitempty" json:"output,omitempty"`
 	Data     string            `yaml:"data,omitempty" json:"data,omitempty"`
+	Profile  string            `yaml:"profile,omitempty" json:"profile,omitempty"`
 
 	// CriteriaStrict, when true, rejects criteria values not in the
 	// embedded OSS catalog (i.e., hides registry entries contributed by

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -198,6 +198,13 @@ func TestValidate_Errors(t *testing.T) {
 			wantSub: "spec.recipe.output.format",
 		},
 		{
+			name: "invalid profile",
+			mutate: func(c *config.AICRConfig) {
+				c.Spec.Recipe.Profile = "gpuStack"
+			},
+			wantSub: "name=value",
+		},
+		{
 			name: "invalid deployer",
 			mutate: func(c *config.AICRConfig) {
 				c.Spec.Bundle = &config.BundleSpec{

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
@@ -103,6 +104,10 @@ func (r *RecipeSpec) validate() error {
 	}
 	if _, err := r.ResolveCriteriaWithRegistry(nil); err != nil {
 		return err
+	}
+	if _, err := recipe.ParseProfileSelection(r.Profile); err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+			"invalid spec.recipe.profile")
 	}
 	if r.Output != nil && r.Output.Format != "" {
 		if serializer.Format(r.Output.Format).IsUnknown() {

--- a/pkg/evidence/project/synthesize.go
+++ b/pkg/evidence/project/synthesize.go
@@ -25,7 +25,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
 	"github.com/NVIDIA/aicr/pkg/recipe"
-	"gopkg.in/yaml.v3"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 // k8sServerVersionConstraint is the recipe constraint whose value is
@@ -243,14 +243,22 @@ func readRecipeView(bundleDir string) (*recipeView, error) {
 		return nil, err
 	}
 
-	var view recipeView
-	if err := yaml.Unmarshal(data, &view); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "parse bundle recipe.yaml", err)
+	result, err := recipe.DecodeRecipeResult(data, serializer.FormatYAML)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+			"parse bundle recipe.yaml")
 	}
-	if view.Criteria == nil {
+	if result.Criteria == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "bundle recipe.yaml has no criteria")
 	}
-	return &view, nil
+	if result.Metadata.SelectedProfile != nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"profile-bearing evidence projection is deferred to the profile adoption rollout")
+	}
+	return &recipeView{
+		Criteria:    result.Criteria,
+		Constraints: result.Constraints,
+	}, nil
 }
 
 // readBoundedFile reads path into memory, capped at max bytes. The +1

--- a/pkg/evidence/project/synthesize_test.go
+++ b/pkg/evidence/project/synthesize_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -157,6 +158,28 @@ func TestSynthesize_HappyPath(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(res.RunDir, "ctrf", "performance.json")); !os.IsNotExist(err) {
 		t.Errorf("performance.json should be absent, stat err = %v", err)
+	}
+}
+
+func TestSynthesize_RejectsProfileRecipeUntilProjectionSupportLands(t *testing.T) {
+	in := baseInput(t)
+	in.BundleDir = writeBundle(t, `apiVersion: aicr.run/v1alpha3
+kind: RecipeResult
+metadata:
+  selectedProfile:
+    name: gpuStack
+    value: driver-installed
+    ownedPaths: {}
+criteria:
+  service: aks
+  accelerator: h100
+  os: ubuntu
+  intent: training
+`, map[string]string{"deployment": "{}"})
+
+	_, err := Synthesize(context.Background(), in)
+	if err == nil || !strings.Contains(err.Error(), "profile-bearing evidence projection") {
+		t.Fatalf("Synthesize() error = %v, want deferred profile projection rejection", err)
 	}
 }
 

--- a/pkg/mirror/discover.go
+++ b/pkg/mirror/discover.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -32,6 +33,8 @@ import (
 	"github.com/NVIDIA/aicr/pkg/helm"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
+
+const logKeyComponent = "component"
 
 // Option configures a Lister.
 type Option func(*Lister)
@@ -89,6 +92,16 @@ type componentResult struct {
 	chart  *ChartRef
 }
 
+// mirrorCandidate is the one effective component/value model shared by
+// profile-lock validation and discovery. Profile-owned values are hydrated and
+// overridden once, validated, then passed unchanged to Helm rendering so the
+// two boundaries cannot disagree about alias precedence or overlapping paths.
+type mirrorCandidate struct {
+	refs          []recipe.ComponentRef
+	overrides     map[string]map[string]string
+	profileValues map[string]map[string]any
+}
+
 // Discover takes a loaded RecipeResult and returns a MirrorList by
 // rendering each component's chart and extracting images.
 //
@@ -101,23 +114,29 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 	if rec == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "recipe is required")
 	}
+	validated := *rec
+	validated.ComponentRefs = append([]recipe.ComponentRef(nil), rec.ComponentRefs...)
+	if err := validated.PrepareAndValidateWithContext(ctx); err != nil {
+		return nil, err
+	}
+	rec = &validated
 
 	// Build override lookup: component → path → value.
 	overrideLookup := buildOverrideLookup(l.valueOverrides)
+	candidate, err := prepareMirrorCandidate(ctx, rec, overrideLookup)
+	if err != nil {
+		return nil, err
+	}
 
 	var (
 		mu      sync.Mutex
-		results = make([]componentResult, 0, len(rec.ComponentRefs))
+		results = make([]componentResult, 0, len(candidate.refs))
 	)
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(defaults.MirrorDiscoveryConcurrency)
 
-	for i, compRef := range rec.ComponentRefs {
-		if !compRef.IsEnabled() {
-			continue
-		}
-
+	for i, compRef := range candidate.refs {
 		g.Go(func() error {
 			// Bail early if context is already canceled.
 			if gctx.Err() != nil {
@@ -137,20 +156,31 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 			// below, so invoking Helm with a fabricated chart name would only
 			// produce a spurious warning.
 			if compRef.Type == recipe.ComponentTypeHelm && compRef.HasExternalChart() {
-				values, valErr := rec.GetValuesForComponentWithContext(gctx, compRef.Name)
+				values, prevalidated := candidate.profileValues[compRef.Name]
+				var valErr error
+				if !prevalidated {
+					values, valErr = rec.GetValuesForComponentWithContext(gctx, compRef.Name)
+				}
 				if valErr != nil {
 					slog.Warn("failed to load values for component",
-						"component", compRef.Name, "error", valErr)
+						logKeyComponent, compRef.Name, "error", valErr)
 					ci.Warnings = append(ci.Warnings,
 						fmt.Sprintf("failed to load values: %v", valErr))
 				} else {
-					// Apply --set overrides by component name and override keys.
-					applyValueOverrides(values, overrideLookup[compRef.Name])
-					keyOverrides, keyErr := overridesByKey(overrideLookup, compRef)
-					if keyErr != nil {
-						return keyErr
+					// Profile-owned values were already overridden and lock-
+					// validated above. Other components retain mirror's
+					// best-effort hydration behavior and apply the same
+					// canonical/alias-resolved override map.
+					if !prevalidated {
+						if applyErr := component.ApplyMapOverrides(
+							values, candidate.overrides[compRef.Name],
+						); applyErr != nil {
+							return errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+								"failed to apply mirror value overrides",
+								applyErr,
+								map[string]any{logKeyComponent: compRef.Name})
+						}
 					}
-					applyValueOverrides(values, keyOverrides)
 
 					// Source-only refs omit the chart name; EffectiveChart
 					// applies the same component-name fallback the deployers
@@ -171,14 +201,14 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 							return gctx.Err()
 						}
 						slog.Warn("helm template failed for component",
-							"component", compRef.Name, "error", renderErr)
+							logKeyComponent, compRef.Name, "error", renderErr)
 						ci.Warnings = append(ci.Warnings,
 							fmt.Sprintf("helm template failed: %v", renderErr))
 					} else {
 						imgs, extractErr := bom.ExtractImagesFromYAML(rendered)
 						if extractErr != nil {
 							slog.Warn("image extraction failed",
-								"component", compRef.Name, "error", extractErr)
+								logKeyComponent, compRef.Name, "error", extractErr)
 							ci.Warnings = append(ci.Warnings,
 								fmt.Sprintf("image extraction failed: %v", extractErr))
 						} else {
@@ -276,7 +306,7 @@ func extractManifestImages(ctx context.Context, dp recipe.DataProvider, acc []st
 	content, readErr := recipe.GetManifestContentWithContext(ctx, dp, mPath)
 	if readErr != nil {
 		slog.Warn("failed to read manifest",
-			"component", compName, "path", mPath, "error", readErr)
+			logKeyComponent, compName, "path", mPath, "error", readErr)
 		ci.Warnings = append(ci.Warnings,
 			fmt.Sprintf("manifest read failed %s: %v", mPath, readErr))
 		return acc
@@ -306,57 +336,32 @@ func buildOverrideLookup(overrides []config.ComponentPath) map[string]map[string
 	return lookup
 }
 
-// applyValueOverrides applies flat key=value overrides to a nested values
-// map. Keys use dot-notation (e.g., "driver.version").
-func applyValueOverrides(values map[string]any, overrides map[string]string) {
-	for path, val := range overrides {
-		setNestedValue(values, path, val)
-	}
-}
+// effectiveOverridesForComponent resolves overrides supplied under the
+// canonical component name and every registry alias. It matches bundler
+// precedence: the canonical name wins a same-path collision, followed by
+// aliases in registry order. A registry failure is fatal whenever overrides
+// are present: otherwise a valid registry-only alias could be silently
+// discarded and mirror would inventory a different candidate than requested.
+func effectiveOverridesForComponent(
+	lookup map[string]map[string]string,
+	ref recipe.ComponentRef,
+	provider recipe.DataProvider,
+) (map[string]string, error) {
 
-// setNestedValue sets a dot-separated path in a nested map.
-func setNestedValue(m map[string]any, path, value string) {
-	parts := strings.Split(path, ".")
-	current := m
-	for i, part := range parts {
-		if i == len(parts)-1 {
-			current[part] = component.ConvertMapValue(value)
-			return
-		}
-		next, ok := current[part]
-		if !ok {
-			next = make(map[string]any)
-			current[part] = next
-		}
-		if nextMap, ok := next.(map[string]any); ok {
-			current = nextMap
-		} else {
-			// Overwrite non-map intermediate with a map.
-			nextMap := make(map[string]any)
-			current[part] = nextMap
-			current = nextMap
-		}
-	}
-}
-
-// overridesByKey returns overrides that match a component by its
-// valueOverrideKeys from the registry. This bridges the gap between
-// --set flag keys (e.g., "gpuoperator:driver.version") and the
-// component name (e.g., "gpu-operator").
-func overridesByKey(lookup map[string]map[string]string, ref recipe.ComponentRef) (map[string]string, error) {
-	registry, err := recipe.GetComponentRegistry()
+	keys := []string{ref.Name}
+	registry, err := recipe.GetComponentRegistryFor(provider)
 	if err != nil {
-		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "overridesByKey: failed to get component registry")
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			"failed to resolve component aliases for mirror overrides")
 	}
-	if registry == nil {
-		return map[string]string{}, nil
-	}
-	cfg := registry.Get(ref.Name)
-	if cfg == nil {
-		return map[string]string{}, nil
+	if registry != nil {
+		if cfg := registry.Get(ref.Name); cfg != nil {
+			keys = append(keys, cfg.ValueOverrideKeys...)
+		}
 	}
 	merged := make(map[string]string)
-	for _, key := range cfg.ValueOverrideKeys {
+	for i := len(keys) - 1; i >= 0; i-- {
+		key := keys[i]
 		if overrides, ok := lookup[key]; ok {
 			for path, val := range overrides {
 				merged[path] = val
@@ -364,6 +369,82 @@ func overridesByKey(lookup map[string]map[string]string, ref recipe.ComponentRef
 		}
 	}
 	return merged, nil
+}
+
+func prepareMirrorCandidate(
+	ctx context.Context,
+	rec *recipe.RecipeResult,
+	overrideLookup map[string]map[string]string,
+) (*mirrorCandidate, error) {
+
+	candidate := &mirrorCandidate{
+		refs:          make([]recipe.ComponentRef, 0, len(rec.ComponentRefs)),
+		overrides:     make(map[string]map[string]string, len(rec.ComponentRefs)),
+		profileValues: make(map[string]map[string]any),
+	}
+	var owned map[string][]string
+	if rec.Metadata.SelectedProfile != nil {
+		owned = rec.Metadata.SelectedProfile.OwnedPaths
+	}
+	for _, ref := range rec.ComponentRefs {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, errors.Wrap(
+				errors.ErrCodeTimeout, "mirror candidate preparation canceled", ctxErr)
+		}
+		var overrides map[string]string
+		if len(overrideLookup) > 0 {
+			var err error
+			overrides, err = effectiveOverridesForComponent(
+				overrideLookup, ref, rec.DataProvider(),
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if raw, exists := overrides[config.ComponentEnabledKey]; exists {
+			enabled, parseErr := strconv.ParseBool(raw)
+			if parseErr != nil {
+				return nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+					"invalid --set enabled value", parseErr,
+					map[string]any{logKeyComponent: ref.Name, "value": raw})
+			}
+			delete(overrides, config.ComponentEnabledKey)
+			if enabled && !ref.IsEnabled() {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("component %q is disabled by the recipe and cannot be re-enabled with --set",
+						ref.Name))
+			}
+			if !enabled {
+				continue
+			}
+		}
+		if !ref.IsEnabled() {
+			continue
+		}
+
+		candidate.refs = append(candidate.refs, ref)
+		candidate.overrides[ref.Name] = overrides
+		if _, profileOwned := owned[ref.Name]; !profileOwned {
+			continue
+		}
+
+		values, valueErr := rec.GetValuesForComponentWithContext(ctx, ref.Name)
+		if valueErr != nil {
+			return nil, errors.PropagateOrWrap(valueErr, errors.ErrCodeInternal,
+				fmt.Sprintf("failed to load profile candidate values for component %q", ref.Name))
+		}
+		if applyErr := component.ApplyMapOverrides(values, overrides); applyErr != nil {
+			return nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+				"failed to apply mirror value overrides",
+				applyErr,
+				map[string]any{logKeyComponent: ref.Name})
+		}
+		candidate.profileValues[ref.Name] = values
+	}
+	if err := rec.ValidateProfileLock(ctx, candidate.refs, candidate.profileValues, nil); err != nil {
+		return nil, err
+	}
+	return candidate, nil
 }
 
 // sortByIndex sorts componentResult slices by their original index

--- a/pkg/mirror/discover_test.go
+++ b/pkg/mirror/discover_test.go
@@ -16,17 +16,66 @@ package mirror
 
 import (
 	"context"
+	stderrors "errors"
 	"io/fs"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/helm"
 	"github.com/NVIDIA/aicr/pkg/helm/helmtest"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
+
+func newProfiledRecipe() *recipe.RecipeResult {
+	result := &recipe.RecipeResult{
+		Kind:       recipe.RecipeResultKind,
+		APIVersion: recipe.RecipeProfileAPIVersion,
+		ComponentRefs: []recipe.ComponentRef{{
+			Name:    "gpu-operator",
+			Type:    recipe.ComponentTypeHelm,
+			Source:  "https://helm.ngc.nvidia.com/nvidia",
+			Chart:   "gpu-operator",
+			Version: "v25.3.0",
+			Overrides: map[string]any{
+				"driver": map[string]any{"enabled": false},
+			},
+		}},
+	}
+	result.Metadata.SelectedProfile = &recipe.SelectedProfile{
+		Name:  "gpuStack",
+		Value: "driver-installed",
+		OwnedPaths: map[string][]string{
+			"gpu-operator": {"driver.enabled", "enabled"},
+		},
+	}
+	return result
+}
+
+func TestPrepareMirrorCandidate_Canceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := prepareMirrorCandidate(ctx, &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{{Name: "gpu-operator"}},
+	}, nil)
+	if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+		t.Fatalf("prepareMirrorCandidate() error = %v, want ErrCodeTimeout", err)
+	}
+}
+
+func mustParseOverride(t *testing.T, raw string) config.ComponentPath {
+	t.Helper()
+	var override config.ComponentPath
+	if err := override.Parse(raw); err != nil {
+		t.Fatalf("ComponentPath.Parse(%q) error = %v", raw, err)
+	}
+	return override
+}
 
 func TestDiscover(t *testing.T) {
 	tests := []struct {
@@ -283,56 +332,253 @@ spec:
 	}
 }
 
-func TestSetNestedValue(t *testing.T) {
+func TestDiscover_ProfileLock(t *testing.T) {
 	tests := []struct {
-		name     string
-		path     string
-		value    string
-		initial  map[string]any
-		expected any
+		name             string
+		override         string
+		wantErr          bool
+		wantDriver       bool
+		wantEnabledValue bool
 	}{
 		{
-			name:     "simple key",
-			path:     "key",
-			value:    "val",
-			initial:  map[string]any{},
-			expected: "val",
+			name:       "divergent owned value",
+			override:   "gpuoperator:driver.enabled=true",
+			wantErr:    true,
+			wantDriver: false,
 		},
 		{
-			name:     "nested key",
-			path:     "a.b.c",
-			value:    "deep",
-			initial:  map[string]any{},
-			expected: "deep",
+			name:       "redundant owned value",
+			override:   "gpuoperator:driver.enabled=false",
+			wantDriver: false,
 		},
 		{
-			name:     "override existing",
-			path:     "driver.version",
-			value:    "new",
-			initial:  map[string]any{"driver": map[string]any{"version": "old"}},
-			expected: "new",
+			name:             "redundant component presence",
+			override:         "gpuoperator:enabled=true",
+			wantDriver:       false,
+			wantEnabledValue: false,
+		},
+		{
+			name:       "divergent component presence",
+			override:   "gpuoperator:enabled=false",
+			wantErr:    true,
+			wantDriver: false,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setNestedValue(tt.initial, tt.path, tt.value)
-
-			// Walk to the value.
-			var current any = tt.initial
-			for _, part := range splitPath(tt.path) {
-				m, ok := current.(map[string]any)
-				if !ok {
-					t.Fatalf("expected map at %q, got %T", part, current)
-				}
-				current = m[part]
+			renderer := &helmtest.MockRenderer{
+				Rendered: map[string][]byte{"gpu-operator": {}},
 			}
-
-			if current != tt.expected {
-				t.Errorf("got %v, want %v", current, tt.expected)
+			lister := NewLister(
+				WithHelmRenderer(renderer),
+				WithValueOverrides([]config.ComponentPath{mustParseOverride(t, tt.override)}),
+			)
+			result := newProfiledRecipe()
+			_, err := lister.Discover(t.Context(), result)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Discover() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if len(renderer.Inputs) != 0 {
+					t.Fatalf("renderer called %d times before profile rejection", len(renderer.Inputs))
+				}
+				return
+			}
+			if len(renderer.Inputs) != 1 {
+				t.Fatalf("renderer calls = %d, want 1", len(renderer.Inputs))
+			}
+			driver := renderer.Inputs[0].Values["driver"].(map[string]any)
+			if driver["enabled"] != tt.wantDriver {
+				t.Fatalf("render driver.enabled = %v, want %v", driver["enabled"], tt.wantDriver)
+			}
+			_, enabledValuePresent := renderer.Inputs[0].Values["enabled"]
+			if enabledValuePresent != tt.wantEnabledValue {
+				t.Fatalf("render values has enabled=%v, want %v",
+					enabledValuePresent, tt.wantEnabledValue)
+			}
+			inputDriver := result.ComponentRefs[0].Overrides["driver"].(map[string]any)
+			if inputDriver["enabled"] != false {
+				t.Fatalf("input recipe mutated: driver.enabled=%v", inputDriver["enabled"])
 			}
 		})
 	}
+}
+
+func TestDiscover_ProfileValidationRejectsBlockedOverridePath(t *testing.T) {
+	result := newProfiledRecipe()
+
+	renderer := &helmtest.MockRenderer{
+		Rendered: map[string][]byte{"gpu-operator": {}},
+	}
+	lister := NewLister(
+		WithHelmRenderer(renderer),
+		WithValueOverrides([]config.ComponentPath{
+			// Even though the canonical child spells the selected value, the
+			// alias replaces its parent with a scalar. Bundling rejects that
+			// structurally blocked path, so mirror discovery must also fail.
+			mustParseOverride(t, "gpuoperator:driver=true"),
+			mustParseOverride(t, "gpu-operator:driver.enabled=false"),
+		}),
+	)
+	_, err := lister.Discover(t.Context(), result)
+	if err == nil ||
+		!strings.Contains(err.Error(), "driver.enabled=false") ||
+		!strings.Contains(err.Error(), "exists but is not a map") {
+
+		t.Fatalf("Discover() error = %v, want deterministic blocked-child rejection", err)
+	}
+	if len(renderer.Inputs) != 0 {
+		t.Fatalf("renderer called %d times before override rejection", len(renderer.Inputs))
+	}
+}
+
+func TestDiscover_RejectsNonMapOverrideAncestor(t *testing.T) {
+	renderer := &helmtest.MockRenderer{
+		Rendered: map[string][]byte{"gpu-operator": {}},
+	}
+	result := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{{
+			Name:    "gpu-operator",
+			Type:    recipe.ComponentTypeHelm,
+			Source:  "https://helm.ngc.nvidia.com/nvidia",
+			Chart:   "gpu-operator",
+			Version: "v25.3.0",
+			Overrides: map[string]any{
+				"driver": "not-a-map",
+			},
+		}},
+	}
+
+	_, err := NewLister(
+		WithHelmRenderer(renderer),
+		WithValueOverrides([]config.ComponentPath{
+			mustParseOverride(t, "gpuoperator:driver.enabled=false"),
+		}),
+	).Discover(t.Context(), result)
+	if err == nil || !strings.Contains(err.Error(), "exists but is not a map") {
+		t.Fatalf("Discover() error = %v, want non-map ancestor rejection", err)
+	}
+	if len(renderer.Inputs) != 0 {
+		t.Fatalf("renderer called %d times before override rejection", len(renderer.Inputs))
+	}
+}
+
+func TestDiscover_SetEnabledOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		wantErr  bool
+	}{
+		{
+			name:     "false skips component",
+			override: "gpuoperator:enabled=false",
+		},
+		{
+			name:     "non-boolean is rejected",
+			override: "gpuoperator:enabled=not-a-bool",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer := &helmtest.MockRenderer{
+				Rendered: map[string][]byte{"gpu-operator": {}},
+			}
+			result, err := NewLister(
+				WithHelmRenderer(renderer),
+				WithValueOverrides([]config.ComponentPath{
+					mustParseOverride(t, tt.override),
+				}),
+			).Discover(t.Context(), &recipe.RecipeResult{
+				ComponentRefs: []recipe.ComponentRef{{
+					Name:    "gpu-operator",
+					Type:    recipe.ComponentTypeHelm,
+					Source:  "https://helm.ngc.nvidia.com/nvidia",
+					Chart:   "gpu-operator",
+					Version: "v25.3.0",
+				}},
+			})
+			switch {
+			case tt.wantErr:
+				if err == nil {
+					t.Fatal("Discover() error = nil, want invalid enabled override")
+				}
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Fatalf("Discover() error = %v, want ErrCodeInvalidRequest", err)
+				}
+				if !strings.Contains(err.Error(), "invalid --set enabled value") {
+					t.Fatalf("Discover() error = %v, want invalid enabled override", err)
+				}
+				if result != nil {
+					t.Fatalf("Discover() result = %#v, want nil after invalid override", result)
+				}
+			case err != nil:
+				t.Fatalf("Discover() error = %v", err)
+			default:
+				if len(result.Components) != 0 || len(result.Charts) != 0 || len(result.Images) != 0 {
+					t.Fatalf("component remained in mirror list: %#v", result)
+				}
+			}
+			if len(renderer.Inputs) != 0 {
+				t.Fatalf("renderer calls = %d, want 0", len(renderer.Inputs))
+			}
+		})
+	}
+}
+
+func TestDiscover_ProfileLockLeavesUnownedHydrationBestEffort(t *testing.T) {
+	result := &recipe.RecipeResult{
+		Kind:       recipe.RecipeResultKind,
+		APIVersion: recipe.RecipeProfileAPIVersion,
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "gpu-operator",
+				Type:    recipe.ComponentTypeHelm,
+				Source:  "https://helm.ngc.nvidia.com/nvidia",
+				Chart:   "gpu-operator",
+				Version: "v25.3.0",
+				Overrides: map[string]any{
+					"driver": map[string]any{"enabled": false},
+				},
+			},
+			{
+				Name:       "network-operator",
+				Type:       recipe.ComponentTypeHelm,
+				Source:     "https://helm.ngc.nvidia.com/nvidia",
+				Chart:      "network-operator",
+				Version:    "v25.1.0",
+				ValuesFile: "components/does-not-exist/values.yaml",
+			},
+		},
+	}
+	result.Metadata.SelectedProfile = &recipe.SelectedProfile{
+		Name:  "gpuStack",
+		Value: "driver-installed",
+		OwnedPaths: map[string][]string{
+			"gpu-operator": {"driver.enabled", "enabled"},
+		},
+	}
+	renderer := &helmtest.MockRenderer{
+		Rendered: map[string][]byte{"gpu-operator": {}},
+	}
+
+	list, err := NewLister(WithHelmRenderer(renderer)).Discover(t.Context(), result)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(list.Components) != 2 {
+		t.Fatalf("components = %d, want 2", len(list.Components))
+	}
+	for _, componentImages := range list.Components {
+		if componentImages.Component != "network-operator" {
+			continue
+		}
+		if len(componentImages.Warnings) == 0 {
+			t.Fatal("network-operator hydration failure did not produce a warning")
+		}
+		return
+	}
+	t.Fatal("network-operator missing from mirror result")
 }
 
 func TestKubeVersionFromConstraints(t *testing.T) {
@@ -393,21 +639,6 @@ func TestKubeVersionFromConstraints(t *testing.T) {
 	}
 }
 
-func splitPath(path string) []string {
-	var parts []string
-	for _, p := range []byte(path) {
-		switch {
-		case p == '.':
-			parts = append(parts, "")
-		case len(parts) == 0:
-			parts = append(parts, string(p))
-		default:
-			parts[len(parts)-1] += string(p)
-		}
-	}
-	return parts
-}
-
 // inMemoryDataProvider is a minimal recipe.DataProvider backed by an
 // in-memory map[path]content. Only ReadFile is exercised by extractManifestImages;
 // WalkDir and Source are implemented to satisfy the interface.
@@ -458,7 +689,7 @@ spec:
 		ComponentRefs: []recipe.ComponentRef{
 			{
 				Name:          "network-operator",
-				Type:          recipe.ComponentTypeKustomize,
+				Type:          recipe.ComponentTypeHelm,
 				ManifestFiles: []string{manifestPath},
 			},
 		},
@@ -481,6 +712,60 @@ spec:
 	}
 }
 
+func TestDiscover_OverrideAliasRegistryFailureIsFatal(t *testing.T) {
+	dp := &inMemoryDataProvider{files: map[string][]byte{
+		"registry.yaml": []byte("components: ["),
+	}}
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{{
+			Name:    "network-operator",
+			Type:    recipe.ComponentTypeHelm,
+			Source:  "https://helm.ngc.nvidia.com/nvidia",
+			Chart:   "network-operator",
+			Version: "v25.7.0",
+		}},
+	}
+	rec.BindDataProvider(dp)
+
+	_, err := NewLister(
+		WithHelmRenderer(&helmtest.MockRenderer{}),
+		WithValueOverrides([]config.ComponentPath{
+			mustParseOverride(t, "networkoperator:feature.enabled=true"),
+		}),
+	).Discover(t.Context(), rec)
+	if err == nil {
+		t.Fatal("Discover() error = nil, want registry failure")
+	}
+	if !strings.Contains(err.Error(), "failed to parse registry.yaml") {
+		t.Fatalf("Discover() error = %v, want registry parse failure", err)
+	}
+}
+
+func TestDiscover_RegistryFailureWithoutOverridesIsNotFatal(t *testing.T) {
+	dp := &inMemoryDataProvider{files: map[string][]byte{
+		"registry.yaml": []byte("components: ["),
+	}}
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{{
+			Name:    "network-operator",
+			Type:    recipe.ComponentTypeHelm,
+			Source:  "https://helm.ngc.nvidia.com/nvidia",
+			Chart:   "network-operator",
+			Version: "v25.7.0",
+		}},
+	}
+	rec.BindDataProvider(dp)
+
+	_, err := NewLister(
+		WithHelmRenderer(&helmtest.MockRenderer{
+			Rendered: map[string][]byte{"network-operator": {}},
+		}),
+	).Discover(t.Context(), rec)
+	if err != nil {
+		t.Fatalf("Discover() error = %v, want malformed registry ignored without overrides", err)
+	}
+}
+
 // TestDiscover_NilDataProviderFallsBackToEmbedded confirms the back-compat
 // path: when a RecipeResult has no bound provider, extractManifestImages must
 // still resolve manifest paths via the package-global embedded provider
@@ -493,7 +778,7 @@ func TestDiscover_NilDataProviderFallsBackToEmbedded(t *testing.T) {
 		ComponentRefs: []recipe.ComponentRef{
 			{
 				Name:          "network-operator",
-				Type:          recipe.ComponentTypeKustomize,
+				Type:          recipe.ComponentTypeHelm,
 				ManifestFiles: []string{embeddedManifest},
 			},
 		},

--- a/pkg/recipe/builder.go
+++ b/pkg/recipe/builder.go
@@ -108,8 +108,15 @@ func (b *Builder) DataProvider() DataProvider {
 // It loads the metadata store, applies matching overlays, and returns
 // a RecipeResult with merged components and computed deployment order.
 func (b *Builder) BuildFromCriteria(ctx context.Context, c *Criteria) (*RecipeResult, error) {
+	return b.BuildFromCriteriaWithProfile(ctx, c, "")
+}
+
+// BuildFromCriteriaWithProfile creates a RecipeResult using an explicit
+// name=value profile selection, or the declaration's default when profile is
+// empty.
+func (b *Builder) BuildFromCriteriaWithProfile(ctx context.Context, c *Criteria, profile string) (*RecipeResult, error) {
 	return b.buildWithStore(ctx, c, func(store *MetadataStore, buildCtx context.Context) (*RecipeResult, error) {
-		return store.BuildRecipeResult(buildCtx, c)
+		return store.BuildRecipeResultWithProfile(buildCtx, c, profile)
 	})
 }
 
@@ -133,8 +140,20 @@ func (b *Builder) BuildFromCriteria(ctx context.Context, c *Criteria) (*RecipeRe
 // invokes BuildFromCriteriaWithEvaluator directly and wants those
 // measurement-driven overrides must apply them itself.
 func (b *Builder) BuildFromCriteriaWithEvaluator(ctx context.Context, c *Criteria, evaluator ConstraintEvaluatorFunc) (*RecipeResult, error) {
+	return b.BuildFromCriteriaWithEvaluatorAndProfile(ctx, c, evaluator, "")
+}
+
+// BuildFromCriteriaWithEvaluatorAndProfile is the snapshot-filtered variant
+// with an explicit profile selection.
+func (b *Builder) BuildFromCriteriaWithEvaluatorAndProfile(
+	ctx context.Context,
+	c *Criteria,
+	evaluator ConstraintEvaluatorFunc,
+	profile string,
+) (*RecipeResult, error) {
+
 	return b.buildWithStore(ctx, c, func(store *MetadataStore, buildCtx context.Context) (*RecipeResult, error) {
-		return store.BuildRecipeResultWithEvaluator(buildCtx, c, evaluator)
+		return store.BuildRecipeResultWithEvaluatorAndProfile(buildCtx, c, evaluator, profile)
 	})
 }
 

--- a/pkg/recipe/catalog.go
+++ b/pkg/recipe/catalog.go
@@ -14,7 +14,12 @@
 
 package recipe
 
-import "sort"
+import (
+	"context"
+	"sort"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
 
 // CatalogEntry describes a single overlay entry in the recipe catalog.
 //
@@ -30,6 +35,12 @@ type CatalogEntry struct {
 	Criteria *Criteria `json:"criteria" yaml:"criteria"`
 	IsLeaf   bool      `json:"is_leaf"  yaml:"is_leaf"`
 	Source   string    `json:"source"   yaml:"source"`
+
+	// Profile is the effective declaration reachable from this overlay,
+	// nil for an unprofiled entry. Only ListCatalogWithProfiles populates
+	// it; ListCatalog leaves it nil because projection requires validating
+	// every reachable declaration and a context for cancellation.
+	Profile *ProfileSummary `json:"profile,omitempty" yaml:"profile,omitempty"`
 }
 
 // ListCatalog returns catalog entries for overlays in the store that have
@@ -84,6 +95,54 @@ func (s *MetadataStore) ListCatalog(filter *Criteria) []CatalogEntry {
 	})
 
 	return entries
+}
+
+// ListCatalogWithProfiles returns the catalog projection with each entry's
+// effective inherited/co-matched profile declaration. It reuses the same
+// pre-filter declaration resolver as recipe generation so discovery cannot
+// disagree with selection, and fails without a partial result when ctx is
+// canceled.
+func (s *MetadataStore) ListCatalogWithProfiles(
+	ctx context.Context,
+	filter *Criteria,
+) ([]CatalogEntry, error) {
+
+	if s == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "metadata store is required")
+	}
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required")
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, errors.Wrap(
+			errors.ErrCodeTimeout, "catalog profile projection canceled before enumeration", ctxErr)
+	}
+	entries := s.ListCatalog(filter)
+	resolvedByCriteria := make(map[Criteria]*effectiveProfileDeclaration)
+	for i := range entries {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, errors.Wrap(
+				errors.ErrCodeTimeout, "catalog profile projection canceled before completion", ctxErr)
+		}
+		key := *entries[i].Criteria
+		effective, resolved := resolvedByCriteria[key]
+		if !resolved {
+			var err error
+			effective, err = s.resolveProfileDeclaration(s.FindMatchingOverlays(entries[i].Criteria))
+			if err != nil {
+				return nil, err
+			}
+			resolvedByCriteria[key] = effective
+		}
+		if effective != nil {
+			entries[i].Profile = profileSummary(effective.Declaration)
+		}
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, errors.Wrap(
+			errors.ErrCodeTimeout, "catalog profile projection canceled before completion", ctxErr)
+	}
+	return entries, nil
 }
 
 // matchesCatalogFilter reports whether overlayCriteria satisfies every

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -1016,6 +1016,29 @@ func loadCriteriaFromHTTPWithContext(ctx context.Context, url string, reg *Crite
 	return validateAndConvertRawSpec(&raw.Spec, reg)
 }
 
+// CriteriaBodyFormat returns the format ParseCriteriaFromBody uses for a
+// Content-Type value. Recognized YAML media types select YAML; empty, JSON, and
+// unrecognized media types select JSON for legacy compatibility.
+func CriteriaBodyFormat(contentType string) serializer.Format {
+	format, _ := criteriaBodyFormat(contentType)
+	return format
+}
+
+func criteriaBodyFormat(contentType string) (serializer.Format, bool) {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if idx := strings.Index(ct, ";"); idx >= 0 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+	switch ct {
+	case "application/x-yaml", "application/yaml", "text/yaml":
+		return serializer.FormatYAML, true
+	case "application/json", "":
+		return serializer.FormatJSON, true
+	default:
+		return serializer.FormatJSON, false
+	}
+}
+
 // ParseCriteriaFromBody parses criteria from an io.Reader (HTTP request body).
 // Supports JSON and YAML based on the Content-Type header.
 // All fields are optional and default to "any" if not specified.
@@ -1054,27 +1077,18 @@ func ParseCriteriaFromBody(body io.Reader, contentType string, reg *CriteriaRegi
 
 	var raw rawRecipeCriteria
 
-	// Determine format from Content-Type header
-	ct := strings.ToLower(strings.TrimSpace(contentType))
-	// Extract media type (strip charset and other params)
-	if idx := strings.Index(ct, ";"); idx != -1 {
-		ct = strings.TrimSpace(ct[:idx])
-	}
-
-	switch ct {
-	case "application/x-yaml", "application/yaml", "text/yaml":
+	format, recognized := criteriaBodyFormat(contentType)
+	if format == serializer.FormatYAML {
 		if err := yaml.Unmarshal(data, &raw); err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse YAML body", err)
 		}
-	case "application/json", "":
-		// Default to JSON for empty or unrecognized content type
+	} else {
 		if err := json.Unmarshal(data, &raw); err != nil {
+			if !recognized {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("unsupported content type %q and failed to parse as JSON", contentType), err)
+			}
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse JSON body", err)
-		}
-	default:
-		// Try JSON first for unrecognized types
-		if err := json.Unmarshal(data, &raw); err != nil {
-			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, fmt.Sprintf("unsupported content type %q and failed to parse as JSON", contentType), err)
 		}
 	}
 

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 func TestParseCriteriaServiceType(t *testing.T) {
@@ -1119,13 +1121,51 @@ spec:
 	})
 }
 
-func TestParseCriteriaFromBody(t *testing.T) {
+func TestCriteriaBodyFormat(t *testing.T) {
 	tests := []struct {
 		name        string
-		body        string
 		contentType string
-		want        *Criteria
-		wantErr     bool
+		want        serializer.Format
+	}{
+		{
+			name:        "YAML with parameters",
+			contentType: "Application/YAML; charset=utf-8",
+			want:        serializer.FormatYAML,
+		},
+		{
+			name:        "JSON",
+			contentType: "application/json",
+			want:        serializer.FormatJSON,
+		},
+		{
+			name:        "empty defaults to JSON",
+			contentType: "",
+			want:        serializer.FormatJSON,
+		},
+		{
+			name:        "unrecognized defaults to JSON",
+			contentType: "text/plain",
+			want:        serializer.FormatJSON,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CriteriaBodyFormat(tt.contentType); got != tt.want {
+				t.Fatalf("CriteriaBodyFormat(%q) = %q, want %q", tt.contentType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCriteriaFromBody(t *testing.T) {
+	tests := []struct {
+		name            string
+		body            string
+		contentType     string
+		want            *Criteria
+		wantErr         bool
+		wantErrContains string
 	}{
 		{
 			name:        "JSON body with full structure",
@@ -1260,6 +1300,13 @@ spec:
 			wantErr: false,
 		},
 		{
+			name:            "malformed JSON with unknown content type",
+			body:            `{invalid json}`,
+			contentType:     "text/plain",
+			wantErr:         true,
+			wantErrContains: `unsupported content type "text/plain" and failed to parse as JSON`,
+		},
+		{
 			name:        "JSON body with platform kubeflow",
 			body:        `{"kind":"RecipeCriteria","apiVersion":"aicr.run/v1alpha2","spec":{"service":"eks","accelerator":"h100","platform":"kubeflow"}}`,
 			contentType: "application/json",
@@ -1310,6 +1357,10 @@ spec:
 				return
 			}
 			if tt.wantErr {
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("ParseCriteriaFromBody() error = %q, want containing %q",
+						err, tt.wantErrContains)
+				}
 				return
 			}
 			if got.Service != tt.want.Service {

--- a/pkg/recipe/decode.go
+++ b/pkg/recipe/decode.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+	"gopkg.in/yaml.v3"
+)
+
+// DecodeRecipeResult decodes one in-memory RecipeResult artifact. Profile
+// artifacts are decoded strictly and as exactly one document; legacy
+// artifacts retain their historical additive/non-strict compatibility. The
+// typed version/profile gate runs in both cases so projections cannot discard
+// profile identity.
+func DecodeRecipeResult(data []byte, format serializer.Format) (*RecipeResult, error) {
+	var artifactHeader struct {
+		Kind       string `json:"kind" yaml:"kind"`
+		APIVersion string `json:"apiVersion" yaml:"apiVersion"`
+	}
+	headerReader, err := serializer.NewReader(format, bytes.NewReader(data))
+	if err != nil {
+		return nil, errors.PropagateOrWrap(
+			err, errors.ErrCodeInvalidRequest, "failed to create recipe artifact header reader")
+	}
+	if headerErr := headerReader.Deserialize(&artifactHeader); headerErr != nil {
+		return nil, errors.PropagateOrWrap(headerErr, errors.ErrCodeInvalidRequest,
+			"failed to decode recipe artifact header")
+	}
+	if artifactHeader.APIVersion == RecipeProfileAPIVersion && artifactHeader.Kind == "" {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe artifact apiVersion %q requires kind %q",
+				RecipeProfileAPIVersion, RecipeResultKind))
+	}
+	if artifactHeader.Kind != "" && artifactHeader.Kind != RecipeResultKind {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe artifact has kind %q, expected %q",
+				artifactHeader.Kind, RecipeResultKind))
+	}
+	if artifactHeader.APIVersion == RecipeProfileAPIVersion {
+		if profileErr := validateProfileExcludedOverlays(data, format); profileErr != nil {
+			return nil, profileErr
+		}
+	}
+
+	var opts []serializer.ReaderOption
+	if artifactHeader.APIVersion == RecipeProfileAPIVersion {
+		opts = append(opts, serializer.WithStrict())
+	}
+	reader, err := serializer.NewReader(format, bytes.NewReader(data), opts...)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(
+			err, errors.ErrCodeInvalidRequest, "failed to create recipe artifact reader")
+	}
+	var result RecipeResult
+	if err := reader.Deserialize(&result); err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+			"failed to decode recipe artifact")
+	}
+	if err := result.ValidateProfileContract(); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func validateProfileExcludedOverlays(data []byte, format serializer.Format) error {
+	switch format {
+	case serializer.FormatJSON:
+		var artifact struct {
+			Metadata struct {
+				ExcludedOverlays []json.RawMessage `json:"excludedOverlays"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(data, &artifact); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				"failed to inspect profile excluded overlays", err)
+		}
+		for index, item := range artifact.Metadata.ExcludedOverlays {
+			type rawExcludedOverlay ExcludedOverlay
+			var overlay *rawExcludedOverlay
+			decoder := json.NewDecoder(bytes.NewReader(item))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&overlay); err != nil {
+				return errors.Wrap(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("failed to decode excluded overlay at index %d", index), err)
+			}
+			if overlay == nil {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("excluded overlay at index %d must be an object", index))
+			}
+		}
+		return nil
+
+	case serializer.FormatYAML:
+		var artifact struct {
+			Metadata struct {
+				ExcludedOverlays []yaml.Node `yaml:"excludedOverlays"`
+			} `yaml:"metadata"`
+		}
+		if err := yaml.Unmarshal(data, &artifact); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				"failed to inspect profile excluded overlays", err)
+		}
+		for index := range artifact.Metadata.ExcludedOverlays {
+			if err := validateProfileExcludedOverlayYAML(
+				&artifact.Metadata.ExcludedOverlays[index], index,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case serializer.FormatTable:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"table format does not support recipe artifacts")
+
+	default:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unsupported recipe artifact format %q", format))
+	}
+}
+
+func validateProfileExcludedOverlayYAML(node *yaml.Node, index int) error {
+	if node.Kind != yaml.MappingNode {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("excluded overlay at index %d must be an object", index))
+	}
+	for contentIndex := 0; contentIndex+1 < len(node.Content); contentIndex += 2 {
+		key := node.Content[contentIndex]
+		value := node.Content[contentIndex+1]
+		if key.Kind != yaml.ScalarNode || key.ShortTag() != excludedOverlayYAMLStringTag {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("excluded overlay at index %d contains a non-string field name", index))
+		}
+		switch key.Value {
+		case "name", "reason":
+		default:
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("excluded overlay at index %d contains unknown field %q", index, key.Value))
+		}
+		if value.Kind != yaml.ScalarNode || value.ShortTag() != excludedOverlayYAMLStringTag {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("excluded overlay field %q at index %d must be a string", key.Value, index))
+		}
+	}
+	return nil
+}

--- a/pkg/recipe/loader.go
+++ b/pkg/recipe/loader.go
@@ -15,7 +15,9 @@
 package recipe
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -30,11 +32,24 @@ import (
 // default), and the returned result carries dp via its provider field. A nil
 // dp falls back to the embedded catalog.
 func LoadFromFileWithProvider(ctx context.Context, path, kubeconfig, version string, dp DataProvider) (*RecipeResult, error) {
-	rec, err := serializer.FromFileWithKubeconfig[RecipeResult](path, kubeconfig)
+	sourceData, sourceFormat, err := serializer.ReadFileBytesWithKubeconfigContext(
+		ctx, path, kubeconfig,
+	)
 	if err != nil {
 		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
 			fmt.Sprintf("failed to load recipe from %q", path))
 	}
+	sourceReader, err := serializer.NewReader(sourceFormat, bytes.NewReader(sourceData))
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("failed to create recipe reader for %q", path))
+	}
+	var source RecipeResult
+	if deserializeErr := sourceReader.Deserialize(&source); deserializeErr != nil {
+		return nil, errors.PropagateOrWrap(deserializeErr, errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("failed to load recipe from %q", path))
+	}
+	rec := &source
 
 	// Capture the apiVersion declared in the source file before any overlay
 	// hydration reassigns rec; otherwise an unsupported apiVersion on a
@@ -42,16 +57,44 @@ func LoadFromFileWithProvider(ctx context.Context, path, kubeconfig, version str
 	// hydrated RecipeResult always carries a supported version).
 	inputAPIVersion := rec.APIVersion
 
+	// Reject an artifact stamped with an apiVersion this build does not
+	// understand before an overlay can trigger provider-backed hydration.
+	// Empty is tolerated for legacy files, while v1alpha3 is the strict
+	// profile artifact version introduced by ADR-015.
+	if inputAPIVersion != "" &&
+		!header.IsSupportedAPIVersion(inputAPIVersion) &&
+		inputAPIVersion != RecipeProfileAPIVersion {
+
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe file has apiVersion %q, which this aicr build does not support (expected %q or %q); "+
+				"regenerate the recipe with a matching aicr version",
+				inputAPIVersion, header.GroupVersion, RecipeProfileAPIVersion))
+	}
+
 	// Users often pass overlay files directly; auto-hydrate so they don't need
 	// a separate "aicr recipe" step before consuming the recipe.
 	if rec.Kind == RecipeMetadataKind {
 		slog.Info("input is a RecipeMetadata overlay; auto-hydrating via recipe builder",
 			"file", path)
 
-		overlay, parseErr := serializer.FromFileWithKubeconfig[RecipeMetadata](path, kubeconfig)
+		var readerOpts []serializer.ReaderOption
+		if inputAPIVersion == RecipeProfileAPIVersion {
+			readerOpts = append(readerOpts, serializer.WithStrict())
+		}
+		overlayReader, parseErr := serializer.NewReader(
+			sourceFormat, bytes.NewReader(sourceData), readerOpts...,
+		)
 		if parseErr != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal,
-				fmt.Sprintf("failed to parse overlay from %q", path), parseErr)
+			return nil, errors.PropagateOrWrap(parseErr, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("failed to create overlay reader for %q", path))
+		}
+		var overlay RecipeMetadata
+		if parseErr := overlayReader.Deserialize(&overlay); parseErr != nil {
+			return nil, errors.PropagateOrWrap(parseErr, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("failed to parse overlay from %q", path))
+		}
+		if profileErr := ValidateRecipeMetadataProfile(&overlay); profileErr != nil {
+			return nil, profileErr
 		}
 
 		if overlay.Spec.Criteria == nil {
@@ -75,35 +118,40 @@ func LoadFromFileWithProvider(ctx context.Context, path, kubeconfig, version str
 		if err != nil {
 			return nil, err
 		}
+		if profileErr := ensureDirectOverlayProfileApplied(ctx, path, &overlay, rec, dp); profileErr != nil {
+			return nil, profileErr
+		}
 
 		slog.Info("overlay hydrated successfully",
 			"appliedOverlays", rec.Metadata.AppliedOverlays)
-	} else if dp != nil {
-		// Already-hydrated RecipeResult: the builder never runs, so bind the
-		// caller's provider directly so downstream value/manifest reads route
-		// through dp rather than the embedded default.
-		rec.provider = dp
+	} else {
+		if inputAPIVersion == RecipeProfileAPIVersion {
+			rec, err = DecodeRecipeResult(sourceData, sourceFormat)
+			if err != nil {
+				return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("failed to strictly decode profile recipe from %q", path))
+			}
+		}
+		if dp != nil {
+			// Already-hydrated RecipeResult: the builder never runs, so bind the
+			// caller's provider directly so downstream value/manifest reads route
+			// through dp rather than the embedded default.
+			rec.provider = dp
+		}
 	}
 
-	// Empty kind is allowed for backward compatibility with older RecipeResult files
-	// that may omit the field; they fall through to existing downstream validation.
+	// The strict profile artifact version requires its discriminator. Empty
+	// kind remains allowed only for legacy RecipeResult files that predate it.
+	if rec.Kind == "" && inputAPIVersion == RecipeProfileAPIVersion {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe file apiVersion %q requires kind %q",
+				RecipeProfileAPIVersion, RecipeResultKind))
+	}
 	if rec.Kind != "" && rec.Kind != RecipeResultKind {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("recipe file has kind %q, but %q is required; "+
 				"run \"aicr recipe\" to generate a hydrated RecipeResult first",
 				rec.Kind, RecipeResultKind))
-	}
-
-	// Reject a recipe stamped with an apiVersion this build does not understand.
-	// Empty is tolerated (older files predate the field); a non-empty unknown
-	// value means the recipe was produced by an incompatible aicr version, so
-	// fail closed rather than risk a schema mismatch downstream. Checked against
-	// the source file's declared version, not the (always-supported) hydrated one.
-	if inputAPIVersion != "" && !header.IsSupportedAPIVersion(inputAPIVersion) {
-		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("recipe file has apiVersion %q, which this aicr build does not support (expected %q); "+
-				"regenerate the recipe with a matching aicr version",
-				inputAPIVersion, header.GroupVersion))
 	}
 
 	// Back-fill missing types from the registry (this boundary does not run
@@ -113,9 +161,69 @@ func LoadFromFileWithProvider(ctx context.Context, path, kubeconfig, version str
 	// Kustomize tag/path would reach the bundler/attestation unchecked, and a
 	// lowercase type would deploy inconsistently — while a type-less registry
 	// ref (valid before #1584) must still resolve, not be rejected. See #1584.
-	if err := rec.PrepareAndValidate(); err != nil {
+	if err := rec.PrepareAndValidateWithContext(ctx); err != nil {
 		return nil, err
 	}
 
 	return rec, nil
+}
+
+func ensureDirectOverlayProfileApplied(
+	ctx context.Context,
+	path string,
+	overlay *RecipeMetadata,
+	result *RecipeResult,
+	dp DataProvider,
+) error {
+
+	if overlay == nil || overlay.Spec.Profile == nil {
+		return nil
+	}
+
+	store, err := LoadMetadataStoreFor(ctx, dp)
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			fmt.Sprintf("failed to verify profile declaration from directly loaded overlay %q", path))
+	}
+	var selected *SelectedProfile
+	var effective *effectiveProfileDeclaration
+	if result != nil {
+		selected = result.Metadata.SelectedProfile
+		effective, err = store.resolveAppliedProfileDeclaration(result.Metadata.AppliedOverlays)
+		if err != nil {
+			return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("failed to resolve the profile applied for directly loaded overlay %q", path))
+		}
+	}
+	declarationMatches := false
+	if effective != nil {
+		declarationMatches, err = profileDeclarationsEqual(effective.Declaration, overlay.Spec.Profile)
+		if err != nil {
+			return err
+		}
+	}
+	if !declarationMatches ||
+		selected == nil ||
+		selected.Name != overlay.Spec.Profile.Name ||
+		selected.Value != overlay.Spec.Profile.Default {
+
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile declaration from directly loaded overlay %q was not applied; "+
+				"add a structurally matching declaration to the active catalog before loading it directly", path))
+	}
+	return nil
+}
+
+func profileDeclarationsEqual(first, second *ProfileDeclaration) (bool, error) {
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		return false, errors.Wrap(
+			errors.ErrCodeInternal, "failed to canonicalize resolved profile declaration", err)
+	}
+	secondJSON, err := json.Marshal(second)
+	if err != nil {
+		return false, errors.Wrap(
+			errors.ErrCodeInternal, "failed to canonicalize directly loaded profile declaration", err)
+	}
+	return bytes.Equal(firstJSON, secondJSON), nil
 }

--- a/pkg/recipe/loader_provider_test.go
+++ b/pkg/recipe/loader_provider_test.go
@@ -112,6 +112,117 @@ func TestLoadFromFileWithProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("profile overlay in active catalog applies its default", func(t *testing.T) {
+		externalDir := t.TempDir()
+		registry := `apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+components: []
+`
+		if err := os.WriteFile(filepath.Join(externalDir, "registry.yaml"), []byte(registry), 0o600); err != nil {
+			t.Fatalf("write registry.yaml: %v", err)
+		}
+		overlaysDir := filepath.Join(externalDir, "overlays")
+		if err := os.MkdirAll(overlaysDir, 0o755); err != nil {
+			t.Fatalf("create overlays directory: %v", err)
+		}
+		path := filepath.Join(overlaysDir, "direct-profile.yaml")
+		content := `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha3
+metadata:
+  name: direct-profile
+spec:
+  criteria:
+    service: eks
+    accelerator: h100
+    intent: training
+  profile:
+    name: gpuStack
+    default: operator-managed
+    values:
+      operator-managed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: true
+              replicas: 1
+`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write profile overlay: %v", err)
+		}
+		alternate := `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha3
+metadata:
+  name: alternate-profile
+spec:
+  criteria:
+    service: aks
+    accelerator: h100
+    intent: training
+  profile:
+    name: gpuStack
+    default: operator-managed
+    values:
+      operator-managed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: false
+              replicas: 2
+`
+		if err := os.WriteFile(
+			filepath.Join(overlaysDir, "alternate-profile.yaml"),
+			[]byte(alternate),
+			0o600,
+		); err != nil {
+			t.Fatalf("write alternate profile overlay: %v", err)
+		}
+		layered, err := NewLayeredDataProvider(
+			NewEmbeddedDataProvider(GetEmbeddedFS(), "."),
+			LayeredProviderConfig{ExternalDir: externalDir},
+		)
+		if err != nil {
+			t.Fatalf("NewLayeredDataProvider: %v", err)
+		}
+		t.Cleanup(func() {
+			EvictCachedStore(layered)
+			EvictCachedRegistry(layered)
+			EvictCachedCriteriaRegistry(layered)
+		})
+
+		rec, err := LoadFromFileWithProvider(t.Context(), path, "", "vtest", layered)
+		if err != nil {
+			t.Fatalf("LoadFromFileWithProvider() error: %v", err)
+		}
+		if rec.Metadata.SelectedProfile == nil {
+			t.Fatal("SelectedProfile = nil, want applied default")
+		}
+		if got := rec.Metadata.SelectedProfile.Name + "=" + rec.Metadata.SelectedProfile.Value; got != "gpuStack=operator-managed" {
+			t.Errorf("SelectedProfile = %q, want %q", got, "gpuStack=operator-managed")
+		}
+
+		renamedPath := filepath.Join(t.TempDir(), "renamed-profile.yaml")
+		renamed := strings.Replace(content, "name: direct-profile", "name: renamed-profile", 1)
+		if err := os.WriteFile(renamedPath, []byte(renamed), 0o600); err != nil {
+			t.Fatalf("write renamed profile overlay: %v", err)
+		}
+		if _, err := LoadFromFileWithProvider(t.Context(), renamedPath, "", "vtest", layered); err != nil {
+			t.Fatalf("renamed equivalent overlay error: %v", err)
+		}
+
+		stalePath := filepath.Join(t.TempDir(), "stale-profile.yaml")
+		stale := strings.Replace(content, "service: eks", "service: aks", 1)
+		if err := os.WriteFile(stalePath, []byte(stale), 0o600); err != nil {
+			t.Fatalf("write stale profile overlay: %v", err)
+		}
+		if _, err := LoadFromFileWithProvider(t.Context(), stalePath, "", "vtest", layered); err == nil ||
+			!strings.Contains(err.Error(), "was not applied") {
+
+			t.Fatalf("stale overlay error = %v, want declaration mismatch", err)
+		}
+	})
+
 	t.Run("nil provider behaves like LoadFromFile", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "recipe.yaml")

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -15,11 +15,42 @@
 package recipe
 
 import (
+	"context"
+	stderrors "errors"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
 )
+
+type unexpectedLoadProvider struct {
+	calls atomic.Int64
+}
+
+func (p *unexpectedLoadProvider) ReadFile(_ context.Context, _ string) ([]byte, error) {
+	p.calls.Add(1)
+	return nil, fs.ErrNotExist
+}
+
+func (p *unexpectedLoadProvider) WalkDir(
+	_ context.Context,
+	_ string,
+	_ fs.WalkDirFunc,
+) error {
+
+	p.calls.Add(1)
+	return fs.ErrNotExist
+}
+
+func (p *unexpectedLoadProvider) Source(path string) string {
+	return path
+}
 
 func TestLoadFromFile(t *testing.T) {
 	tests := []struct {
@@ -62,6 +93,31 @@ func TestLoadFromFile(t *testing.T) {
 			},
 		},
 		{
+			name: "profile RecipeMetadata outside active catalog fails closed",
+			yamlContent: `kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha3
+metadata:
+  name: direct-profile
+spec:
+  criteria:
+    service: eks
+    accelerator: h100
+    intent: training
+  profile:
+    name: gpuStack
+    default: operator-managed
+    values:
+      operator-managed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: true
+`,
+			wantErr:    true,
+			errContain: "was not applied; add a structurally matching declaration to the active catalog",
+		},
+		{
 			name:        "RecipeMetadata without criteria errors",
 			yamlContent: "kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: test\nspec: {}\n",
 			wantErr:     true,
@@ -95,6 +151,72 @@ func TestLoadFromFile(t *testing.T) {
 			yamlContent: "kind: RecipeResult\napiVersion: aicr.nvidia.com/v1alpha1\ncriteria:\n  service: eks\n",
 			wantErr:     true,
 			errContain:  `apiVersion "aicr.nvidia.com/v1alpha1"`,
+		},
+		{
+			name: "profile RecipeResult loads strictly",
+			yamlContent: `kind: RecipeResult
+apiVersion: aicr.run/v1alpha3
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+componentRefs: []
+`,
+			checkResult: func(t *testing.T, rec *RecipeResult) {
+				t.Helper()
+				if rec.Metadata.SelectedProfile == nil ||
+					rec.Metadata.SelectedProfile.Value != "one" {
+
+					t.Fatalf("selectedProfile = %#v", rec.Metadata.SelectedProfile)
+				}
+			},
+		},
+		{
+			name: "profile RecipeResult rejects unknown field",
+			yamlContent: `kind: RecipeResult
+apiVersion: aicr.run/v1alpha3
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+profie: typo
+`,
+			wantErr:    true,
+			errContain: "field profie not found",
+		},
+		{
+			name: "profile RecipeResult requires kind",
+			yamlContent: `apiVersion: aicr.run/v1alpha3
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+componentRefs: []
+`,
+			wantErr:    true,
+			errContain: `requires kind "RecipeResult"`,
+		},
+		{
+			name:        "profile version requires selection",
+			yamlContent: "kind: RecipeResult\napiVersion: aicr.run/v1alpha3\ncomponentRefs: []\n",
+			wantErr:     true,
+			errContain:  "requires metadata.selectedProfile",
+		},
+		{
+			name: "legacy version rejects selection",
+			yamlContent: `kind: RecipeResult
+apiVersion: aicr.run/v1alpha2
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+`,
+			wantErr:    true,
+			errContain: "cannot carry metadata.selectedProfile",
 		},
 		{
 			name:        "unsupported apiVersion on RecipeMetadata overlay rejected",
@@ -140,5 +262,111 @@ func TestLoadFromFile(t *testing.T) {
 				tt.checkResult(t, rec)
 			}
 		})
+	}
+}
+
+func TestProfileDeclarationsEqualNormalizesJSONNumbers(t *testing.T) {
+	declaration := func(value any) *ProfileDeclaration {
+		return &ProfileDeclaration{
+			Name:    "mode",
+			Default: "selected",
+			Values: map[string]ProfileValue{
+				"selected": {
+					ComponentRefs: []ProfileComponentRef{{
+						Name:      "gpu-operator",
+						Overrides: map[string]any{"replicas": value},
+					}},
+				},
+			},
+		}
+	}
+
+	equal, err := profileDeclarationsEqual(declaration(1), declaration(float64(1)))
+	if err != nil {
+		t.Fatalf("profileDeclarationsEqual() error: %v", err)
+	}
+	if !equal {
+		t.Fatal("profileDeclarationsEqual() = false, want numerically equivalent declarations")
+	}
+}
+
+func TestLoadFromFile_UnsupportedOverlayRejectedBeforeHydration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "overlay.yaml")
+	content := `kind: RecipeMetadata
+apiVersion: aicr.nvidia.com/v1alpha1
+metadata:
+  name: unsupported
+spec:
+  criteria:
+    service: eks
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	provider := &unexpectedLoadProvider{}
+	_, err := LoadFromFileWithProvider(t.Context(), path, "", "test", provider)
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("LoadFromFileWithProvider() error = %v, want ErrCodeInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), `apiVersion "aicr.nvidia.com/v1alpha1"`) {
+		t.Fatalf("LoadFromFileWithProvider() error = %v, want apiVersion rejection", err)
+	}
+	if got := provider.calls.Load(); got != 0 {
+		t.Fatalf("provider calls = %d, want 0 before version rejection", got)
+	}
+}
+
+func TestLoadFromFile_ProfileDecodeErrorIsInvalidRequest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "recipe.yaml")
+	content := `kind: RecipeResult
+apiVersion: aicr.run/v1alpha3
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+profie: typo
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write profile recipe: %v", err)
+	}
+
+	_, err := LoadFromFileWithProvider(t.Context(), path, "", "test", nil)
+	if err == nil {
+		t.Fatal("LoadFromFileWithProvider() error = nil, want invalid request")
+	}
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("error code = %v, want ErrCodeInvalidRequest", err)
+	}
+}
+
+func TestLoadFromFile_ProfileSourceReadOnce(t *testing.T) {
+	const content = `kind: RecipeResult
+apiVersion: aicr.run/v1alpha3
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+componentRefs: []
+`
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	_, err := LoadFromFileWithProvider(
+		t.Context(), server.URL+"/recipe.yaml", "", "test", nil,
+	)
+	if err != nil {
+		t.Fatalf("LoadFromFileWithProvider() error = %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("source requests = %d, want 1", got)
 	}
 }

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -16,6 +16,7 @@
 package recipe
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -533,14 +534,14 @@ func (r *RecipeResult) backfillComponentTypes() error {
 }
 
 // PrepareAndValidate normalizes a RecipeResult's component refs and rejects
-// incoherent ones, in the required order: reject refs named with the reserved
-// deployer override key, reject duplicate non-empty ref names, back-fill missing
-// types on enabled refs from the registry, canonicalize the type casing, then
-// validate
+// incoherent ones, in the required order: validate the profile contract;
+// reject refs named with the reserved deployer override key (all refs, enabled
+// or disabled); reject duplicate non-empty ref names; back-fill missing types
+// on enabled refs from the registry; canonicalize the type casing; then validate
 // coherence (which itself only inspects enabled refs). Boundaries
 // that produce a RecipeResult WITHOUT running ApplyRegistryDefaults — file load
 // (LoadFromFileWithProvider) and external adoption (client adoptRecipe) — call
-// this single method so the four steps cannot drift or be partially applied
+// this single method so these gates cannot drift or be partially applied
 // (e.g. validating before canonicalizing would reject legitimate lowercase
 // types; skipping the back-fill would reject type-less registry refs). The
 // resolve path (finalizeRecipeResult) instead back-fills via ApplyRegistryDefaults
@@ -549,7 +550,10 @@ func (r *RecipeResult) PrepareAndValidate() error {
 	if r == nil {
 		return nil
 	}
-	// Fail closed on the reserved deployer key BEFORE anything else, and
+	if err := r.ValidateProfileContract(); err != nil {
+		return err
+	}
+	// Fail closed on the reserved deployer key before registry back-fill and
 	// for ALL refs including disabled ones: registry loads are guarded
 	// (see loadComponentRegistryFor), but a hand-authored recipe passed
 	// to `aicr bundle -r` or POST /v1/bundle can carry a componentRef
@@ -674,6 +678,11 @@ type RecipeMetadataSpec struct {
 	// Validation defines multi-phase validation configuration.
 	// Presence of a phase implies it is enabled.
 	Validation *ValidationConfig `json:"validation,omitempty" yaml:"validation,omitempty"`
+
+	// Profile declares one overlay-scoped configuration choice. It is resolved
+	// after overlay and mixin composition and is never copied into a hydrated
+	// RecipeResult; only metadata.selectedProfile and the selected effects are.
+	Profile *ProfileDeclaration `json:"profile,omitempty" yaml:"profile,omitempty"`
 }
 
 // RecipeMixinKind is the kind value for mixin files.
@@ -747,6 +756,8 @@ const (
 	ExcludedOverlayReasonMixinConstraintFailed ExcludedOverlayReason = "mixin-constraint-failed"
 )
 
+const excludedOverlayYAMLStringTag = "!!str"
+
 // ExcludedOverlay records a matching overlay that was excluded from the final
 // recipe result, along with a machine-readable reason.
 type ExcludedOverlay struct {
@@ -764,6 +775,10 @@ type ExcludedOverlay struct {
 //   - excludedOverlays: [{name: overlay-name, reason: constraint-failed}]
 func (e *ExcludedOverlay) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind == yaml.ScalarNode {
+		if node.ShortTag() != excludedOverlayYAMLStringTag {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				"excluded overlay scalar must be a string")
+		}
 		e.Name = node.Value
 		e.Reason = ""
 		return nil
@@ -774,12 +789,21 @@ func (e *ExcludedOverlay) UnmarshalYAML(node *yaml.Node) error {
 	if err := node.Decode(&raw); err != nil {
 		return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to decode excluded overlay", err)
 	}
+	if raw.Name == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"excluded overlay object requires a non-empty name")
+	}
 	*e = ExcludedOverlay(raw)
 	return nil
 }
 
 // UnmarshalJSON accepts both the legacy string form and the current object form.
 func (e *ExcludedOverlay) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"excluded overlay must be a string or object")
+	}
+
 	var name string
 	if err := json.Unmarshal(data, &name); err == nil {
 		e.Name = name
@@ -791,6 +815,10 @@ func (e *ExcludedOverlay) UnmarshalJSON(data []byte) error {
 	var raw rawExcludedOverlay
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to decode excluded overlay JSON", err)
+	}
+	if raw.Name == "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"excluded overlay object requires a non-empty name")
 	}
 	*e = ExcludedOverlay(raw)
 	return nil
@@ -825,6 +853,10 @@ type RecipeResultMetadata struct {
 	// bundle-time CheckDriverOwnershipCoherence validation to enforce
 	// driver-ownership coherence once --set overrides are known.
 	GPUDriverState string `json:"gpuDriverState,omitempty" yaml:"gpuDriverState,omitempty"`
+
+	// SelectedProfile records the generation-time configuration choice and
+	// its declaration-wide lock surface.
+	SelectedProfile *SelectedProfile `json:"selectedProfile,omitempty" yaml:"selectedProfile,omitempty"`
 }
 
 // RecipeResult represents the final merged recipe output.
@@ -1007,9 +1039,15 @@ func (r *RecipeResult) DeepCopy() *RecipeResult {
 		// read but not consumed via ownership-checked entry points.
 	}
 
-	// Metadata: scalar Version and GPUDriverState plus three slices.
+	// Metadata: scalar Version and GPUDriverState, the SelectedProfile
+	// pointer (cloned with its OwnedPaths map), plus three slices.
 	out.Metadata.Version = r.Metadata.Version
 	out.Metadata.GPUDriverState = r.Metadata.GPUDriverState
+	if r.Metadata.SelectedProfile != nil {
+		selected := *r.Metadata.SelectedProfile
+		selected.OwnedPaths = cloneOwnedPaths(r.Metadata.SelectedProfile.OwnedPaths)
+		out.Metadata.SelectedProfile = &selected
+	}
 	if r.Metadata.AppliedOverlays != nil {
 		out.Metadata.AppliedOverlays = make([]string, len(r.Metadata.AppliedOverlays))
 		copy(out.Metadata.AppliedOverlays, r.Metadata.AppliedOverlays)

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"path/filepath"
@@ -85,6 +86,8 @@ type pendingRegistryEntry struct {
 	criteria *Criteria
 	source   string
 }
+
+const constraintContextKey = "constraint"
 
 // LoadMetadataStoreFor loads (and caches) the metadata store for the supplied
 // DataProvider. Concurrent callers with the same provider observe the same
@@ -263,15 +266,54 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read %s", path), readErr)
 		}
 
+		var metadataHeader RecipeMetadataHeader
+		if parseErr := yaml.Unmarshal(content, &metadataHeader); parseErr != nil {
+			return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse header for %s", path), parseErr)
+		}
+		if metadataHeader.APIVersion == RecipeProfileAPIVersion &&
+			metadataHeader.Kind != RecipeMetadataKind {
+
+			return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile catalog file %s requires kind %q, got %q",
+					path, RecipeMetadataKind, metadataHeader.Kind))
+		}
+		// Skip files with a different kind (e.g., ValidatorCatalog) only
+		// after the profile apiVersion has been gated. A misspelled kind on a
+		// v1alpha3 profile overlay must not silently remove the declaration.
+		if metadataHeader.Kind != "" && metadataHeader.Kind != RecipeMetadataKind {
+			slog.Debug("skipping non-recipe YAML", "path", path, "kind", metadataHeader.Kind)
+			return nil
+		}
+
 		var metadata RecipeMetadata
-		if parseErr := yaml.Unmarshal(content, &metadata); parseErr != nil {
+		if metadataHeader.APIVersion == RecipeProfileAPIVersion {
+			decoder := yaml.NewDecoder(bytes.NewReader(content))
+			decoder.KnownFields(true)
+			if parseErr := decoder.Decode(&metadata); parseErr != nil {
+				return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
+					fmt.Sprintf("failed to parse %s as strict %s RecipeMetadata", path, RecipeProfileAPIVersion),
+					parseErr)
+			}
+			var trailing any
+			if parseErr := decoder.Decode(&trailing); !stderrors.Is(parseErr, io.EOF) {
+				if parseErr == nil {
+					return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+						fmt.Sprintf("profile RecipeMetadata %s contains multiple YAML documents", path))
+				}
+				return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
+					fmt.Sprintf("failed to check trailing content in %s", path), parseErr)
+			}
+		} else if parseErr := yaml.Unmarshal(content, &metadata); parseErr != nil {
 			return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse %s", path), parseErr)
 		}
 
-		// Skip files with a different kind (e.g., ValidatorCatalog).
-		if metadata.Kind != "" && metadata.Kind != RecipeMetadataKind {
-			slog.Debug("skipping non-recipe YAML", "path", path, "kind", metadata.Kind)
-			return nil
+		if profileErr := ValidateRecipeMetadataProfile(&metadata); profileErr != nil {
+			return aicrerrors.PropagateOrWrap(profileErr, aicrerrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid profile declaration in %s", path))
+		}
+		if metadata.APIVersion == RecipeProfileAPIVersion && metadata.Metadata.Name == "" {
+			return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile RecipeMetadata %s requires metadata.name", path))
 		}
 
 		// Categorize as base or overlay
@@ -761,6 +803,9 @@ func (s *MetadataStore) evaluateMixinConstraints(
 		if !mixinConstraintNames[constraint.Name] {
 			continue // already evaluated per-overlay
 		}
+		if constraintErr := validateConstraintWarningSource(constraint); constraintErr != nil {
+			return mixinEvalResult{}, constraintErr
+		}
 		result := evaluator(constraint)
 		if result.Error != nil && !isNotFoundEvalError(result.Error) {
 			// Fail closed on non-NotFound evaluation errors (design 5.2).
@@ -776,8 +821,8 @@ func (s *MetadataStore) evaluateMixinConstraints(
 					aicrerrors.ErrCodeInternal,
 					"failed to map mixin constraint to candidate chain",
 					map[string]any{
-						"constraint":      constraint.Name,
-						"candidate_count": len(candidateOverlays),
+						constraintContextKey: constraint.Name,
+						"candidate_count":    len(candidateOverlays),
 					},
 				)
 			}
@@ -848,6 +893,18 @@ func buildMixinConstraintWarningReason(constraint Constraint, result ConstraintE
 		return fmt.Sprintf("mixin-constraint-failed: %s", result.Error.Error())
 	}
 	return fmt.Sprintf("mixin-constraint-failed: expected %s, got %s", constraint.Value, result.Actual)
+}
+
+func validateConstraintWarningSource(constraint Constraint) error {
+	if constraint.Name == "" {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			"constraint name is required for snapshot evaluation")
+	}
+	if constraint.Value == "" {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("constraint %q value is required for snapshot evaluation", constraint.Name))
+	}
+	return nil
 }
 
 // buildMixinConstraintCandidateIndex maps mixin-contributed constraint names to
@@ -997,6 +1054,13 @@ func finalizeRecipeResult(provider DataProvider, criteria *Criteria, mergedSpec 
 // Each matching overlay is resolved through its inheritance chain before merging.
 // This enables multi-level inheritance: base → intermediate → overlay.
 func (s *MetadataStore) BuildRecipeResult(ctx context.Context, criteria *Criteria) (*RecipeResult, error) {
+	return s.BuildRecipeResultWithProfile(ctx, criteria, "")
+}
+
+// BuildRecipeResultWithProfile builds a RecipeResult and applies an explicit
+// name=value profile selection, or the declaration's default when selection is
+// empty.
+func (s *MetadataStore) BuildRecipeResultWithProfile(ctx context.Context, criteria *Criteria, selection string) (*RecipeResult, error) {
 	select {
 	case <-ctx.Done():
 		return nil, aicrerrors.WrapWithContext(
@@ -1013,25 +1077,29 @@ func (s *MetadataStore) BuildRecipeResult(ctx context.Context, criteria *Criteri
 	if err := s.requireOSIfNeeded(criteria, overlays); err != nil {
 		return nil, err
 	}
+	effectiveProfile, err := s.resolveProfileDeclaration(overlays)
+	if err != nil {
+		return nil, err
+	}
 
 	mergedSpec, appliedOverlays := s.initBaseMergedSpec()
 
-	appliedOverlays, err := s.mergeOverlayChains(overlays, &mergedSpec, appliedOverlays)
+	appliedOverlays, err = s.mergeOverlayChains(overlays, &mergedSpec, appliedOverlays)
 	if err != nil {
 		return nil, err
 	}
 
 	// Merge mixin fragments referenced by overlays in the chain
-	if _, err := s.mergeMixins(&mergedSpec); err != nil {
-		return nil, err
+	if _, mixinErr := s.mergeMixins(&mergedSpec); mixinErr != nil {
+		return nil, mixinErr
 	}
 
 	// Post-condition (issue #1542): every stated criteria dimension must be
 	// honored by the final applied set. Runs after mergeOverlayChains so
 	// ancestor-supplied coverage counts; mixins carry no criteria and cannot
 	// change coverage.
-	if err := s.verifyCriteriaCoverage(criteria, appliedOverlays, nil, nil); err != nil {
-		return nil, err
+	if coverageErr := s.verifyCriteriaCoverage(criteria, appliedOverlays, nil, nil); coverageErr != nil {
+		return nil, coverageErr
 	}
 
 	if len(appliedOverlays) <= 1 {
@@ -1040,7 +1108,23 @@ func (s *MetadataStore) BuildRecipeResult(ctx context.Context, criteria *Criteri
 			"hint", "recipe may not be optimized for your environment")
 	}
 
-	return finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays) //nolint:contextcheck // finalizeRecipeResult routes registry lookups through GetComponentRegistryFor, which is sync.Once-cached and bounds first-load I/O via an internal bounded background context (loadComponentRegistryFor). Threading ctx here is tracked separately if/when the cascade needs caller-driven cancellation.
+	selected, err := applyEffectiveProfile(&mergedSpec, effectiveProfile, selection, nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays) //nolint:contextcheck // finalizeRecipeResult routes registry lookups through GetComponentRegistryFor, which is sync.Once-cached and bounds first-load I/O via an internal bounded background context (loadComponentRegistryFor). Threading ctx here is tracked separately if/when the cascade needs caller-driven cancellation.
+	if err != nil {
+		return nil, err
+	}
+	if selected == nil {
+		return result, nil
+	}
+	result.APIVersion = RecipeProfileAPIVersion
+	result.Metadata.SelectedProfile = selected
+	if err := result.ValidateProfileValuesWithContext(ctx); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // BuildRecipeResultWithEvaluator builds a RecipeResult by merging base with matching overlays,
@@ -1054,8 +1138,20 @@ func (s *MetadataStore) BuildRecipeResult(ctx context.Context, criteria *Criteri
 // The evaluator function is called for each constraint in each matching overlay.
 // If evaluator is nil, this method behaves identically to BuildRecipeResult.
 func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, criteria *Criteria, evaluator ConstraintEvaluatorFunc) (*RecipeResult, error) {
+	return s.BuildRecipeResultWithEvaluatorAndProfile(ctx, criteria, evaluator, "")
+}
+
+// BuildRecipeResultWithEvaluatorAndProfile is the snapshot-filtered profile
+// resolution path.
+func (s *MetadataStore) BuildRecipeResultWithEvaluatorAndProfile(
+	ctx context.Context,
+	criteria *Criteria,
+	evaluator ConstraintEvaluatorFunc,
+	selection string,
+) (*RecipeResult, error) {
+
 	if evaluator == nil {
-		return s.BuildRecipeResult(ctx, criteria)
+		return s.BuildRecipeResultWithProfile(ctx, criteria, selection)
 	}
 
 	select {
@@ -1073,6 +1169,10 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 	overlays := s.FindMatchingOverlays(criteria)
 
 	if err := s.requireOSIfNeeded(criteria, overlays); err != nil {
+		return nil, err
+	}
+	effectiveProfile, err := s.resolveProfileDeclaration(overlays)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1107,7 +1207,7 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 
 	mergedSpec, appliedOverlays := s.initBaseMergedSpec()
 
-	appliedOverlays, err := s.mergeOverlayChains(filteredOverlays, &mergedSpec, appliedOverlays)
+	appliedOverlays, err = s.mergeOverlayChains(filteredOverlays, &mergedSpec, appliedOverlays)
 	if err != nil {
 		return nil, err
 	}
@@ -1138,6 +1238,16 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 		appliedOverlays = mixinResult.AppliedOverlays
 	}
 
+	survivingProfile, err := s.resolveAppliedProfileDeclaration(appliedOverlays)
+	if err != nil {
+		return nil, err
+	}
+	if survivalErr := ensureProfileDeclarationSurvived(
+		effectiveProfile, survivingProfile, excludedOverlays, constraintWarnings,
+	); survivalErr != nil {
+		return nil, survivalErr
+	}
+
 	// Post-condition (issue #1542): runs against the FINAL applied set —
 	// after per-overlay constraint exclusion AND the mixin-failure fallback
 	// rebuild — so a stated dimension whose only coverage was excluded
@@ -1165,9 +1275,20 @@ func (s *MetadataStore) BuildRecipeResultWithEvaluator(ctx context.Context, crit
 		}
 	}
 
+	selected, err := applyEffectiveProfile(&mergedSpec, effectiveProfile, selection, evaluator)
+	if err != nil {
+		return nil, err
+	}
 	result, err := finalizeRecipeResult(s.provider, criteria, &mergedSpec, appliedOverlays) //nolint:contextcheck // see BuildRecipeResult: registry I/O is sync.Once-cached + bounded inside loadComponentRegistryFor.
 	if err != nil {
 		return nil, err
+	}
+	if selected != nil {
+		result.APIVersion = RecipeProfileAPIVersion
+		result.Metadata.SelectedProfile = selected
+		if err := result.ValidateProfileValuesWithContext(ctx); err != nil {
+			return nil, err
+		}
 	}
 	result.Metadata.ExcludedOverlays = excludedOverlays
 	result.Metadata.ConstraintWarnings = constraintWarnings
@@ -1194,6 +1315,9 @@ func (s *MetadataStore) evaluateOverlayConstraints(overlay *RecipeMetadata, eval
 	allPassed := true
 
 	for _, constraint := range overlay.Spec.Constraints {
+		if err := validateConstraintWarningSource(constraint); err != nil {
+			return false, nil, err
+		}
 		result := evaluator(constraint)
 
 		switch {
@@ -1217,7 +1341,7 @@ func (s *MetadataStore) evaluateOverlayConstraints(overlay *RecipeMetadata, eval
 			allPassed = false
 			slog.Debug("constraint evaluation error",
 				"overlay", overlay.Metadata.Name,
-				"constraint", constraint.Name,
+				constraintContextKey, constraint.Name,
 				"error", result.Error)
 		case !result.Passed:
 			warnings = append(warnings, ConstraintWarning{
@@ -1230,13 +1354,13 @@ func (s *MetadataStore) evaluateOverlayConstraints(overlay *RecipeMetadata, eval
 			allPassed = false
 			slog.Debug("constraint failed",
 				"overlay", overlay.Metadata.Name,
-				"constraint", constraint.Name,
+				constraintContextKey, constraint.Name,
 				"expected", constraint.Value,
 				"actual", result.Actual)
 		default:
 			slog.Debug("constraint passed",
 				"overlay", overlay.Metadata.Name,
-				"constraint", constraint.Name,
+				constraintContextKey, constraint.Name,
 				"expected", constraint.Value,
 				"actual", result.Actual)
 		}

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -224,6 +224,7 @@ func TestMetadataStore_EvaluateOverlayConstraints(t *testing.T) {
 		wantPassed   bool
 		wantWarnings int
 		wantErr      bool
+		wantErrCode  aicrerrors.ErrorCode
 	}{
 		{
 			name:        "no constraints passes",
@@ -317,6 +318,32 @@ func TestMetadataStore_EvaluateOverlayConstraints(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "empty constraint name fails closed",
+			constraints: []Constraint{
+				{Value: ">= 1.30"},
+			},
+			evaluator: func(_ Constraint) ConstraintEvalResult {
+				return ConstraintEvalResult{
+					Error: aicrerrors.New(aicrerrors.ErrCodeNotFound, "value not found"),
+				}
+			},
+			wantErr:     true,
+			wantErrCode: aicrerrors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "empty constraint value fails closed",
+			constraints: []Constraint{
+				{Name: "k8s"},
+			},
+			evaluator: func(_ Constraint) ConstraintEvalResult {
+				return ConstraintEvalResult{
+					Error: aicrerrors.New(aicrerrors.ErrCodeNotFound, "value not found"),
+				}
+			},
+			wantErr:     true,
+			wantErrCode: aicrerrors.ErrCodeInvalidRequest,
+		},
 	}
 
 	for _, tt := range tests {
@@ -331,6 +358,9 @@ func TestMetadataStore_EvaluateOverlayConstraints(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+				}
+				if tt.wantErrCode != "" && !errors.Is(err, aicrerrors.New(tt.wantErrCode, "")) {
+					t.Fatalf("error = %v, want code %s", err, tt.wantErrCode)
 				}
 				return
 			}
@@ -2083,6 +2113,50 @@ func TestEvaluateMixinConstraintsReturnsErrorWhenConstraintCannotBeMappedToCandi
 	}
 }
 
+func TestEvaluateMixinConstraintsRejectsIncompleteConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint Constraint
+	}{
+		{
+			name:       "missing name",
+			constraint: Constraint{Value: ">= 6.8"},
+		},
+		{
+			name:       "missing value",
+			constraint: Constraint{Name: "OS.kernel"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overlay := &RecipeMetadata{}
+			overlay.Metadata.Name = "candidate"
+			overlay.Spec.Mixins = []string{"os-gate"}
+			mixin := &RecipeMixin{}
+			mixin.Metadata.Name = "os-gate"
+			mixin.Spec.Constraints = []Constraint{tt.constraint}
+			store := &MetadataStore{
+				Overlays: map[string]*RecipeMetadata{"candidate": overlay},
+				Mixins:   map[string]*RecipeMixin{"os-gate": mixin},
+			}
+
+			_, err := store.evaluateMixinConstraints(
+				&RecipeMetadataSpec{Constraints: []Constraint{tt.constraint}},
+				func(_ Constraint) ConstraintEvalResult {
+					return ConstraintEvalResult{
+						Error: aicrerrors.New(aicrerrors.ErrCodeNotFound, "value not found"),
+					}
+				},
+				map[string]bool{tt.constraint.Name: true},
+				[]string{"candidate"},
+			)
+			if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("error = %v, want code %s", err, aicrerrors.ErrCodeInvalidRequest)
+			}
+		})
+	}
+}
+
 // TestMalformedMixinRejected verifies that mixin files with forbidden fields
 // (base, criteria, mixins, validation) are rejected at load time by
 // KnownFields(true) strict parsing.
@@ -2179,6 +2253,28 @@ func TestExcludedOverlayUnmarshalYAML(t *testing.T) {
 				{Name: "overlay-a"},
 			},
 		},
+		{
+			name:  "legacy object form accepts unknown field",
+			input: "- name: overlay-a\n  reasn: constraint-failed\n",
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a"},
+			},
+		},
+		{
+			name:    "object form requires name",
+			input:   "- {}\n",
+			wantErr: true,
+		},
+		{
+			name:    "object form rejects null name",
+			input:   "- name: null\n",
+			wantErr: true,
+		},
+		{
+			name:    "scalar form requires string",
+			input:   "- 42\n",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2186,6 +2282,9 @@ func TestExcludedOverlayUnmarshalYAML(t *testing.T) {
 			err := yaml.Unmarshal([]byte(tt.input), &got)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
 			}
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("got %+v, want %+v", got, tt.expected)
@@ -2224,6 +2323,28 @@ func TestExcludedOverlayUnmarshalJSON(t *testing.T) {
 				{Name: "overlay-a"},
 			},
 		},
+		{
+			name:  "legacy object form accepts unknown field",
+			input: `[{"name":"overlay-a","reasn":"constraint-failed"}]`,
+			expected: []ExcludedOverlay{
+				{Name: "overlay-a"},
+			},
+		},
+		{
+			name:    "object form requires name",
+			input:   `[{}]`,
+			wantErr: true,
+		},
+		{
+			name:    "object form rejects null name",
+			input:   `[{"name":null}]`,
+			wantErr: true,
+		},
+		{
+			name:    "null is neither legacy string nor object",
+			input:   `[null]`,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2231,6 +2352,9 @@ func TestExcludedOverlayUnmarshalJSON(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.input), &got)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
 			}
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("got %+v, want %+v", got, tt.expected)
@@ -2355,6 +2479,43 @@ spec:
 		"overlays/" + overlayName + ".yaml": overlayYAML,
 	}
 	return newInMemoryProvider(overlayName, files)
+}
+
+func TestLoadMetadataStore_ProfileMetadataRequiresKind(t *testing.T) {
+	t.Cleanup(ResetMetadataStoreForTesting)
+
+	provider := newInMemoryProvider("missing-kind", map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/profile.yaml": []byte(`apiVersion: aicr.run/v1alpha3
+metadata:
+  name: profile
+spec:
+  criteria:
+    service: aks
+  profile:
+    name: gpuStack
+    default: driver-installed
+    values:
+      driver-installed: {}
+`),
+	})
+
+	_, err := LoadMetadataStoreFor(t.Context(), provider)
+	if err == nil {
+		t.Fatal("LoadMetadataStoreFor() error = nil, want missing-kind rejection")
+	}
+	if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("error code = %v, want ErrCodeInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), `requires kind "RecipeMetadata"`) {
+		t.Fatalf("error = %v, want RecipeMetadata kind requirement", err)
+	}
 }
 
 // TestLoadMetadataStore_PerProviderIsolation verifies that distinct

--- a/pkg/recipe/profile.go
+++ b/pkg/recipe/profile.go
@@ -1,0 +1,981 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"math"
+	"reflect"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+// RecipeProfileAPIVersion is the RecipeMetadata and RecipeResult version used
+// when a configuration profile is present. Other AICR artifact kinds remain on
+// header.GroupVersion.
+const RecipeProfileAPIVersion = header.APIGroup + "/v1alpha3"
+
+const (
+	profileAdvertiserExternal   = "external"
+	profileComponentEnabledPath = "enabled"
+	profileJSONSafeIntegerMax   = 1<<53 - 1
+)
+
+var profileIdentifierPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// ProfileDeclaration defines one overlay-scoped configuration choice.
+type ProfileDeclaration struct {
+	Name        string                  `json:"name" yaml:"name"`
+	Description string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	Default     string                  `json:"default" yaml:"default"`
+	Values      map[string]ProfileValue `json:"values" yaml:"values"`
+}
+
+// ProfileValue is the closed fragment applied for one declared value.
+//
+// Advertiser is reserved for the GKE extension in rollout PR 3. It remains in
+// the wire shape so that PR can enable the accepted ADR contract without
+// another schema change; the core mechanism rejects every non-empty value.
+type ProfileValue struct {
+	Advertiser    string                `json:"advertiser,omitempty" yaml:"advertiser,omitempty"`
+	Constraints   []Constraint          `json:"constraints,omitempty" yaml:"constraints,omitempty"`
+	ComponentRefs []ProfileComponentRef `json:"componentRefs,omitempty" yaml:"componentRefs,omitempty"`
+}
+
+// ProfileComponentRef is deliberately smaller than ComponentRef. A profile
+// may only assign values on an existing component; component identity,
+// deployment shape, manifests, health checks, and ordering are not profile
+// effects.
+type ProfileComponentRef struct {
+	Name      string         `json:"name" yaml:"name"`
+	Overrides map[string]any `json:"overrides,omitempty" yaml:"overrides,omitempty"`
+}
+
+// SelectedProfile is persisted in a hydrated RecipeResult. OwnedPaths is the
+// declaration-wide, deterministic lock surface keyed by canonical component
+// name. The synthetic "enabled" path records component presence.
+type SelectedProfile struct {
+	Name       string              `json:"name" yaml:"name"`
+	Value      string              `json:"value" yaml:"value"`
+	Advertiser string              `json:"advertiser,omitempty" yaml:"advertiser,omitempty"`
+	OwnedPaths map[string][]string `json:"ownedPaths" yaml:"ownedPaths"`
+}
+
+// ProfileSummary is the compact catalog projection of an effective profile.
+type ProfileSummary struct {
+	Name        string   `json:"name" yaml:"name"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Default     string   `json:"default" yaml:"default"`
+	Values      []string `json:"values" yaml:"values"`
+}
+
+// ProfileSelection is the parsed name=value selection shared by all public
+// resolution surfaces.
+type ProfileSelection struct {
+	Name  string
+	Value string
+}
+
+// ParseProfileSelection parses the canonical name=value profile selection.
+// Empty input means "use the declaration's default".
+func ParseProfileSelection(raw string) (*ProfileSelection, error) {
+	if raw == "" {
+		return nil, nil //nolint:nilnil // nil selection means use the declaration's default
+	}
+	if strings.TrimSpace(raw) != raw || strings.Count(raw, "=") != 1 {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"profile must use the exact name=value form")
+	}
+	name, value, _ := strings.Cut(raw, "=")
+	if !validProfileIdentifier(name) || !validProfileIdentifier(value) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"profile name and value must match [A-Za-z0-9._-]+")
+	}
+	return &ProfileSelection{Name: name, Value: value}, nil
+}
+
+func validProfileIdentifier(value string) bool {
+	return profileIdentifierPattern.MatchString(value)
+}
+
+// ValidateProfileDeclaration validates the closed v1 profile declaration and
+// returns its declaration-wide ownership record.
+func ValidateProfileDeclaration(decl *ProfileDeclaration) (map[string][]string, error) {
+	if decl == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "profile declaration is required")
+	}
+	if !validProfileIdentifier(decl.Name) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"profile name must match [A-Za-z0-9._-]+")
+	}
+	if !validProfileIdentifier(decl.Default) {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			"profile default must match [A-Za-z0-9._-]+")
+	}
+	if len(decl.Values) == 0 {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile %q must declare at least one value", decl.Name))
+	}
+	if _, ok := decl.Values[decl.Default]; !ok {
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile %q default %q is not a declared value", decl.Name, decl.Default))
+	}
+
+	valueNames := make([]string, 0, len(decl.Values))
+	for name := range decl.Values {
+		valueNames = append(valueNames, name)
+	}
+	sort.Strings(valueNames)
+
+	var expected []string
+	ownedSet := make(map[string]map[string]struct{})
+	for i, valueName := range valueNames {
+		if !validProfileIdentifier(valueName) {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile value %q must match [A-Za-z0-9._-]+", valueName))
+		}
+		value := decl.Values[valueName]
+		if value.Advertiser != "" {
+			if value.Advertiser != profileAdvertiserExternal {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %q value %q has unknown advertiser %q", decl.Name, valueName, value.Advertiser))
+			}
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile %q value %q uses advertiser %q, which is deferred to the GKE profile extension",
+					decl.Name, valueName, value.Advertiser))
+		}
+
+		// Profile constraints reach the merged spec unchanged, and
+		// BuildRecipeResultWithProfile — the snapshot-less generation path —
+		// calls applyEffectiveProfile with a nil evaluator, so on that path
+		// nothing downstream inspects their shape. Overlay and mixin
+		// constraints already fail closed on an empty name or value
+		// (validateConstraintWarningSource); catalog load is the equivalent
+		// boundary for profile-contributed ones.
+		seenConstraints := make(map[string]struct{}, len(value.Constraints))
+		for _, constraint := range value.Constraints {
+			if constraint.Name == "" {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %q value %q declares a constraint with no name", decl.Name, valueName))
+			}
+			if constraint.Value == "" {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %q value %q constraint %q has no value",
+						decl.Name, valueName, constraint.Name))
+			}
+			if _, repeat := seenConstraints[constraint.Name]; repeat {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %q value %q repeats constraint %q",
+						decl.Name, valueName, constraint.Name))
+			}
+			seenConstraints[constraint.Name] = struct{}{}
+		}
+
+		seenComponents := make(map[string]struct{}, len(value.ComponentRefs))
+		var valuePaths []string
+		for _, ref := range value.ComponentRefs {
+			if ref.Name == "" {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %q value %q has a componentRef with an empty name", decl.Name, valueName))
+			}
+			if _, duplicate := seenComponents[ref.Name]; duplicate {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %q value %q repeats componentRef %q", decl.Name, valueName, ref.Name))
+			}
+			seenComponents[ref.Name] = struct{}{}
+
+			if _, assignsEnabled := ref.Overrides[profileComponentEnabledPath]; assignsEnabled {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %q value %q component %q may not assign overrides.enabled",
+						decl.Name, valueName, ref.Name))
+			}
+			paths, err := flattenProfileOverrides(ref.Overrides)
+			if err != nil {
+				return nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+					"invalid profile overrides", err,
+					map[string]any{"profile": decl.Name, "value": valueName, "component": ref.Name})
+			}
+			for _, path := range paths {
+				if isDeferredAllocationPolicyPath(ref.Name, path) {
+					return nil, errors.New(errors.ErrCodeInvalidRequest,
+						fmt.Sprintf("profile %q value %q owns deferred allocation-policy path %s.%s; "+
+							"allocation-policy profiles land with the GKE extension",
+							decl.Name, valueName, ref.Name, path))
+				}
+				valuePaths = append(valuePaths, ref.Name+":"+path)
+				if ownedSet[ref.Name] == nil {
+					ownedSet[ref.Name] = make(map[string]struct{})
+				}
+				ownedSet[ref.Name][path] = struct{}{}
+			}
+			if ownedSet[ref.Name] == nil {
+				ownedSet[ref.Name] = make(map[string]struct{})
+			}
+			// The synthetic presence marker is declaration-wide and is
+			// deliberately kept out of valuePaths: ADR-015 evaluates union
+			// totality over the leaf-flattened override paths alone, "before
+			// synthetic presence paths are added", and exempts the marker
+			// because fragments may not assign it. Folding it in would compare
+			// component-reference sets instead, rejecting a declaration whose
+			// values legitimately differ in which components they reference.
+			ownedSet[ref.Name][profileComponentEnabledPath] = struct{}{}
+		}
+		sort.Strings(valuePaths)
+		if i == 0 {
+			expected = valuePaths
+			continue
+		}
+		if !slices.Equal(valuePaths, expected) {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile %q violates union totality: value %q assigns %v, expected %v",
+					decl.Name, valueName, valuePaths, expected))
+		}
+	}
+
+	owned := make(map[string][]string, len(ownedSet))
+	for component, paths := range ownedSet {
+		owned[component] = make([]string, 0, len(paths))
+		for path := range paths {
+			owned[component] = append(owned[component], path)
+		}
+		sort.Strings(owned[component])
+	}
+	return owned, nil
+}
+
+func flattenProfileOverrides(overrides map[string]any) ([]string, error) {
+	if err := validateProfileOverrideMapKeys(overrides, ""); err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	var walk func(map[string]any, []string) error
+	walk = func(values map[string]any, prefix []string) error {
+		for key, value := range values {
+			if key == "" || strings.Contains(key, ".") {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile override key %q must be nonempty and may not contain a literal dot", key))
+			}
+			path := append(append([]string(nil), prefix...), key)
+			if nested, ok := value.(map[string]any); ok {
+				if len(nested) == 0 {
+					return errors.New(errors.ErrCodeInvalidRequest,
+						fmt.Sprintf("profile override %q assigns an empty map", strings.Join(path, ".")))
+				}
+				if err := walk(nested, path); err != nil {
+					return err
+				}
+				continue
+			}
+			paths = append(paths, strings.Join(path, "."))
+		}
+		return nil
+	}
+	if err := walk(overrides, nil); err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+type profileOverrideReference struct {
+	kind     reflect.Kind
+	pointer  uintptr
+	length   int
+	capacity int
+}
+
+func validateProfileOverrideMapKeys(value any, path string) error {
+	return validateProfileOverrideTree(
+		value,
+		path,
+		make(map[profileOverrideReference]struct{}),
+		true,
+	)
+}
+
+// validateProfileDeepCopyCycles mirrors serializer.DeepCopyAny: only
+// map[string]any and []any recurse, so only those canonical containers can
+// exhaust the stack during adoption or value hydration.
+func validateProfileDeepCopyCycles(value any, path string) error {
+	return validateProfileOverrideTree(
+		value,
+		path,
+		make(map[profileOverrideReference]struct{}),
+		false,
+	)
+}
+
+func validateProfileOverrideTree(
+	value any,
+	path string,
+	active map[profileOverrideReference]struct{},
+	validateValues bool,
+) error {
+
+	reflected := reflect.ValueOf(value)
+	if reference, ok := profileOverrideReferenceFor(reflected); ok {
+		if _, exists := active[reference]; exists {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile override %q contains a cyclic reference", path))
+		}
+		active[reference] = struct{}{}
+		defer delete(active, reference)
+	}
+
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			nestedPath := key
+			if path != "" {
+				nestedPath = path + "." + key
+			}
+			if err := validateProfileOverrideTree(nested, nestedPath, active, validateValues); err != nil {
+				return err
+			}
+		}
+	case map[any]any:
+		if !validateValues {
+			return nil
+		}
+		for key := range typed {
+			if _, ok := key.(string); !ok {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile override %q contains non-string mapping key %v", path, key))
+			}
+		}
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile override %q must use a string-keyed mapping", path))
+	case []any:
+		for index, nested := range typed {
+			nestedPath := fmt.Sprintf("%s[%d]", path, index)
+			if err := validateProfileOverrideTree(nested, nestedPath, active, validateValues); err != nil {
+				return err
+			}
+		}
+	default:
+		if !validateValues {
+			return nil
+		}
+		if !reflected.IsValid() {
+			return nil
+		}
+		if reflected.Kind() == reflect.Map {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile override %q uses unsupported map type %T; "+
+					"nested mappings must use map[string]any", path, value))
+		}
+		if reflected.Kind() == reflect.Pointer {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile override %q uses unsupported pointer type %T", path, value))
+		}
+		if reflected.Kind() == reflect.Array || reflected.Kind() == reflect.Slice {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile override %q uses unsupported list type %T; "+
+					"nested lists must use []any", path, value))
+		}
+		return validateProfileOverrideScalar(value, path)
+	}
+	return nil
+}
+
+func validateProfileOverrideScalar(value any, path string) error {
+	switch typed := value.(type) {
+	case bool, string:
+		return nil
+	case int, int8, int16, int32, int64:
+		integer := reflect.ValueOf(typed).Int()
+		if integer < -profileJSONSafeIntegerMax || integer > profileJSONSafeIntegerMax {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile override %q contains integer %v outside the JSON round-trip-safe range", path, typed))
+		}
+		return nil
+	case uint, uint8, uint16, uint32, uint64, uintptr:
+		if reflect.ValueOf(typed).Uint() > profileJSONSafeIntegerMax {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile override %q contains integer %v outside the JSON round-trip-safe range", path, typed))
+		}
+		return nil
+	case float32:
+		return validateProfileOverrideFloat(float64(typed), path)
+	case float64:
+		return validateProfileOverrideFloat(typed, path)
+	case time.Time:
+		// yaml.v3 resolves unquoted timestamps into time.Time when decoding
+		// into any, so retain this decoder-reachable scalar.
+		if _, err := typed.MarshalJSON(); err != nil {
+			return errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile override %q contains an invalid timestamp", path), err)
+		}
+		return nil
+	default:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile override %q uses unsupported scalar type %T", path, value))
+	}
+}
+
+func validateProfileOverrideFloat(value float64, path string) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile override %q contains a non-finite float", path))
+	}
+	if math.Trunc(value) == value && math.Abs(value) > profileJSONSafeIntegerMax {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile override %q contains an integer-valued float outside the JSON round-trip-safe range", path))
+	}
+	return nil
+}
+
+func profileOverrideReferenceFor(value reflect.Value) (profileOverrideReference, bool) {
+	if !value.IsValid() || value.Kind() != reflect.Map &&
+		value.Kind() != reflect.Slice {
+
+		return profileOverrideReference{}, false
+	}
+	if value.IsNil() {
+		return profileOverrideReference{}, false
+	}
+
+	reference := profileOverrideReference{
+		kind:    value.Kind(),
+		pointer: value.Pointer(),
+	}
+	if value.Kind() == reflect.Slice {
+		reference.length = value.Len()
+		reference.capacity = value.Cap()
+	}
+	return reference, true
+}
+
+func isDeferredAllocationPolicyPath(component, path string) bool {
+	deferred := map[string][]string{
+		"gpu-operator":          {"devicePlugin.enabled"},
+		"gpu-operator-ocp":      {"devicePlugin.enabled"},
+		"nvidia-dra-driver-gpu": {"resources.gpus.enabled", "gpuResourcesEnabledOverride"},
+	}
+	for _, policyPath := range deferred[component] {
+		if PathsIntersect(path, policyPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneOwnedPaths(paths map[string][]string) map[string][]string {
+	if paths == nil {
+		return nil
+	}
+	out := make(map[string][]string, len(paths))
+	for component, values := range paths {
+		out[component] = append([]string(nil), values...)
+	}
+	return out
+}
+
+func profileSummary(decl *ProfileDeclaration) *ProfileSummary {
+	if decl == nil {
+		return nil
+	}
+	values := make([]string, 0, len(decl.Values))
+	for name := range decl.Values {
+		values = append(values, name)
+	}
+	sort.Strings(values)
+	return &ProfileSummary{
+		Name:        decl.Name,
+		Description: decl.Description,
+		Default:     decl.Default,
+		Values:      values,
+	}
+}
+
+// ValidateRecipeMetadataProfile enforces the bidirectional version/declaration
+// contract for typed RecipeMetadata callers. Byte decoders additionally use
+// strict decoding for RecipeProfileAPIVersion so unknown keys cannot vanish.
+func ValidateRecipeMetadataProfile(metadata *RecipeMetadata) error {
+	if metadata == nil {
+		return nil
+	}
+	switch {
+	case metadata.APIVersion == RecipeProfileAPIVersion && metadata.Spec.Profile == nil:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("RecipeMetadata uses apiVersion %q but has no spec.profile declaration",
+				RecipeProfileAPIVersion))
+	case metadata.Spec.Profile != nil && metadata.APIVersion != RecipeProfileAPIVersion:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("RecipeMetadata declares spec.profile but uses apiVersion %q; expected %q",
+				metadata.APIVersion, RecipeProfileAPIVersion))
+	case metadata.Spec.Profile != nil:
+		_, err := ValidateProfileDeclaration(metadata.Spec.Profile)
+		return err
+	default:
+		return nil
+	}
+}
+
+// ValidateProfileContract enforces the bidirectional version/profile coupling
+// and validates profile metadata for typed callers that did not pass through
+// a strict byte decoder.
+func (r *RecipeResult) ValidateProfileContract() error {
+	if r == nil {
+		return nil
+	}
+	switch r.APIVersion {
+	case "", RecipeAPIVersion:
+		if r.Metadata.SelectedProfile != nil {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("recipe apiVersion %q cannot carry metadata.selectedProfile", r.APIVersion))
+		}
+		return r.validateInlineDeepCopyCycles()
+	case RecipeProfileAPIVersion:
+		if r.Metadata.SelectedProfile == nil {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("recipe apiVersion %q requires metadata.selectedProfile", RecipeProfileAPIVersion))
+		}
+	default:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe has unsupported apiVersion %q; expected %q or %q",
+				r.APIVersion, RecipeAPIVersion, RecipeProfileAPIVersion))
+	}
+
+	if err := r.validateProfileMetadataItems(); err != nil {
+		return err
+	}
+
+	selected := r.Metadata.SelectedProfile
+	if !validProfileIdentifier(selected.Name) || !validProfileIdentifier(selected.Value) {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"metadata.selectedProfile name and value must match [A-Za-z0-9._-]+")
+	}
+	if selected.Advertiser != "" {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"metadata.selectedProfile.advertiser is deferred to the GKE profile extension")
+	}
+	if selected.OwnedPaths == nil {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"metadata.selectedProfile.ownedPaths is required")
+	}
+	for component, paths := range selected.OwnedPaths {
+		if component == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				"metadata.selectedProfile.ownedPaths contains an empty component name")
+		}
+		if !sort.StringsAreSorted(paths) {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.selectedProfile.ownedPaths[%q] must be lexicographically sorted", component))
+		}
+		if !slices.Contains(paths, profileComponentEnabledPath) {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.selectedProfile.ownedPaths[%q] must include synthetic path %q",
+					component, profileComponentEnabledPath))
+		}
+		for i, path := range paths {
+			if path == "" || strings.HasPrefix(path, ".") || strings.HasSuffix(path, ".") ||
+				strings.Contains(path, "..") {
+
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("metadata.selectedProfile.ownedPaths[%q] contains invalid path %q", component, path))
+			}
+			if i > 0 && paths[i-1] == path {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("metadata.selectedProfile.ownedPaths[%q] repeats path %q", component, path))
+			}
+			if isDeferredAllocationPolicyPath(component, path) {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("metadata.selectedProfile owns deferred allocation-policy path %s.%s", component, path))
+			}
+		}
+	}
+	return r.validateInlineDeepCopyCycles()
+}
+
+func (r *RecipeResult) validateInlineDeepCopyCycles() error {
+	for index := range r.ComponentRefs {
+		ref := &r.ComponentRefs[index]
+		path := ref.Name
+		if path == "" {
+			path = fmt.Sprintf("componentRefs[%d].overrides", index)
+		}
+		if err := validateProfileDeepCopyCycles(ref.Overrides, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *RecipeResult) validateProfileMetadataItems() error {
+	for index, overlay := range r.Metadata.ExcludedOverlays {
+		if overlay.Name == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.excludedOverlays[%d].name is required", index))
+		}
+		// Reason remains optional for compatibility with stored object-form
+		// entries that predate machine-readable exclusion reasons.
+		switch overlay.Reason {
+		case "", ExcludedOverlayReasonConstraintFailed, ExcludedOverlayReasonMixinConstraintFailed:
+		default:
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.excludedOverlays[%d].reason %q is unsupported",
+					index, overlay.Reason))
+		}
+	}
+	for index, warning := range r.Metadata.ConstraintWarnings {
+		if warning.Overlay == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.constraintWarnings[%d].overlay is required", index))
+		}
+		if warning.Constraint == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.constraintWarnings[%d].constraint is required", index))
+		}
+		if warning.Expected == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.constraintWarnings[%d].expected is required", index))
+		}
+		if warning.Reason == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("metadata.constraintWarnings[%d].reason is required", index))
+		}
+	}
+	return nil
+}
+
+// PrepareAndValidateWithContext runs the shared raw-artifact gate and, only
+// for profiled artifacts, hydrates locked component values to reject an
+// incoherent ownership record. Legacy artifacts perform no additional I/O.
+func (r *RecipeResult) PrepareAndValidateWithContext(ctx context.Context) error {
+	if err := r.PrepareAndValidate(); err != nil {
+		return err
+	}
+	if r == nil || r.Metadata.SelectedProfile == nil {
+		return nil
+	}
+	return r.ValidateProfileValuesWithContext(ctx)
+}
+
+// ValidateProfileValuesWithContext rejects recipe-side blocked paths,
+// unsupported values, missing/disabled locked components, and value-bearing
+// ownership of Kustomize components, which do not consume Helm values
+// overrides.
+func (r *RecipeResult) ValidateProfileValuesWithContext(ctx context.Context) error {
+	_, err := r.validateProfileValuesWithContext(ctx)
+	return err
+}
+
+func (r *RecipeResult) validateProfileValuesWithContext(
+	ctx context.Context,
+) (map[string]map[string]any, error) {
+
+	if r == nil || r.Metadata.SelectedProfile == nil {
+		return map[string]map[string]any{}, nil
+	}
+	hydrated := make(map[string]map[string]any, len(r.Metadata.SelectedProfile.OwnedPaths))
+	components := slices.Sorted(maps.Keys(r.Metadata.SelectedProfile.OwnedPaths))
+	for _, component := range components {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, errors.Wrap(
+				errors.ErrCodeTimeout, "profile value validation canceled", ctxErr)
+		}
+		paths := r.Metadata.SelectedProfile.OwnedPaths[component]
+		ref := r.GetComponentRef(component)
+		if ref == nil || !ref.IsEnabled() {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile-owned component %q is missing or disabled", component))
+		}
+		if ref.Type == ComponentTypeKustomize && slices.ContainsFunc(paths, func(path string) bool {
+			return path != profileComponentEnabledPath
+		}) {
+
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile-owned component %q has type %q, which does not consume values overrides",
+					component, ref.Type))
+		}
+		// Inline canonical maps and slices must be acyclic before hydration:
+		// resolveComponentValues deep-copies those containers recursively.
+		// Value-shape restrictions below remain scoped to owned paths.
+		if err := validateProfileDeepCopyCycles(ref.Overrides, component); err != nil {
+			return nil, err
+		}
+		if err := validateProfileOwnedValues(ref.Overrides, component, paths); err != nil {
+			return nil, err
+		}
+		if err := validateProfileInlineOwnership(ref.Overrides, component, paths); err != nil {
+			return nil, err
+		}
+		values, err := r.GetValuesForComponentWithContext(ctx, component)
+		if err != nil {
+			return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+				fmt.Sprintf("failed to hydrate profile-owned component %q", component))
+		}
+		if err := validateProfileOwnedValues(values, component, paths); err != nil {
+			return nil, err
+		}
+		hydrated[component] = values
+		for _, path := range paths {
+			if path == profileComponentEnabledPath {
+				continue
+			}
+			observation, err := ObserveValuePath(values, path)
+			if err != nil {
+				return nil, err
+			}
+			if observation.State == PathBlocked {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile-owned recipe path %s.%s is blocked by a non-map ancestor", component, path))
+			}
+		}
+	}
+	return hydrated, nil
+}
+
+// validateProfileInlineOwnership requires every non-synthetic owned path to be
+// assigned by the component's inline overrides.
+//
+// Generation always satisfies this: applyEffectiveProfile merges the selected
+// fragment's overrides into the componentRef, and union totality guarantees the
+// selected fragment assigns every non-synthetic path in the declaration-wide
+// union. Raw artifacts reaching LoadFromFile, AdoptRecipe, or POST /v2/bundle
+// carry author-supplied ownedPaths, so the invariant has to be re-established
+// here rather than assumed.
+//
+// ADR-015 states an owned path is never inherited from the baseline:
+// supersession applies only the selected fragment, so an owned path missing
+// from the overrides would let a values-file or external-overlay assignment
+// survive the selection and then be locked and attested as if the profile had
+// qualified it. An explicit null is an assignment and stays valid.
+//
+// The check requires PathPresent, not merely "not absent". A blocking ancestor
+// cannot be deferred to the hydrated-values check, because the two states
+// collapse into each other across the merge: overrides of {"driver": nil} block
+// the owned path driver.version inline, and mergeValues deletes a key whose
+// source value is nil, so the hydrated observation is PathAbsent rather than
+// PathBlocked and neither check fires. Rejecting anything non-present inline
+// closes that gap; an explicit null at the owned leaf itself is still an
+// assignment and stays valid.
+func validateProfileInlineOwnership(overrides map[string]any, component string, paths []string) error {
+	for _, path := range paths {
+		if path == profileComponentEnabledPath {
+			continue
+		}
+		switch _, state := profileValueAtPath(overrides, path); state {
+		case PathPresent:
+		case PathBlocked:
+			// Same defect the hydrated check reports, caught one step earlier;
+			// the wording is shared so the surface does not depend on which
+			// observation happens to fire first.
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile-owned recipe path %s.%s is blocked by a non-map ancestor",
+					component, path))
+		case PathAbsent:
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile-owned path %s.%s is not assigned by the component overrides; "+
+					"an owned path may not be inherited from the baseline values",
+					component, path))
+		default:
+			return errors.New(errors.ErrCodeInternal,
+				fmt.Sprintf("unexpected path state %q observing %s.%s", state, component, path))
+		}
+	}
+	return nil
+}
+
+func validateProfileOwnedValues(values map[string]any, component string, paths []string) error {
+	for _, path := range paths {
+		if path == profileComponentEnabledPath {
+			continue
+		}
+		value, state := profileValueAtPath(values, path)
+		if state != PathPresent {
+			continue
+		}
+		if err := validateProfileOverrideMapKeys(value, component+"."+path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PathState is the three-valued observation used by the profile lock.
+type PathState string
+
+const (
+	// PathPresent means the leaf key exists, including an explicit null.
+	PathPresent PathState = "present"
+	// PathAbsent means traversal reached a map where the next key was absent.
+	PathAbsent PathState = "absent"
+	// PathBlocked means a non-map ancestor prevented traversal to the leaf.
+	PathBlocked PathState = "blocked"
+)
+
+// PathObservation is the canonical state of one dotted values path.
+type PathObservation struct {
+	State PathState
+	Bytes []byte
+}
+
+// ObserveValuePath observes a dotted path without conflating absence with an
+// ancestor scalar/list/null that blocks traversal.
+func ObserveValuePath(values map[string]any, path string) (PathObservation, error) {
+	value, state := profileValueAtPath(values, path)
+	if state != PathPresent {
+		return PathObservation{State: state}, nil
+	}
+	data, err := serializer.MarshalYAMLDeterministic(value)
+	if err != nil {
+		return PathObservation{}, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to serialize value at path %q", path), err)
+	}
+	return PathObservation{State: PathPresent, Bytes: data}, nil
+}
+
+func profileValueAtPath(values map[string]any, path string) (any, PathState) {
+	parts := strings.Split(path, ".")
+	current := values
+	for i, part := range parts {
+		value, ok := current[part]
+		if !ok {
+			return nil, PathAbsent
+		}
+		if i == len(parts)-1 {
+			return value, PathPresent
+		}
+		next, ok := value.(map[string]any)
+		if !ok {
+			return nil, PathBlocked
+		}
+		current = next
+	}
+	return nil, PathAbsent
+}
+
+// PathsIntersect reports exact, ancestor, or descendant path intersection.
+func PathsIntersect(a, b string) bool {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	limit := min(len(aParts), len(bParts))
+	for i := range limit {
+		if aParts[i] != bParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ValidateProfileLock compares the final candidate values and component set
+// against the hydrated selected recipe before an output is written. Dynamic
+// paths model install-time mutability and are rejected on structural
+// intersection even when the current value is identical.
+func (r *RecipeResult) ValidateProfileLock(
+	ctx context.Context,
+	candidateRefs []ComponentRef,
+	candidateValues map[string]map[string]any,
+	dynamicPaths map[string][]string,
+) error {
+
+	if r == nil || r.Metadata.SelectedProfile == nil {
+		return nil
+	}
+	baselineValuesByComponent, err := r.validateProfileValuesWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	candidateEnabled := make(map[string]bool, len(candidateRefs))
+	for _, ref := range candidateRefs {
+		candidateEnabled[ref.Name] = ref.IsEnabled()
+	}
+
+	components := slices.Sorted(maps.Keys(r.Metadata.SelectedProfile.OwnedPaths))
+	for _, component := range components {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return errors.Wrap(
+				errors.ErrCodeTimeout, "profile lock validation canceled", ctxErr)
+		}
+		paths := r.Metadata.SelectedProfile.OwnedPaths[component]
+		baselineRef := r.GetComponentRef(component)
+		if baselineRef == nil {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile-owned component %q is absent from the recipe", component))
+		}
+		if !candidateEnabled[component] {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile-owned component %q is absent or disabled in the output", component))
+		}
+		baselineValues := baselineValuesByComponent[component]
+		candidate, ok := candidateValues[component]
+		if !ok {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile-owned component %q has no candidate values", component))
+		}
+
+		for _, lockedPath := range paths {
+			for _, dynamicPath := range dynamicPaths[component] {
+				if PathsIntersect(lockedPath, dynamicPath) {
+					return errors.New(errors.ErrCodeInvalidRequest,
+						fmt.Sprintf("install-time path %s.%s intersects profile-owned path %s.%s",
+							component, dynamicPath, component, lockedPath))
+				}
+			}
+			if lockedPath == profileComponentEnabledPath {
+				if baselineRef.IsEnabled() != candidateEnabled[component] {
+					return errors.New(errors.ErrCodeInvalidRequest,
+						fmt.Sprintf("profile-owned component presence diverged for %q", component))
+				}
+				continue
+			}
+			want, err := ObserveValuePath(baselineValues, lockedPath)
+			if err != nil {
+				return err
+			}
+			got, err := ObserveValuePath(candidate, lockedPath)
+			if err != nil {
+				return err
+			}
+			if want.State == PathBlocked {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile-owned recipe path %s.%s is blocked", component, lockedPath))
+			}
+			if want.State != got.State || !bytes.Equal(want.Bytes, got.Bytes) {
+				return errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile-owned path %s.%s diverged from selected profile %s=%s",
+						component, lockedPath, r.Metadata.SelectedProfile.Name, r.Metadata.SelectedProfile.Value))
+			}
+		}
+	}
+	return nil
+}
+
+// OwnsProfilePath reports whether selectedProfile owns a component value path.
+func (r *RecipeResult) OwnsProfilePath(component, path string) bool {
+	if r == nil || r.Metadata.SelectedProfile == nil {
+		return false
+	}
+	for _, owned := range r.Metadata.SelectedProfile.OwnedPaths[component] {
+		if PathsIntersect(owned, path) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/recipe/profile_integration_test.go
+++ b/pkg/recipe/profile_integration_test.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	stderrors "errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// The embedded catalog declares no profile, so the unit tests around
+// ValidateProfileDeclaration and applyEffectiveProfile exercise the pieces in
+// isolation and nothing drives the whole path. These tests layer a profiled
+// overlay over the embedded data — the supported out-of-tree adoption route —
+// and resolve through the ordinary Builder so criteria matching, declaration
+// discovery, value selection, and ownership locking run together.
+const profileOverlayDir = "testdata/profile-overlay"
+
+func profiledBuilder(t *testing.T) *Builder {
+	t.Helper()
+	provider, err := NewLayeredDataProvider(
+		NewEmbeddedDataProvider(GetEmbeddedFS(), "."),
+		LayeredProviderConfig{ExternalDir: profileOverlayDir},
+	)
+	if err != nil {
+		t.Fatalf("NewLayeredDataProvider() error = %v", err)
+	}
+	return NewBuilder(WithDataProvider(provider))
+}
+
+func profiledCriteria() *Criteria {
+	return &Criteria{
+		Service:     CriteriaServiceAKS,
+		Accelerator: CriteriaAcceleratorH100,
+		OS:          CriteriaOSUbuntu,
+		Intent:      CriteriaIntentTraining,
+		Platform:    CriteriaPlatformKubeflow,
+	}
+}
+
+func TestProfileResolutionEndToEnd(t *testing.T) {
+	wantOwned := map[string][]string{
+		"gpu-operator":          {"driver.enabled", "enabled"},
+		"nvidia-dra-driver-gpu": {"enabled", "nvidiaDriverRoot"},
+	}
+
+	tests := []struct {
+		name           string
+		selection      string
+		wantValue      string
+		wantDriver     bool
+		wantDriverRoot string
+	}{
+		{
+			// No selection: the declaration's default applies.
+			name:           "default value",
+			selection:      "",
+			wantValue:      "preinstalled",
+			wantDriver:     false,
+			wantDriverRoot: "/",
+		},
+		{
+			name:           "explicit default",
+			selection:      "gpuStack=preinstalled",
+			wantValue:      "preinstalled",
+			wantDriver:     false,
+			wantDriverRoot: "/",
+		},
+		{
+			name:           "explicit non-default",
+			selection:      "gpuStack=operator-managed",
+			wantValue:      "operator-managed",
+			wantDriver:     true,
+			wantDriverRoot: "/run/nvidia/driver",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := profiledBuilder(t).BuildFromCriteriaWithProfile(
+				t.Context(), profiledCriteria(), tt.selection)
+			if err != nil {
+				t.Fatalf("BuildFromCriteriaWithProfile() error = %v", err)
+			}
+
+			// A profiled composition must stamp the gated apiVersion; the
+			// biconditional is enforced in both directions.
+			if result.APIVersion != RecipeProfileAPIVersion {
+				t.Fatalf("apiVersion = %q, want %q", result.APIVersion, RecipeProfileAPIVersion)
+			}
+			selected := result.Metadata.SelectedProfile
+			if selected == nil {
+				t.Fatal("metadata.selectedProfile is nil for a profiled composition")
+			}
+			if selected.Name != "gpuStack" || selected.Value != tt.wantValue {
+				t.Fatalf("selectedProfile = %s=%s, want gpuStack=%s",
+					selected.Name, selected.Value, tt.wantValue)
+			}
+			if selected.Advertiser != "" {
+				t.Fatalf("advertiser = %q, want empty (reserved)", selected.Advertiser)
+			}
+
+			// ownedPaths is the union across every value of the declaration,
+			// not just the selected one, and carries the synthetic presence
+			// path for each referenced component.
+			if !reflect.DeepEqual(selected.OwnedPaths, wantOwned) {
+				t.Fatalf("ownedPaths = %#v, want %#v", selected.OwnedPaths, wantOwned)
+			}
+
+			// The selected fragment's overrides must actually reach the
+			// componentRefs, not merely be recorded in metadata.
+			operator := result.GetComponentRef("gpu-operator")
+			if operator == nil {
+				t.Fatal("gpu-operator componentRef missing")
+			}
+			driver, ok := operator.Overrides["driver"].(map[string]any)
+			if !ok {
+				t.Fatalf("gpu-operator overrides.driver = %#v, want map", operator.Overrides["driver"])
+			}
+			if enabled, _ := driver["enabled"].(bool); enabled != tt.wantDriver {
+				t.Fatalf("driver.enabled = %v, want %v", driver["enabled"], tt.wantDriver)
+			}
+
+			dra := result.GetComponentRef("nvidia-dra-driver-gpu")
+			if dra == nil {
+				t.Fatal("nvidia-dra-driver-gpu componentRef missing")
+			}
+			if root, _ := dra.Overrides["nvidiaDriverRoot"].(string); root != tt.wantDriverRoot {
+				t.Fatalf("nvidiaDriverRoot = %q, want %q", dra.Overrides["nvidiaDriverRoot"], tt.wantDriverRoot)
+			}
+
+			// The artifact must survive the shared raw-artifact gate it will
+			// meet again on the bundle path.
+			if err := result.PrepareAndValidateWithContext(t.Context()); err != nil {
+				t.Fatalf("PrepareAndValidateWithContext() error = %v", err)
+			}
+		})
+	}
+}
+
+// TestProfileSelectionIsolatesOwnedPaths pins the blast radius of a selection:
+// switching values may move the owned paths and the recorded selection, and
+// nothing else.
+func TestProfileSelectionIsolatesOwnedPaths(t *testing.T) {
+	build := func(selection string) *RecipeResult {
+		t.Helper()
+		result, err := profiledBuilder(t).BuildFromCriteriaWithProfile(
+			t.Context(), profiledCriteria(), selection)
+		if err != nil {
+			t.Fatalf("BuildFromCriteriaWithProfile(%q) error = %v", selection, err)
+		}
+		return result
+	}
+
+	first := build("gpuStack=preinstalled")
+	second := build("gpuStack=operator-managed")
+
+	if len(first.ComponentRefs) != len(second.ComponentRefs) {
+		t.Fatalf("componentRef count changed: %d vs %d",
+			len(first.ComponentRefs), len(second.ComponentRefs))
+	}
+	for i := range first.ComponentRefs {
+		a, b := first.ComponentRefs[i], second.ComponentRefs[i]
+		if a.Name != b.Name {
+			t.Fatalf("componentRef order changed at %d: %q vs %q", i, a.Name, b.Name)
+		}
+		if a.Name == "gpu-operator" || a.Name == "nvidia-dra-driver-gpu" {
+			continue // the two components the profile owns
+		}
+		if !reflect.DeepEqual(a, b) {
+			t.Fatalf("unowned component %q differs between profile values", a.Name)
+		}
+	}
+	firstOwned := first.Metadata.SelectedProfile.OwnedPaths
+	secondOwned := second.Metadata.SelectedProfile.OwnedPaths
+	if !reflect.DeepEqual(firstOwned, secondOwned) {
+		t.Fatal("ownedPaths must be declaration-wide and identical across values")
+	}
+}
+
+func TestProfileResolutionFailsClosed(t *testing.T) {
+	tests := []struct {
+		name      string
+		selection string
+		wantErr   string
+	}{
+		{
+			name:      "unknown value",
+			selection: "gpuStack=does-not-exist",
+			wantErr:   `has no value "does-not-exist"`,
+		},
+		{
+			name:      "wrong declaration name",
+			selection: "notAProfile=preinstalled",
+			wantErr:   "declares profile",
+		},
+		{
+			name:      "malformed selection",
+			selection: "gpuStack",
+			wantErr:   "name=value",
+		},
+		{
+			// "gpuStack=" splits cleanly on its one "=", so it passes the
+			// shape check and fails on the empty value's identifier pattern —
+			// a different rejection than the malformed case above.
+			name:      "empty value",
+			selection: "gpuStack=",
+			wantErr:   "must match [A-Za-z0-9._-]+",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := profiledBuilder(t).BuildFromCriteriaWithProfile(
+				t.Context(), profiledCriteria(), tt.selection)
+			if err == nil {
+				t.Fatal("BuildFromCriteriaWithProfile() error = nil, want rejection")
+			}
+			// Match the message, not only the code: every rejection on this
+			// path is ErrCodeInvalidRequest, so the code alone cannot tell the
+			// intended failure from an unrelated validation error.
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("error = %v, want ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+// TestUnprofiledCriteriaStayLegacy is the other half of the biconditional: a
+// composition that reaches no profile declaration keeps the legacy apiVersion
+// and records no selection, even with the profiled overlay present.
+func TestUnprofiledCriteriaStayLegacy(t *testing.T) {
+	criteria := profiledCriteria()
+	criteria.Platform = "" // no longer matches the profiled leaf
+
+	result, err := profiledBuilder(t).BuildFromCriteria(t.Context(), criteria)
+	if err != nil {
+		t.Fatalf("BuildFromCriteria() error = %v", err)
+	}
+	if result.APIVersion != RecipeAPIVersion {
+		t.Fatalf("apiVersion = %q, want %q", result.APIVersion, RecipeAPIVersion)
+	}
+	if result.Metadata.SelectedProfile != nil {
+		t.Fatalf("selectedProfile = %#v, want nil for an unprofiled composition",
+			result.Metadata.SelectedProfile)
+	}
+}

--- a/pkg/recipe/profile_resolution.go
+++ b/pkg/recipe/profile_resolution.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+)
+
+type effectiveProfileDeclaration struct {
+	Source      string
+	Declaration *ProfileDeclaration
+}
+
+// resolveProfileDeclaration finds the one declaration reachable from every
+// criteria-matched candidate chain. It runs before snapshot filtering and
+// deduplicates the same declaring source reached through multiple chains.
+func (s *MetadataStore) resolveProfileDeclaration(overlays []*RecipeMetadata) (*effectiveProfileDeclaration, error) {
+	found := make(map[string]*ProfileDeclaration)
+	add := func(source string, metadata *RecipeMetadata) error {
+		if err := ValidateRecipeMetadataProfile(metadata); err != nil {
+			return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid profile contract in overlay %q", source))
+		}
+		if metadata != nil && metadata.Spec.Profile != nil {
+			found[source] = metadata.Spec.Profile
+		}
+		return nil
+	}
+
+	if err := add(baseRecipeName, s.Base); err != nil {
+		return nil, err
+	}
+	for _, overlay := range overlays {
+		chain, err := s.resolveInheritanceChain(overlay.Metadata.Name)
+		if err != nil {
+			return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("failed to resolve profile declaration for overlay %q", overlay.Metadata.Name))
+		}
+		for _, metadata := range chain {
+			source := metadata.Metadata.Name
+			if metadata == s.Base || source == "" {
+				source = baseRecipeName
+			}
+			if err := add(source, metadata); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(found) == 0 {
+		return nil, nil //nolint:nilnil // no declaration is a valid unprofiled composition
+	}
+	if len(found) > 1 {
+		sources := make([]string, 0, len(found))
+		for source := range found {
+			sources = append(sources, source)
+		}
+		sort.Strings(sources)
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("resolved composition has multiple profile declarations from %v", sources))
+	}
+	for source, declaration := range found {
+		return &effectiveProfileDeclaration{Source: source, Declaration: declaration}, nil
+	}
+	return nil, nil //nolint:nilnil // unreachable defensive fallback for an empty map
+}
+
+func ensureProfileDeclarationSurvived(
+	before, after *effectiveProfileDeclaration,
+	excluded []ExcludedOverlay,
+	warnings []ConstraintWarning,
+) error {
+
+	if before == nil {
+		return nil
+	}
+	if after != nil && after.Source == before.Source {
+		return nil
+	}
+	return errors.NewWithContext(
+		errors.ErrCodeInvalidRequest,
+		fmt.Sprintf("profile declaration from overlay %q was removed by snapshot constraint filtering", before.Source),
+		map[string]any{
+			"excludedOverlays":   excluded,
+			"constraintWarnings": warnings,
+		},
+	)
+}
+
+func (s *MetadataStore) resolveAppliedProfileDeclaration(
+	appliedOverlays []string,
+) (*effectiveProfileDeclaration, error) {
+
+	survivingOverlays := make([]*RecipeMetadata, 0, len(appliedOverlays))
+	for _, name := range appliedOverlays {
+		if name == baseRecipeName {
+			continue
+		}
+		if overlay, exists := s.Overlays[name]; exists {
+			survivingOverlays = append(survivingOverlays, overlay)
+		}
+	}
+	return s.resolveProfileDeclaration(survivingOverlays)
+}
+
+func applyEffectiveProfile(
+	mergedSpec *RecipeMetadataSpec,
+	effective *effectiveProfileDeclaration,
+	rawSelection string,
+	evaluator ConstraintEvaluatorFunc,
+) (*SelectedProfile, error) {
+
+	selection, err := ParseProfileSelection(rawSelection)
+	if err != nil {
+		return nil, err
+	}
+	if effective == nil {
+		if selection != nil {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile %q was selected, but the resolved composition declares no profile", selection.Name))
+		}
+		return nil, nil //nolint:nilnil // no declaration produces an unprofiled result
+	}
+
+	ownedPaths, err := ValidateProfileDeclaration(effective.Declaration)
+	if err != nil {
+		return nil, err
+	}
+	valueName := effective.Declaration.Default
+	if selection != nil {
+		if selection.Name != effective.Declaration.Name {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("resolved composition declares profile %q, not %q",
+					effective.Declaration.Name, selection.Name))
+		}
+		valueName = selection.Value
+	}
+	value, ok := effective.Declaration.Values[valueName]
+	if !ok {
+		names := make([]string, 0, len(effective.Declaration.Values))
+		for name := range effective.Declaration.Values {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return nil, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile %q has no value %q; valid values: %v",
+				effective.Declaration.Name, valueName, names))
+	}
+
+	componentIndex := make(map[string]int, len(mergedSpec.ComponentRefs))
+	for i := range mergedSpec.ComponentRefs {
+		componentIndex[mergedSpec.ComponentRefs[i].Name] = i
+	}
+	components := slices.Sorted(maps.Keys(ownedPaths))
+	for _, component := range components {
+		index, exists := componentIndex[component]
+		if !exists || !mergedSpec.ComponentRefs[index].IsEnabled() {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile %q references component %q, which is not enabled in the surviving composition",
+					effective.Declaration.Name, component))
+		}
+	}
+
+	constraintNames := make(map[string]struct{}, len(mergedSpec.Constraints))
+	for _, constraint := range mergedSpec.Constraints {
+		constraintNames[constraint.Name] = struct{}{}
+	}
+	for _, constraint := range value.Constraints {
+		if _, collision := constraintNames[constraint.Name]; collision {
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile %q value %q constraint %q collides with the composed recipe",
+					effective.Declaration.Name, valueName, constraint.Name))
+		}
+		constraintNames[constraint.Name] = struct{}{}
+		if evaluator != nil {
+			result := evaluator(constraint)
+			switch {
+			case result.Error != nil && isNotFoundEvalError(result.Error):
+				return nil, errors.NewWithContext(
+					errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %s=%s cannot be validated because reading %q is unavailable",
+						effective.Declaration.Name, valueName, constraint.Name),
+					map[string]any{
+						constraintContextKey: constraint.Name,
+						"expected":           constraint.Value,
+						"actual":             result.Actual,
+						"cause":              result.Error.Error(),
+					},
+				)
+			case result.Error != nil:
+				return nil, errors.PropagateOrWrap(result.Error, errors.ErrCodeInternal,
+					fmt.Sprintf("failed to evaluate profile constraint %q", constraint.Name))
+			case !result.Passed:
+				return nil, errors.NewWithContext(
+					errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %s=%s constraint %q failed",
+						effective.Declaration.Name, valueName, constraint.Name),
+					map[string]any{
+						constraintContextKey: constraint.Name,
+						"expected":           constraint.Value,
+						"actual":             result.Actual,
+					},
+				)
+			}
+		}
+		mergedSpec.Constraints = append(mergedSpec.Constraints, constraint)
+	}
+	sort.Slice(mergedSpec.Constraints, func(i, j int) bool {
+		return mergedSpec.Constraints[i].Name < mergedSpec.Constraints[j].Name
+	})
+
+	for _, profileRef := range value.ComponentRefs {
+		index := componentIndex[profileRef.Name]
+		if mergedSpec.ComponentRefs[index].Overrides == nil {
+			mergedSpec.ComponentRefs[index].Overrides = make(map[string]any)
+		} else {
+			mergedSpec.ComponentRefs[index].Overrides =
+				serializer.DeepCopyAnyMap(mergedSpec.ComponentRefs[index].Overrides)
+		}
+		deepMergeMap(mergedSpec.ComponentRefs[index].Overrides, profileRef.Overrides)
+	}
+
+	return &SelectedProfile{
+		Name:       effective.Declaration.Name,
+		Value:      valueName,
+		Advertiser: value.Advertiser,
+		OwnedPaths: cloneOwnedPaths(ownedPaths),
+	}, nil
+}

--- a/pkg/recipe/profile_test.go
+++ b/pkg/recipe/profile_test.go
@@ -1,0 +1,2087 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+	"gopkg.in/yaml.v3"
+)
+
+func testProfileDeclaration() *ProfileDeclaration {
+	return &ProfileDeclaration{
+		Name:        "gpuStack",
+		Description: "Who installs the GPU driver and toolkit.",
+		Default:     "driver-installed",
+		Values: map[string]ProfileValue{
+			"driver-installed": {
+				ComponentRefs: []ProfileComponentRef{{
+					Name: "gpu-operator",
+					Overrides: map[string]any{
+						"driver":  map[string]any{"enabled": false},
+						"toolkit": map[string]any{"enabled": false},
+					},
+				}},
+			},
+			"operator-managed": {
+				ComponentRefs: []ProfileComponentRef{{
+					Name: "gpu-operator",
+					Overrides: map[string]any{
+						"driver":  map[string]any{"enabled": true},
+						"toolkit": map[string]any{"enabled": true},
+					},
+				}},
+			},
+		},
+	}
+}
+
+func testProfileStore(declaration *ProfileDeclaration) *MetadataStore {
+	base := &RecipeMetadata{}
+	base.Metadata.Name = baseRecipeName
+	base.Spec.ComponentRefs = []ComponentRef{{
+		Name: "gpu-operator",
+		Type: ComponentTypeHelm,
+	}}
+
+	overlay := &RecipeMetadata{
+		RecipeMetadataHeader: RecipeMetadataHeader{
+			APIVersion: RecipeProfileAPIVersion,
+			Kind:       RecipeMetadataKind,
+		},
+	}
+	overlay.Metadata.Name = "aks"
+	overlay.Spec.Criteria = &Criteria{Service: CriteriaServiceAKS}
+	overlay.Spec.Profile = declaration
+
+	return &MetadataStore{
+		Base: base,
+		Overlays: map[string]*RecipeMetadata{
+			"aks": overlay,
+		},
+	}
+}
+
+func TestParseProfileSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    *ProfileSelection
+		wantErr bool
+	}{
+		{name: "empty uses default"},
+		{
+			name: "valid",
+			raw:  "gpuStack=operator-managed",
+			want: &ProfileSelection{Name: "gpuStack", Value: "operator-managed"},
+		},
+		{name: "missing equals", raw: "gpuStack", wantErr: true},
+		{name: "multiple equals", raw: "gpuStack=x=y", wantErr: true},
+		{name: "whitespace", raw: " gpuStack=x", wantErr: true},
+		{name: "empty name", raw: "=x", wantErr: true},
+		{name: "empty value", raw: "gpuStack=", wantErr: true},
+		{name: "invalid character", raw: "gpuStack=x/y", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseProfileSelection(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseProfileSelection() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ParseProfileSelection() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateProfileDeclaration(t *testing.T) {
+	valid := testProfileDeclaration()
+	withOverride := func(component string, overrides map[string]any) *ProfileDeclaration {
+		return &ProfileDeclaration{
+			Name:    "mode",
+			Default: "one",
+			Values: map[string]ProfileValue{
+				"one": {ComponentRefs: []ProfileComponentRef{{Name: component, Overrides: overrides}}},
+				"two": {ComponentRefs: []ProfileComponentRef{{Name: component, Overrides: overrides}}},
+			},
+		}
+	}
+	cyclicMap := map[string]any{}
+	cyclicMap["self"] = cyclicMap
+	cyclicSlice := make([]any, 1)
+	cyclicSlice[0] = cyclicSlice
+	pointerMap := &map[string]any{"enabled": true}
+	sharedMap := map[string]any{"enabled": true}
+
+	tests := []struct {
+		name      string
+		decl      *ProfileDeclaration
+		wantOwned map[string][]string
+		wantErr   string
+	}{
+		{
+			name: "valid",
+			decl: valid,
+			wantOwned: map[string][]string{
+				"gpu-operator": {"driver.enabled", "enabled", "toolkit.enabled"},
+			},
+		},
+		{
+			name: "list leaf is valid",
+			decl: withOverride("gpu-operator", map[string]any{
+				"tolerations": []any{map[string]any{"key": "gpu"}},
+			}),
+			wantOwned: map[string][]string{
+				"gpu-operator": {"enabled", "tolerations"},
+			},
+		},
+		{
+			name: "maximum JSON round-trip-safe integer is valid",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": int64(profileJSONSafeIntegerMax),
+			}),
+			wantOwned: map[string][]string{
+				"gpu-operator": {"driver", "enabled"},
+			},
+		},
+		{
+			name: "integer outside JSON round-trip-safe range is unsupported",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": uint64(profileJSONSafeIntegerMax + 1),
+			}),
+			wantErr: "outside the JSON round-trip-safe range",
+		},
+		{
+			name: "typed list is unsupported",
+			decl: withOverride("gpu-operator", map[string]any{
+				"tolerations": []map[string]any{{"key": "gpu"}},
+			}),
+			wantErr: "unsupported list type",
+		},
+		{
+			name: "pointer wrapped mapping is unsupported",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": pointerMap,
+			}),
+			wantErr: "unsupported pointer type",
+		},
+		{
+			name: "shared acyclic map is valid",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver":  sharedMap,
+				"toolkit": sharedMap,
+			}),
+			wantOwned: map[string][]string{
+				"gpu-operator": {"driver.enabled", "enabled", "toolkit.enabled"},
+			},
+		},
+		{
+			name: "function scalar is unsupported",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": func() {},
+			}),
+			wantErr: "unsupported scalar type",
+		},
+		{
+			name: "channel scalar is unsupported",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": make(chan bool),
+			}),
+			wantErr: "unsupported scalar type",
+		},
+		{
+			name: "struct scalar is unsupported",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": struct{ Enabled bool }{Enabled: true},
+			}),
+			wantErr: "unsupported scalar type",
+		},
+		{
+			name: "non-string nested mapping key",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": map[any]any{42: false},
+			}),
+			wantErr: "non-string mapping key",
+		},
+		{
+			name: "non-string mapping key inside list",
+			decl: withOverride("gpu-operator", map[string]any{
+				"tolerations": []any{map[any]any{42: "gpu"}},
+			}),
+			wantErr: "non-string mapping key",
+		},
+		{
+			name: "unsupported typed map",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": map[int]any{1: false},
+			}),
+			wantErr: "unsupported map type",
+		},
+		{
+			name: "unsupported typed list containing typed map",
+			decl: withOverride("gpu-operator", map[string]any{
+				"tolerations": []map[int]any{{1: "gpu"}},
+			}),
+			wantErr: "unsupported list type",
+		},
+		{
+			name: "cyclic map",
+			decl: withOverride("gpu-operator", map[string]any{
+				"driver": cyclicMap,
+			}),
+			wantErr: "cyclic reference",
+		},
+		{
+			name: "cyclic slice",
+			decl: withOverride("gpu-operator", map[string]any{
+				"tolerations": cyclicSlice,
+			}),
+			wantErr: "cyclic reference",
+		},
+		{name: "nil declaration", wantErr: "required"},
+		{
+			name:    "invalid name",
+			decl:    &ProfileDeclaration{Name: "gpu stack", Default: "one", Values: map[string]ProfileValue{"one": {}}},
+			wantErr: "profile name",
+		},
+		{
+			name:    "missing default value",
+			decl:    &ProfileDeclaration{Name: "mode", Default: "missing", Values: map[string]ProfileValue{"one": {}}},
+			wantErr: "is not a declared value",
+		},
+		{
+			name:    "invalid value name",
+			decl:    &ProfileDeclaration{Name: "mode", Default: "one", Values: map[string]ProfileValue{"one": {}, "bad/value": {}}},
+			wantErr: "profile value",
+		},
+		{
+			name:    "no values",
+			decl:    &ProfileDeclaration{Name: "mode", Default: "one"},
+			wantErr: "at least one value",
+		},
+		{
+			name:    "literal dotted key",
+			decl:    withOverride("gpu-operator", map[string]any{"driver.enabled": false}),
+			wantErr: "literal dot",
+		},
+		{
+			name:    "empty nested map",
+			decl:    withOverride("gpu-operator", map[string]any{"driver": map[string]any{}}),
+			wantErr: "empty map",
+		},
+		{
+			name:    "root enabled assignment",
+			decl:    withOverride("gpu-operator", map[string]any{"enabled": false}),
+			wantErr: "may not assign overrides.enabled",
+		},
+		{
+			name: "root enabled map assignment",
+			decl: withOverride("gpu-operator", map[string]any{
+				"enabled": map[string]any{"nested": true},
+			}),
+			wantErr: "may not assign overrides.enabled",
+		},
+		{
+			name: "duplicate component",
+			decl: &ProfileDeclaration{
+				Name: "mode", Default: "one",
+				Values: map[string]ProfileValue{
+					"one": {ComponentRefs: []ProfileComponentRef{
+						{Name: "gpu-operator"},
+						{Name: "gpu-operator"},
+					}},
+				},
+			},
+			wantErr: "repeats componentRef",
+		},
+		{
+			name: "union totality",
+			decl: &ProfileDeclaration{
+				Name: "mode", Default: "one",
+				Values: map[string]ProfileValue{
+					"one": {ComponentRefs: []ProfileComponentRef{{
+						Name: "gpu-operator", Overrides: map[string]any{
+							"driver": map[string]any{"enabled": true},
+						},
+					}}},
+					"two": {ComponentRefs: []ProfileComponentRef{{
+						Name: "gpu-operator", Overrides: map[string]any{
+							"toolkit": map[string]any{"enabled": true},
+						},
+					}}},
+				},
+			},
+			wantErr: "union totality",
+		},
+		{
+			// Totality is evaluated over leaf-flattened override paths only,
+			// before synthetic presence is added, so values may legitimately
+			// differ in which components they reference presence-only. The
+			// synthetic marker still lands in the declaration-wide OwnedPaths
+			// for every referenced component, which is what locks nfd's
+			// presence regardless of the selected value.
+			name: "presence-only componentRef is exempt from union totality",
+			decl: &ProfileDeclaration{
+				Name: "mode", Default: "one",
+				Values: map[string]ProfileValue{
+					"one": {ComponentRefs: []ProfileComponentRef{
+						{Name: "gpu-operator", Overrides: map[string]any{
+							"driver": map[string]any{"enabled": true},
+						}},
+						{Name: "nfd"},
+					}},
+					"two": {ComponentRefs: []ProfileComponentRef{
+						{Name: "gpu-operator", Overrides: map[string]any{
+							"driver": map[string]any{"enabled": false},
+						}},
+					}},
+				},
+			},
+			wantOwned: map[string][]string{
+				"gpu-operator": {"driver.enabled", "enabled"},
+				"nfd":          {"enabled"},
+			},
+		},
+		{
+			name: "constraint without a name",
+			decl: &ProfileDeclaration{
+				Name: "mode", Default: "one",
+				Values: map[string]ProfileValue{
+					"one": {Constraints: []Constraint{{Value: ">= 1.32"}}},
+				},
+			},
+			wantErr: "declares a constraint with no name",
+		},
+		{
+			name: "constraint without a value",
+			decl: &ProfileDeclaration{
+				Name: "mode", Default: "one",
+				Values: map[string]ProfileValue{
+					"one": {Constraints: []Constraint{{Name: "K8s.server.version"}}},
+				},
+			},
+			wantErr: `constraint "K8s.server.version" has no value`,
+		},
+		{
+			name: "repeated constraint name within a value",
+			decl: &ProfileDeclaration{
+				Name: "mode", Default: "one",
+				Values: map[string]ProfileValue{
+					"one": {Constraints: []Constraint{
+						{Name: "K8s.server.version", Value: ">= 1.32"},
+						{Name: "K8s.server.version", Value: ">= 1.33"},
+					}},
+				},
+			},
+			wantErr: `repeats constraint "K8s.server.version"`,
+		},
+		{
+			name: "advertiser deferred",
+			decl: &ProfileDeclaration{
+				Name: "mode", Default: "one",
+				Values: map[string]ProfileValue{"one": {Advertiser: "external"}},
+			},
+			wantErr: "deferred to the GKE",
+		},
+		{
+			name:    "allocation policy deferred",
+			decl:    withOverride("gpu-operator", map[string]any{"devicePlugin": map[string]any{"enabled": false}}),
+			wantErr: "deferred allocation-policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owned, err := ValidateProfileDeclaration(tt.decl)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ValidateProfileDeclaration() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateProfileDeclaration() error = %v", err)
+			}
+			if !reflect.DeepEqual(owned, tt.wantOwned) {
+				t.Fatalf("owned paths = %#v, want %#v", owned, tt.wantOwned)
+			}
+		})
+	}
+}
+
+func TestValidateRecipeMetadataProfileYAMLScalars(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantErr  string
+		wantTime bool
+	}{
+		{
+			name:  "finite float accepted",
+			value: "1.5",
+		},
+		{
+			name:    "NaN rejected",
+			value:   ".nan",
+			wantErr: "non-finite float",
+		},
+		{
+			name:    "infinity rejected",
+			value:   ".inf",
+			wantErr: "non-finite float",
+		},
+		{
+			name:     "timestamp accepted",
+			value:    "2026-07-28T00:00:00Z",
+			wantTime: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var metadata RecipeMetadata
+			data := fmt.Sprintf(`apiVersion: aicr.run/v1alpha3
+kind: RecipeMetadata
+metadata:
+  name: scalar-test
+spec:
+  profile:
+    name: mode
+    default: one
+    values:
+      one:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                value: %s
+`, tt.value)
+			if err := yaml.Unmarshal([]byte(data), &metadata); err != nil {
+				t.Fatalf("yaml.Unmarshal() error = %v", err)
+			}
+			scalar := metadata.Spec.Profile.Values["one"].ComponentRefs[0].
+				Overrides["driver"].(map[string]any)["value"]
+			if tt.wantTime {
+				if _, ok := scalar.(time.Time); !ok {
+					t.Fatalf("decoded scalar type = %T, want time.Time", scalar)
+				}
+			}
+
+			err := ValidateRecipeMetadataProfile(&metadata)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateRecipeMetadataProfile() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateRecipeMetadataProfile() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildRecipeResultWithProfile(t *testing.T) {
+	ctx := context.Background()
+	criteria := &Criteria{Service: CriteriaServiceAKS}
+	store := testProfileStore(testProfileDeclaration())
+
+	tests := []struct {
+		name           string
+		selection      string
+		wantValue      string
+		wantDriver     bool
+		wantToolkit    bool
+		wantErr        string
+		wantAPIVersion string
+	}{
+		{
+			name:           "declared default",
+			wantValue:      "driver-installed",
+			wantDriver:     false,
+			wantToolkit:    false,
+			wantAPIVersion: RecipeProfileAPIVersion,
+		},
+		{
+			name:           "explicit value",
+			selection:      "gpuStack=operator-managed",
+			wantValue:      "operator-managed",
+			wantDriver:     true,
+			wantToolkit:    true,
+			wantAPIVersion: RecipeProfileAPIVersion,
+		},
+		{name: "wrong profile name", selection: "other=operator-managed", wantErr: "declares profile"},
+		{name: "unknown value", selection: "gpuStack=missing", wantErr: "valid values"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := store.BuildRecipeResultWithProfile(ctx, criteria, tt.selection)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("BuildRecipeResultWithProfile() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildRecipeResultWithProfile() error = %v", err)
+			}
+			if result.APIVersion != tt.wantAPIVersion {
+				t.Fatalf("apiVersion = %q, want %q", result.APIVersion, tt.wantAPIVersion)
+			}
+			if result.Metadata.SelectedProfile == nil ||
+				result.Metadata.SelectedProfile.Value != tt.wantValue {
+
+				t.Fatalf("selectedProfile = %#v, want value %q", result.Metadata.SelectedProfile, tt.wantValue)
+			}
+			values, valuesErr := result.GetValuesForComponentWithContext(ctx, "gpu-operator")
+			if valuesErr != nil {
+				t.Fatalf("GetValuesForComponentWithContext() error = %v", valuesErr)
+			}
+			driver := values["driver"].(map[string]any)
+			toolkit := values["toolkit"].(map[string]any)
+			if driver["enabled"] != tt.wantDriver || toolkit["enabled"] != tt.wantToolkit {
+				t.Fatalf("selected values driver=%v toolkit=%v, want driver=%v toolkit=%v",
+					driver["enabled"], toolkit["enabled"], tt.wantDriver, tt.wantToolkit)
+			}
+		})
+	}
+
+	t.Run("selection without declaration fails", func(t *testing.T) {
+		legacy := testProfileStore(nil)
+		legacy.Overlays["aks"].APIVersion = RecipeAPIVersion
+		result, err := legacy.BuildRecipeResultWithProfile(ctx, criteria, "gpuStack=operator-managed")
+		if err == nil || result != nil {
+			t.Fatalf("BuildRecipeResultWithProfile() = (%#v, %v), want error", result, err)
+		}
+	})
+
+	t.Run("composition without declaration stays legacy", func(t *testing.T) {
+		legacy := testProfileStore(nil)
+		legacy.Overlays["aks"].APIVersion = RecipeAPIVersion
+		result, err := legacy.BuildRecipeResult(ctx, criteria)
+		if err != nil {
+			t.Fatalf("BuildRecipeResult() error = %v", err)
+		}
+		if result.APIVersion != RecipeAPIVersion || result.Metadata.SelectedProfile != nil {
+			t.Fatalf("legacy result apiVersion=%q selectedProfile=%#v",
+				result.APIVersion, result.Metadata.SelectedProfile)
+		}
+	})
+}
+
+func TestProfileResolutionGuards(t *testing.T) {
+	base := &RecipeMetadata{}
+	base.Metadata.Name = baseRecipeName
+	base.Spec.ComponentRefs = []ComponentRef{{Name: "gpu-operator", Type: ComponentTypeHelm}}
+
+	newOverlay := func(name string, criteria *Criteria, profile *ProfileDeclaration) *RecipeMetadata {
+		overlay := &RecipeMetadata{}
+		overlay.Metadata.Name = name
+		overlay.Spec.Criteria = criteria
+		overlay.Spec.Profile = profile
+		if profile != nil {
+			overlay.APIVersion = RecipeProfileAPIVersion
+		}
+		return overlay
+	}
+
+	t.Run("typed declaration requires profile api version", func(t *testing.T) {
+		overlay := newOverlay("service", &Criteria{Service: CriteriaServiceAKS}, testProfileDeclaration())
+		overlay.APIVersion = RecipeAPIVersion
+		store := &MetadataStore{
+			Base:     base,
+			Overlays: map[string]*RecipeMetadata{"service": overlay},
+		}
+		_, err := store.BuildRecipeResult(
+			context.Background(),
+			&Criteria{Service: CriteriaServiceAKS},
+		)
+		if err == nil || !strings.Contains(err.Error(), "declares spec.profile") {
+			t.Fatalf("BuildRecipeResult() error = %v, want profile apiVersion failure", err)
+		}
+	})
+
+	t.Run("independent declarations fail before composition", func(t *testing.T) {
+		store := &MetadataStore{
+			Base: base,
+			Overlays: map[string]*RecipeMetadata{
+				"service": newOverlay("service", &Criteria{Service: CriteriaServiceAKS}, testProfileDeclaration()),
+				"gpu": newOverlay("gpu", &Criteria{Accelerator: CriteriaAcceleratorH100}, &ProfileDeclaration{
+					Name: "other", Default: "one", Values: map[string]ProfileValue{"one": {}},
+				}),
+			},
+		}
+		_, err := store.BuildRecipeResult(context.Background(), &Criteria{
+			Service: CriteriaServiceAKS, Accelerator: CriteriaAcceleratorH100,
+		})
+		if err == nil || !strings.Contains(err.Error(), "multiple profile declarations") {
+			t.Fatalf("BuildRecipeResult() error = %v, want uniqueness failure", err)
+		}
+	})
+
+	t.Run("same declaring ancestor reached twice is deduplicated", func(t *testing.T) {
+		owner := newOverlay("owner", &Criteria{Service: CriteriaServiceAKS}, testProfileDeclaration())
+		leafGPU := newOverlay("leaf-gpu", &Criteria{
+			Service: CriteriaServiceAKS, Accelerator: CriteriaAcceleratorH100,
+		}, nil)
+		leafGPU.Spec.Base = "owner"
+		leafIntent := newOverlay("leaf-intent", &Criteria{
+			Service: CriteriaServiceAKS, Intent: CriteriaIntentTraining,
+		}, nil)
+		leafIntent.Spec.Base = "owner"
+		store := &MetadataStore{
+			Base: base,
+			Overlays: map[string]*RecipeMetadata{
+				"owner":       owner,
+				"leaf-gpu":    leafGPU,
+				"leaf-intent": leafIntent,
+			},
+		}
+		result, err := store.BuildRecipeResult(context.Background(), &Criteria{
+			Service: CriteriaServiceAKS, Accelerator: CriteriaAcceleratorH100,
+			Intent: CriteriaIntentTraining,
+		})
+		if err != nil {
+			t.Fatalf("BuildRecipeResult() error = %v", err)
+		}
+		if result.Metadata.SelectedProfile == nil {
+			t.Fatal("selectedProfile is nil")
+		}
+	})
+
+	t.Run("missing components are reported deterministically", func(t *testing.T) {
+		declaration := &ProfileDeclaration{
+			Name:    "mode",
+			Default: "one",
+			Values: map[string]ProfileValue{
+				"one": {
+					ComponentRefs: []ProfileComponentRef{
+						{Name: "z-component"},
+						{Name: "a-component"},
+					},
+				},
+			},
+		}
+		store := &MetadataStore{
+			Base: base,
+			Overlays: map[string]*RecipeMetadata{
+				"service": newOverlay(
+					"service",
+					&Criteria{Service: CriteriaServiceAKS},
+					declaration,
+				),
+			},
+		}
+		for range 100 {
+			_, err := store.BuildRecipeResult(
+				context.Background(),
+				&Criteria{Service: CriteriaServiceAKS},
+			)
+			if err == nil || !strings.Contains(err.Error(), `"a-component"`) {
+				t.Fatalf("BuildRecipeResult() error = %v, want first missing component a-component", err)
+			}
+		}
+	})
+
+	t.Run("snapshot exclusion cannot remove declaration", func(t *testing.T) {
+		owner := newOverlay("owner", &Criteria{Service: CriteriaServiceAKS}, testProfileDeclaration())
+		owner.Spec.Constraints = []Constraint{{Name: "signal", Value: "installed"}}
+		store := &MetadataStore{
+			Base: base,
+			Overlays: map[string]*RecipeMetadata{
+				"owner": owner,
+			},
+		}
+		_, err := store.BuildRecipeResultWithEvaluator(
+			context.Background(),
+			&Criteria{Service: CriteriaServiceAKS},
+			func(_ Constraint) ConstraintEvalResult {
+				return ConstraintEvalResult{Passed: false, Actual: "operator"}
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "removed by snapshot constraint filtering") {
+			t.Fatalf("BuildRecipeResultWithEvaluator() error = %v, want survival failure", err)
+		}
+	})
+
+	t.Run("selected constraints fail closed", func(t *testing.T) {
+		declaration := testProfileDeclaration()
+		value := declaration.Values["driver-installed"]
+		value.Constraints = []Constraint{{Name: "signal", Value: "driver-installed"}}
+		declaration.Values["driver-installed"] = value
+		store := testProfileStore(declaration)
+		_, err := store.BuildRecipeResultWithEvaluator(
+			context.Background(),
+			&Criteria{Service: CriteriaServiceAKS},
+			func(_ Constraint) ConstraintEvalResult {
+				return ConstraintEvalResult{Passed: false, Actual: "operator-managed"}
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "profile gpuStack=driver-installed constraint") {
+			t.Fatalf("BuildRecipeResultWithEvaluator() error = %v, want profile constraint failure", err)
+		}
+	})
+
+	t.Run("missing profile reading is distinguishable", func(t *testing.T) {
+		declaration := testProfileDeclaration()
+		value := declaration.Values["driver-installed"]
+		value.Constraints = []Constraint{{Name: "signal", Value: "driver-installed"}}
+		declaration.Values["driver-installed"] = value
+		store := testProfileStore(declaration)
+		_, err := store.BuildRecipeResultWithEvaluator(
+			context.Background(),
+			&Criteria{Service: CriteriaServiceAKS},
+			func(_ Constraint) ConstraintEvalResult {
+				return ConstraintEvalResult{
+					Error: aicrerrors.New(aicrerrors.ErrCodeNotFound, "missing"),
+				}
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "reading \"signal\" is unavailable") {
+			t.Fatalf("BuildRecipeResultWithEvaluator() error = %v, want unavailable-reading diagnostic", err)
+		}
+	})
+}
+
+func TestProfileArtifactContract(t *testing.T) {
+	selected := &SelectedProfile{
+		Name:  "gpuStack",
+		Value: "driver-installed",
+		OwnedPaths: map[string][]string{
+			"gpu-operator": {"driver.enabled", "enabled"},
+		},
+	}
+	profileResult := func(metadata RecipeResultMetadata) *RecipeResult {
+		metadata.SelectedProfile = selected
+		return &RecipeResult{
+			APIVersion: RecipeProfileAPIVersion,
+			Metadata:   metadata,
+		}
+	}
+	validWarning := ConstraintWarning{
+		Overlay:    "overlay-a",
+		Constraint: "signal",
+		Expected:   "ready",
+		Reason:     "constraint did not match",
+	}
+	warningWithoutConstraint := validWarning
+	warningWithoutConstraint.Constraint = ""
+	warningWithoutExpected := validWarning
+	warningWithoutExpected.Expected = ""
+	warningWithoutReason := validWarning
+	warningWithoutReason.Reason = ""
+
+	tests := []struct {
+		name    string
+		result  *RecipeResult
+		wantErr string
+	}{
+		{name: "legacy", result: &RecipeResult{APIVersion: RecipeAPIVersion}},
+		{
+			name: "profile",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata:   RecipeResultMetadata{SelectedProfile: selected},
+			},
+		},
+		{
+			name: "profile metadata items",
+			result: profileResult(RecipeResultMetadata{
+				ExcludedOverlays: []ExcludedOverlay{{
+					Name:   "overlay-a",
+					Reason: ExcludedOverlayReasonMixinConstraintFailed,
+				}},
+				ConstraintWarnings: []ConstraintWarning{validWarning},
+			}),
+		},
+		{
+			name: "profile excluded overlay requires name",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{
+					SelectedProfile: selected,
+					ExcludedOverlays: []ExcludedOverlay{{
+						Reason: ExcludedOverlayReasonConstraintFailed,
+					}},
+				},
+			},
+			wantErr: "excludedOverlays[0].name is required",
+		},
+		{
+			name: "profile excluded overlay rejects unknown reason",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{
+					SelectedProfile: selected,
+					ExcludedOverlays: []ExcludedOverlay{{
+						Name: "overlay-a", Reason: ExcludedOverlayReason("unknown"),
+					}},
+				},
+			},
+			wantErr: `excludedOverlays[0].reason "unknown" is unsupported`,
+		},
+		{
+			name: "profile excluded overlay permits missing legacy reason",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{
+					SelectedProfile:  selected,
+					ExcludedOverlays: []ExcludedOverlay{{Name: "overlay-a"}},
+				},
+			},
+		},
+		{
+			name:    "profile constraint warning requires overlay",
+			result:  profileResult(RecipeResultMetadata{ConstraintWarnings: []ConstraintWarning{{}}}),
+			wantErr: "constraintWarnings[0].overlay is required",
+		},
+		{
+			name: "profile constraint warning requires constraint",
+			result: profileResult(RecipeResultMetadata{
+				ConstraintWarnings: []ConstraintWarning{warningWithoutConstraint},
+			}),
+			wantErr: "constraintWarnings[0].constraint is required",
+		},
+		{
+			name: "profile constraint warning requires expected",
+			result: profileResult(RecipeResultMetadata{
+				ConstraintWarnings: []ConstraintWarning{warningWithoutExpected},
+			}),
+			wantErr: "constraintWarnings[0].expected is required",
+		},
+		{
+			name: "profile constraint warning requires reason",
+			result: profileResult(RecipeResultMetadata{
+				ConstraintWarnings: []ConstraintWarning{warningWithoutReason},
+			}),
+			wantErr: "constraintWarnings[0].reason is required",
+		},
+		{
+			name: "legacy with selection",
+			result: &RecipeResult{
+				APIVersion: RecipeAPIVersion,
+				Metadata:   RecipeResultMetadata{SelectedProfile: selected},
+			},
+			wantErr: "cannot carry",
+		},
+		{
+			name:    "profile version without selection",
+			result:  &RecipeResult{APIVersion: RecipeProfileAPIVersion},
+			wantErr: "requires",
+		},
+		{
+			name:    "unknown version",
+			result:  &RecipeResult{APIVersion: "aicr.run/v99"},
+			wantErr: "unsupported",
+		},
+		{
+			name: "unsorted ownership paths",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed",
+					OwnedPaths: map[string][]string{"gpu-operator": {"enabled", "driver.enabled"}},
+				}},
+			},
+			wantErr: "lexicographically sorted",
+		},
+		{
+			name: "ownership component requires synthetic enabled path",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed",
+					OwnedPaths: map[string][]string{"gpu-operator": {"driver.enabled"}},
+				}},
+			},
+			wantErr: "must include synthetic path",
+		},
+		{
+			name: "invalid selection identity",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpu stack", Value: "driver-installed", OwnedPaths: map[string][]string{},
+				}},
+			},
+			wantErr: "name and value",
+		},
+		{
+			name: "advertiser deferred",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed", Advertiser: "external",
+					OwnedPaths: map[string][]string{},
+				}},
+			},
+			wantErr: "advertiser is deferred",
+		},
+		{
+			name: "ownership map required",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed",
+				}},
+			},
+			wantErr: "ownedPaths is required",
+		},
+		{
+			name: "empty ownership component",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed",
+					OwnedPaths: map[string][]string{"": {"enabled"}},
+				}},
+			},
+			wantErr: "empty component name",
+		},
+		{
+			name: "invalid ownership path",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed",
+					OwnedPaths: map[string][]string{"gpu-operator": {".driver", "enabled"}},
+				}},
+			},
+			wantErr: "invalid path",
+		},
+		{
+			name: "duplicate ownership path",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed",
+					OwnedPaths: map[string][]string{"gpu-operator": {"enabled", "enabled"}},
+				}},
+			},
+			wantErr: "repeats path",
+		},
+		{
+			name: "allocation policy ownership deferred",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Metadata: RecipeResultMetadata{SelectedProfile: &SelectedProfile{
+					Name: "gpuStack", Value: "driver-installed",
+					OwnedPaths: map[string][]string{
+						"gpu-operator": {"devicePlugin.enabled", "enabled"},
+					},
+				}},
+			},
+			wantErr: "deferred allocation-policy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.result.ValidateProfileContract()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateProfileContract() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateProfileContract() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeRecipeResult_ProfileStrictness(t *testing.T) {
+	valid := []byte(`apiVersion: aicr.run/v1alpha3
+kind: RecipeResult
+metadata:
+  selectedProfile:
+    name: gpuStack
+    value: driver-installed
+    ownedPaths: {}
+componentRefs: []
+`)
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{name: "valid", data: valid},
+		{
+			name:    "unknown field",
+			data:    []byte(strings.Replace(string(valid), "componentRefs:", "profie: typo\ncomponentRefs:", 1)),
+			wantErr: "field profie not found",
+		},
+		{
+			name: "unknown excluded overlay field",
+			data: []byte(strings.Replace(
+				string(valid),
+				"  selectedProfile:",
+				"  excludedOverlays:\n    - name: overlay-a\n      reasn: constraint-failed\n  selectedProfile:",
+				1,
+			)),
+			wantErr: `unknown field "reasn"`,
+		},
+		{
+			name: "excluded overlay must be object",
+			data: []byte(strings.Replace(
+				string(valid),
+				"  selectedProfile:",
+				"  excludedOverlays:\n    - 42\n  selectedProfile:",
+				1,
+			)),
+			wantErr: "must be an object",
+		},
+		{
+			name: "excluded overlay fields must be strings",
+			data: []byte(strings.Replace(
+				string(valid),
+				"  selectedProfile:",
+				"  excludedOverlays:\n    - name: 42\n  selectedProfile:",
+				1,
+			)),
+			wantErr: `field "name"`,
+		},
+		{
+			name: "excluded overlay requires name",
+			data: []byte(strings.Replace(
+				string(valid),
+				"  selectedProfile:",
+				"  excludedOverlays:\n    - reason: constraint-failed\n  selectedProfile:",
+				1,
+			)),
+			wantErr: "excluded overlay object requires a non-empty name",
+		},
+		{
+			name: "excluded overlay rejects unknown reason",
+			data: []byte(strings.Replace(
+				string(valid),
+				"  selectedProfile:",
+				"  excludedOverlays:\n    - name: overlay-a\n      reason: unknown\n  selectedProfile:",
+				1,
+			)),
+			wantErr: `excludedOverlays[0].reason "unknown" is unsupported`,
+		},
+		{
+			name: "constraint warning requires fields",
+			data: []byte(strings.Replace(
+				string(valid),
+				"  selectedProfile:",
+				"  constraintWarnings:\n    - {}\n  selectedProfile:",
+				1,
+			)),
+			wantErr: "constraintWarnings[0].overlay is required",
+		},
+		{
+			name:    "profile version requires kind",
+			data:    []byte(strings.Replace(string(valid), "kind: RecipeResult\n", "", 1)),
+			wantErr: `requires kind "RecipeResult"`,
+		},
+		{
+			name:    "trailing document",
+			data:    append(append([]byte(nil), valid...), []byte("---\nkind: RecipeResult\n")...),
+			wantErr: "trailing document",
+		},
+		{
+			name:    "legacy version with selected profile",
+			data:    []byte(strings.Replace(string(valid), RecipeProfileAPIVersion, RecipeAPIVersion, 1)),
+			wantErr: "cannot carry",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := DecodeRecipeResult(tt.data, serializer.FormatYAML)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("DecodeRecipeResult() error = %v", err)
+				}
+				if result.Metadata.SelectedProfile == nil {
+					t.Fatal("selectedProfile is nil")
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("DecodeRecipeResult() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeRecipeResult_ProfileStrictJSONExcludedOverlays(t *testing.T) {
+	const prefix = `{
+  "apiVersion": "aicr.run/v1alpha3",
+  "kind": "RecipeResult",
+  "metadata": {
+    "excludedOverlays": [`
+	const suffix = `],
+    "selectedProfile": {
+      "name": "gpuStack",
+      "value": "driver-installed",
+      "ownedPaths": {}
+    }
+  },
+  "componentRefs": []
+}`
+	tests := []struct {
+		name    string
+		item    string
+		wantErr string
+	}{
+		{
+			name:    "unknown field",
+			item:    `{"name":"overlay-a","reasn":"constraint-failed"}`,
+			wantErr: `unknown field "reasn"`,
+		},
+		{
+			name:    "numeric name",
+			item:    `{"name":42}`,
+			wantErr: "cannot unmarshal number",
+		},
+		{
+			name:    "missing name",
+			item:    `{"reason":"constraint-failed"}`,
+			wantErr: "excluded overlay object requires a non-empty name",
+		},
+		{
+			name:    "unknown reason",
+			item:    `{"name":"overlay-a","reason":"unknown"}`,
+			wantErr: `excludedOverlays[0].reason "unknown" is unsupported`,
+		},
+		{
+			name:    "null item",
+			item:    "null",
+			wantErr: "must be an object",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeRecipeResult(
+				[]byte(prefix+tt.item+suffix),
+				serializer.FormatJSON,
+			)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("DecodeRecipeResult() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeRecipeResult_LegacyExcludedOverlaysCompatibility(t *testing.T) {
+	tests := []struct {
+		name   string
+		format serializer.Format
+		data   []byte
+	}{
+		{
+			name:   "YAML scalar and additive object",
+			format: serializer.FormatYAML,
+			data: []byte(`apiVersion: aicr.run/v1alpha2
+kind: RecipeResult
+metadata:
+  excludedOverlays:
+    - overlay-a
+    - name: overlay-b
+      futureField: accepted
+componentRefs: []
+`),
+		},
+		{
+			name:   "JSON scalar and additive object",
+			format: serializer.FormatJSON,
+			data: []byte(`{
+  "apiVersion": "aicr.run/v1alpha2",
+  "kind": "RecipeResult",
+  "metadata": {
+    "excludedOverlays": [
+      "overlay-a",
+      {"name": "overlay-b", "futureField": "accepted"}
+    ]
+  },
+  "componentRefs": []
+}`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := DecodeRecipeResult(tt.data, tt.format)
+			if err != nil {
+				t.Fatalf("DecodeRecipeResult() error = %v", err)
+			}
+			want := []ExcludedOverlay{{Name: "overlay-a"}, {Name: "overlay-b"}}
+			if !reflect.DeepEqual(result.Metadata.ExcludedOverlays, want) {
+				t.Errorf("excludedOverlays = %+v, want %+v", result.Metadata.ExcludedOverlays, want)
+			}
+		})
+	}
+}
+
+func TestBuildMetadataStore_ProfileVersionMatrix(t *testing.T) {
+	base := []byte(`apiVersion: aicr.run/v1alpha2
+kind: RecipeMetadata
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`)
+	validProfile := `profile:
+    name: mode
+    default: one
+    values:
+      one:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: false
+      two:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: true
+`
+	overlay := func(version, extra string) []byte {
+		return fmt.Appendf(nil, `apiVersion: %s
+kind: RecipeMetadata
+metadata:
+  name: aks
+spec:
+  criteria:
+    service: aks
+  componentRefs: []
+  %s
+`, version, extra)
+	}
+
+	tests := []struct {
+		name    string
+		content []byte
+		wantErr string
+	}{
+		{name: "legacy without profile", content: overlay(RecipeAPIVersion, "")},
+		{name: "empty version without profile", content: overlay("", "")},
+		{name: "unknown version without profile", content: overlay("aicr.run/v99", "")},
+		{name: "profile version with declaration", content: overlay(RecipeProfileAPIVersion, validProfile)},
+		{
+			name:    "profile version without declaration",
+			content: overlay(RecipeProfileAPIVersion, ""),
+			wantErr: "has no spec.profile",
+		},
+		{
+			name: "profile version rejects wrong kind",
+			content: []byte(strings.Replace(
+				string(overlay(RecipeProfileAPIVersion, validProfile)),
+				"kind: RecipeMetadata", "kind: RecipeMetdata", 1,
+			)),
+			wantErr: `requires kind "RecipeMetadata", got "RecipeMetdata"`,
+		},
+		{
+			name: "profile version requires metadata name",
+			content: []byte(strings.Replace(
+				string(overlay(RecipeProfileAPIVersion, validProfile)),
+				"  name: aks\n", "", 1,
+			)),
+			wantErr: "requires metadata.name",
+		},
+		{
+			name:    "legacy version with declaration",
+			content: overlay(RecipeAPIVersion, validProfile),
+			wantErr: "expected \"aicr.run/v1alpha3\"",
+		},
+		{
+			name: "profile version rejects unknown root field",
+			content: []byte(strings.Replace(
+				string(overlay(RecipeProfileAPIVersion, validProfile)),
+				"  profile:", "  profie:", 1,
+			)),
+			wantErr: "field profie not found",
+		},
+		{
+			name: "profile version rejects expanded component ref",
+			content: []byte(strings.Replace(
+				string(overlay(RecipeProfileAPIVersion, validProfile)),
+				"            overrides:", "            valuesFile: other.yaml\n            overrides:", 1,
+			)),
+			wantErr: "field valuesFile not found",
+		},
+		{
+			name: "profile version rejects non-string override key",
+			content: overlay(RecipeProfileAPIVersion, strings.Replace(
+				validProfile,
+				"              driver:\n                enabled: false",
+				"              driver:\n                42: false",
+				1,
+			)),
+			wantErr: "non-string mapping key",
+		},
+		{
+			name: "profile version rejects multiple documents",
+			content: append(
+				overlay(RecipeProfileAPIVersion, validProfile),
+				[]byte("---\nkind: RecipeMetadata\n")...,
+			),
+			wantErr: "multiple YAML documents",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newInMemoryProvider(tt.name, map[string][]byte{
+				"overlays/base.yaml": base,
+				"overlays/aks.yaml":  tt.content,
+			})
+			store, err := buildMetadataStore(context.Background(), provider)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("buildMetadataStore() error = %v", err)
+				}
+				if store.Overlays["aks"] == nil {
+					t.Fatal("aks overlay was not loaded")
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("buildMetadataStore() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestListCatalogWithProfiles_ProjectsEffectiveDeclaration(t *testing.T) {
+	store := testProfileStore(testProfileDeclaration())
+	leaf := &RecipeMetadata{}
+	leaf.Metadata.Name = "h100-aks"
+	leaf.Spec.Base = "aks"
+	leaf.Spec.Criteria = &Criteria{
+		Service:     CriteriaServiceAKS,
+		Accelerator: CriteriaAcceleratorH100,
+	}
+	store.Overlays[leaf.Metadata.Name] = leaf
+
+	entries, err := store.ListCatalogWithProfiles(t.Context(), &Criteria{
+		Service: CriteriaServiceAKS,
+	})
+	if err != nil {
+		t.Fatalf("ListCatalogWithProfiles() error = %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name != leaf.Metadata.Name {
+			continue
+		}
+		if entry.Profile == nil || entry.Profile.Name != "gpuStack" ||
+			entry.Profile.Default != "driver-installed" ||
+			!reflect.DeepEqual(entry.Profile.Values, []string{"driver-installed", "operator-managed"}) {
+
+			t.Fatalf("leaf profile summary = %#v", entry.Profile)
+		}
+		return
+	}
+	t.Fatalf("catalog entries do not contain %q: %#v", leaf.Metadata.Name, entries)
+}
+
+func TestListCatalogWithProfilesCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	entries, err := testProfileStore(testProfileDeclaration()).
+		ListCatalogWithProfiles(ctx, nil)
+	if entries != nil {
+		t.Fatalf("ListCatalogWithProfiles() entries = %#v, want nil", entries)
+	}
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeTimeout, "")) {
+		t.Fatalf("ListCatalogWithProfiles() error = %v, want ErrCodeTimeout", err)
+	}
+}
+
+func TestObserveValuePath(t *testing.T) {
+	values := map[string]any{
+		"driver": map[string]any{
+			"enabled": false,
+			"null":    nil,
+		},
+		"blocked": "scalar",
+	}
+	tests := []struct {
+		name  string
+		path  string
+		state PathState
+	}{
+		{name: "present", path: "driver.enabled", state: PathPresent},
+		{name: "explicit null is present", path: "driver.null", state: PathPresent},
+		{name: "absent", path: "driver.version", state: PathAbsent},
+		{name: "blocked", path: "blocked.child", state: PathBlocked},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ObserveValuePath(values, tt.path)
+			if err != nil {
+				t.Fatalf("ObserveValuePath() error = %v", err)
+			}
+			if got.State != tt.state {
+				t.Fatalf("ObserveValuePath() state = %q, want %q", got.State, tt.state)
+			}
+		})
+	}
+}
+
+func TestValidateProfileLock(t *testing.T) {
+	ctx := context.Background()
+	store := testProfileStore(testProfileDeclaration())
+	result, err := store.BuildRecipeResult(ctx, &Criteria{Service: CriteriaServiceAKS})
+	if err != nil {
+		t.Fatalf("BuildRecipeResult() error = %v", err)
+	}
+	baseline, err := result.GetValuesForComponentWithContext(ctx, "gpu-operator")
+	if err != nil {
+		t.Fatalf("GetValuesForComponentWithContext() error = %v", err)
+	}
+	refs := append([]ComponentRef(nil), result.ComponentRefs...)
+	if !result.OwnsProfilePath("gpu-operator", "driver.enabled") {
+		t.Fatal("OwnsProfilePath() = false for exact owned path")
+	}
+	if result.OwnsProfilePath("gpu-operator", "driver.version") {
+		t.Fatal("OwnsProfilePath() = true for unrelated path")
+	}
+	var nilResult *RecipeResult
+	if nilResult.OwnsProfilePath("gpu-operator", "driver.enabled") {
+		t.Fatal("nil RecipeResult owns a profile path")
+	}
+
+	tests := []struct {
+		name    string
+		refs    []ComponentRef
+		values  map[string]map[string]any
+		dynamic map[string][]string
+		wantErr string
+	}{
+		{
+			name: "identical",
+			refs: refs,
+			values: map[string]map[string]any{
+				"gpu-operator": serializer.DeepCopyAnyMap(baseline),
+			},
+		},
+		{
+			name: "divergent leaf",
+			refs: refs,
+			values: map[string]map[string]any{
+				"gpu-operator": func() map[string]any {
+					values := serializer.DeepCopyAnyMap(baseline)
+					values["driver"].(map[string]any)["enabled"] = true
+					return values
+				}(),
+			},
+			wantErr: "driver.enabled diverged",
+		},
+		{
+			name: "blocked candidate",
+			refs: refs,
+			values: map[string]map[string]any{
+				"gpu-operator": func() map[string]any {
+					values := serializer.DeepCopyAnyMap(baseline)
+					values["driver"] = "blocked"
+					return values
+				}(),
+			},
+			wantErr: "driver.enabled diverged",
+		},
+		{
+			name:    "component omitted",
+			refs:    nil,
+			values:  map[string]map[string]any{},
+			wantErr: "absent or disabled",
+		},
+		{
+			name: "dynamic exact",
+			refs: refs,
+			values: map[string]map[string]any{
+				"gpu-operator": serializer.DeepCopyAnyMap(baseline),
+			},
+			dynamic: map[string][]string{"gpu-operator": {"driver.enabled"}},
+			wantErr: "intersects profile-owned",
+		},
+		{
+			name: "dynamic ancestor",
+			refs: refs,
+			values: map[string]map[string]any{
+				"gpu-operator": serializer.DeepCopyAnyMap(baseline),
+			},
+			dynamic: map[string][]string{"gpu-operator": {"driver"}},
+			wantErr: "intersects profile-owned",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := result.ValidateProfileLock(ctx, tt.refs, tt.values, tt.dynamic)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateProfileLock() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateProfileLock() error = %v, want containing %q", err, tt.wantErr)
+			}
+			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("ValidateProfileLock() error code = %v, want ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+type readCountingProvider struct {
+	DataProvider
+	reads int
+}
+
+func (p *readCountingProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	p.reads++
+	return p.DataProvider.ReadFile(ctx, path)
+}
+
+func TestValidateProfileLockHydratesOwnedValuesOnce(t *testing.T) {
+	ctx := t.Context()
+	result, err := testProfileStore(testProfileDeclaration()).
+		BuildRecipeResult(ctx, &Criteria{Service: CriteriaServiceAKS})
+	if err != nil {
+		t.Fatalf("BuildRecipeResult() error = %v", err)
+	}
+
+	const valuesFile = "components/gpu-operator/values.yaml"
+	ref := result.GetComponentRef("gpu-operator")
+	if ref == nil {
+		t.Fatal("resolved recipe has no gpu-operator component")
+	}
+	ref.ValuesFile = valuesFile
+	provider := &readCountingProvider{DataProvider: defaultEmbeddedProvider}
+	result.BindDataProvider(provider)
+	baseline, err := result.GetValuesForComponentWithContext(ctx, "gpu-operator")
+	if err != nil {
+		t.Fatalf("GetValuesForComponentWithContext() error = %v", err)
+	}
+	provider.reads = 0
+
+	err = result.ValidateProfileLock(
+		ctx,
+		append([]ComponentRef(nil), result.ComponentRefs...),
+		map[string]map[string]any{"gpu-operator": baseline},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ValidateProfileLock() error = %v", err)
+	}
+	if provider.reads != 1 {
+		t.Errorf("profile-owned values read count = %d, want 1", provider.reads)
+	}
+}
+
+func TestValidateProfileValuesWithContextCanceled(t *testing.T) {
+	result, err := testProfileStore(testProfileDeclaration()).
+		BuildRecipeResult(t.Context(), &Criteria{Service: CriteriaServiceAKS})
+	if err != nil {
+		t.Fatalf("BuildRecipeResult() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = result.ValidateProfileValuesWithContext(ctx)
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeTimeout, "")) {
+		t.Fatalf("ValidateProfileValuesWithContext() error = %v, want ErrCodeTimeout", err)
+	}
+}
+
+func TestValidateProfileValuesRejectsInvalidBaseline(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *RecipeResult
+		wantErr string
+	}{
+		{
+			name: "missing components are checked deterministically",
+			result: func() *RecipeResult {
+				result := &RecipeResult{APIVersion: RecipeProfileAPIVersion}
+				result.Metadata.SelectedProfile = &SelectedProfile{
+					Name:  "gpuStack",
+					Value: "driver-installed",
+					OwnedPaths: map[string][]string{
+						"z-component": {"enabled"},
+						"a-component": {"enabled"},
+					},
+				}
+				return result
+			}(),
+			wantErr: `"a-component" is missing or disabled`,
+		},
+		{
+			name: "blocked recipe path",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				ComponentRefs: []ComponentRef{{
+					Name:      "gpu-operator",
+					Overrides: map[string]any{"driver": "blocked"},
+				}},
+				Metadata: RecipeResultMetadata{
+					SelectedProfile: &SelectedProfile{
+						Name:  "gpuStack",
+						Value: "driver-installed",
+						OwnedPaths: map[string][]string{
+							"gpu-operator": {"driver.enabled"},
+						},
+					},
+				},
+			},
+			wantErr: "profile-owned recipe path gpu-operator.driver.enabled is blocked by a non-map ancestor",
+		},
+		{
+			// Generation cannot produce this: the selected fragment's overrides
+			// are merged into the componentRef, and totality makes that fragment
+			// assign every non-synthetic owned path. A hand-authored or
+			// externally-supplied artifact can, and inheriting the value from
+			// valuesFile would get it locked and attested as profile-qualified.
+			name: "owned path absent from component overrides",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				ComponentRefs: []ComponentRef{{
+					Name:      "gpu-operator",
+					Overrides: map[string]any{"driver": map[string]any{"version": "570.86.16"}},
+				}},
+				Metadata: RecipeResultMetadata{
+					SelectedProfile: &SelectedProfile{
+						Name:  "gpuStack",
+						Value: "driver-installed",
+						OwnedPaths: map[string][]string{
+							"gpu-operator": {"driver.enabled", "enabled"},
+						},
+					},
+				},
+			},
+			wantErr: "profile-owned path gpu-operator.driver.enabled is not assigned by the component overrides",
+		},
+		{
+			// A null ancestor is the case the inline and hydrated checks cannot
+			// split between them: inline it observes as PathBlocked, and
+			// mergeValues deletes a nil-valued key, so the hydrated observation
+			// is PathAbsent. Deferring either state to the other check lets the
+			// artifact through with driver.version inherited from the baseline.
+			name: "owned path shadowed by a null ancestor in overrides",
+			result: &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				Kind:       RecipeResultKind,
+				ComponentRefs: []ComponentRef{{
+					Name:      "gpu-operator",
+					Type:      ComponentTypeHelm,
+					Overrides: map[string]any{"driver": nil},
+				}},
+				Metadata: RecipeResultMetadata{
+					SelectedProfile: &SelectedProfile{
+						Name:  "gpuStack",
+						Value: "preinstalled",
+						OwnedPaths: map[string][]string{
+							"gpu-operator": {"driver.version", "enabled"},
+						},
+					},
+				},
+			},
+			wantErr: "profile-owned recipe path gpu-operator.driver.version is blocked by a non-map ancestor",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.result.ValidateProfileValuesWithContext(t.Context())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want containing %q", err, tt.wantErr)
+			}
+			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+// TestApplyEffectiveProfileConstraints covers the two constraint outcomes of a
+// selection: a name already present in the composed recipe is rejected rather
+// than silently shadowing it, and a fresh name is appended in sorted order.
+func TestApplyEffectiveProfileConstraints(t *testing.T) {
+	newDecl := func(constraintName string) *effectiveProfileDeclaration {
+		return &effectiveProfileDeclaration{
+			Source: "test-overlay",
+			Declaration: &ProfileDeclaration{
+				Name: "gpuStack", Default: "preinstalled",
+				Values: map[string]ProfileValue{
+					"preinstalled": {
+						ComponentRefs: []ProfileComponentRef{{
+							Name:      "gpu-operator",
+							Overrides: map[string]any{"driver": map[string]any{"enabled": false}},
+						}},
+						Constraints: []Constraint{{Name: constraintName, Value: ">= 1.32"}},
+					},
+				},
+			},
+		}
+	}
+	newSpec := func() *RecipeMetadataSpec {
+		return &RecipeMetadataSpec{
+			ComponentRefs: []ComponentRef{{Name: "gpu-operator", Type: ComponentTypeHelm}},
+			Constraints:   []Constraint{{Name: "K8s.server.version", Value: ">= 1.30"}},
+		}
+	}
+
+	t.Run("collision with the composed recipe is rejected", func(t *testing.T) {
+		spec := newSpec()
+		_, err := applyEffectiveProfile(spec, newDecl("K8s.server.version"), "", nil)
+		if err == nil || !strings.Contains(err.Error(), "collides with the composed recipe") {
+			t.Fatalf("applyEffectiveProfile() error = %v, want collision", err)
+		}
+		if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+			t.Fatalf("applyEffectiveProfile() error = %v, want ErrCodeInvalidRequest", err)
+		}
+		if len(spec.Constraints) != 1 {
+			t.Fatalf("composed constraints = %v, want the recipe's own left intact", spec.Constraints)
+		}
+	})
+
+	t.Run("distinct constraint is merged", func(t *testing.T) {
+		spec := newSpec()
+		selected, err := applyEffectiveProfile(spec, newDecl("Driver.gpu.mode"), "", nil)
+		if err != nil {
+			t.Fatalf("applyEffectiveProfile() error = %v", err)
+		}
+		if selected == nil || selected.Value != "preinstalled" {
+			t.Fatalf("selected profile = %#v, want value preinstalled", selected)
+		}
+		got := make([]string, 0, len(spec.Constraints))
+		for _, constraint := range spec.Constraints {
+			got = append(got, constraint.Name)
+		}
+		want := []string{"Driver.gpu.mode", "K8s.server.version"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("composed constraint names = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestValidateProfileValuesAcceptsNullOwnedAssignment pins the boundary of the
+// inline-ownership check: an explicit null is an assignment by the fragment, so
+// it must not be read as the baseline-inheritance case the check rejects.
+func TestValidateProfileValuesAcceptsNullOwnedAssignment(t *testing.T) {
+	result := &RecipeResult{
+		APIVersion: RecipeProfileAPIVersion,
+		ComponentRefs: []ComponentRef{{
+			Name:      "gpu-operator",
+			Overrides: map[string]any{"driver": map[string]any{"enabled": nil}},
+		}},
+		Metadata: RecipeResultMetadata{
+			SelectedProfile: &SelectedProfile{
+				Name:  "gpuStack",
+				Value: "driver-installed",
+				OwnedPaths: map[string][]string{
+					"gpu-operator": {"driver.enabled", "enabled"},
+				},
+			},
+		},
+	}
+	if err := result.ValidateProfileValuesWithContext(t.Context()); err != nil {
+		t.Fatalf("ValidateProfileValuesWithContext() error = %v, want nil", err)
+	}
+}
+
+func TestValidateProfileValuesRejectsUnsupportedArtifactScalars(t *testing.T) {
+	resultWithValue := func(value any) *RecipeResult {
+		return &RecipeResult{
+			APIVersion: RecipeProfileAPIVersion,
+			Kind:       RecipeResultKind,
+			ComponentRefs: []ComponentRef{{
+				Name: "gpu-operator",
+				Overrides: map[string]any{
+					"driver": map[string]any{"enabled": value},
+				},
+			}},
+			Metadata: RecipeResultMetadata{
+				SelectedProfile: &SelectedProfile{
+					Name:  "gpuStack",
+					Value: "driver-installed",
+					OwnedPaths: map[string][]string{
+						"gpu-operator": {"driver.enabled", "enabled"},
+					},
+				},
+			},
+		}
+	}
+	decode := func(t *testing.T, input *RecipeResult, format serializer.Format) *RecipeResult {
+		t.Helper()
+		var (
+			data []byte
+			err  error
+		)
+		switch format {
+		case serializer.FormatJSON:
+			data, err = json.Marshal(input)
+		case serializer.FormatYAML:
+			data, err = yaml.Marshal(input)
+		case serializer.FormatTable:
+			t.Fatalf("table format is unsupported for profile artifacts")
+		default:
+			t.Fatalf("unsupported test format %q", format)
+		}
+		if err != nil {
+			t.Fatalf("marshal profile artifact: %v", err)
+		}
+		result, err := DecodeRecipeResult(data, format)
+		if err != nil {
+			t.Fatalf("DecodeRecipeResult() error: %v", err)
+		}
+		return result
+	}
+
+	tests := []struct {
+		name    string
+		result  func(*testing.T) *RecipeResult
+		wantErr string
+	}{
+		{
+			name: "typed channel",
+			result: func(*testing.T) *RecipeResult {
+				return resultWithValue(make(chan bool))
+			},
+			wantErr: "unsupported scalar type",
+		},
+		{
+			name: "typed cyclic map",
+			result: func(*testing.T) *RecipeResult {
+				result := resultWithValue(false)
+				result.ComponentRefs[0].Overrides["driver"] =
+					result.ComponentRefs[0].Overrides
+				return result
+			},
+			wantErr: "cyclic reference",
+		},
+		{
+			name: "YAML non-finite float",
+			result: func(t *testing.T) *RecipeResult {
+				return decode(t, resultWithValue(math.NaN()), serializer.FormatYAML)
+			},
+			wantErr: "non-finite float",
+		},
+		{
+			name: "JSON integer outside round-trip-safe range",
+			result: func(t *testing.T) *RecipeResult {
+				return decode(t, resultWithValue(^uint64(0)), serializer.FormatJSON)
+			},
+			wantErr: "outside the JSON round-trip-safe range",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.result(t).ValidateProfileValuesWithContext(t.Context())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want containing %q", err, tt.wantErr)
+			}
+			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+func TestValidateProfileValuesScopesArtifactValidationToOwnedPaths(t *testing.T) {
+	newResult := func() *RecipeResult {
+		return &RecipeResult{
+			APIVersion: RecipeProfileAPIVersion,
+			Kind:       RecipeResultKind,
+			ComponentRefs: []ComponentRef{{
+				Name: "gpu-operator",
+			}},
+			Metadata: RecipeResultMetadata{
+				SelectedProfile: &SelectedProfile{
+					Name:  "gpuStack",
+					Value: "driver-installed",
+					OwnedPaths: map[string][]string{
+						"gpu-operator": {"driver.enabled", "enabled"},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		prepare func(*RecipeResult)
+		wantErr string
+	}{
+		{
+			name: "typed list at unowned inline path",
+			prepare: func(result *RecipeResult) {
+				result.ComponentRefs[0].Overrides = map[string]any{
+					"driver":  map[string]any{"enabled": true},
+					"unowned": []string{"one", "two"},
+				}
+			},
+		},
+		{
+			name: "large integer at unowned values-file path",
+			prepare: func(result *RecipeResult) {
+				const valuesFile = "components/gpu-operator/values.yaml"
+				result.ComponentRefs[0].Overrides = map[string]any{
+					"driver": map[string]any{"enabled": true},
+				}
+				result.ComponentRefs[0].ValuesFile = valuesFile
+				result.BindDataProvider(newInMemoryProvider("unowned-large-integer", map[string][]byte{
+					valuesFile: []byte("driver:\n  enabled: true\nunowned: 9007199254740992\n"),
+				}))
+			},
+		},
+		{
+			// The owned value may not come from the values file at all. A
+			// non-finite float there is therefore unreachable rather than
+			// caught: the fragment's override wins the merge, so an owned-path
+			// scalar is only ever validated from the overrides, which
+			// TestValidateProfileValuesRejectsUnsupportedArtifactScalars covers.
+			name: "owned path supplied only by the values file",
+			prepare: func(result *RecipeResult) {
+				const valuesFile = "components/gpu-operator/values.yaml"
+				result.ComponentRefs[0].ValuesFile = valuesFile
+				result.BindDataProvider(newInMemoryProvider("owned-non-finite", map[string][]byte{
+					valuesFile: []byte("driver:\n  enabled: .nan\n"),
+				}))
+			},
+			wantErr: "is not assigned by the component overrides",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := newResult()
+			tt.prepare(result)
+			err := result.ValidateProfileValuesWithContext(t.Context())
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateProfileValuesWithContext() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want containing %q", err, tt.wantErr)
+			}
+			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+func TestValidateProfileValuesKustomizeOwnership(t *testing.T) {
+	tests := []struct {
+		name    string
+		paths   []string
+		wantErr string
+	}{
+		{
+			name:  "presence-only ownership remains valid",
+			paths: []string{"enabled"},
+		},
+		{
+			name:    "values ownership is rejected",
+			paths:   []string{"enabled", "feature.mode"},
+			wantErr: `profile-owned component "kustomize-app" has type "Kustomize", which does not consume values overrides`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &RecipeResult{
+				APIVersion: RecipeProfileAPIVersion,
+				ComponentRefs: []ComponentRef{{
+					Name:   "kustomize-app",
+					Type:   ComponentTypeKustomize,
+					Source: "https://github.com/example/app",
+					Tag:    "v1.0.0",
+					Path:   "deploy",
+					Overrides: map[string]any{
+						"feature": map[string]any{"mode": "profiled"},
+					},
+				}},
+				Metadata: RecipeResultMetadata{
+					SelectedProfile: &SelectedProfile{
+						Name:       "mode",
+						Value:      "profiled",
+						OwnedPaths: map[string][]string{"kustomize-app": tt.paths},
+					},
+				},
+			}
+
+			err := result.ValidateProfileValuesWithContext(t.Context())
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateProfileValuesWithContext() error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want containing %q", err, tt.wantErr)
+			}
+			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("ValidateProfileValuesWithContext() error = %v, want ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+// TestPathsIntersect covers the exported helper directly. It is otherwise
+// reached only through isDeferredAllocationPolicyPath, the dynamic-path guard,
+// and OwnsProfilePath, so a change to its prefix semantics would surface as a
+// failure in one of those rather than here — and the ancestor/descendant cases
+// below are precisely what the profile lock depends on.
+func TestPathsIntersect(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", "driver.enabled", "driver.enabled", true},
+		{"b is ancestor of a", "driver.enabled", "driver", true},
+		{"a is ancestor of b", "driver", "driver.enabled", true},
+		{"common ancestor, divergent leaf", "driver.enabled", "driver.version", false},
+		{"disjoint roots", "driver.enabled", "toolkit.enabled", false},
+		{"single segment equal", "driver", "driver", true},
+		{"single segment differing", "driver", "toolkit", false},
+		{"empty both", "", "", true},
+		{"empty vs populated", "", "driver", false},
+		// Prefix comparison is per segment, not per character: "driver" must not
+		// be treated as intersecting "driverRoot".
+		{"segment prefix is not an intersection", "driver", "driverRoot", false},
+		{"deep shared prefix", "a.b.c.d", "a.b.c", true},
+		{"deep divergence", "a.b.c.d", "a.b.x", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PathsIntersect(tt.a, tt.b); got != tt.want {
+				t.Errorf("PathsIntersect(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+			if got := PathsIntersect(tt.b, tt.a); got != tt.want {
+				t.Errorf("PathsIntersect(%q, %q) = %v, want %v (must be symmetric)",
+					tt.b, tt.a, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/recipe/query.go
+++ b/pkg/recipe/query.go
@@ -24,6 +24,8 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
+const hydratedNameKey = "name"
+
 // HydrateResult builds a fully hydrated map from a RecipeResult.
 // Component values are merged via GetValuesForComponent so the output
 // contains the final resolved configuration, not file references.
@@ -57,6 +59,17 @@ func HydrateResultWithContext(ctx context.Context, result *RecipeResult) (map[st
 	if result.Metadata.GPUDriverState != "" {
 		metadata["gpuDriverState"] = result.Metadata.GPUDriverState
 	}
+	if result.Metadata.SelectedProfile != nil {
+		metadata["selectedProfile"] = map[string]any{
+			hydratedNameKey: result.Metadata.SelectedProfile.Name,
+			"value":         result.Metadata.SelectedProfile.Value,
+			"ownedPaths":    cloneOwnedPaths(result.Metadata.SelectedProfile.OwnedPaths),
+		}
+		if result.Metadata.SelectedProfile.Advertiser != "" {
+			metadata["selectedProfile"].(map[string]any)["advertiser"] =
+				result.Metadata.SelectedProfile.Advertiser
+		}
+	}
 
 	hydrated := map[string]any{
 		"kind":            result.Kind,
@@ -80,8 +93,8 @@ func HydrateResultWithContext(ctx context.Context, result *RecipeResult) (map[st
 		constraintList := make([]map[string]any, 0, len(result.Constraints))
 		for _, c := range result.Constraints {
 			entry := map[string]any{
-				"name":   c.Name,
-				keyValue: c.Value,
+				hydratedNameKey: c.Name,
+				keyValue:        c.Value,
 			}
 			if c.Severity != "" {
 				entry["severity"] = c.Severity
@@ -100,9 +113,9 @@ func HydrateResultWithContext(ctx context.Context, result *RecipeResult) (map[st
 	components := make(map[string]any, len(result.ComponentRefs))
 	for _, ref := range result.ComponentRefs {
 		comp := map[string]any{
-			"name":   ref.Name,
-			"type":   string(ref.Type),
-			"source": ref.Source,
+			hydratedNameKey: ref.Name,
+			"type":          string(ref.Type),
+			"source":        ref.Source,
 		}
 
 		if ref.Namespace != "" {

--- a/pkg/recipe/query_request.go
+++ b/pkg/recipe/query_request.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,6 +30,16 @@ import (
 type QueryRequest struct {
 	Criteria *Criteria `json:"criteria" yaml:"criteria"`
 	Selector string    `json:"selector" yaml:"selector"`
+}
+
+// QueryRequestBodyFormat returns the format ParseQueryRequestFromBody uses for
+// a Content-Type value. Values containing "json" select JSON; empty and every
+// other value select YAML for legacy compatibility.
+func QueryRequestBodyFormat(contentType string) serializer.Format {
+	if strings.Contains(contentType, "json") {
+		return serializer.FormatJSON
+	}
+	return serializer.FormatYAML
 }
 
 // ParseQueryRequestFromBody parses a QueryRequest from the request body,
@@ -53,7 +64,7 @@ func ParseQueryRequestFromBody(body io.Reader, contentType string) (*QueryReques
 	}
 
 	var req QueryRequest
-	if strings.Contains(contentType, "json") {
+	if QueryRequestBodyFormat(contentType) == serializer.FormatJSON {
 		if err := json.Unmarshal(data, &req); err != nil {
 			return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, "failed to parse JSON body", err)
 		}

--- a/pkg/recipe/query_test.go
+++ b/pkg/recipe/query_test.go
@@ -16,9 +16,53 @@ package recipe
 
 import (
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 const testQueryService = "eks"
+
+func TestQueryRequestBodyFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        serializer.Format
+	}{
+		{
+			name:        "JSON",
+			contentType: "application/json",
+			want:        serializer.FormatJSON,
+		},
+		{
+			name:        "vendor JSON",
+			contentType: "application/vnd.aicr+json",
+			want:        serializer.FormatJSON,
+		},
+		{
+			name:        "empty defaults to YAML",
+			contentType: "",
+			want:        serializer.FormatYAML,
+		},
+		{
+			name:        "YAML",
+			contentType: "application/yaml",
+			want:        serializer.FormatYAML,
+		},
+		{
+			name:        "legacy matching is case sensitive",
+			contentType: "APPLICATION/JSON",
+			want:        serializer.FormatYAML,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := QueryRequestBodyFormat(tt.contentType); got != tt.want {
+				t.Fatalf("QueryRequestBodyFormat(%q) = %q, want %q", tt.contentType, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestSelect(t *testing.T) {
 	hydrated := map[string]any{

--- a/pkg/recipe/testdata/profile-overlay/overlays/h100-aks-ubuntu-training-kubeflow.yaml
+++ b/pkg/recipe/testdata/profile-overlay/overlays/h100-aks-ubuntu-training-kubeflow.yaml
@@ -1,0 +1,53 @@
+# Test fixture: a profiled leaf overlay layered over the embedded catalog.
+#
+# It shadows the embedded overlay of the same name so the resolution path runs
+# end to end — criteria match, profile declaration discovery, value selection,
+# ownership locking — without the shipped catalog declaring a profile.
+#
+# This is deliberately NOT a shippable declaration: ADR-015 requires each value
+# to carry a constraint distinguishing it from its siblings, and the driver
+# ownership signal does not exist yet (the AKS gpuProfile.driver projection is
+# the planned one). Test input only; see docs/integrator/recipe-development.md.
+kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha3
+
+metadata:
+  name: h100-aks-ubuntu-training-kubeflow
+
+spec:
+  base: h100-aks-ubuntu-training
+
+  criteria:
+    service: aks
+    accelerator: h100
+    os: ubuntu
+    intent: training
+    platform: kubeflow
+
+  mixins:
+    - os-ubuntu
+    - platform-kubeflow
+
+  profile:
+    name: gpuStack
+    description: Which component owns the GPU driver lifecycle.
+    default: preinstalled
+    values:
+      preinstalled:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: false
+          - name: nvidia-dra-driver-gpu
+            overrides:
+              nvidiaDriverRoot: /
+      operator-managed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: true
+          - name: nvidia-dra-driver-gpu
+            overrides:
+              nvidiaDriverRoot: /run/nvidia/driver

--- a/pkg/recipe/testdata/profile-overlay/registry.yaml
+++ b/pkg/recipe/testdata/profile-overlay/registry.yaml
@@ -1,0 +1,7 @@
+# Required by LayeredDataProvider: an external data directory must carry a
+# registry.yaml, which is merged with the embedded one by component name.
+#
+# This fixture contributes no components — it exists so the profiled overlay
+# beside it can layer over the embedded catalog. Every component the overlay
+# references resolves from the embedded registry.
+components: []

--- a/pkg/serializer/reader.go
+++ b/pkg/serializer/reader.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,6 +32,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/k8s/client"
 	"github.com/NVIDIA/aicr/pkg/k8s/pod"
 	"gopkg.in/yaml.v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -86,6 +88,14 @@ func WithStrict() ReaderOption {
 	}
 }
 
+func applyReaderOptions(r *Reader, opts ...ReaderOption) {
+	for _, opt := range opts {
+		if opt != nil {
+			opt(r)
+		}
+	}
+}
+
 // NewReader creates a new Reader for deserializing data from an io.Reader source.
 //
 // Parameters:
@@ -106,7 +116,7 @@ func WithStrict() ReaderOption {
 //	if err != nil { panic(err) }
 //	var data map[string]string
 //	err = reader.Deserialize(&data)
-func NewReader(format Format, input io.Reader) (*Reader, error) {
+func NewReader(format Format, input io.Reader, opts ...ReaderOption) (*Reader, error) {
 	if format.IsUnknown() {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("unknown format: %s", format))
 	}
@@ -119,6 +129,7 @@ func NewReader(format Format, input io.Reader) (*Reader, error) {
 		format: format,
 		input:  input,
 	}
+	applyReaderOptions(r, opts...)
 
 	// Store closer if input implements it
 	if closer, ok := input.(io.Closer); ok {
@@ -153,20 +164,20 @@ func NewReader(format Format, input io.Reader) (*Reader, error) {
 //	reader, err := NewFileReader(FormatJSON, "/path/to/config.json")
 //	if err != nil { panic(err) }
 //	defer reader.Close()
-func NewFileReader(format Format, filePath string) (*Reader, error) {
+func NewFileReader(format Format, filePath string, opts ...ReaderOption) (*Reader, error) {
 	// Bound the read with FileReadTimeout so a hung filesystem (network
 	// mount, FUSE, /proc anomaly) cannot stall the caller indefinitely.
 	// Callers that need a different bound should use NewFileReaderWithContext.
 	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
 	defer cancel()
-	return NewFileReaderWithContext(ctx, format, filePath)
+	return NewFileReaderWithContext(ctx, format, filePath, opts...)
 }
 
 // NewFileReaderWithContext is the context-aware variant of NewFileReader.
 // The context bounds both the URL-download path and the local read: the local
 // content is read fully (up to MaxSpecFileBytes) so the size cap is enforced
 // and a hung filesystem cannot outlive the deadline.
-func NewFileReaderWithContext(ctx context.Context, format Format, filePath string) (*Reader, error) {
+func NewFileReaderWithContext(ctx context.Context, format Format, filePath string, opts ...ReaderOption) (*Reader, error) {
 	if format.IsUnknown() {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("unknown format: %s", format))
 	}
@@ -239,11 +250,13 @@ func NewFileReaderWithContext(ctx context.Context, format Format, filePath strin
 			fmt.Sprintf("file exceeds maximum allowed size of %d bytes", defaults.MaxSpecFileBytes))
 	}
 
-	return &Reader{
+	r := &Reader{
 		format: format,
 		input:  bytes.NewReader(data),
 		closer: file,
-	}, nil
+	}
+	applyReaderOptions(r, opts...)
+	return r, nil
 }
 
 // readAllBounded reads up to limit bytes from r, returning early if ctx is
@@ -316,6 +329,17 @@ func (r *Reader) Deserialize(v any) error {
 		if err := decoder.Decode(v); err != nil {
 			return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to decode JSON", err)
 		}
+		if r.strict {
+			var trailing any
+			if err := decoder.Decode(&trailing); !stderrors.Is(err, io.EOF) {
+				if err == nil {
+					return errors.New(errors.ErrCodeInvalidRequest,
+						"strict JSON input contains a trailing document")
+				}
+				return errors.Wrap(errors.ErrCodeInvalidRequest,
+					"failed to validate trailing JSON input", err)
+			}
+		}
 		return nil
 
 	case FormatYAML:
@@ -325,6 +349,17 @@ func (r *Reader) Deserialize(v any) error {
 		}
 		if err := decoder.Decode(v); err != nil {
 			return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to decode YAML", err)
+		}
+		if r.strict {
+			var trailing any
+			if err := decoder.Decode(&trailing); !stderrors.Is(err, io.EOF) {
+				if err == nil {
+					return errors.New(errors.ErrCodeInvalidRequest,
+						"strict YAML input contains a trailing document")
+				}
+				return errors.Wrap(errors.ErrCodeInvalidRequest,
+					"failed to validate trailing YAML input", err)
+			}
 		}
 		return nil
 
@@ -414,8 +449,8 @@ func (r *Reader) Close() error {
 // Example:
 //
 //	snap, err := FromFile[Snapshot]("cm://gpu-operator/aicr-snapshot")
-func FromFile[T any](path string) (*T, error) {
-	return FromFileWithKubeconfig[T](path, "")
+func FromFile[T any](path string, opts ...ReaderOption) (*T, error) {
+	return FromFileWithKubeconfig[T](path, "", opts...)
 }
 
 // FromFileContext is the context-aware variant of FromFile. The provided
@@ -423,8 +458,8 @@ func FromFile[T any](path string) (*T, error) {
 // into NewFileReaderWithContext for plain file and HTTP reads. Prefer this
 // variant in CLI/handler call sites that already hold a request-scoped
 // context.
-func FromFileContext[T any](ctx context.Context, path string) (*T, error) {
-	return FromFileWithKubeconfigContext[T](ctx, path, "")
+func FromFileContext[T any](ctx context.Context, path string, opts ...ReaderOption) (*T, error) {
+	return FromFileWithKubeconfigContext[T](ctx, path, "", opts...)
 }
 
 // FromFileWithKubeconfig reads and deserializes data from a file path, HTTP URL, or ConfigMap URI with custom kubeconfig.
@@ -439,21 +474,60 @@ func FromFileContext[T any](ctx context.Context, path string) (*T, error) {
 // Example:
 //
 //	snap, err := FromFileWithKubeconfig[Snapshot]("cm://gpu-operator/aicr-snapshot", "/custom/kubeconfig")
-func FromFileWithKubeconfig[T any](path, kubeconfig string) (*T, error) {
-	return FromFileWithKubeconfigContext[T](context.Background(), path, kubeconfig)
+func FromFileWithKubeconfig[T any](path, kubeconfig string, opts ...ReaderOption) (*T, error) {
+	return FromFileWithKubeconfigContext[T](context.Background(), path, kubeconfig, opts...)
+}
+
+// ReadFileBytesWithKubeconfigContext reads one supported file, URL, or
+// ConfigMap source and returns its bounded raw bytes together with the detected
+// format. Callers that need multiple decoding passes over one immutable input
+// should use this helper so remote sources are fetched exactly once.
+func ReadFileBytesWithKubeconfigContext(
+	ctx context.Context,
+	path, kubeconfig string,
+) ([]byte, Format, error) {
+
+	if strings.HasPrefix(path, ConfigMapURIScheme) {
+		namespace, name, err := pod.ParseConfigMapURI(path)
+		if err != nil {
+			return nil, Format(""), errors.Wrap(errors.ErrCodeInvalidRequest, "invalid ConfigMap URI", err)
+		}
+		return readConfigMapDataWithKubeconfigContext(ctx, namespace, name, kubeconfig)
+	}
+
+	format := FormatFromPath(path)
+	reader, err := NewFileReaderWithContext(ctx, format, path)
+	if err != nil {
+		return nil, Format(""), errors.PropagateOrWrap(
+			err, errors.ErrCodeInternal, fmt.Sprintf("failed to create serializer for %q", path))
+	}
+	defer func() {
+		if closeErr := reader.Close(); closeErr != nil {
+			slog.Warn("failed to close serializer", "error", closeErr)
+		}
+	}()
+
+	// NewFileReaderWithContext has already fully buffered and size-bounded
+	// reader.input.
+	data, err := io.ReadAll(reader.input)
+	if err != nil {
+		return nil, Format(""), errors.Wrap(
+			errors.ErrCodeInternal, fmt.Sprintf("failed to read serialized data from %q", path), err)
+	}
+	return data, format, nil
 }
 
 // FromFileWithKubeconfigContext is the context-aware variant of
 // FromFileWithKubeconfig. The context bounds the ConfigMap read when path is
 // a cm:// URI.
-func FromFileWithKubeconfigContext[T any](ctx context.Context, path, kubeconfig string) (*T, error) {
+func FromFileWithKubeconfigContext[T any](ctx context.Context, path, kubeconfig string, opts ...ReaderOption) (*T, error) {
 	// Check for ConfigMap URI
 	if strings.HasPrefix(path, ConfigMapURIScheme) {
 		namespace, name, err := pod.ParseConfigMapURI(path)
 		if err != nil {
 			return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid ConfigMap URI", err)
 		}
-		return fromConfigMapWithKubeconfigContext[T](ctx, namespace, name, kubeconfig)
+		return fromConfigMapWithKubeconfigContext[T](ctx, namespace, name, kubeconfig, opts...)
 	}
 
 	fileFormat := FormatFromPath(path)
@@ -462,7 +536,7 @@ func FromFileWithKubeconfigContext[T any](ctx context.Context, path, kubeconfig 
 		slog.String("format", string(fileFormat)),
 	)
 
-	ser, err := NewFileReaderWithContext(ctx, fileFormat, path)
+	ser, err := NewFileReaderWithContext(ctx, fileFormat, path, opts...)
 	if err != nil {
 		slog.Error("failed to create file reader", "error", err, "path", path, "format", fileFormat)
 		// Preserve the reader's structured code (NotFound / InvalidRequest /
@@ -483,7 +557,8 @@ func FromFileWithKubeconfigContext[T any](ctx context.Context, path, kubeconfig 
 
 	var r T
 	if err := ser.Deserialize(&r); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, fmt.Sprintf("failed to deserialize object from %q", path), err)
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			fmt.Sprintf("failed to deserialize object from %q", path))
 	}
 
 	slog.Debug("successfully loaded object from file",
@@ -496,7 +571,37 @@ func FromFileWithKubeconfigContext[T any](ctx context.Context, path, kubeconfig 
 // fromConfigMapWithKubeconfigContext reads and deserializes data from a Kubernetes ConfigMap.
 // The provided context is wrapped with defaults.ConfigMapWriteTimeout so the read is bounded
 // even when the caller passes context.Background().
-func fromConfigMapWithKubeconfigContext[T any](ctx context.Context, namespace, name, kubeconfig string) (*T, error) {
+func fromConfigMapWithKubeconfigContext[T any](
+	ctx context.Context,
+	namespace, name, kubeconfig string,
+	opts ...ReaderOption,
+) (*T, error) {
+
+	data, format, err := readConfigMapDataWithKubeconfigContext(ctx, namespace, name, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	reader, err := NewReader(format, bytes.NewReader(data), opts...)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			"failed to create reader for ConfigMap data")
+	}
+
+	var result T
+	if err := reader.Deserialize(&result); err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			"failed to deserialize ConfigMap data")
+	}
+
+	return &result, nil
+}
+
+func readConfigMapDataWithKubeconfigContext(
+	ctx context.Context,
+	namespace, name, kubeconfig string,
+) ([]byte, Format, error) {
+
 	var k8sClient client.Interface
 	var err error
 
@@ -506,14 +611,15 @@ func fromConfigMapWithKubeconfigContext[T any](ctx context.Context, namespace, n
 		k8sClient, _, err = client.GetKubeClient()
 	}
 	if err != nil {
-		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to get kubernetes client")
+		return nil, Format(""), errors.PropagateOrWrap(
+			err, errors.ErrCodeInternal, "failed to get kubernetes client")
 	}
 
 	readCtx, cancel := context.WithTimeout(ctx, defaults.ConfigMapWriteTimeout)
 	defer cancel()
 	cm, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(readCtx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeNotFound, fmt.Sprintf("failed to get ConfigMap %s/%s", namespace, name), err)
+		return nil, Format(""), classifyConfigMapGetError(namespace, name, err)
 	}
 
 	// Try to get format from ConfigMap metadata
@@ -537,7 +643,8 @@ func fromConfigMapWithKubeconfigContext[T any](ctx context.Context, namespace, n
 			}
 		}
 		if content == "" {
-			return nil, errors.New(errors.ErrCodeNotFound, fmt.Sprintf("ConfigMap %s/%s has no snapshot data", namespace, name))
+			return nil, Format(""), errors.New(
+				errors.ErrCodeNotFound, fmt.Sprintf("ConfigMap %s/%s has no snapshot data", namespace, name))
 		}
 	}
 
@@ -547,16 +654,33 @@ func fromConfigMapWithKubeconfigContext[T any](ctx context.Context, namespace, n
 		"format", format,
 		"size", len(content))
 
-	// Deserialize content
-	reader, err := NewReader(format, strings.NewReader(content))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create reader for ConfigMap data", err)
+	if int64(len(content)) > defaults.MaxSpecFileBytes {
+		return nil, Format(""), errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("ConfigMap data exceeds maximum allowed size of %d bytes", defaults.MaxSpecFileBytes))
 	}
+	return []byte(content), format, nil
+}
 
-	var result T
-	if err := reader.Deserialize(&result); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to deserialize ConfigMap data", err)
+func classifyConfigMapGetError(namespace, name string, err error) error {
+	switch {
+	case stderrors.Is(err, context.DeadlineExceeded),
+		stderrors.Is(err, context.Canceled),
+		apierrors.IsTimeout(err),
+		apierrors.IsServerTimeout(err):
+
+		return errors.Wrap(
+			errors.ErrCodeTimeout, fmt.Sprintf("timed out getting ConfigMap %s/%s", namespace, name), err)
+	case apierrors.IsNotFound(err):
+		return errors.Wrap(
+			errors.ErrCodeNotFound, fmt.Sprintf("ConfigMap %s/%s not found", namespace, name), err)
+	case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+		return errors.Wrap(
+			errors.ErrCodeUnauthorized,
+			fmt.Sprintf("not authorized to get ConfigMap %s/%s", namespace, name),
+			err,
+		)
+	default:
+		return errors.Wrap(
+			errors.ErrCodeUnavailable, fmt.Sprintf("failed to get ConfigMap %s/%s", namespace, name), err)
 	}
-
-	return &result, nil
 }

--- a/pkg/serializer/reader_test.go
+++ b/pkg/serializer/reader_test.go
@@ -22,12 +22,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"gopkg.in/yaml.v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Test data structures
@@ -192,6 +195,98 @@ func TestFromConfigMapPreservesKubeconfigErrorCode(t *testing.T) {
 		t.Context(),
 		"cm://default/test",
 		kubeconfig,
+	)
+	assertOutermostErrorCode(t, err, errors.ErrCodeInvalidRequest)
+}
+
+func TestReadFileBytesWithKubeconfigContext(t *testing.T) {
+	type input struct {
+		path       string
+		kubeconfig string
+	}
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T) input
+		wantData    []byte
+		wantFormat  Format
+		wantErrCode errors.ErrorCode
+	}{
+		{
+			name: "local file",
+			setup: func(t *testing.T) input {
+				t.Helper()
+				path := filepath.Join(t.TempDir(), "recipe.yaml")
+				if err := os.WriteFile(path, []byte("name: test\nvalue: 1\n"), 0o600); err != nil {
+					t.Fatalf("write input: %v", err)
+				}
+				return input{path: path}
+			},
+			wantData:   []byte("name: test\nvalue: 1\n"),
+			wantFormat: FormatYAML,
+		},
+		{
+			name: "missing local file",
+			setup: func(t *testing.T) input {
+				t.Helper()
+				return input{path: filepath.Join(t.TempDir(), "missing.json")}
+			},
+			wantErrCode: errors.ErrCodeNotFound,
+		},
+		{
+			name: "invalid ConfigMap URI",
+			setup: func(t *testing.T) input {
+				t.Helper()
+				return input{path: "cm://missing-name"}
+			},
+			wantErrCode: errors.ErrCodeInvalidRequest,
+		},
+		{
+			name: "ConfigMap kubeconfig error",
+			setup: func(t *testing.T) input {
+				t.Helper()
+				return input{
+					path:       "cm://default/test",
+					kubeconfig: writeInvalidKubeconfig(t),
+				}
+			},
+			wantErrCode: errors.ErrCodeInvalidRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := tt.setup(t)
+			got, format, err := ReadFileBytesWithKubeconfigContext(
+				t.Context(), in.path, in.kubeconfig,
+			)
+			if tt.wantErrCode != "" {
+				assertOutermostErrorCode(t, err, tt.wantErrCode)
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadFileBytesWithKubeconfigContext() error = %v", err)
+			}
+			if !bytes.Equal(got, tt.wantData) {
+				t.Fatalf("data = %q, want %q", got, tt.wantData)
+			}
+			if format != tt.wantFormat {
+				t.Fatalf("format = %q, want %q", format, tt.wantFormat)
+			}
+		})
+	}
+}
+
+func TestFromFilePreservesDecodeErrorCode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "strict.yaml")
+	if err := os.WriteFile(path, []byte("name: test\nunknown: value\n"), 0o600); err != nil {
+		t.Fatalf("write strict input: %v", err)
+	}
+
+	_, err := FromFileWithKubeconfigContext[testConfig](
+		t.Context(),
+		path,
+		"",
+		WithStrict(),
 	)
 	assertOutermostErrorCode(t, err, errors.ErrCodeInvalidRequest)
 }
@@ -1127,8 +1222,8 @@ func TestFromFile_Errors(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected error for invalid JSON")
 		}
-		if !strings.Contains(err.Error(), "failed to deserialize") {
-			t.Errorf("Expected deserialization error, got: %v", err)
+		if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+			t.Errorf("Expected ErrCodeInvalidRequest, got: %v", err)
 		}
 	})
 
@@ -1148,6 +1243,78 @@ func TestFromFile_Errors(t *testing.T) {
 			t.Fatal("Expected error for type mismatch")
 		}
 	})
+}
+
+func TestClassifyConfigMapGetError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode errors.ErrorCode
+	}{
+		{
+			name:     "deadline exceeded",
+			err:      context.DeadlineExceeded,
+			wantCode: errors.ErrCodeTimeout,
+		},
+		{
+			name:     "wrapped cancellation",
+			err:      fmt.Errorf("ConfigMap get interrupted: %w", context.Canceled),
+			wantCode: errors.ErrCodeTimeout,
+		},
+		{
+			name:     "Kubernetes timeout status",
+			err:      apierrors.NewTimeoutError("request timed out", 1),
+			wantCode: errors.ErrCodeTimeout,
+		},
+		{
+			name: "Kubernetes server timeout status",
+			err: apierrors.NewServerTimeout(
+				schema.GroupResource{Resource: "configmaps"},
+				"get",
+				1,
+			),
+			wantCode: errors.ErrCodeTimeout,
+		},
+		{
+			name: "not found",
+			err: apierrors.NewNotFound(
+				schema.GroupResource{Resource: "configmaps"},
+				"missing",
+			),
+			wantCode: errors.ErrCodeNotFound,
+		},
+		{
+			name:     "unauthorized",
+			err:      apierrors.NewUnauthorized("authentication required"),
+			wantCode: errors.ErrCodeUnauthorized,
+		},
+		{
+			name: "forbidden",
+			err: apierrors.NewForbidden(
+				schema.GroupResource{Resource: "configmaps"},
+				"snapshot",
+				stderrors.New("permission denied"),
+			),
+			wantCode: errors.ErrCodeUnauthorized,
+		},
+		{
+			name:     "API unavailable",
+			err:      stderrors.New("apiserver unavailable"),
+			wantCode: errors.ErrCodeUnavailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := classifyConfigMapGetError("default", "snapshot", tt.err)
+			if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Errorf("classifyConfigMapGetError() error = %v, want code %s", err, tt.wantCode)
+			}
+		})
+	}
 }
 
 func TestReader_DeserializeTableFormat(t *testing.T) {
@@ -1398,6 +1565,84 @@ func TestFormatFromPath_EdgeCases(t *testing.T) {
 			result := FormatFromPath(tt.path)
 			if result != tt.expected {
 				t.Errorf("FormatFromPath(%q) = %v, want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReader_Strict(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  Format
+		input   string
+		strict  bool
+		wantErr bool
+	}{
+		{
+			name:   "strict JSON",
+			format: FormatJSON,
+			input:  `{"name":"test","value":1}`,
+			strict: true,
+		},
+		{
+			name:    "strict JSON rejects unknown field",
+			format:  FormatJSON,
+			input:   `{"name":"test","value":1,"typo":true}`,
+			strict:  true,
+			wantErr: true,
+		},
+		{
+			name:    "strict JSON rejects trailing document",
+			format:  FormatJSON,
+			input:   `{"name":"test","value":1} {"name":"other","value":2}`,
+			strict:  true,
+			wantErr: true,
+		},
+		{
+			name:   "strict YAML",
+			format: FormatYAML,
+			input:  "name: test\nvalue: 1\n",
+			strict: true,
+		},
+		{
+			name:    "strict YAML rejects unknown field",
+			format:  FormatYAML,
+			input:   "name: test\nvalue: 1\ntypo: true\n",
+			strict:  true,
+			wantErr: true,
+		},
+		{
+			name:    "strict YAML rejects trailing document",
+			format:  FormatYAML,
+			input:   "name: test\nvalue: 1\n---\nname: other\nvalue: 2\n",
+			strict:  true,
+			wantErr: true,
+		},
+		{
+			name:   "legacy non-strict JSON remains additive",
+			format: FormatJSON,
+			input:  `{"name":"test","value":1,"future":true}`,
+		},
+		{
+			name:   "legacy non-strict JSON accepts trailing document",
+			format: FormatJSON,
+			input:  `{"name":"test","value":1} {"name":"other","value":2}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []ReaderOption
+			if tt.strict {
+				opts = append(opts, WithStrict())
+			}
+			reader, err := NewReader(tt.format, strings.NewReader(tt.input), opts...)
+			if err != nil {
+				t.Fatalf("NewReader() error = %v", err)
+			}
+			var result testConfig
+			err = reader.Deserialize(&result)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Deserialize() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/server/bundle_handler.go
+++ b/pkg/server/bundle_handler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -49,12 +50,14 @@ var bundleZipResponseHeaders = []string{
 
 type streamZipFunc func(context.Context, http.ResponseWriter, string, *result.Output) error
 
-// bundleHandler backs the /v1/bundle endpoint with an aicr.Client. It
-// reproduces pkg/bundler.(*DefaultBundler).HandleBundles exactly — same
-// method gate, body decode, allowlist check, query-param parsing, and zip
-// response — swapping the direct bundler.New + Make for the Client facade
-// (AdoptRecipe + MakeBundle). The body, headers, and status codes are
-// byte-identical to the legacy handler.
+// bundleHandler backs the /v1/bundle and /v2/bundle endpoints with an
+// aicr.Client. The v1 handler reproduces
+// pkg/bundler.(*DefaultBundler).HandleBundles exactly — same method gate, body
+// decode, allowlist check, query-param parsing, and zip response — swapping
+// the direct bundler.New + Make for the Client facade (AdoptRecipe +
+// MakeBundle). Its headers and status codes match the legacy handler;
+// error-body detail strings may differ where the facade wraps decode errors. The v2 handler shares that path and additionally accepts
+// strict v1alpha3 profile recipes.
 type bundleHandler struct {
 	client    *aicr.Client
 	streamZip streamZipFunc
@@ -89,14 +92,49 @@ func newBundleHandler(client *aicr.Client, allowLists *aicr.AllowLists, signing 
 // deployer, node selectors/tolerations, repo, workload-gate, workload-selector,
 // nodes, vendor-charts, app-name). The response is a zip archive of the bundle.
 func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
+	h.handleBundles(w, r, false)
+}
+
+// HandleBundlesV2 accepts legacy recipes and strict v1alpha3 profile recipes.
+func (h *bundleHandler) HandleBundlesV2(w http.ResponseWriter, r *http.Request) {
+	h.handleBundles(w, r, true)
+}
+
+func decodeBundleRecipe(
+	input io.Reader,
+	contentType string,
+	v2 bool,
+) (recipe.RecipeResult, error) {
+
+	var result recipe.RecipeResult
+	if !v2 {
+		if err := json.NewDecoder(input).Decode(&result); err != nil {
+			return result, aicrerrors.PropagateOrWrap(
+				err, aicrerrors.ErrCodeInvalidRequest, "failed to decode bundle recipe")
+		}
+		return result, nil
+	}
+	bodyData, err := io.ReadAll(input)
+	if err != nil {
+		return result, aicrerrors.PropagateOrWrap(
+			err, aicrerrors.ErrCodeInvalidRequest, "failed to read bundle recipe")
+	}
+	format, err := v2BodyFormat(contentType)
+	if err != nil {
+		return result, err
+	}
+	decoded, err := recipe.DecodeRecipeResult(bodyData, format)
+	if err != nil {
+		return result, aicrerrors.PropagateOrWrap(
+			err, aicrerrors.ErrCodeInvalidRequest, "failed to decode bundle recipe")
+	}
+	return *decoded, nil
+}
+
+func (h *bundleHandler) handleBundles(w http.ResponseWriter, r *http.Request, v2 bool) {
 	logger := slog.With("requestID", RequestIDFromContext(r.Context()))
 
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", http.MethodPost)
-		WriteError(w, r, http.StatusMethodNotAllowed, aicrerrors.ErrCodeMethodNotAllowed,
-			"Method not allowed", false, map[string]any{
-				keyMethod: r.Method,
-			})
+	if bundleRequestRejected(w, r, v2) {
 		return
 	}
 
@@ -121,9 +159,13 @@ func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 
 	// Parse request body directly as RecipeResult. Bound the body to defend
 	// against memory exhaustion (same cap as the legacy handler).
-	bounded := http.MaxBytesReader(w, r.Body, defaults.MaxBundlePOSTBytes)
-	var recipeResult recipe.RecipeResult
-	if err = json.NewDecoder(bounded).Decode(&recipeResult); err != nil {
+	recipeResult, err := decodeBundleRecipe(
+		http.MaxBytesReader(w, r.Body, defaults.MaxBundlePOSTBytes),
+		r.Header.Get("Content-Type"),
+		v2,
+	)
+
+	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if stderrors.As(err, &maxBytesErr) {
 			logger.Warn("bundle POST body exceeded size limit",
@@ -140,6 +182,11 @@ func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 			"Invalid request body", false, map[string]any{
 				keyError: err.Error(),
 			})
+		return
+	}
+	if !v2 && recipeResult.Metadata.SelectedProfile != nil {
+		WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Profiled recipes are available only on /v2/bundle", false, nil)
 		return
 	}
 
@@ -164,15 +211,6 @@ func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 		"components", len(recipeResult.ComponentRefs),
 	)
 
-	// Create temporary directory for bundle output.
-	tempDir, err := os.MkdirTemp("", "aicr-bundle-*")
-	if err != nil {
-		WriteError(w, r, http.StatusInternalServerError, aicrerrors.ErrCodeInternal,
-			"Failed to create temporary directory", true, nil)
-		return
-	}
-	defer os.RemoveAll(tempDir) // Clean up on exit
-
 	// Adopt the decoded recipe onto the Client (binds the Client's provider
 	// + owner token) so MakeBundle accepts it and provider-scoped reads route
 	// through the Client's recipe source.
@@ -181,6 +219,15 @@ func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 		WriteErrorFromErr(w, r, err, "Failed to prepare recipe for bundling", nil)
 		return
 	}
+
+	// Create the output directory only after the raw artifact gate succeeds.
+	tempDir, err := os.MkdirTemp("", "aicr-bundle-*")
+	if err != nil {
+		WriteError(w, r, http.StatusInternalServerError, aicrerrors.ErrCodeInternal,
+			"Failed to create temporary directory", true, nil)
+		return
+	}
+	defer os.RemoveAll(tempDir) // Clean up on exit
 
 	// Generate bundle through the facade. Set Timeout as a belt-and-
 	// suspenders cap that matches the ctx deadline above — MakeBundle
@@ -252,6 +299,31 @@ func (h *bundleHandler) HandleBundles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.writeZipResponse(ctx, w, r, tempDir, output)
+}
+
+func bundleRequestRejected(w http.ResponseWriter, r *http.Request, v2 bool) bool {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		WriteError(w, r, http.StatusMethodNotAllowed, aicrerrors.ErrCodeMethodNotAllowed,
+			"Method not allowed", false, map[string]any{
+				keyMethod: r.Method,
+			})
+		return true
+	}
+
+	if v2 {
+		if err := validateV2BundleQueryParameters(r); err != nil {
+			WriteErrorFromErr(w, r, err, "Invalid query parameters", nil)
+			return true
+		}
+	}
+	return false
+}
+
+func validateV2BundleQueryParameters(r *http.Request) error {
+	allowed := bundler.SupportedBundleQueryParameters()
+	allowed["attest"] = struct{}{}
+	return validateV2QueryParameters(r, allowed)
 }
 
 // resolveAttestRequest parses the ?attest query parameter and validates it

--- a/pkg/server/bundle_handler_test.go
+++ b/pkg/server/bundle_handler_test.go
@@ -97,6 +97,237 @@ func resolveEmbeddedBundleBody(t *testing.T) []byte {
 	return body
 }
 
+func profileBundleBody(t *testing.T) []byte {
+	t.Helper()
+	result := &recipe.RecipeResult{
+		APIVersion: recipe.RecipeProfileAPIVersion,
+		Kind:       recipe.RecipeResultKind,
+		Criteria: &recipe.Criteria{
+			Service:     recipe.CriteriaServiceAKS,
+			Accelerator: recipe.CriteriaAcceleratorH100,
+			Intent:      recipe.CriteriaIntentTraining,
+		},
+		ComponentRefs: []recipe.ComponentRef{{
+			Name:    "gpu-operator",
+			Version: "v25.3.3",
+			Type:    recipe.ComponentTypeHelm,
+			Source:  "https://helm.ngc.nvidia.com/nvidia",
+			Chart:   "gpu-operator",
+			Overrides: map[string]any{
+				"driver": map[string]any{"enabled": false},
+			},
+		}},
+		DeploymentOrder: []string{"gpu-operator"},
+	}
+	result.Metadata.SelectedProfile = &recipe.SelectedProfile{
+		Name:  "gpuStack",
+		Value: "driver-installed",
+		OwnedPaths: map[string][]string{
+			"gpu-operator": {"driver.enabled", "enabled"},
+		},
+	}
+	body, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal profile recipe: %v", err)
+	}
+	return body
+}
+
+func TestDecodeBundleRecipeV2ContentType(t *testing.T) {
+	body := profileBundleBody(t)
+	tests := []struct {
+		name        string
+		contentType string
+		wantErr     string
+	}{
+		{
+			name:        "JSON parameter containing yaml remains JSON",
+			contentType: "application/json; note=yaml",
+		},
+		{
+			name:    "missing content type",
+			wantErr: "Content-Type is required",
+		},
+		{
+			name:        "unsupported content type",
+			contentType: "text/plain",
+			wantErr:     `unsupported Content-Type "text/plain"`,
+		},
+		{
+			name:        "undeclared application YAML alias",
+			contentType: "application/yaml",
+			wantErr:     `unsupported Content-Type "application/yaml"`,
+		},
+		{
+			name:        "undeclared text YAML alias",
+			contentType: "text/yaml",
+			wantErr:     `unsupported Content-Type "text/yaml"`,
+		},
+		{
+			name:        "vendor JSON is not declared",
+			contentType: "application/vnd.example+json",
+			wantErr:     `unsupported Content-Type "application/vnd.example+json"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := decodeBundleRecipe(bytes.NewReader(body), tt.contentType, true)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("decodeBundleRecipe() error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("decodeBundleRecipe() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProfileAwareBundleEndpoints(t *testing.T) {
+	h := newTestBundleHandler(t)
+	post := func(t *testing.T, v2 bool, query string, body []byte) *httptest.ResponseRecorder {
+		t.Helper()
+		path := "/v1/bundle"
+		if v2 {
+			path = "/v2/bundle"
+		}
+		path += query
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		if v2 {
+			h.HandleBundlesV2(w, req)
+		} else {
+			h.HandleBundles(w, req)
+		}
+		return w
+	}
+
+	t.Run("v1 rejects profile artifact", func(t *testing.T) {
+		w := post(t, false, "", profileBundleBody(t))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("v2 accepts profile artifact", func(t *testing.T) {
+		w := post(t, true, "", profileBundleBody(t))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+		if w.Header().Get("Content-Type") != "application/zip" {
+			t.Fatalf("Content-Type = %q, want application/zip", w.Header().Get("Content-Type"))
+		}
+	})
+
+	t.Run("v2 accepts legacy artifact", func(t *testing.T) {
+		w := post(t, true, "", resolveEmbeddedBundleBody(t))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("v2 strictly rejects unknown artifact field", func(t *testing.T) {
+		body := profileBundleBody(t)
+		body = bytes.Replace(body, []byte(`"componentRefs"`), []byte(`"profie":true,"componentRefs"`), 1)
+		w := post(t, true, "", body)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("v2 strictly rejects unknown excluded overlay field", func(t *testing.T) {
+		body := profileBundleBody(t)
+		body = bytes.Replace(
+			body,
+			[]byte(`"metadata":{`),
+			[]byte(`"metadata":{"excludedOverlays":[{"name":"overlay-a","reasn":"constraint-failed"}],`),
+			1,
+		)
+		w := post(t, true, "", body)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	invalidMetadataItems := []struct {
+		name        string
+		fixtureBody func(*testing.T) []byte
+		replacement string
+	}{
+		{
+			name:        "v2 rejects incomplete profile metadata item",
+			fixtureBody: profileBundleBody,
+			replacement: `"metadata":{"excludedOverlays":[{"reason":"constraint-failed"}],`,
+		},
+		{
+			name:        "v2 rejects null legacy excluded overlay",
+			fixtureBody: resolveEmbeddedBundleBody,
+			replacement: `"metadata":{"excludedOverlays":[null],`,
+		},
+	}
+	for _, tt := range invalidMetadataItems {
+		t.Run(tt.name, func(t *testing.T) {
+			body := bytes.Replace(
+				tt.fixtureBody(t),
+				[]byte(`"metadata":{`),
+				[]byte(tt.replacement),
+				1,
+			)
+			w := post(t, true, "", body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	t.Run("v2 rejects profile version without selection", func(t *testing.T) {
+		var result recipe.RecipeResult
+		if err := json.Unmarshal(profileBundleBody(t), &result); err != nil {
+			t.Fatalf("decode fixture: %v", err)
+		}
+		result.Metadata.SelectedProfile = nil
+		body, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("marshal fixture: %v", err)
+		}
+		w := post(t, true, "", body)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("v2 rejects unknown query parameter", func(t *testing.T) {
+		w := post(t, true, "?profie=gpuStack%3Ddriver-installed", profileBundleBody(t))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "v2 rejects set override of profile-owned path",
+			query: "?set=gpu-operator:driver.enabled=true",
+		},
+		{
+			name:  "v2 rejects dynamic override of profile-owned path",
+			query: "?dynamic=gpu-operator:driver.enabled",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w := post(t, true, tt.query, profileBundleBody(t))
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 // TestBundleHandler_Attest pins the ?attest=true signing seam: a configured
 // server signs via the injected attesterBuilder, an unconfigured server rejects
 // the request with 400, and the default (no attest) path never touches signing.

--- a/pkg/server/consts.go
+++ b/pkg/server/consts.go
@@ -32,4 +32,7 @@ const (
 	keyError      = "error"
 	keyAllowed    = "allowed"
 	keyLimitBytes = "limit_bytes"
+	keyService    = "service"
+	keyProfile    = "profile"
+	keyNodes      = "nodes"
 )

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -17,8 +17,8 @@
 //
 // This package is the binary's home, not a reusable framework. cmd/aicrd/main.go
 // calls Serve() and exits. The package owns the HTTP entry point, the
-// middleware chain, the /v1/recipe, /v1/query, and /v1/bundle handlers, and
-// the health/readiness probes.
+// middleware chain, the v1 and v2 recipe/query/bundle handlers, and the
+// health/readiness probes.
 //
 // # Architecture
 //
@@ -43,7 +43,8 @@
 //   - rateLimitMiddleware — token bucket (golang.org/x/time/rate).
 //   - bodyLimitMiddleware — defaults.ServerMaxBodyBytes (8 MiB) via
 //     http.MaxBytesReader; handlers install tighter caps where appropriate
-//     (MaxRecipePOSTBytes for /v1/recipe, MaxBundlePOSTBytes for /v1/bundle).
+//     (MaxRecipePOSTBytes for recipe/query routes and MaxBundlePOSTBytes for
+//     bundle routes, in both v1 and v2).
 //
 // Graceful shutdown is wired via signal.NotifyContext on SIGINT/SIGTERM.
 //
@@ -61,6 +62,11 @@
 // RecipeResult body. Query parameters control deployer, value overrides
 // (set=), dynamic declarations (dynamic=), node selectors/tolerations, and
 // workload gating.
+//
+// The corresponding /v2/recipe, /v2/query, and /v2/bundle routes add strict,
+// profile-aware request and artifact contracts. The v1 routes preserve their
+// legacy input behavior and reject explicit profile selection or profiled
+// artifacts.
 //
 // GET /health — liveness probe; always 200.
 // GET /ready — readiness probe; 200 when ready, 503 otherwise.

--- a/pkg/server/openapi_sync_test.go
+++ b/pkg/server/openapi_sync_test.go
@@ -211,7 +211,7 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if want := "#/components/schemas/RecipeResponse"; tt.got != want {
+			if want := "#/components/schemas/LegacyRecipeResponse"; tt.got != want {
 				t.Errorf("$ref = %q, want %q", tt.got, want)
 			}
 		})
@@ -220,16 +220,22 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
 		schema      openAPIContractSchema
+		baseRef     string
 		required    []string
 		apiVersions []string
 		kinds       []string
 	}{
 		{
+			// /v1 responses are pinned to v1alpha2 by LegacyRecipeResponse,
+			// which wraps RecipeResponse and narrows the apiVersion enum.
+			// RecipeResponse itself now also admits v1alpha3 for /v2, so
+			// asserting on it directly would no longer prove v1 stays legacy.
+			// required and kind come from the RecipeResponse base and are
+			// checked there; this case owns the narrowing.
 			name:        "versioned response",
-			schema:      spec.Components.Schemas["RecipeResponse"],
-			required:    []string{"apiVersion", "kind"},
+			schema:      spec.Components.Schemas["LegacyRecipeResponse"],
+			baseRef:     "#/components/schemas/RecipeResponse",
 			apiVersions: []string{recipe.RecipeAPIVersion},
-			kinds:       []string{recipe.RecipeResultKind},
 		},
 		{
 			// The bundle request also admits the legacy Recipe kind: that was
@@ -244,8 +250,12 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			closure := allOfConstraint(t, tt.schema, "#/components/schemas/RecipeResponseBase")
-			if !equalStringsUnordered(closure.Required, tt.required) {
+			baseRef := tt.baseRef
+			if baseRef == "" {
+				baseRef = "#/components/schemas/RecipeResponseBase"
+			}
+			closure := allOfConstraint(t, tt.schema, baseRef)
+			if tt.required != nil && !equalStringsUnordered(closure.Required, tt.required) {
 				t.Errorf("required = %v, want %v", closure.Required, tt.required)
 			}
 			gotAPIVersions := closure.Properties["apiVersion"].Enum
@@ -253,7 +263,7 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 				t.Errorf("apiVersion enum = %v, want %v", gotAPIVersions, tt.apiVersions)
 			}
 			gotKinds := closure.Properties["kind"].Enum
-			if !equalStringsUnordered(gotKinds, tt.kinds) {
+			if tt.kinds != nil && !equalStringsUnordered(gotKinds, tt.kinds) {
 				t.Errorf("kind enum = %v, want %v", gotKinds, tt.kinds)
 			}
 		})
@@ -273,6 +283,282 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 			t.Errorf("RecipeResponseBase %s enum = %v, want wrapper-owned enum", name, got)
 		}
 	}
+}
+
+func TestOpenAPIV2BundleContract(t *testing.T) {
+	specPath := filepath.Join("..", "..", "api", "aicr", "v1", "server.yaml")
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read spec %q: %v", specPath, err)
+	}
+	var spec map[string]any
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+
+	content := openAPIObjectAt(t, spec,
+		"paths", "/v2/bundle", "post", "requestBody", "content")
+	for _, mediaType := range []string{"application/json", "application/x-yaml"} {
+		schema := openAPIObjectAt(t, content, mediaType, "schema")
+		if got := schema["$ref"]; got != "#/components/schemas/BundleRecipeV2Request" {
+			t.Errorf("%s request schema = %v, want BundleRecipeV2Request", mediaType, got)
+		}
+	}
+
+	responses := openAPIObjectAt(t, spec, "paths", "/v2/bundle", "post", "responses")
+	for _, status := range []string{"401", "404", "503", "504"} {
+		if _, ok := responses[status]; !ok {
+			t.Errorf("/v2/bundle response %s is not declared", status)
+		}
+	}
+
+	schemas := openAPIObjectAt(t, spec, "components", "schemas")
+	union := openAPIObjectAt(t, schemas, "BundleRecipeV2Request")
+	refs := map[string]bool{}
+	for _, item := range openAPISequence(t, union["oneOf"], "BundleRecipeV2Request.oneOf") {
+		schema := openAPIObject(t, item, "BundleRecipeV2Request.oneOf item")
+		ref, _ := schema["$ref"].(string)
+		refs[ref] = true
+	}
+	for _, ref := range []string{
+		"#/components/schemas/LegacyBundleRecipeV2Request",
+		"#/components/schemas/ProfileRecipeResponse",
+	} {
+		if !refs[ref] {
+			t.Errorf("BundleRecipeV2Request.oneOf does not reference %s", ref)
+		}
+	}
+	// The strict response schema must NOT be a request branch: reusing it
+	// there re-requires kind: RecipeResult and re-rejects the legacy shapes
+	// (kind absent/empty) the v2 decode path accepts.
+	if refs["#/components/schemas/LegacyRecipeResponse"] {
+		t.Error("BundleRecipeV2Request.oneOf must not reuse the strict LegacyRecipeResponse response schema")
+	}
+
+	// The legacy request branch covers the whole accepted legacy square:
+	// apiVersion absent/""/v1alpha2 × kind absent/""/RecipeResult, headers
+	// optional. Anything narrower leaves /v2/bundle stricter than its own
+	// server (DecodeRecipeResult enforces kind only when non-empty).
+	legacyBranch := openAPIObjectAt(t, schemas, "LegacyBundleRecipeV2Request")
+	legacyBranchAllOf := openAPISequence(t, legacyBranch["allOf"], "LegacyBundleRecipeV2Request.allOf")
+	legacyOverlay := openAPIObject(t, legacyBranchAllOf[1], "LegacyBundleRecipeV2Request overlay")
+	if _, required := legacyOverlay["required"]; required {
+		t.Error("LegacyBundleRecipeV2Request must not require header fields")
+	}
+	legacyAPIVersion := openAPIObjectAt(t, legacyOverlay, "properties", "apiVersion")
+	legacyAPIVersions := openAPISequence(t, legacyAPIVersion["enum"],
+		"LegacyBundleRecipeV2Request apiVersion enum")
+	for _, value := range []string{"", "aicr.run/v1alpha2"} {
+		if !openAPIHasString(legacyAPIVersions, value) {
+			t.Errorf("LegacyBundleRecipeV2Request apiVersion enum missing %q", value)
+		}
+	}
+	legacyKind := openAPIObjectAt(t, legacyOverlay, "properties", "kind")
+	legacyKinds := openAPISequence(t, legacyKind["enum"],
+		"LegacyBundleRecipeV2Request kind enum")
+	for _, value := range []string{"", "RecipeResult"} {
+		if !openAPIHasString(legacyKinds, value) {
+			t.Errorf("LegacyBundleRecipeV2Request kind enum missing %q", value)
+		}
+	}
+	if _, ok := union["discriminator"]; ok {
+		t.Error("BundleRecipeV2Request must not discriminate a versionless branch by apiVersion")
+	}
+
+	profile := openAPIObjectAt(t, schemas, "ProfileRecipeResponse")
+	profileAllOf := openAPISequence(t, profile["allOf"], "ProfileRecipeResponse.allOf")
+	if len(profileAllOf) != 2 {
+		t.Fatalf("ProfileRecipeResponse.allOf has %d entries, want 2", len(profileAllOf))
+	}
+	profileClosure := openAPIObject(t, profileAllOf[1], "ProfileRecipeResponse closure")
+	if closed, ok := profileClosure["additionalProperties"].(bool); !ok || closed {
+		t.Errorf("ProfileRecipeResponse additionalProperties = %v, want false", profileClosure["additionalProperties"])
+	}
+	profileMetadata := openAPIObjectAt(t, profileClosure, "properties", "metadata")
+	if !openAPIHasString(
+		openAPISequence(t, profileMetadata["required"], "ProfileRecipeResponse metadata.required"),
+		"selectedProfile",
+	) {
+
+		t.Error("ProfileRecipeResponse metadata does not require selectedProfile")
+	}
+	profileExcludedOverlay := openAPIObjectAt(t, profileMetadata,
+		"properties", "excludedOverlays", "items", "propertyNames")
+	profileExcludedOverlayNames := openAPISequence(t, profileExcludedOverlay["enum"],
+		"ProfileRecipeResponse excludedOverlays propertyNames.enum")
+	excludedOverlayFields := []string{"name", "reason"}
+	if len(profileExcludedOverlayNames) != len(excludedOverlayFields) {
+		t.Errorf("ProfileRecipeResponse excludedOverlays allows %d fields, want %d",
+			len(profileExcludedOverlayNames), len(excludedOverlayFields))
+	}
+	for _, field := range excludedOverlayFields {
+		if !openAPIHasString(profileExcludedOverlayNames, field) {
+			t.Errorf("ProfileRecipeResponse excludedOverlays does not allow %s", field)
+		}
+	}
+	baseExcludedOverlay := openAPIObjectAt(t, schemas, "RecipeResponseBase",
+		"properties", "metadata", "properties", "excludedOverlays", "items")
+	baseExcludedOverlayBranches := openAPISequence(t, baseExcludedOverlay["oneOf"],
+		"RecipeResponseBase excludedOverlays oneOf")
+	baseExcludedOverlayTypes := map[any]bool{}
+	var baseExcludedOverlayObject map[string]any
+	for _, branch := range baseExcludedOverlayBranches {
+		branchObject := openAPIObject(t, branch,
+			"RecipeResponseBase excludedOverlays oneOf item")
+		baseExcludedOverlayTypes[branchObject["type"]] = true
+		if branchObject["type"] == "object" {
+			baseExcludedOverlayObject = branchObject
+		}
+	}
+	for _, wantType := range []string{"string", "object"} {
+		if !baseExcludedOverlayTypes[wantType] {
+			t.Errorf("RecipeResponseBase excludedOverlays does not accept %s entries", wantType)
+		}
+	}
+	if baseExcludedOverlayObject == nil {
+		t.Fatal("RecipeResponseBase excludedOverlays has no object branch")
+	}
+	baseExcludedOverlayName := openAPIObjectAt(t, baseExcludedOverlayObject,
+		"properties", "name")
+	if got := baseExcludedOverlayName["minLength"]; got != 1 {
+		t.Errorf("RecipeResponseBase excludedOverlays object name minLength = %v, want 1", got)
+	}
+	profileConstraintWarning := openAPIObjectAt(t, profileMetadata,
+		"properties", "constraintWarnings", "items", "propertyNames")
+	profileConstraintWarningNames := openAPISequence(t, profileConstraintWarning["enum"],
+		"ProfileRecipeResponse constraintWarnings propertyNames.enum")
+	constraintWarningFields := []string{"overlay", "constraint", "expected", "actual", "reason"}
+	if len(profileConstraintWarningNames) != len(constraintWarningFields) {
+		t.Errorf("ProfileRecipeResponse constraintWarnings allows %d fields, want %d",
+			len(profileConstraintWarningNames), len(constraintWarningFields))
+	}
+	for _, field := range constraintWarningFields {
+		if !openAPIHasString(profileConstraintWarningNames, field) {
+			t.Errorf("ProfileRecipeResponse constraintWarnings does not allow %s", field)
+		}
+	}
+	componentFieldTypes := map[string]string{
+		"name":               "string",
+		"namespace":          "string",
+		"chart":              "string",
+		"type":               "string",
+		"source":             "string",
+		"version":            "string",
+		"tag":                "string",
+		"valuesFile":         "string",
+		"overrides":          "object",
+		"patches":            "array",
+		"dependencyRefs":     "array",
+		"manifestFiles":      "array",
+		"preManifestFiles":   "array",
+		"path":               "string",
+		"cleanup":            "boolean",
+		"expectedResources":  "array",
+		"healthCheckAsserts": "string",
+		"healthCheckSkip":    "boolean",
+	}
+	recipeResponseBase := openAPIObjectAt(t, schemas, "RecipeResponseBase")
+	componentProperties := openAPIObjectAt(t, recipeResponseBase,
+		"properties", "componentRefs", "items", "properties")
+	for field, wantType := range componentFieldTypes {
+		property := openAPIObjectAt(t, componentProperties, field)
+		if got := property["type"]; got != wantType {
+			t.Errorf("RecipeResponse componentRefs.%s type = %v, want %s", field, got, wantType)
+		}
+	}
+	profileComponent := openAPIObjectAt(t, profileClosure,
+		"properties", "componentRefs", "items")
+	profileComponentNames := openAPISequence(t,
+		openAPIObjectAt(t, profileComponent, "propertyNames")["enum"],
+		"ProfileRecipeResponse componentRefs propertyNames.enum")
+	if len(profileComponentNames) != len(componentFieldTypes) {
+		t.Errorf("ProfileRecipeResponse componentRefs allows %d fields, want %d",
+			len(profileComponentNames), len(componentFieldTypes))
+	}
+	for field := range componentFieldTypes {
+		if !openAPIHasString(profileComponentNames, field) {
+			t.Errorf("ProfileRecipeResponse componentRefs does not allow %s", field)
+		}
+	}
+	expectedResource := openAPIObjectAt(t, profileComponent,
+		"properties", "expectedResources", "items")
+	if closed, ok := expectedResource["additionalProperties"].(bool); !ok || closed {
+		t.Errorf("ProfileRecipeResponse expectedResources additionalProperties = %v, want false",
+			expectedResource["additionalProperties"])
+	}
+	expectedResourceProperties := openAPIObjectAt(t, expectedResource, "properties")
+	for _, field := range []string{"kind", "name", "namespace"} {
+		property := openAPIObjectAt(t, expectedResourceProperties, field)
+		if got := property["type"]; got != "string" {
+			t.Errorf("ProfileRecipeResponse expectedResources.%s type = %v, want string", field, got)
+		}
+	}
+
+	legacy := openAPIObjectAt(t, schemas, "LegacyRecipeResponse")
+	legacyAllOf := openAPISequence(t, legacy["allOf"], "LegacyRecipeResponse.allOf")
+	if len(legacyAllOf) != 2 {
+		t.Fatalf("LegacyRecipeResponse.allOf has %d entries, want 2", len(legacyAllOf))
+	}
+	legacyMetadata := openAPIObjectAt(t,
+		openAPIObject(t, legacyAllOf[1], "LegacyRecipeResponse version schema"),
+		"properties", "metadata", "not")
+	if !openAPIHasString(
+		openAPISequence(t, legacyMetadata["required"], "LegacyRecipeResponse metadata.not.required"),
+		"selectedProfile",
+	) {
+
+		t.Error("LegacyRecipeResponse does not prohibit selectedProfile")
+	}
+
+	// The legacy request branch prohibits selectedProfile and keeps its
+	// header enums to the legacy square only — a v1alpha3 artifact must
+	// still fail this branch so oneOf matches exactly one.
+	legacyBranchMetadata := openAPIObjectAt(t, legacyOverlay,
+		"properties", "metadata", "not")
+	if !openAPIHasString(
+		openAPISequence(t, legacyBranchMetadata["required"],
+			"LegacyBundleRecipeV2Request metadata.not.required"),
+		"selectedProfile",
+	) {
+
+		t.Error("LegacyBundleRecipeV2Request does not prohibit selectedProfile")
+	}
+}
+
+func openAPIObjectAt(t *testing.T, root map[string]any, path ...string) map[string]any {
+	t.Helper()
+	current := root
+	for _, key := range path {
+		current = openAPIObject(t, current[key], key)
+	}
+	return current
+}
+
+func openAPIObject(t *testing.T, value any, label string) map[string]any {
+	t.Helper()
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %T, want object", label, value)
+	}
+	return object
+}
+
+func openAPISequence(t *testing.T, value any, label string) []any {
+	t.Helper()
+	sequence, ok := value.([]any)
+	if !ok {
+		t.Fatalf("%s = %T, want array", label, value)
+	}
+	return sequence
+}
+
+func openAPIHasString(values []any, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 // collectCriteriaEnumSites walks the YAML tree and returns every enum array

--- a/pkg/server/recipe_handler.go
+++ b/pkg/server/recipe_handler.go
@@ -15,18 +15,25 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
+	"mime"
 	"net/http"
+	"net/url"
+	"strings"
 
 	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
+	"gopkg.in/yaml.v3"
 )
 
 // recipeCacheTTL controls the Cache-Control max-age on successful recipe and
@@ -34,10 +41,24 @@ import (
 // facade-backed handlers stay byte-identical.
 var recipeCacheTTL = defaults.RecipeCacheTTL
 
-// recipeHandler backs the /v1/recipe and /v1/query endpoints with an
-// aicr.Client. It reproduces the behavior of the pkg/recipe Builder handlers
-// exactly, swapping the recipe build for the facade's
-// ResolveRecipeFromCriteria.
+var v2CriteriaQueryParameters = map[string]struct{}{
+	keyService:    {},
+	"accelerator": {},
+	"gpu":         {},
+	"intent":      {},
+	"os":          {},
+	"platform":    {},
+	keyNodes:      {},
+	keyProfile:    {},
+}
+
+// recipeHandler backs the recipe and query endpoints on both routes —
+// /v1/recipe, /v1/query, /v2/recipe, and /v2/query — with an aicr.Client. The
+// v1 handlers reproduce the behavior of the pkg/recipe Builder handlers,
+// swapping the recipe build for the facade's ResolveRecipeFromCriteria; the
+// one v1 addition is rejecting explicit profile input, which legacy clients
+// could never send. The v2 handlers add strict decoding, media-type
+// enforcement, and profile selection over the same resolution path.
 type recipeHandler struct {
 	client *aicr.Client
 	// allowLists is held for exact error-message parity on rejection: the
@@ -53,12 +74,32 @@ func newRecipeHandler(client *aicr.Client, allowLists *aicr.AllowLists) *recipeH
 	return &recipeHandler{client: client, allowLists: allowLists}
 }
 
+type recipeV2Envelope struct {
+	Criteria *recipe.Criteria `json:"criteria" yaml:"criteria"`
+	Profile  *string          `json:"profile,omitempty" yaml:"profile,omitempty"`
+}
+
+type queryV2Envelope struct {
+	Criteria *recipe.Criteria `json:"criteria" yaml:"criteria"`
+	Profile  *string          `json:"profile,omitempty" yaml:"profile,omitempty"`
+	Selector *string          `json:"selector" yaml:"selector"`
+}
+
 // HandleRecipes processes recipe requests using the criteria-based system.
 // It supports GET requests with query parameters and POST requests with JSON/YAML body
 // to specify recipe criteria.
 // The response returns a RecipeResult with component references and constraints.
 // Errors are handled and returned in a structured format.
 func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
+	h.handleRecipes(w, r, false)
+}
+
+// HandleRecipesV2 is the strict, profile-aware recipe endpoint.
+func (h *recipeHandler) HandleRecipesV2(w http.ResponseWriter, r *http.Request) {
+	h.handleRecipes(w, r, true)
+}
+
+func (h *recipeHandler) handleRecipes(w http.ResponseWriter, r *http.Request, v2 bool) {
 	// Add request-scoped timeout
 	ctx, cancel := context.WithTimeout(r.Context(), defaults.RecipeHandlerTimeout)
 	defer cancel()
@@ -66,10 +107,24 @@ func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
 	logger := slog.With("requestID", RequestIDFromContext(r.Context()))
 
 	var criteria *recipe.Criteria
+	var profile string
 	var err error
 
 	switch r.Method {
 	case http.MethodGet:
+		if v2 {
+			if err = validateV2QueryParameters(r, v2CriteriaQueryParameters); err != nil {
+				break
+			}
+			profile, err = singleQueryValue(r, keyProfile)
+			if err != nil {
+				break
+			}
+		} else if _, supplied := r.URL.Query()[keyProfile]; supplied {
+			err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				"profile selection is available only on /v2/recipe")
+			break
+		}
 		criteria, err = recipe.ParseCriteriaFromRequest(r, h.client.CriteriaRegistry())
 	case http.MethodPost:
 		// Bound request body to defend against memory exhaustion.
@@ -85,18 +140,54 @@ func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
 				logger.Debug("request body close failed", "error", closeErr)
 			}
 		}()
-		criteria, err = recipe.ParseCriteriaFromBody(bounded, r.Header.Get("Content-Type"), h.client.CriteriaRegistry())
-		var maxBytesErr *http.MaxBytesError
-		if err != nil && stderrors.As(err, &maxBytesErr) {
-			logger.Warn("recipe POST body exceeded size limit",
-				"limit", defaults.MaxRecipePOSTBytes,
-				"received", maxBytesErr.Limit,
-			)
-			WriteError(w, r, http.StatusRequestEntityTooLarge, aicrerrors.ErrCodeInvalidRequest,
-				"Request body exceeds maximum allowed size", false, map[string]any{
-					keyLimitBytes: defaults.MaxRecipePOSTBytes,
-				})
-			return
+		bodyData, readErr := io.ReadAll(bounded)
+		if readErr != nil {
+			var maxBytesErr *http.MaxBytesError
+			if stderrors.As(readErr, &maxBytesErr) {
+				logger.Warn("recipe POST body exceeded size limit",
+					"limit", defaults.MaxRecipePOSTBytes,
+					"received", maxBytesErr.Limit,
+				)
+				WriteError(w, r, http.StatusRequestEntityTooLarge, aicrerrors.ErrCodeInvalidRequest,
+					"Request body exceeds maximum allowed size", false, map[string]any{
+						keyLimitBytes: defaults.MaxRecipePOSTBytes,
+					})
+				return
+			}
+			err = readErr
+			break
+		}
+		if v2 {
+			var envelope recipeV2Envelope
+			if err = decodeStrictV2Envelope(bodyData, r.Header.Get("Content-Type"), &envelope); err == nil {
+				err = validateV2EnvelopeProfile(
+					bodyData, r.Header.Get("Content-Type"), envelope.Profile)
+				if err == nil {
+					criteria = envelope.Criteria
+					profile, err = resolvePOSTProfileSelection(r, true, "/v2/recipe", envelope.Profile)
+				}
+				if err == nil {
+					err = validateV2Criteria(criteria, h.client.CriteriaRegistry())
+				}
+			}
+		} else {
+			if hasProfile, detectErr := bodyHasTopLevelProfile(
+				bodyData,
+				recipe.CriteriaBodyFormat(r.Header.Get("Content-Type")),
+			); detectErr == nil && hasProfile {
+				err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+					"profile selection is available only on /v2/recipe")
+			} else {
+				// The v1 pre-detector exists only to reject a successfully
+				// decoded profile field. On malformed input, preserve the
+				// legacy parser's canonical error contract.
+				criteria, err = recipe.ParseCriteriaFromBody(
+					bytes.NewReader(bodyData), r.Header.Get("Content-Type"), h.client.CriteriaRegistry(),
+				)
+				if err == nil {
+					profile, err = resolvePOSTProfileSelection(r, false, "/v2/recipe", nil)
+				}
+			}
 		}
 	default:
 		w.Header().Set("Allow", "GET, POST")
@@ -123,12 +214,12 @@ func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Debug("criteria",
-		"service", criteria.Service,
+		keyService, criteria.Service,
 		"accelerator", criteria.Accelerator,
 		"intent", criteria.Intent,
 		"os", criteria.OS,
 		"platform", criteria.Platform,
-		"nodes", criteria.Nodes,
+		keyNodes, criteria.Nodes,
 	)
 
 	// Validate criteria against allowlists (if configured). This explicit
@@ -141,9 +232,16 @@ func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result, err := h.client.ResolveRecipeFromCriteria(ctx, aicr.WrapCriteria(criteria))
+	result, err := h.client.ResolveRecipeFromCriteriaWithProfile(
+		ctx, aicr.WrapCriteria(criteria), profile,
+	)
 	if err != nil {
 		WriteErrorFromErr(w, r, err, "Failed to build recipe", nil)
+		return
+	}
+	if !v2 && result.Resolved().Metadata.SelectedProfile != nil {
+		WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Profiled recipes are available only on /v2/recipe", false, nil)
 		return
 	}
 
@@ -162,6 +260,113 @@ func (h *recipeHandler) HandleRecipes(w http.ResponseWriter, r *http.Request) {
 // hydrates all component values, and returns the value at the given selector path.
 // Supports GET with query parameters (+selector) and POST with JSON/YAML body.
 func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
+	h.handleQuery(w, r, false)
+}
+
+// HandleQueryV2 is the strict, profile-aware query endpoint.
+func (h *recipeHandler) HandleQueryV2(w http.ResponseWriter, r *http.Request) {
+	h.handleQuery(w, r, true)
+}
+
+func (h *recipeHandler) parseQueryPOSTBody(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	v2 bool,
+) (*recipe.QueryRequest, *string, bool) {
+
+	bounded := http.MaxBytesReader(w, r.Body, defaults.MaxRecipePOSTBytes)
+	defer func() {
+		if _, drainErr := io.Copy(io.Discard, bounded); drainErr != nil {
+			logger.Debug("query request body drain failed", "error", drainErr)
+		}
+		if closeErr := bounded.Close(); closeErr != nil {
+			logger.Debug("query request body close failed", "error", closeErr)
+		}
+	}()
+
+	bodyData, err := io.ReadAll(bounded)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if stderrors.As(err, &maxBytesErr) {
+			logger.Warn("query POST body exceeded size limit",
+				"limit", defaults.MaxRecipePOSTBytes,
+				"received", maxBytesErr.Limit,
+			)
+			WriteError(w, r, http.StatusRequestEntityTooLarge, aicrerrors.ErrCodeInvalidRequest,
+				"Request body exceeds maximum allowed size", false, map[string]any{
+					keyLimitBytes: defaults.MaxRecipePOSTBytes,
+				})
+			return nil, nil, true
+		}
+		WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Invalid query request body", false, map[string]any{keyError: err.Error()})
+		return nil, nil, true
+	}
+
+	var req *recipe.QueryRequest
+	var profile *string
+	if v2 {
+		var envelope queryV2Envelope
+		err = decodeStrictV2Envelope(bodyData, r.Header.Get("Content-Type"), &envelope)
+		if err == nil {
+			err = validateV2EnvelopeProfile(
+				bodyData, r.Header.Get("Content-Type"), envelope.Profile)
+		}
+		if err == nil {
+			if envelope.Selector == nil {
+				err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+					"selector is required on /v2/query")
+			} else {
+				req = &recipe.QueryRequest{Criteria: envelope.Criteria, Selector: *envelope.Selector}
+				profile = envelope.Profile
+			}
+		}
+	} else {
+		hasProfile, detectErr := bodyHasTopLevelProfile(
+			bodyData,
+			recipe.QueryRequestBodyFormat(r.Header.Get("Content-Type")),
+		)
+		if detectErr == nil && hasProfile {
+			err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				"profile selection is available only on /v2/query")
+		} else {
+			// As on /v1/recipe, detection failures fall through so the
+			// established v1 parser remains the source of parse errors.
+			req, err = recipe.ParseQueryRequestFromBody(
+				bytes.NewReader(bodyData), r.Header.Get("Content-Type"),
+			)
+		}
+	}
+	if err != nil {
+		WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Invalid query request body", false, map[string]any{keyError: err.Error()})
+		return nil, nil, true
+	}
+	if req == nil {
+		WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Invalid query request body", false, nil)
+		return nil, nil, true
+	}
+	if req.Criteria != nil {
+		var validateErr error
+		if v2 {
+			validateErr = validateV2Criteria(req.Criteria, h.client.CriteriaRegistry())
+		} else {
+			validateErr = req.Criteria.ValidateWithRegistry(h.client.CriteriaRegistry())
+		}
+		if validateErr != nil {
+			WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+				"Invalid criteria in request body", false, map[string]any{
+					keyError: validateErr.Error(),
+				})
+			return nil, nil, true
+		}
+	}
+	return req, profile, false
+}
+
+func (h *recipeHandler) handleQuery(w http.ResponseWriter, r *http.Request, v2 bool) {
 	ctx, cancel := context.WithTimeout(r.Context(), defaults.RecipeHandlerTimeout)
 	defer cancel()
 
@@ -169,54 +374,45 @@ func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 
 	var criteria *recipe.Criteria
 	var selector string
+	var profile string
 	var err error
 
 	switch r.Method {
 	case http.MethodGet:
+		if v2 {
+			allowed := maps.Clone(v2CriteriaQueryParameters)
+			allowed["selector"] = struct{}{}
+			if err = validateV2QueryParameters(r, allowed); err != nil {
+				break
+			}
+			profile, err = singleQueryValue(r, keyProfile)
+			if err != nil {
+				break
+			}
+			if _, supplied := r.URL.Query()["selector"]; !supplied {
+				err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+					"selector is required on /v2/query")
+				break
+			}
+			selector, err = singleQueryValue(r, "selector")
+			if err != nil {
+				break
+			}
+		} else if _, supplied := r.URL.Query()[keyProfile]; supplied {
+			err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				"profile selection is available only on /v2/query")
+			break
+		}
 		criteria, err = recipe.ParseCriteriaFromRequest(r, h.client.CriteriaRegistry())
-		selector = r.URL.Query().Get("selector")
+		if !v2 {
+			selector = r.URL.Query().Get("selector")
+		}
 	case http.MethodPost:
-		// Bound request body to defend against memory exhaustion.
-		bounded := http.MaxBytesReader(w, r.Body, defaults.MaxRecipePOSTBytes)
-		defer func() {
-			// Drain via the bounded reader so any remaining bytes still
-			// count against MaxBytesReader. Errors are debug-only.
-			if _, drainErr := io.Copy(io.Discard, bounded); drainErr != nil {
-				logger.Debug("query request body drain failed", "error", drainErr)
-			}
-			if closeErr := bounded.Close(); closeErr != nil {
-				logger.Debug("query request body close failed", "error", closeErr)
-			}
-		}()
-		req, parseErr := recipe.ParseQueryRequestFromBody(bounded, r.Header.Get("Content-Type"))
-		if parseErr != nil {
-			var maxBytesErr *http.MaxBytesError
-			if stderrors.As(parseErr, &maxBytesErr) {
-				logger.Warn("query POST body exceeded size limit",
-					"limit", defaults.MaxRecipePOSTBytes,
-					"received", maxBytesErr.Limit,
-				)
-				WriteError(w, r, http.StatusRequestEntityTooLarge, aicrerrors.ErrCodeInvalidRequest,
-					"Request body exceeds maximum allowed size", false, map[string]any{
-						keyLimitBytes: defaults.MaxRecipePOSTBytes,
-					})
-				return
-			}
-			WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
-				"Invalid query request body", false, map[string]any{
-					keyError: parseErr.Error(),
-				})
+		req, bodyProfile, handled := h.parseQueryPOSTBody(w, r, logger, v2)
+		if handled {
 			return
 		}
-		if req.Criteria != nil {
-			if validateErr := req.Criteria.ValidateWithRegistry(h.client.CriteriaRegistry()); validateErr != nil {
-				WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
-					"Invalid criteria in request body", false, map[string]any{
-						keyError: validateErr.Error(),
-					})
-				return
-			}
-		}
+		profile, err = resolvePOSTProfileSelection(r, v2, "/v2/query", bodyProfile)
 		criteria = req.Criteria
 		selector = req.Selector
 	default:
@@ -244,7 +440,7 @@ func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Debug("query",
-		"service", criteria.Service,
+		keyService, criteria.Service,
 		"accelerator", criteria.Accelerator,
 		"intent", criteria.Intent,
 		"os", criteria.OS,
@@ -262,9 +458,16 @@ func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	rec, err := h.client.ResolveRecipeFromCriteria(ctx, aicr.WrapCriteria(criteria))
+	rec, err := h.client.ResolveRecipeFromCriteriaWithProfile(
+		ctx, aicr.WrapCriteria(criteria), profile,
+	)
 	if err != nil {
 		WriteErrorFromErr(w, r, err, "Failed to build recipe", nil)
+		return
+	}
+	if !v2 && rec.Resolved().Metadata.SelectedProfile != nil {
+		WriteError(w, r, http.StatusBadRequest, aicrerrors.ErrCodeInvalidRequest,
+			"Profiled recipes are available only on /v2/query", false, nil)
 		return
 	}
 
@@ -292,4 +495,179 @@ func (h *recipeHandler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(recipeCacheTTL.Seconds())))
 
 	serializer.RespondJSON(w, http.StatusOK, selected)
+}
+
+func validateV2QueryParameters(r *http.Request, allowed map[string]struct{}) error {
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		return aicrerrors.Wrap(
+			aicrerrors.ErrCodeInvalidRequest, "malformed query parameters", err)
+	}
+	for key := range values {
+		if _, ok := allowed[key]; !ok {
+			return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("unknown query parameter %q", key))
+		}
+	}
+	return nil
+}
+
+func singleQueryValue(r *http.Request, key string) (string, error) {
+	values, ok := r.URL.Query()[key]
+	if !ok {
+		return "", nil
+	}
+	if len(values) == 0 {
+		return "", nil
+	}
+	for _, value := range values[1:] {
+		if value != values[0] {
+			return "", aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("query parameter %q has conflicting values", key))
+		}
+	}
+	return values[0], nil
+}
+
+// resolvePOSTProfileSelection applies the ADR-015 transport rules shared by
+// the recipe and query POST endpoints. V2 accepts profile in the query string,
+// the strict body envelope, or both when the values agree. V1 rejects the
+// exact profile query parameter; its body rejection remains parser-specific.
+func resolvePOSTProfileSelection(
+	r *http.Request,
+	v2 bool,
+	v2Endpoint string,
+	bodyProfile *string,
+) (string, error) {
+
+	if !v2 {
+		if _, supplied := r.URL.Query()[keyProfile]; supplied {
+			return "", aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("profile selection is available only on %s", v2Endpoint))
+		}
+		return "", nil
+	}
+	if err := validateV2QueryParameters(r, map[string]struct{}{keyProfile: {}}); err != nil {
+		return "", err
+	}
+	queryProfile, err := singleQueryValue(r, keyProfile)
+	if err != nil {
+		return "", err
+	}
+	_, querySupplied := r.URL.Query()[keyProfile]
+	switch {
+	case querySupplied && bodyProfile != nil && queryProfile != *bodyProfile:
+		return "", aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			"profile selection conflicts between the query parameter and request body")
+	case querySupplied:
+		return queryProfile, nil
+	case bodyProfile != nil:
+		return *bodyProfile, nil
+	default:
+		return "", nil
+	}
+}
+
+func decodeStrictV2Envelope(data []byte, contentType string, target any) error {
+	format, err := v2BodyFormat(contentType)
+	if err != nil {
+		return err
+	}
+	reader, err := serializer.NewReader(
+		format, bytes.NewReader(data), serializer.WithStrict(),
+	)
+	if err != nil {
+		return aicrerrors.PropagateOrWrap(
+			err, aicrerrors.ErrCodeInvalidRequest, "failed to create request envelope reader")
+	}
+	if err := reader.Deserialize(target); err != nil {
+		return aicrerrors.PropagateOrWrap(
+			err, aicrerrors.ErrCodeInvalidRequest, "failed to decode request envelope")
+	}
+	return nil
+}
+
+func v2BodyFormat(contentType string) (serializer.Format, error) {
+	if strings.TrimSpace(contentType) == "" {
+		return serializer.Format(""), aicrerrors.New(
+			aicrerrors.ErrCodeInvalidRequest, "Content-Type is required for v2 request bodies")
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return serializer.Format(""), aicrerrors.Wrap(
+			aicrerrors.ErrCodeInvalidRequest, "invalid Content-Type for v2 request body", err)
+	}
+	switch strings.ToLower(mediaType) {
+	case "application/json":
+		return serializer.FormatJSON, nil
+	case "application/x-yaml":
+		return serializer.FormatYAML, nil
+	default:
+		return serializer.Format(""), aicrerrors.New(
+			aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unsupported Content-Type %q for v2 request body", mediaType))
+	}
+}
+
+// validateV2EnvelopeProfile distinguishes an omitted optional profile from an
+// explicitly null profile. Both JSON and YAML decode null into a nil *string,
+// but the strict v2 contract permits only a string in name=value form when the
+// field is present.
+func validateV2EnvelopeProfile(data []byte, contentType string, profile *string) error {
+	format, err := v2BodyFormat(contentType)
+	if err != nil {
+		return err
+	}
+	present, err := bodyHasTopLevelProfile(data, format)
+	if err != nil {
+		return aicrerrors.PropagateOrWrap(
+			err, aicrerrors.ErrCodeInvalidRequest, "failed to inspect profile field")
+	}
+	if present && profile == nil {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			"profile must be a string in name=value form; null is not allowed")
+	}
+	return nil
+}
+
+// validateV2Criteria applies constraints specific to the strict v2 envelope
+// without changing the legacy v1 body contract.
+func validateV2Criteria(criteria *recipe.Criteria, registry *recipe.CriteriaRegistry) error {
+	if criteria == nil {
+		return nil
+	}
+	if criteria.Nodes < 0 {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			"criteria nodes must be a non-negative integer")
+	}
+	return criteria.ValidateWithRegistry(registry)
+}
+
+func bodyHasTopLevelProfile(data []byte, format serializer.Format) (bool, error) {
+	switch format {
+	case serializer.FormatJSON:
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(data, &fields); err != nil {
+			return false, aicrerrors.Wrap(
+				aicrerrors.ErrCodeInvalidRequest, "failed to decode profile field", err)
+		}
+		_, exists := fields[keyProfile]
+		return exists, nil
+	case serializer.FormatYAML:
+		var fields map[string]yaml.Node
+		if err := yaml.Unmarshal(data, &fields); err != nil {
+			return false, aicrerrors.Wrap(
+				aicrerrors.ErrCodeInvalidRequest, "failed to decode profile field", err)
+		}
+		_, exists := fields[keyProfile]
+		return exists, nil
+	case serializer.FormatTable:
+		return false, aicrerrors.New(
+			aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unsupported profile field format %q", format))
+	default:
+		return false, aicrerrors.New(
+			aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unsupported profile field format %q", format))
+	}
 }

--- a/pkg/server/recipe_handler_test.go
+++ b/pkg/server/recipe_handler_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -45,6 +47,59 @@ func newTestHandler(t *testing.T, allowLists *aicr.AllowLists) *recipeHandler {
 	return newRecipeHandler(client, allowLists)
 }
 
+func newProfileTestHandler(t *testing.T) *recipeHandler {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "overlays"), 0o755); err != nil {
+		t.Fatalf("setup overlays directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"),
+		[]byte("components: []\n"), 0o600); err != nil {
+		t.Fatalf("setup registry.yaml: %v", err)
+	}
+	overlay := []byte(`apiVersion: aicr.run/v1alpha3
+kind: RecipeMetadata
+metadata:
+  name: profile-aks
+spec:
+  criteria:
+    service: aks
+  profile:
+    name: gpuStack
+    default: driver-installed
+    values:
+      driver-installed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: false
+      operator-managed:
+        componentRefs:
+          - name: gpu-operator
+            overrides:
+              driver:
+                enabled: true
+`)
+	if err := os.WriteFile(filepath.Join(dir, "overlays", "profile-aks.yaml"),
+		overlay, 0o600); err != nil {
+		t.Fatalf("setup profile overlay: %v", err)
+	}
+	client, err := aicr.NewClient(
+		aicr.WithRecipeSource(aicr.FilesystemSource(dir)),
+		aicr.WithVersion("test"),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct profile test client: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := client.Close(); closeErr != nil {
+			t.Errorf("client close failed: %v", closeErr)
+		}
+	})
+	return newRecipeHandler(client, nil)
+}
+
 // TestHandleRecipes_Success verifies GET and POST resolve a recipe with a 200
 // status and a Cache-Control header.
 func TestHandleRecipes_Success(t *testing.T) {
@@ -68,6 +123,19 @@ func TestHandleRecipes_Success(t *testing.T) {
 			target:      "/v1/recipe",
 			body:        `{"kind":"RecipeCriteria","apiVersion":"aicr.run/v1alpha2","spec":{"service":"eks","accelerator":"h100","intent":"training"}}`,
 			contentType: "application/json",
+		},
+		{
+			name:   "POST JSON without content type preserves legacy default",
+			method: http.MethodPost,
+			target: "/v1/recipe",
+			body:   `{"kind":"RecipeCriteria","apiVersion":"aicr.run/v1alpha2","spec":{"service":"eks","accelerator":"h100","intent":"training"}}`,
+		},
+		{
+			name:        "POST JSON with text plain preserves legacy fallback",
+			method:      http.MethodPost,
+			target:      "/v1/recipe",
+			body:        `{"kind":"RecipeCriteria","apiVersion":"aicr.run/v1alpha2","spec":{"service":"eks","accelerator":"h100","intent":"training"}}`,
+			contentType: "text/plain",
 		},
 	}
 
@@ -97,6 +165,444 @@ func TestHandleRecipes_Success(t *testing.T) {
 			}
 			if len(result.ComponentRefs) == 0 {
 				t.Error("expected at least one component in resolved recipe")
+			}
+		})
+	}
+}
+
+func TestProfileAwareRecipeEndpoints(t *testing.T) {
+	h := newProfileTestHandler(t)
+
+	t.Run("v2 GET selects explicit value", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v2/recipe?service=aks&accelerator=h100&intent=training&profile=gpuStack%3Doperator-managed",
+			nil,
+		)
+		w := httptest.NewRecorder()
+		h.HandleRecipesV2(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+		var result recipe.RecipeResult
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("decode result: %v", err)
+		}
+		if result.APIVersion != recipe.RecipeProfileAPIVersion ||
+			result.Metadata.SelectedProfile == nil ||
+			result.Metadata.SelectedProfile.Value != "operator-managed" {
+
+			t.Fatalf("profile result apiVersion=%q selected=%#v",
+				result.APIVersion, result.Metadata.SelectedProfile)
+		}
+	})
+
+	t.Run("v2 POST applies default", func(t *testing.T) {
+		body := `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"}}`
+		req := httptest.NewRequest(http.MethodPost, "/v2/recipe", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleRecipesV2(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+		var result recipe.RecipeResult
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("decode result: %v", err)
+		}
+		if result.Metadata.SelectedProfile == nil ||
+			result.Metadata.SelectedProfile.Value != "driver-installed" {
+
+			t.Fatalf("default selectedProfile = %#v", result.Metadata.SelectedProfile)
+		}
+	})
+
+	for _, tt := range []struct {
+		name   string
+		target string
+		body   string
+	}{
+		{
+			name:   "v2 POST selects profile from query",
+			target: "/v2/recipe?profile=gpuStack%3Doperator-managed",
+			body:   `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"}}`,
+		},
+		{
+			name:   "v2 POST accepts agreeing query and body profiles",
+			target: "/v2/recipe?profile=gpuStack%3Doperator-managed",
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},` +
+				`"profile":"gpuStack=operator-managed"}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.target, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.HandleRecipesV2(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+			}
+			var result recipe.RecipeResult
+			if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+				t.Fatalf("decode result: %v", err)
+			}
+			if result.Metadata.SelectedProfile == nil ||
+				result.Metadata.SelectedProfile.Value != "operator-managed" {
+
+				t.Fatalf("selectedProfile = %#v, want operator-managed",
+					result.Metadata.SelectedProfile)
+			}
+		})
+	}
+
+	t.Run("v2 query exposes selected profile", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v2/query?service=aks&accelerator=h100&intent=training&"+
+				"profile=gpuStack%3Doperator-managed&selector=metadata.selectedProfile.value",
+			nil,
+		)
+		w := httptest.NewRecorder()
+		h.HandleQueryV2(w, req)
+		if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != `"operator-managed"` {
+			t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+		}
+	})
+
+	for _, tt := range []struct {
+		name   string
+		target string
+		body   string
+	}{
+		{
+			name:   "v2 POST query selects profile from query",
+			target: "/v2/query?profile=gpuStack%3Doperator-managed",
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},` +
+				`"selector":"metadata.selectedProfile.value"}`,
+		},
+		{
+			name:   "v2 POST query accepts agreeing query and body profiles",
+			target: "/v2/query?profile=gpuStack%3Doperator-managed",
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},` +
+				`"profile":"gpuStack=operator-managed","selector":"metadata.selectedProfile.value"}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.target, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.HandleQueryV2(w, req)
+			if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != `"operator-managed"` {
+				t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	t.Run("v2 GET query requires selector presence", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v2/query?service=eks&accelerator=h100&intent=training",
+			nil,
+		)
+		w := httptest.NewRecorder()
+		h.HandleQueryV2(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("v2 POST query requires selector presence", func(t *testing.T) {
+		body := `{"criteria":{"service":"eks","accelerator":"h100","intent":"training"}}`
+		req := httptest.NewRequest(http.MethodPost, "/v2/query", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleQueryV2(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("v2 query accepts an explicitly empty selector", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v2/query?service=aks&accelerator=h100&intent=training&selector=",
+			nil,
+		)
+		w := httptest.NewRecorder()
+		h.HandleQueryV2(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+		var hydrated map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &hydrated); err != nil {
+			t.Fatalf("decode hydrated recipe: %v", err)
+		}
+		if _, ok := hydrated["components"]; !ok {
+			t.Fatalf("hydrated recipe keys = %v, want components", keysOf(hydrated))
+		}
+	})
+
+	t.Run("v2 POST query accepts an explicitly empty selector", func(t *testing.T) {
+		body := `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},"selector":""}`
+		req := httptest.NewRequest(http.MethodPost, "/v2/query", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleQueryV2(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+		var hydrated map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &hydrated); err != nil {
+			t.Fatalf("decode hydrated recipe: %v", err)
+		}
+		if _, ok := hydrated["components"]; !ok {
+			t.Fatalf("hydrated recipe keys = %v, want components", keysOf(hydrated))
+		}
+	})
+
+	t.Run("v1 rejects resolved profiled composition", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v1/recipe?service=aks&accelerator=h100&intent=training", nil)
+		w := httptest.NewRecorder()
+		h.HandleRecipes(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("v1 rejects explicit profile input", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v1/recipe?service=eks&profile=gpuStack%3Doperator-managed", nil)
+		w := httptest.NewRecorder()
+		h.HandleRecipes(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	tests := []struct {
+		name   string
+		method string
+		target string
+		body   string
+	}{
+		{
+			name:   "v2 rejects unknown query parameter",
+			method: http.MethodGet,
+			target: "/v2/recipe?service=eks&profie=gpuStack%3Dx",
+		},
+		{
+			name:   "v2 rejects malformed raw query",
+			method: http.MethodGet,
+			target: "/v2/recipe?service=aks&profile=gpuStack%3Doperator-managed;ignored=x",
+		},
+		{
+			name:   "v2 rejects conflicting repeated profile",
+			method: http.MethodGet,
+			target: "/v2/recipe?service=eks&profile=a%3Db&profile=a%3Dc",
+		},
+		{
+			name:   "v2 rejects unknown envelope field",
+			method: http.MethodPost,
+			target: "/v2/recipe",
+			body:   `{"criteria":{"service":"eks"},"profie":"gpuStack=x"}`,
+		},
+		{
+			name:   "v2 rejects unknown POST query parameter",
+			method: http.MethodPost,
+			target: "/v2/recipe?profie=gpuStack%3Dx",
+			body:   `{"criteria":{"service":"eks"}}`,
+		},
+		{
+			name:   "v2 rejects conflicting POST profile surfaces",
+			method: http.MethodPost,
+			target: "/v2/recipe?profile=gpuStack%3Doperator-managed",
+			body:   `{"criteria":{"service":"aks"},"profile":"gpuStack=driver-installed"}`,
+		},
+		{
+			name:   "v2 rejects negative nodes in POST criteria",
+			method: http.MethodPost,
+			target: "/v2/recipe",
+			body:   `{"criteria":{"service":"aks","nodes":-1}}`,
+		},
+		{
+			name:   "v1 rejects top-level POST profile",
+			method: http.MethodPost,
+			target: "/v1/recipe",
+			body:   `{"profile":"gpuStack=x","spec":{"service":"eks"}}`,
+		},
+		{
+			name:   "v1 rejects POST profile query parameter",
+			method: http.MethodPost,
+			target: "/v1/recipe?profile=gpuStack%3Dx",
+			body: `{"kind":"RecipeCriteria","apiVersion":"aicr.run/v1alpha2",` +
+				`"spec":{"service":"eks"}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.target, strings.NewReader(tt.body))
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			w := httptest.NewRecorder()
+			if strings.HasPrefix(tt.target, "/v2/") {
+				h.HandleRecipesV2(w, req)
+			} else {
+				h.HandleRecipes(w, req)
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	queryRejections := []struct {
+		name   string
+		v2     bool
+		target string
+		body   string
+	}{
+		{
+			name:   "v2 query rejects unknown POST query parameter",
+			v2:     true,
+			target: "/v2/query?profie=gpuStack%3Dx",
+			body: `{"criteria":{"service":"aks"},"selector":` +
+				`"metadata.selectedProfile.value"}`,
+		},
+		{
+			name:   "v2 query rejects conflicting POST profile surfaces",
+			v2:     true,
+			target: "/v2/query?profile=gpuStack%3Doperator-managed",
+			body: `{"criteria":{"service":"aks"},"profile":"gpuStack=driver-installed",` +
+				`"selector":"metadata.selectedProfile.value"}`,
+		},
+		{
+			name:   "v2 query rejects negative nodes in POST criteria",
+			v2:     true,
+			target: "/v2/query",
+			body: `{"criteria":{"service":"aks","nodes":-1},` +
+				`"selector":"metadata.selectedProfile.value"}`,
+		},
+		{
+			name:   "v1 query rejects POST profile query parameter",
+			target: "/v1/query?profile=gpuStack%3Dx",
+			body: `{"criteria":{"service":"eks"},"selector":` +
+				`"metadata.selectedProfile.value"}`,
+		},
+	}
+	for _, tt := range queryRejections {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.target, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			if tt.v2 {
+				h.HandleQueryV2(w, req)
+			} else {
+				h.HandleQuery(w, req)
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	unsupportedContentTypes := []struct {
+		name        string
+		query       bool
+		contentType string
+		body        string
+	}{
+		{
+			name: "v2 recipe rejects missing content type",
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"}}`,
+		},
+		{
+			name:        "v2 recipe rejects unsupported content type",
+			contentType: "text/plain",
+			body:        `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"}}`,
+		},
+		{
+			name:  "v2 query rejects missing content type",
+			query: true,
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},` +
+				`"selector":"metadata.selectedProfile.value"}`,
+		},
+		{
+			name:        "v2 query rejects unsupported content type",
+			query:       true,
+			contentType: "text/plain",
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},` +
+				`"selector":"metadata.selectedProfile.value"}`,
+		},
+	}
+	for _, tt := range unsupportedContentTypes {
+		t.Run(tt.name, func(t *testing.T) {
+			target := "/v2/recipe"
+			if tt.query {
+				target = "/v2/query"
+			}
+			req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(tt.body))
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			w := httptest.NewRecorder()
+			if tt.query {
+				h.HandleQueryV2(w, req)
+			} else {
+				h.HandleRecipesV2(w, req)
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	nullProfileRejections := []struct {
+		name        string
+		query       bool
+		contentType string
+		body        string
+	}{
+		{
+			name:        "v2 recipe rejects JSON null profile",
+			contentType: "application/json",
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},` +
+				`"profile":null}`,
+		},
+		{
+			name:        "v2 recipe rejects YAML null profile",
+			contentType: "application/x-yaml",
+			body: "criteria:\n  service: aks\n  accelerator: h100\n  intent: training\n" +
+				"profile: null\n",
+		},
+		{
+			name:        "v2 query rejects JSON null profile",
+			query:       true,
+			contentType: "application/json",
+			body: `{"criteria":{"service":"aks","accelerator":"h100","intent":"training"},` +
+				`"profile":null,"selector":"metadata.selectedProfile.value"}`,
+		},
+		{
+			name:        "v2 query rejects YAML null profile",
+			query:       true,
+			contentType: "application/x-yaml",
+			body: "criteria:\n  service: aks\n  accelerator: h100\n  intent: training\n" +
+				"profile: null\nselector: metadata.selectedProfile.value\n",
+		},
+	}
+	for _, tt := range nullProfileRejections {
+		t.Run(tt.name, func(t *testing.T) {
+			target := "/v2/recipe"
+			if tt.query {
+				target = "/v2/query"
+			}
+			req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", tt.contentType)
+			w := httptest.NewRecorder()
+			if tt.query {
+				h.HandleQueryV2(w, req)
+			} else {
+				h.HandleRecipesV2(w, req)
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 			}
 		})
 	}
@@ -151,6 +657,93 @@ func TestHandleRecipes_AllowListRejection(t *testing.T) {
 	}
 }
 
+// TestV1ProfileDetectionPreservesLegacyContracts verifies the v2-only profile
+// pre-detector preserves established v1 parse errors and the query route's
+// legacy YAML-without-content-type behavior.
+func TestV1ProfileDetectionPreservesLegacyContracts(t *testing.T) {
+	h := newTestHandler(t, nil)
+	tests := []struct {
+		name        string
+		target      string
+		body        string
+		contentType string
+		handle      http.HandlerFunc
+		wantError   string
+	}{
+		{
+			name:        "recipe empty body",
+			target:      "/v1/recipe",
+			contentType: "application/json",
+			handle:      h.HandleRecipes,
+			wantError:   "[INVALID_REQUEST] request body is empty",
+		},
+		{
+			name:        "query empty body",
+			target:      "/v1/query",
+			contentType: "application/json",
+			handle:      h.HandleQuery,
+			wantError:   "[INVALID_REQUEST] request body cannot be empty",
+		},
+		{
+			name:   "recipe YAML profile without content type preserves JSON default",
+			target: "/v1/recipe",
+			body: "profile: gpuStack=driver-installed\n" +
+				"spec:\n" +
+				"  service: aks\n",
+			handle:    h.HandleRecipes,
+			wantError: "[INVALID_REQUEST] failed to parse JSON body: invalid character 'p' looking for beginning of value",
+		},
+		{
+			name:   "query YAML profile without content type",
+			target: "/v1/query",
+			body: "profile: gpuStack=driver-installed\n" +
+				"criteria:\n" +
+				"  service: aks\n" +
+				"selector: components.gpu-operator.values.driver.enabled\n",
+			handle:    h.HandleQuery,
+			wantError: "[INVALID_REQUEST] profile selection is available only on /v2/query",
+		},
+		{
+			name:        "recipe profile detected despite ignored out-of-range number",
+			target:      "/v1/recipe",
+			body:        `{"profile":"gpuStack=operator-managed","unmapped":1e999,"spec":{"service":"eks"}}`,
+			contentType: "application/json",
+			handle:      h.HandleRecipes,
+			wantError:   "[INVALID_REQUEST] profile selection is available only on /v2/recipe",
+		},
+		{
+			name:        "query profile detected despite ignored out-of-range number",
+			target:      "/v1/query",
+			body:        `{"profile":"gpuStack=operator-managed","unmapped":1e999,"criteria":{"service":"eks"},"selector":"components"}`,
+			contentType: "application/json",
+			handle:      h.HandleQuery,
+			wantError:   "[INVALID_REQUEST] profile selection is available only on /v2/query",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.target, strings.NewReader(tt.body))
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			w := httptest.NewRecorder()
+
+			tt.handle(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+			var response errorResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if got := response.Details[keyError]; got != tt.wantError {
+				t.Fatalf("details.error = %q, want %q", got, tt.wantError)
+			}
+		})
+	}
+}
+
 // TestHandleQuery_Success verifies GET and POST query against a selector return
 // the selected value.
 func TestHandleQuery_Success(t *testing.T) {
@@ -179,6 +772,27 @@ func TestHandleQuery_Success(t *testing.T) {
 			target:      "/v1/query",
 			body:        `{"criteria":{"service":"eks","accelerator":"h100","intent":"training"},"selector":"` + selector + `"}`,
 			contentType: "application/json",
+		},
+		{
+			name:   "POST YAML without content type preserves legacy default",
+			method: http.MethodPost,
+			target: "/v1/query",
+			body: "criteria:\n" +
+				"  service: eks\n" +
+				"  accelerator: h100\n" +
+				"  intent: training\n" +
+				"selector: " + selector + "\n",
+		},
+		{
+			name:        "POST YAML with text plain preserves legacy fallback",
+			method:      http.MethodPost,
+			target:      "/v1/query",
+			contentType: "text/plain",
+			body: "criteria:\n" +
+				"  service: eks\n" +
+				"  accelerator: h100\n" +
+				"  intent: training\n" +
+				"selector: " + selector + "\n",
 		},
 	}
 

--- a/pkg/server/serve.go
+++ b/pkg/server/serve.go
@@ -40,6 +40,17 @@ var (
 	date    = "unknown"
 )
 
+func newRoutes(h *recipeHandler, bh *bundleHandler) map[string]http.HandlerFunc {
+	return map[string]http.HandlerFunc{
+		"/v1/recipe": h.HandleRecipes,
+		"/v1/query":  h.HandleQuery,
+		"/v1/bundle": bh.HandleBundles,
+		"/v2/recipe": h.HandleRecipesV2,
+		"/v2/query":  h.HandleQueryV2,
+		"/v2/bundle": bh.HandleBundlesV2,
+	}
+}
+
 // Serve starts the aicrd HTTP server and blocks until shutdown.
 // It configures logging, sets up routes, and handles graceful shutdown.
 // Returns an error if the server fails to start or encounters a fatal error.
@@ -131,17 +142,11 @@ func Serve() error {
 	// the Client owns both, completing #1077 acceptance criterion #2.
 	bh := newBundleHandler(client, allowLists, signing)
 
-	r := map[string]http.HandlerFunc{
-		"/v1/recipe": h.HandleRecipes,
-		"/v1/query":  h.HandleQuery,
-		"/v1/bundle": bh.HandleBundles,
-	}
-
 	// Create and run server
 	s := New(
 		WithName(name),
 		WithVersion(version),
-		WithHandler(r),
+		WithHandler(newRoutes(h, bh)),
 	)
 
 	if err := s.Run(ctx); err != nil {

--- a/pkg/server/serve_test.go
+++ b/pkg/server/serve_test.go
@@ -70,20 +70,19 @@ func TestConstants(t *testing.T) {
 }
 
 // TestRouteConfiguration verifies that the correct routes are set up,
-// mirroring how Serve wires them: /v1/recipe and /v1/query are backed by the
-// aicr.Client-based recipeHandler, and /v1/bundle by the aicr.Client-based
-// bundleHandler.
+// mirroring how Serve wires them: v1 and v2 recipe/query routes are backed by
+// the aicr.Client-based recipeHandler, and both bundle routes by the
+// aicr.Client-based bundleHandler.
 func TestRouteConfiguration(t *testing.T) {
 	h := newTestHandler(t, nil)
 	bh := newTestBundleHandler(t)
 
-	routes := map[string]http.HandlerFunc{
-		"/v1/recipe": h.HandleRecipes,
-		"/v1/query":  h.HandleQuery,
-		"/v1/bundle": bh.HandleBundles,
-	}
+	routes := newRoutes(h, bh)
 
-	for _, path := range []string{"/v1/recipe", "/v1/query", "/v1/bundle"} {
+	for _, path := range []string{
+		"/v1/recipe", "/v1/query", "/v1/bundle",
+		"/v2/recipe", "/v2/query", "/v2/bundle",
+	} {
 		if handler, exists := routes[path]; !exists {
 			t.Errorf("expected %s route to exist", path)
 		} else if handler == nil {
@@ -92,8 +91,8 @@ func TestRouteConfiguration(t *testing.T) {
 	}
 
 	// Verify no extra routes
-	if len(routes) != 3 {
-		t.Errorf("expected exactly 3 routes, got %d", len(routes))
+	if len(routes) != 6 {
+		t.Errorf("expected exactly 6 routes, got %d", len(routes))
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -250,9 +250,9 @@ func (s *Server) configureRootHandler() {
 			sort.Strings(routes)
 
 			response := map[string]any{
-				"service": s.config.Name,
-				"version": s.config.Version,
-				"routes":  routes,
+				keyService: s.config.Name,
+				"version":  s.config.Version,
+				"routes":   routes,
 			}
 
 			serializer.RespondJSON(w, http.StatusOK, response)

--- a/tools/testgrid-publish/bundle.go
+++ b/tools/testgrid-publish/bundle.go
@@ -22,11 +22,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 // readBoundedFile reads a file up to maxBytes. It returns ErrCodeInvalidRequest
@@ -48,23 +48,6 @@ func readBoundedFile(path string, maxBytes int64) ([]byte, error) {
 	return data, nil
 }
 
-// recipeFile is the minimal subset of recipe.yaml we need for coordinate
-// resolution. Field names match the on-disk YAML schema.
-type recipeFile struct {
-	Criteria struct {
-		Service     string `yaml:"service"`
-		Accelerator string `yaml:"accelerator"`
-		OS          string `yaml:"os"`
-		Intent      string `yaml:"intent"`
-		Platform    string `yaml:"platform"`
-	} `yaml:"criteria"`
-	// k8s constraint lives outside criteria in the recipe spec.
-	Constraints []struct {
-		Name  string `yaml:"name"`
-		Value string `yaml:"value"`
-	} `yaml:"constraints"`
-}
-
 // parseCriteria reads recipe.yaml from bundleDir and returns a
 // RecipeCriteria suitable for CoordinateFor.
 func parseCriteria(bundleDir string) (RecipeCriteria, error) {
@@ -78,20 +61,28 @@ func parseCriteria(bundleDir string) (RecipeCriteria, error) {
 		return RecipeCriteria{}, err // already structured (e.g. ErrCodeInvalidRequest for size limit)
 	}
 
-	var r recipeFile
-	if err := yaml.Unmarshal(data, &r); err != nil {
-		return RecipeCriteria{}, errors.Wrap(errors.ErrCodeInvalidRequest,
-			"failed to parse recipe.yaml", err)
+	r, err := recipe.DecodeRecipeResult(data, serializer.FormatYAML)
+	if err != nil {
+		return RecipeCriteria{}, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+			"failed to parse recipe.yaml")
+	}
+	if r.Criteria == nil {
+		return RecipeCriteria{}, errors.New(errors.ErrCodeInvalidRequest,
+			"recipe.yaml has no criteria")
+	}
+	if r.Metadata.SelectedProfile != nil {
+		return RecipeCriteria{}, errors.New(errors.ErrCodeInvalidRequest,
+			"profile-bearing TestGrid publication is deferred to the profile adoption rollout")
 	}
 
 	// Normalize: trim whitespace and lowercase so "EKS" and " eks " both
 	// map to the same GCS group path as the config-gen taxonomy expects.
 	c := r.Criteria
-	service := strings.ToLower(strings.TrimSpace(c.Service))
-	accelerator := strings.ToLower(strings.TrimSpace(c.Accelerator))
-	os_ := strings.ToLower(strings.TrimSpace(c.OS))
-	intent := strings.ToLower(strings.TrimSpace(c.Intent))
-	platform := strings.ToLower(strings.TrimSpace(c.Platform))
+	service := strings.ToLower(strings.TrimSpace(string(c.Service)))
+	accelerator := strings.ToLower(strings.TrimSpace(string(c.Accelerator)))
+	os_ := strings.ToLower(strings.TrimSpace(string(c.OS)))
+	intent := strings.ToLower(strings.TrimSpace(string(c.Intent)))
+	platform := strings.ToLower(strings.TrimSpace(string(c.Platform)))
 
 	if service == "" || accelerator == "" || os_ == "" || intent == "" {
 		return RecipeCriteria{}, errors.New(errors.ErrCodeInvalidRequest,

--- a/tools/testgrid-publish/bundle_test.go
+++ b/tools/testgrid-publish/bundle_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,15 +28,16 @@ import (
 
 func TestParseCriteria(t *testing.T) {
 	tests := []struct {
-		name           string
-		recipeYAML     string
-		wantService    string
-		wantAccel      string
-		wantOS         string
-		wantIntent     string
-		wantPlatform   string
-		wantConstraint string
-		wantErr        bool
+		name            string
+		recipeYAML      string
+		wantService     string
+		wantAccel       string
+		wantOS          string
+		wantIntent      string
+		wantPlatform    string
+		wantConstraint  string
+		wantErr         bool
+		wantErrContains string
 	}{
 		{
 			name: "full criteria with k8s constraint",
@@ -117,6 +119,24 @@ criteria:
 			recipeYAML: "this: is: not: valid: yaml: : :",
 			wantErr:    true,
 		},
+		{
+			name: "profile artifact rejected until publication support lands",
+			recipeYAML: `apiVersion: aicr.run/v1alpha3
+kind: RecipeResult
+metadata:
+  selectedProfile:
+    name: gpuStack
+    value: driver-installed
+    ownedPaths: {}
+criteria:
+  service: aks
+  accelerator: h100
+  os: ubuntu
+  intent: training
+`,
+			wantErr:         true,
+			wantErrContains: "profile-bearing TestGrid publication is deferred to the profile adoption rollout",
+		},
 	}
 
 	for _, tt := range tests {
@@ -132,6 +152,9 @@ criteria:
 				t.Fatalf("parseCriteria() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("parseCriteria() error = %v, want containing %q", err, tt.wantErrContains)
+				}
 				return
 			}
 			if got.Service != tt.wantService {


### PR DESCRIPTION
## Summary

Implement the ADR-015 configuration-profile core without adopting it in an existing recipe family. This adds fail-closed profile resolution and ownership locking, strict v2 API and artifact contracts, and documentation for the supported integration boundaries.

## Motivation / Context

Recipes need to capture mutually exclusive, qualified installation modes as part of the resolved recipe rather than relying on bundle-time overrides. This is the first roll-in PR: AKS adoption will follow, then GKE adoption.

Fixes: N/A
Related: #1761, #1716

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: API contract, client SDK, serializer, configuration, mirror discovery, evidence, and TestGrid publishing

## Implementation Notes

- Enforce one effective profile declaration per resolved composition. Selection is deterministic through the declared default or an explicit `name=value`.
- Validate declaration structure, union totality (every value assigns the same flattened override paths), ownership conflicts, canonical JSON/YAML-shaped override containers with recursively string-keyed and acyclic values, and an explicit scalar allowlist with finite numbers, JSON round-trip-safe integers, and YAML timestamps.
- Limit value-bearing profile ownership to Helm components. Kustomize components may participate only through a valueless presence lock because their deployment path does not consume Helm values.
- Record the selected profile and owned paths in `aicr.run/v1alpha3` `RecipeResult` artifacts. Unprofiled results retain the legacy API version and behavior.
- Resolve directly loaded profile overlays through the active catalog and require the effective applied declaration to structurally match after JSON normalization. Equivalent renamed overlays are accepted; stale or divergent declarations fail closed.
- Revalidate inline and hydrated profile-owned values when adopting or loading raw `RecipeResult` artifacts, before observation or serialization, and enforce the same lock at recipe, bundle, mirror, and Argo CD Helm boundaries.
- Honor cancellation throughout catalog profile projection and response conversion. Sort profile-owned component checks so invalid external compositions produce deterministic diagnostics.
- Preserve v1 compatibility while exposing strict profile-aware `/v2/recipe`, `/v2/query`, and `/v2/bundle` routes. V2 POST bodies accept only `application/json` and `application/x-yaml`, and nested criteria reject unknown fields.
- Keep HTTP route versions and persisted recipe `apiVersion`s independent. `/v2/recipe` can return either `aicr.run/v1alpha2` or `aicr.run/v1alpha3`, while `/v2/bundle` accepts both plus versionless legacy artifacts.
- Align the published `/v1/bundle` request schema with the input the runtime already accepts. `BundleRecipeRequest` requires neither header field and admits an empty `apiVersion` or `kind`, matching a legacy artifact decoded and remarshaled through `RecipeResult` (neither field carries `omitempty`). Header enums move from `RecipeResponseBase` onto each wrapper, so `GET /v1/recipe` responses stay strict. Fixes the same contract drift as #1941 on the v1 route.
- Model `/v2/bundle` as a version-partitioned union without an `apiVersion` discriminator. Legacy artifacts stamped `aicr.run/v1alpha2` or omitting `apiVersion` reuse the additive known-field schema and cannot carry a profile lock; `aicr.run/v1alpha3` is closed and requires `metadata.selectedProfile`.
- Decode `metadata.excludedOverlays` by artifact version. Legacy artifacts accept string entries and additive objects with a nonempty name; v1alpha3 requires closed objects with a nonempty name and a recognized optional reason. Profile artifacts also require complete `constraintWarnings` entries; the schema defines every `ComponentRef` field type and closes nested expected-resource objects.
- Document supported 401, 404, 503, and 504 `/v2/bundle` failures from vendored-chart and upstream operations.
- Preserve ConfigMap authorization failures as `UNAUTHORIZED` and context or Kubernetes API timeout failures as `TIMEOUT`. Warn when a preinstalled driver conflicts with a profile-owned driver setting.
- Keep unsupported advertiser, allocation-policy, canonical-descriptor, and qualification-evidence fields fail closed. No recipe family adopts profiles in this PR.

## Testing

```bash
# Full PR validation completed before the final review-fix deltas.
unset GITLAB_TOKEN && make qualify
golangci-lint run -c .golangci.yaml ./...

# Focused validation of the latest review-fix delta, rerun after the latest rebase.
GOFLAGS="-mod=vendor" go test -race -count=1 ./pkg/recipe \
  -run '^(TestValidateProfileDeclaration|TestValidateRecipeMetadataProfileYAMLScalars|TestProfileResolutionGuards|TestListCatalogWithProfiles_ProjectsEffectiveDeclaration|TestListCatalogWithProfilesCanceled|TestValidateProfileValuesRejectsInvalidBaseline|TestValidateProfileValuesRejectsUnsupportedArtifactScalars|TestValidateProfileValuesScopesArtifactValidationToOwnedPaths|TestValidateProfileValuesKustomizeOwnership)$'
GOFLAGS="-mod=vendor" go test -race -count=1 ./pkg/client/v1 \
  -run '^(TestResolveRecipeWithProfile|TestAdoptRecipe_DeepCopiesForClientIsolation|TestAdoptRecipe_RejectsCyclicProfileOverridesBeforeDeepCopy)$'
GOFLAGS="-mod=vendor" go test -race -count=1 ./pkg/bundler/deployer/argocdhelm \
  -run '^(TestGenerate_ProfileLockTemplate|TestHasGeneratedProfileLockHeader_BoundedRead|TestWriteProfileLockTemplateRejectsUnownedExistingFile)$'

# Focused OpenAPI validation from the preceding review-fix delta.
GOFLAGS="-mod=vendor" go test -race -count=1 ./pkg/server \
  -run '^TestOpenAPIV2BundleContract$'

# Focused validation from the preceding review-fix delta.
GOFLAGS="-mod=vendor" go test -race ./pkg/recipe \
  -run '^(TestMetadataStore_EvaluateOverlayConstraints|TestEvaluateMixinConstraintsRejectsIncompleteConstraint)$'
GOFLAGS="-mod=vendor" go test -race ./pkg/serializer \
  -run '^TestClassifyConfigMapGetError$'
GOFLAGS="-mod=vendor" go test -race ./pkg/server \
  -run '^TestProfileAwareBundleEndpoints$'

# Affected-package lint and contract checks across the review-fix deltas.
golangci-lint run -c .golangci.yaml \
  ./pkg/recipe/... ./pkg/server/... ./pkg/serializer/...
yamllint -c .yamllint.yaml api/aicr/v1/server.yaml
git diff --check origin/main...HEAD

# Documentation-only version-axis clarification.
./tools/check-docs-mdx
lychee --offline --no-progress \
  docs/user/api-reference.md docs/integrator/data-flow.md docs/integrator/go-library.md
```

The full qualification run passed, including race-enabled unit tests, the 80% aggregate coverage gate (81.0%), lint, 23 end-to-end suites, vulnerability scanning, license checks, and repository-specific validation. Coverage comparisons against `origin/main` found no affected package decrease greater than 0.5 percentage points.

Across the review-fix deltas, the focused race tests above and affected-package Go lint passed with zero issues. Focused YAML lint and diff checks passed, and independent review feedback on the delta was addressed. The final documentation changes passed the MDX safety check, offline link checks, diff check, and an independent review with zero findings. Full qualification, full-module lint, and coverage were not rerun after those deltas.

### Independent verification (commit `a941f19e5`)

The CLI, server, and `aicrd` were rebuilt from this revision and compared against `main` at `905bec6e1`. Every comparison asserts non-empty output and reports byte or file counts. A run that fails identically on both binaries is classified separately and never registers as a pass.

**Regression — no output difference anywhere.** 800 comparisons across the full catalog (all 100 resolvable entries; `monitoring-hpa` is excluded because its criteria are entirely `any` and nothing resolves it).

- `recipe`: 100 comparisons, 8,306,000 bytes of generated YAML, 0 diffs
- `bundle`: 500 comparisons (100 entries × `helm`, `argocd`, `argocd-helm`, `flux`, `helmfile`), 22,603 files compared with `diff -r`, 0 diffs
- `query`: 100 comparisons, 0 diffs
- `mirror list`: 100 comparisons, 0 diffs
- `recipe list`: identical, 14,240 bytes

Fifty bundle comparisons produced no comparison: the ten AKS entries fail on both binaries at the keyless-toleration gate, which requires `--accelerated-node-toleration`. They are counted as `bothfail`, not as agreement. The AKS bundle path is covered separately by the live-cluster run below, which passes that flag.

**Profile mechanism.** The catalog declares no profile, so the regression sweep above exercises only the unprofiled path. Two things cover the new path instead.

`TestProfileResolutionEndToEnd` and its siblings in `pkg/recipe/profile_integration_test.go` layer a profiled overlay from `testdata/profile-overlay/` over the embedded catalog and resolve through the ordinary `Builder`, so criteria matching, declaration discovery, value selection, override merging, and ownership locking run together rather than as isolated units. Eleven subtests cover default and explicit selection, the owned-path union, override delivery to the componentRefs, the raw-artifact gate, four fail-closed selections, and the legacy half of the biconditional. Both directions were confirmed to fail when the fixture is perturbed: flipping the declared default fails the selection assertion, and dropping one value's override trips union totality.

The fixture is test input, not catalog. It carries no distinguishing constraint, which ADR-015 requires of a shippable declaration, and the file says so — the driver-ownership signal does not exist yet.

Beyond CI, the same mechanism was driven manually through an out-of-tree `--data` overlay to cover bundle rendering, which the integration tests do not reach.

- Both values resolve to `aicr.run/v1alpha3` with `metadata.selectedProfile` populated, and bundle cleanly under `helm` (321 files), `argocd` (290), and `argocd-helm` (307) — 1,836 files in total.
- Selecting the other value changes exactly the two owned paths plus the recorded selection, and nothing else: a three-line diff between the resolved recipes.
- `ownedPaths` spans both components, including the synthetic `enabled` presence path.
- Fail-closed paths reject as expected: unknown profile value, wrong profile name, and a `--set` diverging from a profile-owned path.
- The `main` binary reads the same profiled overlay as `aicr.run/v1alpha2` with no `selectedProfile`, confirming the mechanism is inert to anything that does not understand it.

**Live cluster — AKS H100 (`aicr-test6`, 2× ND96isr_H100_v5, Kubernetes 1.35).** Run against a pinned kubeconfig with the cluster identity verified before use.

- Snapshot captured from real hardware: 111,221 bytes.
- Recipe resolved from that live snapshot is identical on both binaries: 79,057 bytes.
- Bundles from the live recipe are identical across all five deployers: 274 files.
- `aicr validate` passed all three phases against the cluster — deployment, conformance, and performance including `nccl-all-reduce-bw`.

**API surface, live against `aicrd`.** Fifteen checks, all passing; byte counts are asserted so a 200 with an empty body fails.

- `/v1/recipe` and `/v2/recipe` return identical bodies for unprofiled criteria: 76,439 bytes each.
- `/v2` accepts `application/json` and `application/x-yaml`, and rejects a missing content type, `text/plain`, and the undeclared `application/yaml` alias.
- `/v2` rejects unknown envelope fields and unknown query parameters; `/v1` remains lenient as designed. Both reject explicit profile input against an unprofiled composition.
- `/v2/query` returns a 16,168-byte body.

**Review-fix verification.** Each fix in this round was checked against a failing state rather than only a passing one.

- Union totality now matches ADR-015, which evaluates it before synthetic presence paths are added. The earlier implementation folded the synthetic `enabled` marker into the comparison and rejected a declaration whose values legitimately differ in which components they reference presence-only.
- Inline ownership requires `PathPresent` for every non-synthetic owned path. Requiring merely "not absent" left a hole: overrides of `{"driver": null}` observe as `PathBlocked` inline, and `mergeValues` deletes a nil-valued key, so the hydrated observation is `PathAbsent` and neither check fired. Reproduced before the fix, and the added test fails when the fix is reverted.
- Profile-value constraints are now shape-validated at catalog load, matching the fail-closed treatment overlay and mixin constraints already receive.
- The `/v2/bundle` schema widening was validated with a draft-4 schema validator over real generated artifacts — the check a request-validating gateway or codegen client performs, and one a live request cannot make, since the server accepted these bodies either way.

| artifact | pre-fix schema | this revision |
|---|---|---|
| `apiVersion: ""`, `kind: ""` | rejected — matched no `oneOf` branch | accepted |
| `apiVersion` absent | accepted | accepted |
| `aicr.run/v1alpha2` | accepted | accepted |
| `aicr.run/v1alpha3` profiled | accepted | accepted |

Each shape matches exactly one branch, so the widening admits the round-tripped legacy body without relaxing the versioned ones.

The full `./pkg/... ./cmd/...` suite passes: 75 packages ok, 0 failures. `golangci-lint run ./...` reports 0 issues.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

The mechanism spans recipe generation, APIs, clients, serialization, and bundle paths. It remains dormant until a recipe composition declares a profile. Compatibility tests cover unprofiled and legacy behavior, while strict v2 media-type and artifact handling intentionally reject undeclared or contradictory inputs.

**Rollout notes:** No recipe family adopts profiles in this PR. Follow-up PRs will adopt the mechanism for AKS first and GKE next.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)







