### PR TITLE
fix(api): accept versionless legacy bundle recipes

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -193,7 +193,7 @@ paths:
                   summary: Basic recipe request
                   value:
                     apiVersion: aicr.run/v1alpha2
-                    kind: Recipe
+                    kind: RecipeResult
                     metadata:
                       version: v1.0.0
                       created: "2025-01-15T10:30:00Z"
@@ -861,6 +861,11 @@ paths:
         This design enables a simple workflow: pipe the output from GET /v1/recipe directly
         to POST /v1/bundle.
 
+        Current recipes carry apiVersion aicr.run/v1alpha2 and kind RecipeResult.
+        For backward compatibility, legacy artifacts may omit either header field,
+        carry it as an empty string after a decode/remarshal round trip, or carry
+        the kind Recipe published by this contract through v0.18.0.
+
         The response is a binary zip file containing all generated bundle artifacts
         organized by bundler type (e.g., gpu-operator/, network-operator/).
       parameters:
@@ -1113,13 +1118,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RecipeResponse"
+              $ref: "#/components/schemas/BundleRecipeRequest"
             examples:
               simpleRecipe:
                 summary: Simple recipe with GPU operator
                 value:
                   apiVersion: aicr.run/v1alpha2
-                  kind: Recipe
+                  kind: RecipeResult
                   componentRefs:
                     - name: gpu-operator
                       type: Helm
@@ -1130,7 +1135,7 @@ paths:
                 summary: Full recipe with metadata
                 value:
                   apiVersion: aicr.run/v1alpha2
-                  kind: Recipe
+                  kind: RecipeResult
                   metadata:
                     version: v1.0.0
                     created: "2025-01-15T10:30:00Z"
@@ -1562,21 +1567,22 @@ components:
             $ref: "#/components/schemas/Subtype"
           description: List of configuration subtypes within this measurement
 
-    RecipeResponse:
+    RecipeResponseBase:
       type: object
-      description: Complete recipe response with metadata and component references
-      required: [apiVersion, kind]
+      description: >
+        Reusable RecipeResult shape. Response and bundle-request wrappers apply
+        their respective apiVersion requirements.
       properties:
         apiVersion:
           type: string
-          description: API version of the recipe format
-          enum: [aicr.run/v1alpha2]
-          example: aicr.run/v1alpha2
+          description: >
+            API version of the recipe format. Response and bundle-request
+            wrappers constrain the supported value.
         kind:
           type: string
-          description: Resource type
-          enum: [Recipe]
-          example: Recipe
+          description: >
+            Resource type. Response and bundle-request wrappers constrain the
+            supported value.
         metadata:
           type: object
           description: Recipe metadata
@@ -1761,6 +1767,61 @@ components:
           description: Deployment constraints (driver versions, etc.)
           additionalProperties: true
 
+    RecipeResponse:
+      description: Complete recipe response with metadata and component references
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponseBase"
+        - type: object
+          required: [apiVersion, kind]
+          properties:
+            apiVersion:
+              type: string
+              enum: [aicr.run/v1alpha2]
+              example: aicr.run/v1alpha2
+            kind:
+              type: string
+              enum: [RecipeResult]
+              example: RecipeResult
+
+    BundleRecipeRequest:
+      description: >
+        RecipeResult accepted by POST /v1/bundle. Current aicr.run/v1alpha2
+        artifacts and legacy artifacts with absent or empty header fields are
+        accepted. The kind value Recipe is also accepted: it was the value this
+        contract published through v0.18.0, and the handler performs no header
+        validation, so clients written against that spec must keep working.
+
+        A legacy kind is echoed into the generated bundle's recipe.yaml rather
+        than normalized, and the CLI file loader accepts an absent or empty kind
+        but rejects Recipe. A bundle generated from a kind Recipe body is
+        therefore not reloadable via aicr bundle -r or aicr validate -r. Send
+        kind RecipeResult to keep the emitted artifact round-trippable.
+
+        apiVersion deliberately has no equivalent legacy window. The artifact
+        group/version bump is a hard break with no transition period (see
+        docs/design/011-artifact-apiversion-policy.md), so an artifact stamped
+        with a prior group/version should be regenerated rather than sent. That
+        is a client-contract rule rather than an enforced one: this endpoint
+        validates no header field, so a prior apiVersion is ignored rather than
+        rejected. The CLI file-load path does enforce it.
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponseBase"
+        - type: object
+          properties:
+            apiVersion:
+              type: string
+              description: >
+                Current API version, or empty after a legacy struct round trip.
+                Prior group/versions are not accepted — see the schema
+                description for the hard-break policy.
+              enum: ["", aicr.run/v1alpha2]
+            kind:
+              type: string
+              description: >
+                RecipeResult, the legacy Recipe value published through
+                v0.18.0, or empty for a legacy artifact
+              enum: ["", Recipe, RecipeResult]
+
     QueryRequest:
       type: object
       description: Query request with criteria and dot-path selector
