### PR TITLE
fix(bundler): create argocd-helm static/ only when populated

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1993,6 +1993,8 @@ bundles/
 
 Manifest-only components and mixed-component raw manifests are supported by `--deployer argocd-helm` via the path-based Application shape.
 
+`static/` holds per-component values for upstream-helm Applications only. A recipe whose components are all local charts — the OpenShift overlays, for example — contributes no such files, and the directory is omitted from the bundle entirely rather than emitted empty.
+
 **The bundle's `repoURL` defaults to the registry it was pushed to.** No `--repo` flag is needed (and is ignored if passed with `--deployer argocd-helm`). When pushed to an OCI registry, the parent namespace is baked into `values.yaml` as the default `repoURL` — a plain `helm install` works with no `--set repoURL` needed. Override with `--set repoURL=oci://mirror` when deploying from a different registry.
 **Recommended deploy flow:**
 

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -40,8 +40,8 @@
 //     layer.
 //  3. Build a root values.yaml with ONLY dynamic paths (recipe defaults when
 //     available, empty strings otherwise). Static values stay in chart files.
-//  4. Write Chart.yaml + static/ + templates/ + values.yaml as a valid Helm
-//     chart.
+//  4. Write Chart.yaml + templates/ + values.yaml as a valid Helm chart,
+//     plus static/ when any component contributes a values file to it.
 //
 // This approach means changes to the Argo CD deployer (new component types,
 // sync policies, etc.) automatically flow through without duplication.
@@ -439,9 +439,14 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 // targetRevision, and deployer defaults injected), and values.schema.json.
 // Each written file is appended to output.Files/TotalSize.
 func (g *Generator) writeValuesFiles(outputDir string, output *deployer.Output) error {
+	// PropagateOrWrap rather than Wrap: writeStaticValuesAndBuildStubs now
+	// reports a non-directory at the static path as ErrCodeInvalidRequest, and
+	// re-coding that as INTERNAL would present a bad --output path as a server
+	// fault — and over the API would withhold the cause from the response,
+	// since 5xx bodies omit it.
 	staticFiles, staticSize, dynamicOnlyValues, err := g.writeStaticValuesAndBuildStubs(outputDir)
 	if err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to write static values", err)
+		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to write static values")
 	}
 	output.Files = append(output.Files, staticFiles...)
 	output.TotalSize += staticSize
@@ -523,20 +528,40 @@ func (g *Generator) finalizeOutput(ctx context.Context, output *deployer.Output,
 	return nil
 }
 
-// writeStaticValuesAndBuildStubs writes each component's values to static/<name>.yaml
-// and builds the dynamic-only stubs map for the root values.yaml.
+// writeStaticValuesAndBuildStubs writes static/<name>.yaml for each component
+// that resolves to a remote Helm chart, and builds the dynamic-only stubs map
+// for the root values.yaml. When no component qualifies, static/ is not
+// created and a stale one from an earlier run is removed.
 func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, int64, map[string]any, error) {
 	staticDir, err := deployer.SafeJoin(outputDir, "static")
 	if err != nil {
 		return nil, 0, nil, err
 	}
-	if mkdirErr := os.MkdirAll(staticDir, 0755); mkdirErr != nil {
-		return nil, 0, nil, errors.Wrap(errors.ErrCodeInternal, "failed to create static directory", mkdirErr)
-	}
 
 	var files []string
 	var totalSize int64
 	dynamicOnlyValues := make(map[string]any)
+
+	// static/ is created lazily, immediately before the first component
+	// values file is written. A recipe whose components all render as local
+	// charts (type Helm with no upstream Source, as the OCP overlays do)
+	// skips every iteration below, and an unconditional MkdirAll would then
+	// leave an empty directory that the bundle inventory validator rejects
+	// as unexpected. See issue #1942.
+	staticDirReady := false
+	ensureStaticDir := func() error {
+		if staticDirReady {
+			return nil
+		}
+		if err := checkStaticPath(staticDir); err != nil {
+			return err
+		}
+		if mkdirErr := os.MkdirAll(staticDir, 0755); mkdirErr != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to create static directory", mkdirErr)
+		}
+		staticDirReady = true
+		return nil
+	}
 
 	for _, ref := range g.RecipeResult.ComponentRefs {
 		// Skip non-Helm components (Kustomize, manifest-only)
@@ -584,6 +609,9 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 		}
 
 		// Write static values (dynamic paths removed)
