### PR TITLE
fix(ci): sync coverage docs to 80% and fail closed on bad threshold

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -582,7 +582,7 @@ Follow the heading conventions in the `## Documentation Style` section above. Do
 Before pushing a PR that changes Go source, check coverage on affected packages. Set `pkg` to the narrowest changed root — `$pkg/...` includes descendants (e.g. use `pkg=pkg/collector/topology`, not `pkg=pkg/collector`, unless you want a combined delta).
 1. Current: `GOFLAGS="-mod=vendor" go test -coverprofile=cover.out ./$pkg/...` on each changed package.
 2. Baseline (skip for new packages; commit changes first): `(git worktree add $TMPDIR/baseline origin/main && (cd $TMPDIR/baseline && GOFLAGS="-mod=vendor" go test -coverprofile=$TMPDIR/base.out ./$pkg/...); rc=$?; git worktree remove --force $TMPDIR/baseline; return $rc 2>/dev/null || (exit $rc))` — `$TMPDIR/base.out` survives cleanup and `rc` preserves test status. Compare with `go tool cover -func`.
-3. **Block** if `make test-coverage` fails (enforces the project-wide 75% floor from `.settings.yaml`; do not use per-package profiles for this check).
+3. **Block** if `make test-coverage` fails (enforces the project-wide 80% floor from `.settings.yaml`; do not use per-package profiles for this check).
 4. **Flag** any package with per-package decrease > 0.5% (step 1 vs 2).
 5. **Block** if any new exported func/method (`git diff origin/main -- $pkg/`, added uppercase `func` lines) has 0% coverage — add tests first.
 6. Report the delta in the PR's Testing section (e.g. `pkg/recipe: 90.4% → 90.3% (-0.1%)`).

--- a/.github/actions/go-coverage/action.yml
+++ b/.github/actions/go-coverage/action.yml
@@ -52,8 +52,22 @@ runs:
 
         COVERAGE_FILE="${{ inputs.coverage_file }}"
         THRESHOLD="${{ inputs.threshold }}"
