### PR TITLE
test(bundler): cover argocd-helm OCP bundling and pin its error contract

### DIFF
--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -643,9 +643,23 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 // an upstream chart.
 //
 // The check matters most before removal, since os.Remove unlinks regular files
-// as readily as it removes empty directories. Lstat rather than Stat also
-// rejects a symlink planted after checksum.ValidateOutputRoot ran, which
-// happens before generation and permits pre-existing regular files.
+// as readily as it removes empty directories. A pre-existing regular file at
+// this path reaches generation on every route: checksum.ValidateOutputRoot
+// runs first on the DefaultBundler path but permits regular files, rejecting
+// only symlinks and special objects.
+//
+// Lstat rather than Stat additionally rejects a symlink here. On the
+// DefaultBundler path that is redundant, since ValidateOutputRoot already
+// rejects a symlink anywhere under the output root before any deployer runs;
+// it still holds for a caller that constructs this Generator directly and
+// bypasses that check.
+//
+// The guarantee stops there. This is a check-then-act on a path, so a symlink
+// planted between this call and the MkdirAll or Remove that follows is not
+// caught. Closing that would require openat-based operations throughout, and
+// it buys nothing in a supported configuration: it takes a local process with
+// write access to --output, and anything with that access can already rewrite
+// the finished bundle and its checksums.
 func checkStaticPath(staticDir string) error {
 	info, statErr := os.Lstat(staticDir)
 	switch {
@@ -694,7 +708,7 @@ func removeStaleStaticDir(staticDir string) error {
 			"failed to inspect static directory", readErr)
 	}
 	if len(entries) > 0 {
-		slog.Debug("keeping populated static directory from an earlier run",
+		slog.Warn("keeping populated static directory from an earlier run",
 			"path", staticDir, "entries", len(entries))
 		return nil
 	}

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -775,7 +775,27 @@ func TestGenerate_StaleStaticPathIsNotDestroyed(t *testing.T) {
 			RepoURL:                "https://github.com/example/repo.git",
 			TargetRevision:         "main",
 			ComponentPostManifests: map[string]map[string][]byte{"nfd-ocp": localManifest},
-			IncludeChecksums:       true,
+			// Reaches finalizeOutput -> checksum.WriteChecksums ->
+			// validateExactTree, the check that rejected the empty directory
+			// in #1942.
+			//
+			// This only affects the "populated static dir is preserved"
+			// subtest, the one that runs far enough to reach the validator.
+			// The file and symlink subtests fail earlier inside
+			// checkStaticPath and return before finalizeOutput, so they assert
+			// checkStaticPath's own message and DO pin the error code in both
+			// directions -- including the no-ErrCodeInternal check that keeps
+			// the CLI exit code at 2. Do not relax those.
+			//
+			// For the validator subtest only: production builds this Generator
+			// with IncludeChecksums false (the argocdhelm.Generator literal in
+			// DefaultBundler.buildDeployer) and reaches the same validator from
+			// DefaultBundler.runDeployer instead, so the wrapper around that
+			// failure differs from the shipped CLI. Its assertion is on
+			// validateExactTree's message, identical on both routes; its
+			// surrounding error code is not pinned. End-to-end coverage of the
+			// production path lives in tests/chainsaw/cli/bundle-ocp.
+			IncludeChecksums: true,
 		}
 	}
 
@@ -805,6 +825,15 @@ func TestGenerate_StaleStaticPathIsNotDestroyed(t *testing.T) {
 			// be INVALID_REQUEST for one recipe shape and INTERNAL for another.
 			if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
 				t.Errorf("Generate() error code = %v, want ErrCodeInvalidRequest", err)
+			}
+			// The negative direction is what actually pins writeValuesFiles to
+			// PropagateOrWrap. errors.Is walks the Unwrap chain, so the check
+			// above still passes when an outer Wrap(ErrCodeInternal, ...) buries
+			// the real code — while ExitCodeFromError reads the OUTERMOST
+			// StructuredError, so the exit code a user observes would flip from
+			// 2 to 8 with the assertion above still green.
+			if errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInternal, "")) {
+				t.Errorf("Generate() error = %v, want no ErrCodeInternal anywhere in the chain", err)
 			}
 
 			got, readErr := os.ReadFile(staticPath)
@@ -848,13 +877,21 @@ func TestGenerate_StaleStaticPathIsNotDestroyed(t *testing.T) {
 			t.Fatalf("failed to seed leftover file: %v", err)
 		}
 