+		if dirErr := ensureStaticDir(); dirErr != nil {
+			return nil, 0, nil, dirErr
+		}
 		staticPath, staticSize, staticErr := deployer.WriteValuesFile(staticValues, staticDir, ref.Name+".yaml")
 		if staticErr != nil {
 			return nil, 0, nil, errors.Wrap(errors.ErrCodeInternal,
@@ -593,7 +621,89 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 		totalSize += staticSize
 	}
 
+	// Generation writes directly into --output and the directory is not
+	// cleared between runs, so a failed pre-fix run leaves its empty static/
+	// behind. Without this, retrying into that same directory reproduces the
+	// original failure even though nothing new is created.
+	if !staticDirReady {
+		if err := removeStaleStaticDir(staticDir); err != nil {
+			return nil, 0, nil, err
+		}
+	}
+
 	return files, totalSize, dynamicOnlyValues, nil
+}
+
+// checkStaticPath rejects anything occupying the static path that is not a
+// plain directory. Both the create and the remove path call it, so a
+// pre-existing file or symlink produces the same ErrCodeInvalidRequest
+// regardless of whether the recipe happens to contribute static values —
+// otherwise the identical user error would surface as INVALID_REQUEST for an
+// all-local recipe and INTERNAL (from MkdirAll's ENOTDIR) for any recipe with
+// an upstream chart.
+//
+// The check matters most before removal, since os.Remove unlinks regular files
+// as readily as it removes empty directories. Lstat rather than Stat also
+// rejects a symlink planted after checksum.ValidateOutputRoot ran, which
+// happens before generation and permits pre-existing regular files.
+func checkStaticPath(staticDir string) error {
+	info, statErr := os.Lstat(staticDir)
+	switch {
+	case os.IsNotExist(statErr):
+		return nil
+	case statErr != nil:
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to inspect static directory", statErr)
+	case info.Mode()&os.ModeSymlink != 0:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("output path %q is a symbolic link", staticDir))
+	case !info.IsDir():
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("output path %q exists and is not a directory", staticDir))
+	}
+	return nil
+}
+
+// removeStaleStaticDir clears a static/ left behind by an earlier run when the
+// current generation contributed no files to it.
+//
+// Emptiness is checked explicitly rather than inferred from an os.Remove
+// errno, which keeps the intent readable and avoids platform-specific error
+// values. A populated static/ is kept: its contents are reported by
+// validateExactTree as unexpected output, though only when checksums are
+// enabled, since that validator runs inside the IncludeChecksums path. With
+// checksums off a stale static/ survives into the bundle, which is unchanged
+// from before this fix — a reused --output was never cleared, so stale files
+// of any kind already persisted.
+//
+// Anything that blocks removal of an empty directory fails generation rather
+// than being logged and ignored: leaving it behind either trips that same
+// validator or, when checksums are disabled, ships the bundle this fix exists
+// to prevent.
+func removeStaleStaticDir(staticDir string) error {
+	if err := checkStaticPath(staticDir); err != nil {
+		return err
+	}
+
+	entries, readErr := os.ReadDir(staticDir)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return nil
+		}
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to inspect static directory", readErr)
+	}
+	if len(entries) > 0 {
+		slog.Debug("keeping populated static directory from an earlier run",
+			"path", staticDir, "entries", len(entries))
+		return nil
+	}
+
+	if rmErr := os.Remove(staticDir); rmErr != nil && !os.IsNotExist(rmErr) {
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to remove empty static directory %q", staticDir), rmErr)
+	}
+	return nil
 }
 
 // valuesSchemaProperty, valuesSchemaDeployerProps, valuesSchemaDeployer,

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -592,6 +592,273 @@ func TestGenerate_DataFiles(t *testing.T) {
 	}
 }
 