@@ -1782,12 +1843,12 @@ components:
       description: Request body for bundle generation
       deprecated: true
       x-deprecation-reason: >
-        Use RecipeResponse directly as the request body and specify bundlers
+        Use a RecipeResult directly as the request body and specify bundlers
         via the "bundlers" query parameter (comma-delimited).
       required: [recipe]
       properties:
         recipe:
-          $ref: "#/components/schemas/RecipeResponse"
+          $ref: "#/components/schemas/BundleRecipeRequest"
           description: The recipe to generate bundles from
         bundlers:
           type: array

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -42,7 +42,7 @@ All server code lives in [`pkg/server`](https://github.com/NVIDIA/aicr/tree/main
 | `allowlist.go` | Handler-level allowlist pre-check (`validateAgainstAllowLists`) |
 | `response_writer.go` | Status-capture wrapper so middleware can observe the handler's status code |
 | `context.go` | Typed context keys and `RequestIDFromContext` helper |
-| `openapi_sync_test.go` | CI gate: enum drift between OpenAPI spec and Go criteria types fails the build |
+| `openapi_sync_test.go` | CI gate: criteria-enum and `/v1/bundle` contract drift fails the build |
 
 `cmd/aicrd/main.go` is a one-liner that calls `server.Serve()`.
 
@@ -275,10 +275,23 @@ a `go test` executable cannot satisfy.
 ## OpenAPI Parity Test
 
 [`pkg/server/openapi_sync_test.go`](https://github.com/NVIDIA/aicr/blob/main/pkg/server/openapi_sync_test.go)
-asserts that every criteria-field enum in `api/aicr/v1/server.yaml`
-matches the corresponding `pkg/recipe.GetCriteria*Types()` function.
-It scans both query-parameter enums and `components.schemas.Criteria`
-properties.
+contains two contract gates:
+
+- `TestOpenAPIEnumsMatchGoTypes` asserts that every criteria-field enum in
+  `api/aicr/v1/server.yaml` matches the corresponding
+  `pkg/recipe.GetCriteria*Types()` function. It scans both query-parameter enums
+  and `components.schemas.Criteria` properties.
+- `TestOpenAPIV1BundleRecipeContract` asserts that `/v1/bundle` and its
+  deprecated wrapper share the request schema, that both `/v1/recipe` success
+  responses still point at the strict `RecipeResponse`, and that the header
+  enums on both sides stay synchronized with the Go constants. It matches the
+  `allOf` branches by content rather than position, since `allOf` is
+  semantically unordered.
+
+  Runtime acceptance of the legacy header shapes is pinned separately by
+  `TestBundleHandler_LegacyRecipeHeaders`, which posts absent, empty, and
+  `kind: Recipe` bodies to the handler and asserts 200. The spec gate alone
+  would only be checking the spec against itself.
 
 Drift is a contract bug: clients conforming to the spec will reject
 inputs the server actually accepts, or generate types that reject
@@ -296,7 +309,10 @@ test strips it before comparison.
 4. **Register the route.** Add an entry to the `map[string]http.HandlerFunc` in `serve.go` (the `WithHandler` argument). The route picks up the full middleware chain automatically.
 5. **Wire allowlists if needed.** Pass `allowLists` into the handler constructor and call `validateAgainstAllowLists` before the facade call. Do not invent a parallel allowlist path; reuse `aicr.ToInternalAllowLists`.
 6. **Tighten the body cap.** If the endpoint accepts POST bodies and 8 MiB is wrong, define a `defaults.Max<Name>POSTBytes` constant and wrap `r.Body` with `http.MaxBytesReader` inside the handler. Handle `*http.MaxBytesError` explicitly → 413.
-7. **Run the parity test.** `go test -run TestOpenAPIEnumsMatchGoTypes ./pkg/server/...`. Add cases to `openapi_sync_test.go` if you introduced a new enum-bearing field.
+7. **Run the contract tests.**
+   `go test -run '^(TestOpenAPIEnumsMatchGoTypes|TestOpenAPIV1BundleRecipeContract)$' ./pkg/server/...`.
+   Add cases to `openapi_sync_test.go` if you introduced a new enum-bearing
+   field or changed the `/v1/bundle` recipe schema.
 8. **Update [docs/user/api-reference.md](../user/api-reference.md)** in the same PR. CLAUDE.md's docs-updates-with-behavior-changes rule applies.
 
 The endpoint cannot return business types raw — it must serialize

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -416,7 +416,34 @@ Generate deployment bundles from a recipe.
 
 **Request Body:**
 
-The request body is the recipe (RecipeResult) directly. No wrapper object needed.
+The request body is the recipe (`RecipeResult`) directly. No wrapper object is
+needed. Current artifacts carry `apiVersion: aicr.run/v1alpha2` and
+`kind: RecipeResult`, and new clients should send that versioned form.
+
+For backward compatibility, the endpoint also accepts:
+
+- Legacy artifacts that omit `apiVersion` or `kind`, or carry them as empty
+  strings after a decode/remarshal round trip.
+- The `kind: Recipe` value this contract published through v0.18.0.
+
+The handler does not validate these header fields, so all three shapes reach the
+bundler identically.
+
+`apiVersion` has no equivalent legacy window on purpose. An artifact
+group/version bump is a hard break with no transition period, so a recipe
+stamped with a prior group/version should be regenerated rather than sent.
+
+That is a client-contract rule, not an enforced one. As above, this endpoint
+validates no header field: a prior `apiVersion` is ignored rather than rejected,
+so such a request still succeeds. The CLI file-load path does enforce it and
+rejects an unsupported `apiVersion` outright.
+
+**Round-trip caveat for `kind: Recipe`.** The header is copied into the
+generated bundle's `recipe.yaml` rather than normalized. The CLI file loader
+tolerates an absent or empty `kind` but rejects `Recipe`, so a bundle generated
+from a `kind: Recipe` body cannot be fed back through `aicr bundle -r` or
+`aicr validate -r`. Send `kind: RecipeResult` if you need the emitted artifact
+to remain reloadable.
 
 #### Components
 

--- a/pkg/server/bundle_handler_test.go
+++ b/pkg/server/bundle_handler_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
 	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
 // fixtureBundleAttester returns fixed, non-nil bundle JSON from Attest so the
@@ -341,7 +343,7 @@ func TestBundleHandler_EmptyComponentRefs(t *testing.T) {
 	t.Parallel()
 	h := newTestBundleHandler(t)
 
-	body := `{"apiVersion": "aicr.run/v1alpha2", "kind": "Recipe", "componentRefs": []}`
+	body := `{"apiVersion": "aicr.run/v1alpha2", "kind": "RecipeResult", "componentRefs": []}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/bundle", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -359,7 +361,7 @@ func TestBundleHandler_IncoherentComponentRef(t *testing.T) {
 	t.Parallel()
 	h := newTestBundleHandler(t)
 
-	body := `{"apiVersion": "aicr.run/v1alpha2", "kind": "Recipe", "componentRefs": [` +
+	body := `{"apiVersion": "aicr.run/v1alpha2", "kind": "RecipeResult", "componentRefs": [` +
 		`{"name": "gpu-operator", "type": "Helm", "version": "v1", "tag": "v2"}]}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/bundle", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -367,6 +369,130 @@ func TestBundleHandler_IncoherentComponentRef(t *testing.T) {
 	h.HandleBundles(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d. Body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+// TestBundleHandler_LegacyRecipeHeaders pins the backward compatibility the
+// BundleRecipeRequest schema advertises: POST /v1/bundle accepts a recipe whose
+// header fields are absent, empty, or carry the legacy Recipe kind this
+// contract published through v0.18.0.
+//
+// The handler validates no header field, so without this test the promise is
+// enforced only by TestOpenAPIV1BundleRecipeContract parsing the spec against
+// itself — a later header check would break the documented contract while every
+// test stayed green. The canonical case is included deliberately as a control:
+// it proves a 200 here means the body was accepted, not that the assertion is
+// vacuous.
+func TestBundleHandler_LegacyRecipeHeaders(t *testing.T) {
+	t.Parallel()
+
+	canonical := resolveEmbeddedBundleBody(t)
+
+	// Fail closed if the fixture ever stops being the canonical shape: a
+	// "legacy" case below must differ from the baseline to be meaningful.
+	var fixture map[string]any
+	if err := json.Unmarshal(canonical, &fixture); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	if got := fixture["kind"]; got != recipe.RecipeResultKind {
+		t.Fatalf("fixture kind = %v, want %q", got, recipe.RecipeResultKind)
+	}
+	if got := fixture["apiVersion"]; got != recipe.RecipeAPIVersion {
+		t.Fatalf("fixture apiVersion = %v, want %q", got, recipe.RecipeAPIVersion)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{
+			name:   "canonical headers (control)",
+			mutate: func(map[string]any) {},
+		},
+		{
+			name: "both headers absent",
+			mutate: func(body map[string]any) {
+				delete(body, "kind")
+				delete(body, "apiVersion")
+			},
+		},
+		{
+			name: "both headers empty-string",
+			mutate: func(body map[string]any) {
+				body["kind"] = ""
+				body["apiVersion"] = ""
+			},
+		},
+		// The schema constrains apiVersion and kind independently — neither is
+		// in a required[] and each admits its own empty value — and
+		// pkg/recipe/loader.go tolerates each one missing on its own ("empty
+		// kind allowed", "empty apiVersion allowed for backward compat" in
+		// loader_test.go). Mutating both together would leave a paired check
+		// ("either both canonical or both absent") passing every case above
+		// while it broke the single-field forms below.
+		{
+			name: "kind absent, apiVersion canonical",
+			mutate: func(body map[string]any) {
+				delete(body, "kind")
+			},
+		},
+		{
+			name: "apiVersion absent, kind canonical",
+			mutate: func(body map[string]any) {
+				delete(body, "apiVersion")
+			},
+		},
+		{
+			name: "kind empty, apiVersion canonical",
+			mutate: func(body map[string]any) {
+				body["kind"] = ""
+			},
+		},
+		{
+			name: "apiVersion empty, kind canonical",
+			mutate: func(body map[string]any) {
+				body["apiVersion"] = ""
+			},
+		},
+		{
+			name: "legacy Recipe kind with apiVersion absent",
+			mutate: func(body map[string]any) {
+				body["kind"] = string(header.KindRecipe)
+				delete(body, "apiVersion")
+			},
+		},
+		{
+			name: "legacy Recipe kind",
+			mutate: func(body map[string]any) {
+				body["kind"] = string(header.KindRecipe)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body map[string]any
+			if err := json.Unmarshal(canonical, &body); err != nil {
+				t.Fatalf("unmarshal fixture: %v", err)
+			}
+			tt.mutate(body)
+			encoded, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal body: %v", err)
+			}
+
+			h := newTestBundleHandler(t)
+			req := httptest.NewRequest(http.MethodPost, "/v1/bundle", bytes.NewReader(encoded))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.HandleBundles(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d. Body: %s", w.Code, http.StatusOK, w.Body.String())
+			}
+		})
 	}
 }
 

--- a/pkg/server/openapi_sync_test.go
+++ b/pkg/server/openapi_sync_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"gopkg.in/yaml.v3"
 )
@@ -79,6 +80,197 @@ func TestOpenAPIEnumsMatchGoTypes(t *testing.T) {
 				t.Errorf("criteria field %q, enum site %d: got %v (sans \"any\"), want %v",
 					field, i, got, sortedWant)
 			}
+		}
+	}
+}
+
+type openAPIContractSchema struct {
+	Ref        string                           `yaml:"$ref"`
+	AllOf      []openAPIContractSchema          `yaml:"allOf"`
+	Required   []string                         `yaml:"required"`
+	Properties map[string]openAPIContractSchema `yaml:"properties"`
+	Enum       []string                         `yaml:"enum"`
+}
+
+type openAPIContractMedia struct {
+	Schema openAPIContractSchema `yaml:"schema"`
+}
+
+// openAPIContractOperation models the two sides of an operation this gate
+// constrains: the request body schema, and the success-response schema. Both
+// are needed — checking only the component definitions would let a future edit
+// repoint an operation at a different schema with every assertion still green.
+type openAPIContractOperation struct {
+	RequestBody struct {
+		Content map[string]openAPIContractMedia `yaml:"content"`
+	} `yaml:"requestBody"`
+	Responses map[string]struct {
+		Content map[string]openAPIContractMedia `yaml:"content"`
+	} `yaml:"responses"`
+}
+
+type openAPIBundleContract struct {
+	Paths map[string]struct {
+		Get  openAPIContractOperation `yaml:"get"`
+		Post openAPIContractOperation `yaml:"post"`
+	} `yaml:"paths"`
+	Components struct {
+		Schemas map[string]openAPIContractSchema `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
+// allOfConstraint splits a wrapper schema's allOf into the shared base $ref and
+// the wrapper's own inline constraint object, identifying each by content
+// rather than by position. allOf is semantically unordered, so a spec author
+// who swaps the two entries writes an equivalent contract and must not trip
+// this gate.
+//
+// It accounts for every entry rather than picking out the two it recognizes.
+// allOf intersects its branches, so an unrecognized third $ref would tighten
+// the effective contract — grafting a strict schema onto BundleRecipeRequest
+// would make validators reject the versionless requests this gate exists to
+// protect, and ignoring the entry would leave the test green while it happened.
+// A duplicated base $ref is rejected for the same reason: counted rather than
+// flagged by a boolean, so a second one cannot pass unnoticed.
+func allOfConstraint(t *testing.T, schema openAPIContractSchema, baseRef string) openAPIContractSchema {
+	t.Helper()
+
+	var constraints []openAPIContractSchema
+	var baseRefs int
+	for _, entry := range schema.AllOf {
+		switch {
+		case entry.Ref == baseRef:
+			baseRefs++
+		case entry.Ref != "":
+			t.Fatalf("allOf references unexpected schema %q; only %q plus one inline "+
+				"constraint object are allowed, and allOf intersects every branch",
+				entry.Ref, baseRef)
+		default:
+			constraints = append(constraints, entry)
+		}
+	}
+	if baseRefs != 1 {
+		t.Fatalf("allOf references %q %d times, want exactly 1", baseRef, baseRefs)
+	}
+	if len(constraints) != 1 {
+		t.Fatalf("allOf has %d inline constraint objects, want exactly 1", len(constraints))
+	}
+	return constraints[0]
+}
+
+func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
+	specPath := filepath.Join("..", "..", "api", "aicr", "v1", "server.yaml")
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read spec %q: %v", specPath, err)
+	}
+
+	var spec openAPIBundleContract
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name string
+		got  string
+	}{
+		{
+			name: "v1 bundle request body",
+			got: spec.Paths["/v1/bundle"].Post.RequestBody.
+				Content["application/json"].Schema.Ref,
+		},
+		{
+			name: "deprecated bundle wrapper",
+			got:  spec.Components.Schemas["BundleRequest"].Properties["recipe"].Ref,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if want := "#/components/schemas/BundleRecipeRequest"; tt.got != want {
+				t.Errorf("$ref = %q, want %q", tt.got, want)
+			}
+		})
+	}
+
+	// Response sites, checked separately from the RecipeResponse component
+	// below. Asserting only the component's shape would let a future edit
+	// repoint an operation's 200 at RecipeResponseBase or BundleRecipeRequest
+	// — silently relaxing responses to the permissive legacy enums — while
+	// every other assertion here stayed green.
+	recipePath := spec.Paths["/v1/recipe"]
+	for _, tt := range []struct {
+		name string
+		got  string
+	}{
+		{
+			name: "GET /v1/recipe 200",
+			got:  recipePath.Get.Responses["200"].Content["application/json"].Schema.Ref,
+		},
+		{
+			name: "POST /v1/recipe 200",
+			got:  recipePath.Post.Responses["200"].Content["application/json"].Schema.Ref,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if want := "#/components/schemas/RecipeResponse"; tt.got != want {
+				t.Errorf("$ref = %q, want %q", tt.got, want)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name        string
+		schema      openAPIContractSchema
+		required    []string
+		apiVersions []string
+		kinds       []string
+	}{
+		{
+			name:        "versioned response",
+			schema:      spec.Components.Schemas["RecipeResponse"],
+			required:    []string{"apiVersion", "kind"},
+			apiVersions: []string{recipe.RecipeAPIVersion},
+			kinds:       []string{recipe.RecipeResultKind},
+		},
+		{
+			// The bundle request also admits the legacy Recipe kind: that was
+			// the value this contract published through v0.18.0, and the
+			// handler validates no header field, so dropping it from the enum
+			// would make previously conforming clients spec-invalid against a
+			// request-validating gateway.
+			name:        "bundle request",
+			schema:      spec.Components.Schemas["BundleRecipeRequest"],
+			apiVersions: []string{"", recipe.RecipeAPIVersion},
+			kinds:       []string{"", string(header.KindRecipe), recipe.RecipeResultKind},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			closure := allOfConstraint(t, tt.schema, "#/components/schemas/RecipeResponseBase")
+			if !equalStringsUnordered(closure.Required, tt.required) {
+				t.Errorf("required = %v, want %v", closure.Required, tt.required)
+			}
+			gotAPIVersions := closure.Properties["apiVersion"].Enum
+			if !equalStringsUnordered(gotAPIVersions, tt.apiVersions) {
+				t.Errorf("apiVersion enum = %v, want %v", gotAPIVersions, tt.apiVersions)
+			}
+			gotKinds := closure.Properties["kind"].Enum
+			if !equalStringsUnordered(gotKinds, tt.kinds) {
+				t.Errorf("kind enum = %v, want %v", gotKinds, tt.kinds)
+			}
+		})
+	}
+
+	base := spec.Components.Schemas["RecipeResponseBase"]
+	if len(base.Required) != 0 {
+		t.Fatal("RecipeResponseBase must not require apiVersion; wrappers own header requirements")
+	}
+	for _, name := range []string{"apiVersion", "kind"} {
+		property, ok := base.Properties[name]
+		if !ok {
+			t.Errorf("RecipeResponseBase is missing %s property", name)
+			continue
+		}
+		if got := property.Enum; len(got) != 0 {
+			t.Errorf("RecipeResponseBase %s enum = %v, want wrapper-owned enum", name, got)
 		}
 	}
 }
@@ -197,4 +389,17 @@ func equalStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// equalStringsUnordered reports whether a and b hold the same elements in any
+// order. It is an order-insensitive slice compare, NOT set equality: duplicates
+// are significant, so ["a","a"] and ["a"] differ. That is the behavior wanted
+// for enum comparison — a repeated enum member is itself a spec defect worth
+// failing on, not something to silently collapse.
+func equalStringsUnordered(a, b []string) bool {
+	sortedA := append([]string(nil), a...)
+	sortedB := append([]string(nil), b...)
+	sort.Strings(sortedA)
+	sort.Strings(sortedB)
+	return equalStrings(sortedA, sortedB)
 }


### PR DESCRIPTION
## Summary

Align the `/v1/bundle` OpenAPI request contract with the server's supported
legacy `RecipeResult` header shapes. Keep current recipe responses strict while
reusing the same request schema in the deprecated bundle wrapper.

## Motivation / Context

The runtime accepts legacy recipes with missing or empty header fields, but the
published request schema required canonical `apiVersion` and `kind` values.
OpenAPI validators and generated clients therefore rejected supported requests
before they reached the server.

Fixes #1941.

Fixes: #1941
Related: #1933 (overlapping schema and test surface), #1953 (runtime kind
normalization follow-up)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Split the shared `RecipeResult` shape from wrappers that impose header
  requirements and constraints.
- Keep `RecipeResponse` strict while allowing `/v1/bundle` requests to omit
  `apiVersion` or `kind`, or carry their legacy empty-string values.
- Keep the legacy `kind: Recipe` value valid on the request side. It was the
  value this contract published through v0.18.0, and the handler validates no
  header field, so removing it would make previously conforming clients
  spec-invalid against a request-validating gateway.
- Apply the same request schema to the deprecated `BundleRequest.recipe` field.
- Correct the resource kind to `RecipeResult`, fail closed when shared header
  properties disappear, and document both OpenAPI contract tests.
- Gate runtime acceptance separately from the spec: `TestBundleHandler_LegacyRecipeHeaders`
  posts absent, empty, single-field, and legacy `kind: Recipe` bodies to the
  handler. The spec gate alone only checks the spec against itself.
- Assert the `/v1/recipe` response `$ref` sites, and match `allOf` branches by
  content rather than position so a reordered — or grafted-on — branch is caught.

## Testing

```bash
# Full package. Run outside the agent sandbox: TestGracefulShutdown binds a
# port, which the sandbox denies with "operation not permitted".
GOFLAGS="-mod=vendor" go test -race -count=1 ./pkg/server
GOFLAGS="-mod=vendor" go test -race -count=1 ./pkg/server -run '^(TestOpenAPIV1BundleRecipeContract|TestOpenAPIEnumsMatchGoTypes|TestBundleHandler_LegacyRecipeHeaders|TestBundleHandler_EmptyComponentRefs|TestBundleHandler_IncoherentComponentRef)$'
env -u GITLAB_TOKEN make test-coverage
golangci-lint run -c .golangci.yaml ./pkg/server/...
yamllint -c .yamllint.yaml api/aicr/v1/server.yaml
./tools/check-docs-mdx
git diff origin/main...HEAD --check
```

**Control checks.** Every new gate was verified to fail when the defect it
guards against is introduced, then reverted:

- Adding a `kind` check to `HandleBundles` fails the legacy cases in
  `TestBundleHandler_LegacyRecipeHeaders` while the canonical control passes.
- Adding a paired-header check (`(kind == "") != (apiVersion == "")`) fails
  exactly the five single-field cases and none of the paired ones — the shape
  the earlier version of this test would have missed entirely.
- Removing `Recipe` from the `BundleRecipeRequest` kind enum fails
  `TestOpenAPIV1BundleRecipeContract`.
- Grafting a third strict `$ref` onto the `allOf` fails the contract gate. Before
  the fail-closed rewrite of the helper it passed silently.

Project coverage passed at 80.7% against the 80% threshold; `pkg/server` is
unchanged at 78.7% on both this branch and `origin/main`. Scoped lint reports
zero issues.

Full `make qualify` was not rerun for the focused test and doc passes: the
change touches only the OpenAPI contract, docs, and tests, with no production Go
code.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration is required. Current versioned requests remain
valid, and requests written against the v0.18.0 contract stay valid; the schema
now represents the legacy input already accepted at runtime.

The request schema is deliberately looser than the response schema because
`bundleHandler.HandleBundles` performs no header validation at all. Tightening
the runtime to enforce the documented contract is a separate question and is
not in scope here.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)