-        if [[ -z "$THRESHOLD" ]]; then
-          THRESHOLD=70
+        # Fail closed: defaulting here would silently enforce a looser floor
+        # than .settings.yaml declares. Two distinct bad inputs to reject:
+        #   - empty      -> load-versions could not read .settings.yaml at all
+        #   - "null"     -> yq prints the literal string for a missing key and
+        #                   exits 0, so load-versions happily emits it
+        # The numeric check is the real backstop: bc resolves any non-numeric
+        # token to 0, so a bad threshold would make "$COVERAGE < $THRESHOLD"
+        # false and silently pass the gate with no floor at all.
+        # Keep in sync with the matching guard in the Makefile's test-coverage.
+        if [[ -z "$THRESHOLD" || "$THRESHOLD" == "null" ]]; then
+          echo "::error::Coverage threshold is empty or null (expected quality.coverage_threshold from .settings.yaml via load-versions)"
+          exit 1
+        fi
+        if ! [[ "$THRESHOLD" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+          echo "::error::Coverage threshold is not numeric: '$THRESHOLD'"
+          exit 1
         fi
 
         if [[ ! -f "$COVERAGE_FILE" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -582,7 +582,7 @@ Follow the heading conventions in the `## Documentation Style` section above. Do
 Before pushing a PR that changes Go source, check coverage on affected packages. Set `pkg` to the narrowest changed root — `$pkg/...` includes descendants (e.g. use `pkg=pkg/collector/topology`, not `pkg=pkg/collector`, unless you want a combined delta).
 1. Current: `GOFLAGS="-mod=vendor" go test -coverprofile=cover.out ./$pkg/...` on each changed package.
 2. Baseline (skip for new packages; commit changes first): `(git worktree add $TMPDIR/baseline origin/main && (cd $TMPDIR/baseline && GOFLAGS="-mod=vendor" go test -coverprofile=$TMPDIR/base.out ./$pkg/...); rc=$?; git worktree remove --force $TMPDIR/baseline; return $rc 2>/dev/null || (exit $rc))` — `$TMPDIR/base.out` survives cleanup and `rc` preserves test status. Compare with `go tool cover -func`.
-3. **Block** if `make test-coverage` fails (enforces the project-wide 75% floor from `.settings.yaml`; do not use per-package profiles for this check).
+3. **Block** if `make test-coverage` fails (enforces the project-wide 80% floor from `.settings.yaml`; do not use per-package profiles for this check).
 4. **Flag** any package with per-package decrease > 0.5% (step 1 vs 2).
 5. **Block** if any new exported func/method (`git diff origin/main -- $pkg/`, added uppercase `func` lines) has 0% coverage — add tests first.
 6. Report the delta in the PR's Testing section (e.g. `pkg/recipe: 90.4% → 90.3% (-0.1%)`).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -455,7 +455,7 @@ See [kwok/README.md](kwok/README.md) for adding recipes, profiles, and troublesh
 |--------|-------------|
 | `make qualify` | Full qualification (test + lint + e2e + scan) |
 | `make test` | Unit tests with race detector and coverage |
-| `make test-coverage` | Tests with coverage threshold (default 70%) |
+| `make test-coverage` | Tests with coverage threshold (from `.settings.yaml` `quality.coverage_threshold`) |
 | `make lint` | Lint Go, YAML, and verify license headers |
 | `make lint-go` | Go linting only |
 | `make lint-yaml` | YAML linting only |

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ export GOTOOLCHAIN  = go$(GO_VERSION)
 GOLINT_VERSION      = $(shell golangci-lint --version 2>/dev/null | awk '{print $$4}' | sed 's/golangci-lint version //' || echo "not installed")
 KO_VERSION          = $(shell ko version 2>/dev/null || echo "not installed")
 GORELEASER_VERSION  = $(shell goreleaser --version 2>/dev/null | sed -n 's/^GitVersion:[[:space:]]*//p' || echo "not installed")
+# No fallback on purpose: an unreadable threshold (missing yq, missing key)
+# must fail the gate in test-coverage rather than silently enforce a looser
+# floor than .settings.yaml declares.
 COVERAGE_THRESHOLD ?= $(shell yq -r '.quality.coverage_threshold' .settings.yaml 2>/dev/null)
-ifeq ($(COVERAGE_THRESHOLD),)
-COVERAGE_THRESHOLD := 70
-endif
 LINT_TIMEOUT       ?= $(shell yq -r '.quality.lint_timeout' .settings.yaml 2>/dev/null)
 ifeq ($(LINT_TIMEOUT),)
 LINT_TIMEOUT       := 5m
@@ -230,8 +230,22 @@ test: test-shell ## Runs unit tests with race detector and coverage (use -short 
 	echo "Test coverage:"; \
 	go tool cover -func=coverage.out | tail -1
 
+# Listed before `test` so an unreadable threshold fails in seconds rather than
+# after the full race-enabled suite. Fails closed on both an empty value (yq
+# missing) and the literal "null" (yq prints that for a missing key, exit 0) --
+# bc would resolve either to 0 and silently pass the check below with no floor.
+# Keep in sync with the matching guard in .github/actions/go-coverage.
+.PHONY: check-coverage-threshold
+check-coverage-threshold:
+	@if [ -z "$(COVERAGE_THRESHOLD)" ] || [ "$(COVERAGE_THRESHOLD)" = "null" ]; then \
+		echo "ERROR: coverage threshold unavailable from .settings.yaml (quality.coverage_threshold)"; \
+		echo "       Check that yq is installed ('make tools-setup') and that"; \
+		echo "       .settings.yaml defines quality.coverage_threshold."; \
+		exit 1; \
+	fi
+
 .PHONY: test-coverage
-test-coverage: test ## Runs tests and enforces coverage threshold (from .settings.yaml quality.coverage_threshold)
+test-coverage: check-coverage-threshold test ## Runs tests and enforces coverage threshold (from .settings.yaml quality.coverage_threshold)
 	@coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//'); \
 	echo "Coverage: $$coverage% (threshold: $(COVERAGE_THRESHOLD)%)"; \
 	if [ $$(echo "$$coverage < $(COVERAGE_THRESHOLD)" | bc) -eq 1 ]; then \

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -91,7 +91,7 @@ command name — there is no Cobra-style `SetOut`/`SetArgs`/`Execute`.)
 Direct `fmt.Println` / `fmt.Printf` to stdout in `pkg/cli` breaks
 this pattern and is a review-blocker.
 
-**Coverage floor: 75%** (project-wide, from `.settings.yaml`
+**Coverage floor: 80%** (project-wide, from `.settings.yaml`
 `quality.coverage_threshold`). `make test-coverage` enforces it.
 Per-package decreases > 0.5% are flagged for justification.
 
@@ -167,7 +167,7 @@ profile inside the worktree disappears with `worktree remove --force`.
 
 **Gates:**
 
-- **Block** if `make test-coverage` fails (project-wide 75% floor).
+- **Block** if `make test-coverage` fails (project-wide 80% floor).
 - **Block** if any new exported function or method has 0% coverage
   in the diff — add tests before pushing.
 - **Flag** any per-package decrease > 0.5% and explain in the PR.
@@ -478,7 +478,7 @@ half of the pipeline and skips deploy-side assertions.
 
 `make qualify` is the canonical pre-push command. It runs:
 
-- `test-coverage` — `go test -race ./...` plus the 75% coverage floor.
+- `test-coverage` — `go test -race ./...` plus the 80% coverage floor.
 - `lint` — golangci-lint with `.golangci.yaml` plus yamllint.
 - `e2e` — the end-to-end pipeline runner.
 - `scan` — Grype vulnerability scan.
@@ -529,7 +529,7 @@ the pre-push gate is local.
   The generator sets a fixed platform matrix and `LC_ALL=C`, so
   `make notices` produces byte-identical output on macOS and Linux.
 - **Coverage decrease > 0.5%** is flagged for justification (the project-wide
-  75% floor is what blocks). Add tests rather than
+  80% floor is what blocks). Add tests rather than
   reaching for `// nolint` or `t.Skip` — both are review-blockers
   under the no-skip-tests rule in CLAUDE.md.
 - **Live-cluster connections from unit tests.** A test that forgets


### PR DESCRIPTION
## Summary

Sync the documented Go coverage floor to the 80% already enforced by `.settings.yaml`, and make the two hardcoded `70` fallbacks fail closed instead of silently enforcing a looser floor.

## Motivation / Context

`quality.coverage_threshold` was raised 75 → 80 in `298e9a0a`, but the documented floor still said 75% in four places and two code paths defaulted to `70`. Investigating that drift surfaced a live fail-open bug in the CI gate (see Implementation Notes).

Fixes: N/A
Related: `298e9a0a`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `Makefile`, `.github/actions/go-coverage`

## Implementation Notes

**The fail-open bug.** `load-versions` emits the literal string `null` for a missing key, because `yq` prints `null` and exits 0 with no `2>/dev/null` or failure check on that line. A `null` threshold is non-empty, so an empty-only guard lets it through. GNU `bc` then resolves `null` to `0`, making `$COVERAGE < $THRESHOLD` false, so `PASS=true` and the `Enforce Threshold` step is skipped by its `if:` condition. The merge gate goes green with **no floor enforced at all** — strictly looser than the hardcoded 70 it would have replaced. Verified locally:

```
$ echo "80.7 < null" | bc -l
0
```

Both guards now reject empty and `null`, plus a numeric regex backstop since *any* non-numeric token degrades to 0 under `bc`.

**Fail closed rather than bump to 80.** An unreadable threshold means `yq` is missing or `load-versions` broke. Substituting any default enforces a floor nobody chose, which is the "gate that passes on an ambiguous condition" anti-pattern in `CLAUDE.md`.

**Guard ordering.** In the `Makefile` the check became a `check-coverage-threshold` prerequisite listed before `test`, so a misconfigured threshold fails in ~3s rather than after the full race-enabled suite. Prerequisites are serial (no `MAKEFLAGS`/`-j` in this repo).

**`DEVELOPMENT.md`** now points at `.settings.yaml quality.coverage_threshold` without restating the number, since re-hardcoding it would recreate the exact drift this PR fixes. The literal stays in the canonical prose at `docs/contributor/tests.md` and in the agent instruction files, where the concrete number is the point.

Deliberately out of scope: the badge colour ladder in `go-coverage/action.yml` hardcodes 80/70/60/50, so 70–79.9% renders `green` while the gate fails. Pre-existing and unrelated to threshold plumbing. Hardening `load-versions` at source is also left alone — every output there shares the `null` behaviour, so it is a broader refactor; the consumer-side guard closes this hole.

## Testing

```bash
make lint          # golangci-lint 0 issues, yamllint, agents-sync, docs checks — all pass
make qualify       # blocked locally, see below
```

Guard behaviour verified empirically rather than by inspection:

| Input | `Makefile` guard | `action.yml` guard |
|---|---|---|
| `""` (yq missing) | blocks, rc=2 | blocks |
| `null` (key missing) | blocks, rc=2 | blocks |
| `abc` / `8 0` | n/a | blocks (non-numeric) |
| `80` / `80.5` | passes | passes |

`make test-coverage` with an empty threshold aborts in 3s **before** the test suite runs, confirming prerequisite ordering.

Coverage on the gated scope: **80.3%** local, consistent with the 80.7% CI reports.

`make qualify` cannot complete on the author's macOS box for reasons unrelated to this change, both reproduced on a clean `main` checkout with zero local modifications:
- `tests/releasepolicy` fails with `timeout: command not found` (no GNU coreutils)
- `pkg/oci` `TestHelmV4_2_3ExplicitVersionPull` fails with installed helm v4.2.0 vs the v4.2.3 pin

The full suite excluding the `timeout`-dependent package is green.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

No product code is touched. The worst case is a CI job failing loudly on a misconfigured threshold, which is the intent. Current coverage (80.7%) clears the floor, so the gate stays green.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — excluding the two pre-existing environment failures documented above
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — guard behaviour verified manually; a `test-shell` regression case is a reasonable follow-up
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