+// TestGenerate_StaticDirCreatedOnlyWhenPopulated verifies that static/ is
+// emitted only when at least one component contributes a values file.
+//
+// Components land in static/ only when they resolve to a remote Helm chart
+// (type Helm with a non-empty Source). A recipe whose components are all
+// local charts — the OCP overlays, which build from manifestFiles with no
+// upstream Source — contributes nothing, so an unconditionally created
+// static/ would remain empty. The bundle inventory validator walks the
+// finished tree and rejects any directory contributing no files, which
+// failed generation outright. See issue #1942.
+func TestGenerate_StaticDirCreatedOnlyWhenPopulated(t *testing.T) {
+	// Manifest-only components must carry post-manifests so the delegated
+	// argocd.Generator wraps them as local charts, mirroring how the OCP
+	// overlays supply manifestFiles.
+	localManifest := func(name string) map[string][]byte {
+		return map[string][]byte{
+			name + ".yaml": []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + name + "\n"),
+		}
+	}
+
+	localOnlyRefs := []recipe.ComponentRef{
+		{Name: "nfd-ocp-olm", Namespace: "nfd", Type: recipe.ComponentTypeHelm, Source: ""},
+		{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm, Source: ""},
+	}
+	localOnlyValues := map[string]map[string]any{
+		"nfd-ocp-olm": {"enabled": true},
+		"nfd-ocp":     {"enabled": true},
+	}
+	localOnlyManifests := map[string]map[string][]byte{
+		"nfd-ocp-olm": localManifest("nfd-ocp-olm"),
+		"nfd-ocp":     localManifest("nfd-ocp"),
+	}
+
+	tests := []struct {
+		name           string
+		refs           []recipe.ComponentRef
+		values         map[string]map[string]any
+		postManifests  map[string]map[string][]byte
+		staleStaticDir bool
+		wantStaticDir  bool
+	}{
+		{
+			name:          "all components local charts omits static dir",
+			refs:          localOnlyRefs,
+			values:        localOnlyValues,
+			postManifests: localOnlyManifests,
+			wantStaticDir: false,
+		},
+		{
+			// A pre-fix failed run leaves an empty static/ in --output, and
+			// generation does not clear the directory between runs, so the
+			// retry must remove it rather than fail the same way again.
+			name:           "stale empty static dir from a prior run is removed",
+			refs:           localOnlyRefs,
+			values:         localOnlyValues,
+			postManifests:  localOnlyManifests,
+			staleStaticDir: true,
+			wantStaticDir:  false,
+		},
+		{
+			name: "at least one remote chart creates static dir",
+			refs: []recipe.ComponentRef{
+				{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm, Source: ""},
+				{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+					Type:      recipe.ComponentTypeHelm,
+					Chart:     "cert-manager",
+					Version:   "v1.20.2",
+					Source:    "https://charts.jetstack.io",
+				},
+			},
+			values: map[string]map[string]any{
+				"nfd-ocp":      {"enabled": true},
+				"cert-manager": {"replicaCount": 1},
+			},
+			postManifests: map[string]map[string][]byte{
+				"nfd-ocp": localManifest("nfd-ocp"),
+			},
+			wantStaticDir: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			rr := newRecipeResult("v1.0.0", tt.refs)
+			order := make([]string, 0, len(tt.refs))
+			for _, ref := range tt.refs {
+				order = append(order, ref.Name)
+			}
+			rr.DeploymentOrder = order
+
+			g := &Generator{
+				RecipeResult:           rr,
+				ComponentValues:        tt.values,
+				Version:                "test",
+				RepoURL:                "https://github.com/example/repo.git",
+				TargetRevision:         "main",
+				ComponentPostManifests: tt.postManifests,
+				// Drives finalizeOutput -> checksum.WriteChecksums ->
+				// validateExactTree, the check that actually rejected the
+				// empty directory in #1942. Without it this test asserts
+				// only the proxy (static/ absent from a fresh tree).
+				IncludeChecksums: true,
+			}
+
+			if tt.staleStaticDir {
+				if err := os.MkdirAll(filepath.Join(outputDir, "static"), 0o755); err != nil {
+					t.Fatalf("failed to seed stale static/: %v", err)
+				}
+			}
+
+			if _, err := g.Generate(context.Background(), outputDir); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+
+			staticPath := filepath.Join(outputDir, "static")
+			info, err := os.Stat(staticPath)
+			switch {
+			case tt.wantStaticDir:
+				if err != nil {
+					t.Fatalf("static/ missing, want present: %v", err)
+				}
+				entries, readErr := os.ReadDir(staticPath)
+				if readErr != nil {
+					t.Fatalf("failed to read static/: %v", readErr)
+				}
+				if len(entries) == 0 {
+					t.Error("static/ exists but is empty; an empty directory fails bundle inventory validation")
+				}
+			case err == nil:
+				t.Errorf("static/ present (isDir=%v), want omitted when no component contributes values", info.IsDir())
+			case !os.IsNotExist(err):
+				t.Fatalf("unexpected error stating static/: %v", err)
+			}
+		})
+	}
+}
+
+// TestGenerate_StaleStaticPathIsNotDestroyed verifies that clearing a stale
+// static/ never destroys data at that path.
+//
+// os.Remove unlinks regular files as readily as it removes empty directories,
+// so a non-directory must be rejected rather than silently deleted, and a
+// populated directory must be preserved for validateExactTree to report.
+func TestGenerate_StaleStaticPathIsNotDestroyed(t *testing.T) {
+	localManifest := map[string][]byte{
+		"nfd-ocp.yaml": []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nfd-ocp\n"),
+	}
+	// withRemoteChart toggles between the two routes to the static path: with
+	// no remote chart every component is skipped and only removeStaleStaticDir
+	// runs, while a single upstream chart reaches ensureStaticDir first. Both
+	// must reject a non-directory identically.
+	newGen := func(withRemoteChart bool) *Generator {
+		refs := []recipe.ComponentRef{
+			{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm, Source: ""},
+		}
+		values := map[string]map[string]any{"nfd-ocp": {"enabled": true}}
+		if withRemoteChart {
+			refs = append(refs, recipe.ComponentRef{
+				Name:      "cert-manager",
+				Namespace: "cert-manager",
+				Type:      recipe.ComponentTypeHelm,
+				Chart:     "cert-manager",
+				Version:   "v1.20.2",
+				Source:    "https://charts.jetstack.io",
+			})
+			values["cert-manager"] = map[string]any{"replicaCount": 1}
+		}
+		rr := newRecipeResult("v1.0.0", refs)
+		order := make([]string, 0, len(refs))
+		for _, ref := range refs {
+			order = append(order, ref.Name)
+		}
+		rr.DeploymentOrder = order
+		return &Generator{
+			RecipeResult:           rr,
+			ComponentValues:        values,
+			Version:                "test",
+			RepoURL:                "https://github.com/example/repo.git",
+			TargetRevision:         "main",
+			ComponentPostManifests: map[string]map[string][]byte{"nfd-ocp": localManifest},
+			IncludeChecksums:       true,
+		}
+	}
+
+	for _, tc := range []struct {
+		name            string
+		withRemoteChart bool
+	}{
+		{"no remote chart (removeStaleStaticDir path)", false},
+		{"with remote chart (ensureStaticDir path)", true},
+	} {
+		t.Run("regular file at the static path is rejected, not unlinked: "+tc.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			staticPath := filepath.Join(outputDir, "static")
+			const payload = "user data that must survive\n"
+			if err := os.WriteFile(staticPath, []byte(payload), 0o600); err != nil {
+				t.Fatalf("failed to seed file: %v", err)
+			}
+
+			_, err := newGen(tc.withRemoteChart).Generate(context.Background(), outputDir)
+			if err == nil {
+				t.Fatal("Generate() succeeded, want failure when static path is not a directory")
+			}
+			if !strings.Contains(err.Error(), "is not a directory") {
+				t.Errorf("Generate() error = %v, want it to name the non-directory path", err)
+			}
+			// Both routes must agree on the code: the same user error must not
+			// be INVALID_REQUEST for one recipe shape and INTERNAL for another.
+			if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("Generate() error code = %v, want ErrCodeInvalidRequest", err)
+			}
+
+			got, readErr := os.ReadFile(staticPath)
+			if readErr != nil {
+				t.Fatalf("file at static path was destroyed: %v", readErr)
+			}
+			if string(got) != payload {
+				t.Errorf("file contents = %q, want %q", got, payload)
+			}
+		})
+	}
+
+	t.Run("symlink at the static path is rejected", func(t *testing.T) {
+		outputDir := t.TempDir()
+		target := t.TempDir()
+		staticPath := filepath.Join(outputDir, "static")
+		if err := os.Symlink(target, staticPath); err != nil {
+			t.Skipf("symlinks unsupported here: %v", err)
+		}
+
+		_, err := newGen(false).Generate(context.Background(), outputDir)
+		if err == nil {
+			t.Fatal("Generate() succeeded, want failure when static path is a symlink")
+		}
+		if !strings.Contains(err.Error(), "symbolic link") {
+			t.Errorf("Generate() error = %v, want it to name the symlink", err)
+		}
+		if _, statErr := os.Lstat(staticPath); statErr != nil {
+			t.Errorf("symlink was removed: %v", statErr)
+		}
+	})
+
+	t.Run("populated static dir is preserved", func(t *testing.T) {
+		outputDir := t.TempDir()
+		staticPath := filepath.Join(outputDir, "static")
+		if err := os.MkdirAll(staticPath, 0o755); err != nil {
+			t.Fatalf("failed to seed dir: %v", err)
+		}
+		leftover := filepath.Join(staticPath, "leftover.yaml")
+		if err := os.WriteFile(leftover, []byte("stale: true\n"), 0o600); err != nil {
+			t.Fatalf("failed to seed leftover file: %v", err)
+		}
+
+		// Generation fails because validateExactTree reports the stale file
+		// as unexpected output. The file itself must still be there.
+		if _, err := newGen(false).Generate(context.Background(), outputDir); err == nil {
+			t.Error("Generate() succeeded, want failure on unexpected stale output")
+		}
+		if _, err := os.Stat(leftover); err != nil {
+			t.Errorf("populated static/ was removed: %v", err)
+		}
+	})
+}
+
 // TestConvertToSingleSourceWithValues verifies the structured YAML
 // transformation from multi-source to single-source with helm.values.
 func TestConvertToSingleSourceWithValues(t *testing.T) {


### PR DESCRIPTION
## Summary

Create the argocd-helm bundle's `static/` directory lazily, so a bundle whose components contribute no static values omits it entirely instead of emitting an empty directory that fails bundle inventory validation. Also remove an empty `static/` left behind by an earlier failed run, so retrying into the same output directory succeeds.

## Motivation / Context

`aicr bundle --deployer argocd-helm` failed for every OCP recipe with:

```
[INVALID_REQUEST] bundle contains an unexpected directory: "static"
```

`writeStaticValuesAndBuildStubs` created `<output>/static` unconditionally, then wrote a values file into it only for components resolving to a remote Helm chart:

```go
isHelmChart := ref.Type != recipe.ComponentTypeKustomize && ref.Source != ""
```

The OCP overlays declare every component as `type: Helm` built from `manifestFiles` with **no** upstream `source`, so `Source == ""` skips all of them and nothing is ever written. `validateExactTree` in `pkg/bundler/checksum/inventory.go` then walks the finished tree and rejects any directory absent from `expectedDirectories` — an empty directory contributes no files, so it never enters that set.

Fixes: #1942
Related: #1947

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: N/A

## Implementation Notes

The `MkdirAll` moves behind an `ensureStaticDir` closure invoked immediately before the first component values file is written. Bundles that do write static values are unaffected — the directory is created at the same point in the flow, with the same permissions, before the same write.

Lazy creation alone does not help a user who already hit the bug. Generation writes directly into `--output` and does not clear it between runs, so the failed run's empty `static/` is still on disk and a plain retry reproduces the same error. When nothing is written, the directory is therefore removed.

The path is guarded in one place, `checkStaticPath`, shared by the create and remove routes. `os.Remove` unlinks regular files as readily as it removes empty directories, so removal must not run blind; and `MkdirAll` reports a non-directory only as a generic `ENOTDIR`, so without a shared guard the same user error surfaced as `INVALID_REQUEST` for an all-local recipe but `INTERNAL` for any recipe carrying an upstream chart — the outcome decided by recipe shape rather than by the mistake. `Lstat` rather than `Stat` also rejects a symlink planted after `checksum.ValidateOutputRoot` ran, which permits pre-existing regular files, and a symlink gets its own message rather than being reported as "not a directory".

Emptiness is checked explicitly rather than inferred from an `os.Remove` errno, which keeps the intent readable and avoids platform-specific error values. A populated `static/` is kept and reported by `validateExactTree` as unexpected output — though only when checksums are enabled, since that validator runs inside the `IncludeChecksums` path. With checksums off a stale `static/` survives into the bundle, unchanged from before this fix: a reused `--output` was never cleared, so stale files of any kind already persisted.

That new `ErrCodeInvalidRequest` is why `writeValuesFiles` switches to `errors.PropagateOrWrap`: re-coding it as `INTERNAL` would present a bad `--output` path as a server fault, and over the API a 5xx withholds the cause from the response.

Of the three options in the issue, lazy creation was chosen over pruning after the fact or registering `static/` as always-expected. It keeps the emitted tree free of empty directories, preserving the inventory validator's exact-tree contract rather than widening it.

Only the `argocd-helm` deployer is touched. `helm`, `argocd`, and `helmfile` already bundled OCP recipes cleanly and are unchanged.

`flux` has the same defect on its OCI output path — `sources/` is created unconditionally and stays empty for an OCP recipe — filed as #1947 rather than fixed here. The catalog sweep above did not surface it because it bundles to a local directory, where `gitSources` is populated. Widening this PR to a second deployer would be scope creep, and the two fixes should be reviewable independently.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race ./pkg/bundler/deployer/argocdhelm/ -count=1
GOFLAGS="-mod=vendor" go test ./pkg/bundler/... -count=1
golangci-lint run -c .golangci.yaml ./pkg/bundler/deployer/argocdhelm/...
./tools/check-docs-mdx
```

The argocd-helm package passes with the race detector, affected-package lint reports 0 issues, and the MDX doc check passes.

**Regression sweep.** Binaries built from this branch and from the merge-base were run against all 100 embedded catalog overlays on the `argocd-helm` deployer, comparing whole output trees:

| Result | Count |
|---|---|
| Byte-identical to baseline | 97 |
| Newly succeeding (`ocp`, `ocp-training`, `ocp-inference`) | 3 |
| Differing output | 0 |

The three OCP overlays go from exit 2 to exit 0, producing 34 files each with `static/` correctly absent. The other 97 are unchanged, including their `static/` contents.

**Regression tests.** `TestGenerate_StaticDirCreatedOnlyWhenPopulated` is table-driven with three cases and sets `IncludeChecksums: true`, so it exercises `finalizeOutput` → `checksum.WriteChecksums` → `validateExactTree` — the check that actually rejected the empty directory — rather than asserting only the proxy that `static/` is absent. Verified against three source states:

| Source state | all-local | stale `static/` | remote chart (control) |
|---|---|---|---|
| `origin/main` | fail | fail | pass |
| lazy creation only | pass | fail | pass |
| this branch | pass | pass | pass |

Both failure modes report the real `bundle contains an unexpected directory: "static"` error, and the control case passes in every state, so the test cannot pass vacuously.

`TestGenerate_StaleStaticPathIsNotDestroyed` covers the guard's safety across both routes to the static path. A regular file is rejected with the path named, its contents intact, and the same `ErrCodeInvalidRequest` asserted for a recipe with no remote chart (reaching `removeStaleStaticDir`) and one with an upstream chart (reaching `ensureStaticDir`) — so the two routes cannot drift apart. A symlink is rejected and left in place, and a populated stale directory is preserved. The two file/symlink cases covering `ensureStaticDir` fail without the shared guard; the `removeStaleStaticDir` and populated-directory cases pass with or without it, serving as controls.

Package coverage: `pkg/bundler/deployer/argocdhelm` 82.6% → 83.7% (+1.1%).

`make qualify` was not run in full. Two `pkg/bundler/attestation` tests fail in this environment (`TestNewKeyVerificationIdentity_PEM`, `TestFetchAmbientOIDCToken`); both are pre-existing sandbox/network failures in a package this change does not touch, and both pass in CI.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

The change is confined to one deployer. Its effects are to skip creating a directory that would otherwise be empty, and to remove that directory when a previous run left it behind. Bundles that populate `static/` follow an identical code path; a non-empty `static/` is never removed, and a non-directory or symlink at that path is reported rather than deleted. Package documentation was updated alongside the code so it no longer describes `static/` as unconditional.

**Rollout notes:** No migration or flag. Bundles previously containing an empty `static/` could not be generated at all, so no existing artifact layout changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