-		// Generation fails because validateExactTree reports the stale file
-		// as unexpected output. The file itself must still be there.
-		if _, err := newGen(false).Generate(context.Background(), outputDir); err == nil {
-			t.Error("Generate() succeeded, want failure on unexpected stale output")
+		// Generation fails because validateExactTree reports the stale output.
+		// For an all-local recipe static/ is not an expected directory at all,
+		// so the walk rejects the directory itself before reaching its
+		// contents — the message names the directory, not leftover.yaml.
+		// Asserted specifically so the subtest cannot drift into passing on
+		// some unrelated error.
+		_, err := newGen(false).Generate(context.Background(), outputDir)
+		if err == nil {
+			t.Fatal("Generate() succeeded, want failure on unexpected stale output")
 		}
-		if _, err := os.Stat(leftover); err != nil {
-			t.Errorf("populated static/ was removed: %v", err)
+		if !strings.Contains(err.Error(), `unexpected directory: "static"`) {
+			t.Errorf("Generate() error = %v, want validateExactTree to reject the stale static/", err)
+		}
+		if _, statErr := os.Stat(leftover); statErr != nil {
+			t.Errorf("populated static/ was removed: %v", statErr)
 		}
 	})
 }

--- a/tests/chainsaw/cli/bundle-ocp/chainsaw-test.yaml
+++ b/tests/chainsaw/cli/bundle-ocp/chainsaw-test.yaml
@@ -69,10 +69,18 @@ spec:
       try:
         - script:
             content: |
+              # Each check below carries its own `|| { …; exit 1; }`, which is
+              # what makes it fail closed — `set -e` does not apply to the left
+              # side of `||`. set -eu is defence in depth for anything added
+              # later without that guard: a bare `test -f` returns 1 without
+              # terminating, and Chainsaw reads only the script's final exit
+              # status, so an unguarded check would pass silently.
+              set -eu
               WORK="/tmp/chainsaw-bundle-ocp"
-              test -f "${WORK}/bundle/deploy.sh"
-              test -f "${WORK}/bundle/README.md"
-              test -f "${WORK}/bundle/recipe.yaml"
+              for f in deploy.sh README.md recipe.yaml; do
+                test -f "${WORK}/bundle/${f}" \
+                  || { echo "missing scaffold file: ${f}" >&2; exit 1; }
+              done
               ls "${WORK}"/bundle/[0-9][0-9][0-9]-*/ >/dev/null 2>&1 \
                 || { echo "no numbered component folders found" >&2; exit 1; }
             check:
@@ -136,6 +144,57 @@ spec:
                 [ "${rdns_seq}" -lt "${cr_seq}" ] \
                   || { echo "readiness gate (${rdns_seq}) must precede CR ${cr_name} (${cr_seq})" >&2; exit 1; }
               done
+            check:
+              ($error == null): true
+
+    - name: generate-argocd-helm-bundle
+      description: >-
+        Bundle the same OCP recipe with --deployer argocd-helm. Every OCP
+        component is a local chart, so none contributes a static/ values file.
+        Emitting that directory anyway made it empty, and the bundle inventory
+        validator rejects a directory contributing no files, which failed
+        generation outright. See issue #1942.
+      try:
+        - script:
+            content: |
+              AICR_BIN="${AICR_BIN:?Set AICR_BIN to the path of the aicr binary}"
+              WORK="/tmp/chainsaw-bundle-ocp"
+              ${AICR_BIN} bundle \
+                --recipe "${WORK}/recipe.yaml" \
+                --output "${WORK}/bundle-argocd-helm" \
+                --deployer argocd-helm
+            check:
+              ($error == null): true
+
+    - name: assert-argocd-helm-omits-empty-static
+      description: >-
+        The bundle must be emitted without a static/ directory rather than with
+        an empty one, and must still carry its chart scaffold.
+      try:
+        - script:
+            content: |
+              # As above: the explicit `|| { …; exit 1; }` on each check is
+              # the safeguard, and set -eu covers anything added later without
+              # one. That matters most here, where the script ends in an `if`
+              # that yields 0 whenever static/ is absent, so an unguarded
+              # scaffold check would never fail the step.
+              set -eu
+              WORK="/tmp/chainsaw-bundle-ocp"
+              BUNDLE="${WORK}/bundle-argocd-helm"
+              for f in Chart.yaml values.yaml; do
+                test -f "${BUNDLE}/${f}" \
+                  || { echo "missing scaffold file: ${f}" >&2; exit 1; }
+              done
+              ls "${BUNDLE}"/[0-9][0-9][0-9]-*/ >/dev/null 2>&1 \
+                || { echo "no numbered component folders found" >&2; exit 1; }
+              # -e dereferences, so it reads false for a dangling symlink;
+              # -L catches that case and keeps the assertion honest about any
+              # entry at this path, not just a resolvable one.
+              if [ -e "${BUNDLE}/static" ] || [ -L "${BUNDLE}/static" ]; then
+                echo "static/ present; expected omitted for an all-local recipe" >&2
+                ls -la "${BUNDLE}/static" >&2
+                exit 1
+              fi
             check:
               ($error == null): true
       cleanup:


### PR DESCRIPTION
## Summary

Follow-up to #1944, which merged before this round of review fixes landed. Adds end-to-end coverage for the fix itself, makes the error-code assertion added there capable of failing, tightens a stale-output assertion, promotes one log to `Warn`, and scopes a threat-model comment to what the code actually delivers.

## Motivation / Context

#1944 changed `writeValuesFiles` to `errors.PropagateOrWrap` so a bad `--output` path reports as `INVALID_REQUEST` instead of an internal fault, and added an assertion intended to pin that.

The assertion could not fail. `stderrors.Is` walks the `Unwrap` chain and `StructuredError.Is` matches on `Code`, so under an outer `Wrap(ErrCodeInternal, ...)` the chain is `INTERNAL → INVALID_REQUEST` and the positive check still passes. `ExitCodeFromError` reads the **outermost** `StructuredError`, so reverting that one line flipped `aicr bundle` from exit 2 back to exit 8 with the suite green — verified by reverting it and watching the tests pass.

Related: #1942, #1944

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: N/A

## Implementation Notes

**End-to-end coverage.** No test bundled a real OCP recipe through `--deployer argocd-helm`. The chainsaw suite at `tests/chainsaw/cli/bundle-ocp/` used the default helm deployer, and `.github/workflows/kwok-recipes.yaml` skips `service==ocp` for every deployer in its matrix, so the merged fix had Go unit coverage only — the 100-overlay sweep that actually exercised it is not part of CI. Two steps are added to the existing suite: bundle the recipe it already generates with `--deployer argocd-helm`, and assert `static/` is omitted rather than emitted empty.

**Error-code assertion.** Adds the negative direction — no `ErrCodeInternal` anywhere in the chain — which is what actually pins `writeValuesFiles` to `PropagateOrWrap`. The positive assertion alone is satisfied by a buried code.

**Stale-output assertion.** The "populated static dir is preserved" subtest accepted any error from `Generate`, unlike its two siblings. It now asserts the specific message. Worth noting the validator reports the stale **directory**, not the file inside it: for an all-local recipe `static/` is not an expected directory at all, so the walk rejects it before reaching its contents. Asserting the file-level message would have failed.

**Log level.** The kept-stale-directory message moves from `Debug` to `Warn`. It reports artifact residue surviving into the bundle, which `Debug` puts below the CLI's default level.

**Threat model.** The `checkStaticPath` comment claimed `Lstat` "rejects a symlink planted after `checksum.ValidateOutputRoot` ran." That overstates it. `Lstat` rejects a symlink already present when generation reaches the path, but this is a check-then-act on a path name, so one planted between the check and the following `MkdirAll` or `Remove` is not caught.

No TOCTOU code was added. Closing that window would require `openat`-based operations throughout, and buys nothing in a supported configuration: it needs a local process with write access to `--output`, and anything with that access can already rewrite the finished bundle and its checksums. The comment is scoped to the guarantee the code delivers rather than the code being changed to model an attacker who has already won.

No behavior change beyond the log level.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race ./pkg/bundler/deployer/argocdhelm/ -count=1
golangci-lint run -c .golangci.yaml ./pkg/bundler/deployer/argocdhelm/...
yamllint -c .yamllint.yaml tests/chainsaw/cli/bundle-ocp/chainsaw-test.yaml
cd tests/chainsaw/cli/bundle-ocp && chainsaw test --test-dir . --no-cluster
```

Passes with the race detector; affected-package lint and yamllint both report 0 issues.

**Both new guards have a failing state**, which is the point — an assertion that cannot fail is not coverage.

| guard | against | result |
|---|---|---|
| error-code assertion | revert `PropagateOrWrap` → `Wrap` on current `main` | before: suite **green**; now: suite **fails** |
| chainsaw argocd-helm step | binary built from `fd26a4741^` (pre-#1944) | **fails** at `generate-argocd-helm-bundle` with `bundle contains an unexpected directory: "static"` |

The chainsaw suite was run locally both ways:

```bash
cd tests/chainsaw/cli/bundle-ocp
AICR_BIN=<fixed>   chainsaw test --test-dir . --no-cluster   # 1 passed
AICR_BIN=<pre-fix> chainsaw test --test-dir . --no-cluster   # 1 failed, at the new step
```

Of everything #1944 changed, the error-code half was the only part with no failing state at all.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Test assertions, two added chainsaw steps, one log level, and one comment. No production code path changes; the only runtime effect is that a kept stale `static/` is now visible at the CLI's default log level.

**Rollout notes:** None.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
