### PR TITLE
fix(bom): extract nested operator images

### DIFF
--- a/docs/user/air-gap-mirror.md
+++ b/docs/user/air-gap-mirror.md
@@ -272,7 +272,9 @@ generate the deployment-specific manifest for a specific deployment.
 > field; the Hauler and Zarf outputs **omit them entirely**. Treat a
 > tool-specific manifest as authoritative only after confirming the YAML/JSON
 > run reported no warnings — otherwise the mirrored set may be silently
-> incomplete.
+> incomplete. Invalid members in a recognized mapping-valued `image` or
+> `scalingPodImage` descriptor are the exception: `mirror list` exits nonzero
+> instead of emitting a known-incomplete image set.
 
 > **Runtime validation image:** `slinky-slurm-health` launches
 > `docker.io/library/alpine:3.23.3` dynamically through `srun` on GPU-backed

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2678,6 +2678,9 @@ mirroring. Renders each component's Helm chart with recipe-resolved values and
 scans referenced manifests to produce a deduplicated image and chart list. When
 the recipe was resolved with `--data <dir>`, both values and manifests are read
 through the overlay so overlay-shadowed paths take precedence over embedded.
+Recognized mapping-valued image descriptors with null, empty, or non-scalar
+members are rejected so the command cannot succeed with a known-incomplete
+image set.
 
 For an end-to-end walkthrough covering Hauler and Zarf workflows, see
 [Air-Gapped Mirroring](air-gap-mirror.md).

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -20,7 +20,7 @@ A machine-readable **CycloneDX 1.6 JSON** companion to this page is produced by 
 ## Summary
 
 - Components: **34**
-- Unique images: **87**
+- Unique images: **96**
 - Distinct registries: **11**
 
 Registries: `602401143452.dkr.ecr.us-west-2.amazonaws.com`, `cr.agentgateway.dev`, `docker.io`, `gcr.io`, `ghcr.io`, `gke.gcr.io`, `nvcr.io`, `public.ecr.aws`, `quay.io`, `registry.k8s.io`, `us-docker.pkg.dev`
@@ -45,7 +45,7 @@ _Rendering fidelity:_ `catalog-parity: charts are rendered with the shared recip
 | grove | helm | grove-charts | v0.1.0-alpha.8 | 1 |
 | k8s-ephemeral-storage-metrics | helm | k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics | 1.19.2 | 1 |
 | k8s-nim-operator | helm | k8s-nim-operator | 3.1.0 | 1 |
-| kai-scheduler | helm | kai-scheduler | v0.14.1 | 2 |
+| kai-scheduler | helm | kai-scheduler | v0.14.1 | 11 |
 | kube-prometheus-stack | helm | prometheus-community/kube-prometheus-stack | 84.4.0 | 8 |
 | kubeflow-trainer | helm | kubeflow-trainer | 2.2.0 | 3 |
 | kueue | helm | kueue | 0.18.2 | 1 |
@@ -164,8 +164,17 @@ _No images extracted._
 
 ### kai-scheduler
 
+- `ghcr.io/kai-scheduler/kai-scheduler/admission:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/binder:v0.14.1`
 - `ghcr.io/kai-scheduler/kai-scheduler/crd-upgrader:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/nodescaleadjuster:v0.14.1`
 - `ghcr.io/kai-scheduler/kai-scheduler/operator:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/podgroupcontroller:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/podgrouper:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/queuecontroller:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/resourcereservation:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/scalingpod:v0.14.1`
+- `ghcr.io/kai-scheduler/kai-scheduler/scheduler:v0.14.1`
 
 ### kube-prometheus-stack
 

--- a/pkg/bom/doc.go
+++ b/pkg/bom/doc.go
@@ -18,7 +18,10 @@
 // It exposes the reusable pieces of the BOM pipeline:
 //
 //   - ExtractImagesFromYAML walks rendered Helm output (or any K8s manifest
-//     bundle) and returns the unique sorted set of `image:` scalar values.
+//     bundle) and returns the unique sorted set of scalar `image:` references
+//     plus recognized structured `image:` and `scalingPodImage:` descriptors.
+//     Invalid members in a recognized descriptor return an error rather than
+//     silently producing an incomplete inventory.
 //   - ParseImageRef splits a container image string into registry, repository,
 //     tag, and digest components.
 //   - BuildBOM assembles a CycloneDX 1.6 document from per-component image

--- a/pkg/bom/extract.go
+++ b/pkg/bom/extract.go
@@ -31,16 +31,23 @@ import (
 // YAML parsing. Files under recipes/components/*/manifests/ are sometimes
 // Helm-template-shaped (the bundler processes them as chart templates), so
 // raw YAML parsing would fail on the bare directives.
-const helmTemplatePlaceholder = "_aicr_helm_template_"
+const (
+	helmTemplatePlaceholder = "_aicr_helm_template_"
+	imageRepositoryKey      = "repository"
+	imageTagKey             = "tag"
+)
 
 var helmTemplateRE = regexp.MustCompile(`\{\{[^{}]*\}\}`)
 
 // stripHelmTemplates pre-processes a YAML document so the parser doesn't
 // choke on Go-template directives. Two passes:
-//  1. Drop any line whose non-whitespace content consists entirely of one or
-//     more Helm directives (e.g., `  {{- if foo }}`, `  {{- end }}`,
+//  1. Blank out any line whose non-whitespace content consists entirely of
+//     one or more Helm directives (e.g., `  {{- if foo }}`, `  {{- end }}`,
 //     `  {{- toYaml . | nindent 4 }}`). These are control-flow scaffolding
-//     that produces no YAML node when rendered.
+//     that produces no YAML node when rendered. The line is kept (empty)
+//     rather than deleted so yaml.Node positions — and therefore the
+//     line/column reported by descriptor errors — still index the original
+//     file.
 //  2. On surviving lines, replace inline directives with a placeholder so a
 //     value like `key: {{ .Values.x }}` becomes `key: _aicr_helm_template_`
 //     instead of breaking YAML parsing. The placeholder is filtered out by
@@ -51,6 +58,7 @@ func stripHelmTemplates(data []byte) []byte {
 	for _, l := range lines {
 		stripped := helmTemplateRE.ReplaceAll(l, nil)
 		if len(bytes.TrimSpace(stripped)) == 0 && bytes.Contains(l, []byte("{{")) {
+			out = append(out, nil)
 			continue
 		}
 		out = append(out, helmTemplateRE.ReplaceAll(l, []byte(helmTemplatePlaceholder)))
@@ -59,8 +67,15 @@ func stripHelmTemplates(data []byte) []byte {
 }
 
 // ExtractImagesFromYAML walks every YAML document in data and returns the
-// sorted, de-duplicated set of `image:` scalar values. It skips empty values,
-// `null`, and any value still containing an unrendered Go template directive.
+// sorted, de-duplicated set of container image references. It recognizes both
+// scalar `image:` values and operator-style `image: {name, repository, tag}`
+// mappings. Empty or null scalar `image:` values and values still containing an
+// unrendered Go template directive are skipped. A recognized structured
+// descriptor returns an invalid-request error when a present name or
+// repository field is null, empty, or non-scalar, when a tag field is
+// non-scalar, or when a registry or digest member is present (dropping either
+// would emit a wrong or un-pinned reference). A null or empty tag follows the
+// Helm appVersion idiom and is treated as absent.
 //
 // Helm template directives ({{ ... }}) are replaced with a placeholder before
 // parsing, so files mixing YAML with Helm templates (those under
@@ -105,12 +120,19 @@ func walkForImages(n *yaml.Node, seen map[string]struct{}) error {
 		// `version` siblings carry the registry and tag. A sibling
 		// `containerSHA` (Skyhook Package CRD; ghcr.io/nvidia/nodewright)
 		// supplies the OCI digest and is folded in as `@<sha>`.
-		var imgScalar, repoScalar, verScalar, shaScalar string
+		var (
+			imgScalar, repoScalar, verScalar, shaScalar string
+			imgMappings                                 []*yaml.Node
+		)
 		for i := 0; i+1 < len(n.Content); i += 2 {
 			k, v := n.Content[i], n.Content[i+1]
 			target := v
 			if v.Kind == yaml.AliasNode && v.Alias != nil {
 				target = v.Alias
+			}
+			if isStructuredImageKey(k.Value) && target.Kind == yaml.MappingNode {
+				imgMappings = append(imgMappings, target)
+				continue
 			}
 			if target.Kind != yaml.ScalarNode {
 				continue
@@ -118,12 +140,21 @@ func walkForImages(n *yaml.Node, seen map[string]struct{}) error {
 			switch k.Value {
 			case "image":
 				imgScalar = strings.TrimSpace(target.Value)
-			case "repository":
+			case imageRepositoryKey:
 				repoScalar = strings.TrimSpace(target.Value)
 			case "version":
 				verScalar = strings.TrimSpace(target.Value)
 			case "containerSHA":
 				shaScalar = strings.TrimSpace(target.Value)
+			}
+		}
+		for _, imgMapping := range imgMappings {
+			mapped, err := imageReferenceFromMapping(imgMapping)
+			if err != nil {
+				return err
+			}
+			if isLikelyImage(mapped) {
+				seen[mapped] = struct{}{}
 			}
 		}
 		if imgScalar != "" {
@@ -158,6 +189,141 @@ func walkForImages(n *yaml.Node, seen map[string]struct{}) error {
 		// Scalar leaf — no nested image references.
 	}
 	return nil
+}
+
+// isStructuredImageKey allowlists mapping-valued image descriptor keys known
+// to be consumed as container images. Matching every *Image key would risk
+// inventorying chart metadata or templates that never become workloads.
+func isStructuredImageKey(key string) bool {
+	return key == "image" || key == "scalingPodImage"
+}
+
+// imageReferenceFromMapping recognizes the image descriptor shape used by
+// operator-managed workloads such as KAI Scheduler:
+//
+//	image:
+//	  name: binder
+//	  repository: ghcr.io/kai-scheduler/kai-scheduler
+//	  tag: v0.14.1
+//
+// Some charts omit name because repository already carries the full image
+// path. In that form, repository becomes the image name before tag is
+// appended. A present name or repository must be a non-null, non-empty
+// scalar. A null or empty tag is the Helm idiom for "default to the chart
+// appVersion" and is treated like an absent tag. Only name, repository, and
+// tag are combined; a present registry or digest member is rejected because
+// dropping it would emit a reference that resolves to the wrong registry or
+// silently un-pins a digest. Other members (pullPolicy, pullSecrets, ...)
+// do not affect the reference identity and are ignored.
+func imageReferenceFromMapping(n *yaml.Node) (string, error) {
+	var name, repository, tag string
+	var namePresent bool
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		key, value := n.Content[i], n.Content[i+1]
+		switch key.Value {
+		case "name", imageRepositoryKey, imageTagKey:
+		case "registry", "digest":
+			return "", errors.Wrap(
+				errors.ErrCodeInvalidRequest,
+				"invalid image descriptor member",
+				&invalidStructuredImageDescriptorError{
+					field:  key.Value,
+					line:   key.Line,
+					column: key.Column,
+					reason: "is not combined into the extracted reference; fold it into repository or tag",
+				},
+			)
+		default:
+			continue
+		}
+
+		scalar, ok := nonNullImageMappingScalar(value)
+		if !ok {
+			if key.Value == imageTagKey && isNullOrEmptyScalar(value) {
+				// tag: "" / tag: null — the Helm "use appVersion"
+				// idiom. Treat like an absent tag instead of failing
+				// the whole survey.
+				continue
+			}
+			return "", errors.Wrap(
+				errors.ErrCodeInvalidRequest,
+				"invalid image descriptor member",
+				&invalidStructuredImageDescriptorError{
+					field:  key.Value,
+					line:   value.Line,
+					column: value.Column,
+					reason: "must be a non-null, non-empty scalar",
+				},
+			)
+		}
+		switch key.Value {
+		case "name":
+			namePresent = true
+			name = scalar
+		case imageRepositoryKey:
+			repository = scalar
+		case imageTagKey:
+			tag = scalar
+		}
+	}
+	if !namePresent {
+		// combineCRDTriplet trims a trailing slash from repository only
+		// when it is prepended to a separate name, so trim here before
+		// repository itself becomes the name.
+		name = strings.TrimRight(repository, "/")
+		repository = ""
+	}
+	if name == "" {
+		return "", nil
+	}
+	return combineCRDTriplet(name, repository, tag), nil
+}
+
+func nonNullImageMappingScalar(n *yaml.Node) (string, bool) {
+	if n.Kind == yaml.AliasNode && n.Alias != nil {
+		n = n.Alias
+	}
+	if n.Kind != yaml.ScalarNode || n.Tag == "!!null" {
+		return "", false
+	}
+	value := strings.TrimSpace(n.Value)
+	return value, value != ""
+}
+
+// isNullOrEmptyScalar reports whether n is a null or empty-string scalar —
+// the shapes a Helm chart's `tag: ""` appVersion default renders to. A
+// non-scalar node is not covered; that stays a descriptor error.
+func isNullOrEmptyScalar(n *yaml.Node) bool {
+	if n.Kind == yaml.AliasNode && n.Alias != nil {
+		n = n.Alias
+	}
+	return n.Kind == yaml.ScalarNode &&
+		(n.Tag == "!!null" || strings.TrimSpace(n.Value) == "")
+}
+
+type invalidStructuredImageDescriptorError struct {
+	field  string
+	line   int
+	column int
+	reason string
+}
+
+func (e *invalidStructuredImageDescriptorError) Error() string {
+	return fmt.Sprintf(
+		"field %q at line %d, column %d %s",
+		e.field,
+		e.line,
+		e.column,
+		e.reason,
+	)
+}
+
+// IsInvalidStructuredImageDescriptor reports whether err was caused by a
+// recognized mapping-valued image descriptor whose name, repository, or tag
+// field was present but null, empty, or non-scalar.
+func IsInvalidStructuredImageDescriptor(err error) bool {
+	var target *invalidStructuredImageDescriptorError
+	return stderrors.As(err, &target)
 }
 
 // combineCRDTriplet builds a fully-qualified image reference from

--- a/pkg/bom/extract_test.go
+++ b/pkg/bom/extract_test.go
@@ -15,6 +15,7 @@
 package bom
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -271,6 +272,84 @@ spec:
 				"nvcr.io/nvidia/k8s/container-toolkit:v1.18.0",
 			},
 		},
+		{
+			name: "operator image mappings with name repository and tag",
+			in: `apiVersion: kai.scheduler/v1
+kind: Config
+metadata:
+  name: kai-config
+spec:
+  binder:
+    service:
+      image:
+        name: binder
+        repository: ghcr.io/kai-scheduler/kai-scheduler
+        tag: &kaiTag v0.14.1
+        pullPolicy: IfNotPresent
+  scheduler:
+    service:
+      image:
+        name: scheduler
+        repository: ghcr.io/kai-scheduler/kai-scheduler/
+        tag: *kaiTag
+  operator:
+    image:
+      repository: ghcr.io/kai-scheduler/kai-scheduler/operator
+      tag: v0.14.1
+`,
+			want: []string{
+				"ghcr.io/kai-scheduler/kai-scheduler/binder:v0.14.1",
+				"ghcr.io/kai-scheduler/kai-scheduler/operator:v0.14.1",
+				"ghcr.io/kai-scheduler/kai-scheduler/scheduler:v0.14.1",
+			},
+		},
+		{
+			name: "operator image mapping skips unresolved templates and incomplete descriptors",
+			in: `spec:
+  templated:
+    image:
+      name: "{{ .Values.image.name }}"
+      repository: ghcr.io/example
+      tag: v1.0.0
+  missing:
+    image:
+      tag: v1.0.0
+`,
+			want: []string{},
+		},
+		{
+			// A trailing slash on repository must be trimmed in the
+			// name-absent fallback too, not only when repository is
+			// prepended to a separate name.
+			name: "operator image mapping trims trailing repository slash in name fallback",
+			in: `spec:
+  operator:
+    image:
+      repository: ghcr.io/kai-scheduler/kai-scheduler/
+      tag: v0.14.1
+`,
+			want: []string{"ghcr.io/kai-scheduler/kai-scheduler:v0.14.1"},
+		},
+		{
+			// tag: "" and tag: null are the Helm "use appVersion" idiom —
+			// treated like an absent tag, emitting an untagged reference
+			// rather than failing the survey.
+			name: "operator image mapping treats empty and null tag as absent",
+			in: `spec:
+  empty:
+    image:
+      repository: ghcr.io/example/empty-tag
+      tag: ""
+  nulltag:
+    image:
+      repository: ghcr.io/example/null-tag
+      tag:
+`,
+			want: []string{
+				"ghcr.io/example/empty-tag",
+				"ghcr.io/example/null-tag",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -282,6 +361,105 @@ spec:
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractImagesFromYAML_InvalidStructuredImageDescriptor(t *testing.T) {
+	tests := []struct {
+		name       string
+		descriptor string
+		wantField  string
+	}{
+		{
+			name: "null name",
+			descriptor: `name: null
+      repository: ghcr.io/kai-scheduler/kai-scheduler
+      tag: v0.14.1`,
+			wantField: "name",
+		},
+		{
+			name: "null repository",
+			descriptor: `name: binder
+      repository: ~
+      tag: v0.14.1`,
+			wantField: imageRepositoryKey,
+		},
+		{
+			name: "non-scalar tag",
+			descriptor: `name: binder
+      repository: ghcr.io/kai-scheduler/kai-scheduler
+      tag:
+        - v0.14.1`,
+			wantField: "tag",
+		},
+		{
+			name: "registry member present",
+			descriptor: `registry: nvcr.io
+      repository: nvidia/foo
+      tag: v1`,
+			wantField: "registry",
+		},
+		{
+			name: "digest member present",
+			descriptor: `repository: ghcr.io/example/pinned
+      tag: v1
+      digest: sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b`,
+			wantField: "digest",
+		},
+		{
+			name: "empty name",
+			descriptor: `name: ""
+      repository: ghcr.io/kai-scheduler/kai-scheduler
+      tag: v0.14.1`,
+			wantField: "name",
+		},
+		{
+			name: "non-scalar name",
+			descriptor: `name:
+        - binder
+      repository: ghcr.io/kai-scheduler/kai-scheduler
+      tag: v0.14.1`,
+			wantField: "name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := "spec:\n  binder:\n    image:\n      " + tt.descriptor + "\n"
+			_, err := ExtractImagesFromYAML([]byte(input))
+			if err == nil {
+				t.Fatal("expected invalid structured image descriptor error")
+			}
+			if !IsInvalidStructuredImageDescriptor(err) {
+				t.Errorf("IsInvalidStructuredImageDescriptor(%v) = false, want true", err)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("field %q", tt.wantField)) {
+				t.Errorf("error %q does not identify field %q", err.Error(), tt.wantField)
+			}
+		})
+	}
+}
+
+// TestExtractImagesFromYAML_DescriptorErrorLineMatchesFile pins that a
+// descriptor error reports the line number of the original file, not of the
+// buffer with directive-only Helm lines stripped: stripHelmTemplates must
+// blank those lines out rather than delete them.
+func TestExtractImagesFromYAML_DescriptorErrorLineMatchesFile(t *testing.T) {
+	input := `{{- if .Values.enabled }}
+{{- $tag := .Values.tag }}
+spec:
+  binder:
+    image:
+      name: ""
+      repository: ghcr.io/kai-scheduler/kai-scheduler
+`
+	// `name: ""` sits on line 6 of the file; with the two directive-only
+	// lines deleted it would misreport as line 4.
+	_, err := ExtractImagesFromYAML([]byte(input))
+	if err == nil {
+		t.Fatal("expected invalid structured image descriptor error")
+	}
+	if !strings.Contains(err.Error(), "line 6") {
+		t.Errorf("error %q does not report original file line 6", err.Error())
 	}
 }
 

--- a/pkg/mirror/discover.go
+++ b/pkg/mirror/discover.go
@@ -207,6 +207,17 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 					} else {
 						imgs, extractErr := bom.ExtractImagesFromYAML(rendered)
 						if extractErr != nil {
+							if bom.IsInvalidStructuredImageDescriptor(extractErr) {
+								return errors.WrapWithContext(
+									errors.ErrCodeInvalidRequest,
+									fmt.Sprintf(
+										"invalid structured image descriptor in component %q",
+										compRef.Name,
+									),
+									extractErr,
+									map[string]any{"component": compRef.Name},
+								)
+							}
 							slog.Warn("image extraction failed",
 								logKeyComponent, compRef.Name, "error", extractErr)
 							ci.Warnings = append(ci.Warnings,
@@ -227,11 +238,23 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 				return gctx.Err()
 			}
 			dp := rec.DataProvider()
-			for _, mPath := range compRef.ManifestFiles {
-				allImages = extractManifestImages(gctx, dp, allImages, &ci, compRef.Name, mPath)
+			manifestSets := [][]string{
+				compRef.ManifestFiles,
+				compRef.PreManifestFiles,
 			}
-			for _, mPath := range compRef.PreManifestFiles {
-				allImages = extractManifestImages(gctx, dp, allImages, &ci, compRef.Name, mPath)
+			for _, paths := range manifestSets {
+				for _, mPath := range paths {
+					if err := gctx.Err(); err != nil {
+						return err
+					}
+					var manifestErr error
+					allImages, manifestErr = extractManifestImages(
+						gctx, dp, allImages, &ci, compRef.Name, mPath,
+					)
+					if manifestErr != nil {
+						return manifestErr
+					}
+				}
 			}
 
 			slices.Sort(allImages)
@@ -299,25 +322,51 @@ func (l *Lister) Discover(ctx context.Context, rec *recipe.RecipeResult) (*Mirro
 }
 
 // extractManifestImages reads a manifest file from the supplied DataProvider
-// and appends extracted images to the accumulator, recording warnings on
-// failure. A nil provider falls back to the package-global embedded provider
-// inside recipe.GetManifestContentWithContext.
-func extractManifestImages(ctx context.Context, dp recipe.DataProvider, acc []string, ci *ComponentImages, compName, mPath string) []string {
+// and appends extracted images to the accumulator. Read and general parse
+// failures are recorded as warnings; invalid structured image descriptors are
+// returned as errors so discovery cannot succeed with a known-incomplete image
+// set. A nil provider falls back to the package-global embedded provider inside
+// recipe.GetManifestContentWithContext.
+func extractManifestImages(
+	ctx context.Context,
+	dp recipe.DataProvider,
+	acc []string,
+	ci *ComponentImages,
+	compName, mPath string,
+) ([]string, error) {
+
 	content, readErr := recipe.GetManifestContentWithContext(ctx, dp, mPath)
 	if readErr != nil {
+		if ctx.Err() != nil {
+			return acc, ctx.Err()
+		}
 		slog.Warn("failed to read manifest",
 			logKeyComponent, compName, "path", mPath, "error", readErr)
 		ci.Warnings = append(ci.Warnings,
 			fmt.Sprintf("manifest read failed %s: %v", mPath, readErr))
-		return acc
+		return acc, nil
 	}
 	imgs, extractErr := bom.ExtractImagesFromYAML(content)
 	if extractErr != nil {
+		if bom.IsInvalidStructuredImageDescriptor(extractErr) {
+			return acc, errors.WrapWithContext(
+				errors.ErrCodeInvalidRequest,
+				fmt.Sprintf(
+					"invalid structured image descriptor in component %q manifest %q",
+					compName,
+					mPath,
+				),
+				extractErr,
+				map[string]any{"component": compName, "manifest": mPath},
+			)
+		}
+		slog.Warn("manifest image extraction failed",
+			"component", compName, "path", mPath, "error", extractErr)
 		ci.Warnings = append(ci.Warnings,
 			fmt.Sprintf("manifest image extraction failed %s: %v", mPath, extractErr))
-		return acc
+		return acc, nil
 	}
-	return append(acc, imgs...)
+	return append(acc, imgs...), nil
 }
 
 // buildOverrideLookup converts a slice of ComponentPath overrides into

--- a/pkg/mirror/discover_test.go
+++ b/pkg/mirror/discover_test.go
@@ -17,12 +17,14 @@ package mirror
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"io/fs"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/bom"
 	"github.com/NVIDIA/aicr/pkg/bundler/config"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -639,14 +641,181 @@ func TestKubeVersionFromConstraints(t *testing.T) {
 	}
 }
 
+type kaiConfigRenderer struct {
+	inputs []helm.ChartInput
+}
+
+func (r *kaiConfigRenderer) Render(_ context.Context, input helm.ChartInput) ([]byte, error) {
+	r.inputs = append(r.inputs, input)
+
+	binderName := "binder"
+	if binder, ok := input.Values["binder"].(map[string]any); ok {
+		if image, ok := binder["image"].(map[string]any); ok {
+			if name, ok := image["name"]; ok {
+				binderName = fmt.Sprint(name)
+			}
+		}
+	}
+
+	scalingPodImage := ""
+	if global, ok := input.Values["global"].(map[string]any); ok {
+		if enabled, ok := global["clusterAutoscaling"].(bool); ok && enabled {
+			scalingPodImage = `
+  nodeScaleAdjuster:
+    service:
+      enabled: true
+    args:
+      scalingPodImage:
+        name: scalingpod
+        repository: ghcr.io/kai-scheduler/kai-scheduler
+        tag: v0.14.1`
+		}
+	}
+
+	return []byte(fmt.Sprintf(`
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: operator
+          image: ghcr.io/kai-scheduler/kai-scheduler/operator:v0.14.1
+---
+apiVersion: kai.scheduler/v1
+kind: Config
+spec:
+  binder:
+    service:
+      image:
+        name: %s
+        repository: ghcr.io/kai-scheduler/kai-scheduler
+        tag: v0.14.1
+  scheduler:
+    service:
+      image:
+        name: scheduler
+        repository: ghcr.io/kai-scheduler/kai-scheduler
+        tag: v0.14.1%s
+`, binderName, scalingPodImage)), nil
+}
+
+func TestDiscoverOperatorManagedImagesWithAutoscalingOverride(t *testing.T) {
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "kai-scheduler",
+				Type:    recipe.ComponentTypeHelm,
+				Source:  "oci://ghcr.io/kai-scheduler/kai-scheduler",
+				Chart:   "kai-scheduler",
+				Version: "v0.14.1",
+			},
+		},
+	}
+	renderer := &kaiConfigRenderer{}
+
+	overrides, err := config.ParseValueOverrides([]string{
+		"kaischeduler:global.clusterAutoscaling=true",
+	})
+	if err != nil {
+		t.Fatalf("ParseValueOverrides() error = %v", err)
+	}
+
+	list, err := NewLister(
+		WithHelmRenderer(renderer),
+		WithValueOverrides(overrides),
+	).Discover(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	want := []string{
+		"ghcr.io/kai-scheduler/kai-scheduler/binder:v0.14.1",
+		"ghcr.io/kai-scheduler/kai-scheduler/operator:v0.14.1",
+		"ghcr.io/kai-scheduler/kai-scheduler/scalingpod:v0.14.1",
+		"ghcr.io/kai-scheduler/kai-scheduler/scheduler:v0.14.1",
+	}
+	if !slices.Equal(list.Images, want) {
+		t.Errorf("Images = %v, want %v", list.Images, want)
+	}
+
+	if len(renderer.inputs) != 1 {
+		t.Fatalf("renderer inputs = %d, want 1", len(renderer.inputs))
+	}
+	global, ok := renderer.inputs[0].Values["global"].(map[string]any)
+	if !ok {
+		t.Fatalf("global values = %T, want map[string]any", renderer.inputs[0].Values["global"])
+	}
+	if enabled, ok := global["clusterAutoscaling"].(bool); !ok || !enabled {
+		t.Errorf("global.clusterAutoscaling = %#v, want true", global["clusterAutoscaling"])
+	}
+}
+
+func TestDiscoverRejectsNullOperatorImageNameOverride(t *testing.T) {
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:    "kai-scheduler",
+				Type:    recipe.ComponentTypeHelm,
+				Source:  "oci://ghcr.io/kai-scheduler/kai-scheduler",
+				Chart:   "kai-scheduler",
+				Version: "v0.14.1",
+			},
+		},
+	}
+	renderer := &kaiConfigRenderer{}
+
+	overrides, err := config.ParseValueOverrides([]string{
+		"kaischeduler:binder.image.name=null",
+	})
+	if err != nil {
+		t.Fatalf("ParseValueOverrides() error = %v", err)
+	}
+
+	_, err = NewLister(
+		WithHelmRenderer(renderer),
+		WithValueOverrides(overrides),
+	).Discover(context.Background(), rec)
+	if err == nil {
+		t.Fatal("Discover() error = nil, want invalid structured image descriptor error")
+	}
+	if !bom.IsInvalidStructuredImageDescriptor(err) {
+		t.Errorf("IsInvalidStructuredImageDescriptor(%v) = false, want true", err)
+	}
+	if !strings.Contains(err.Error(), `component "kai-scheduler"`) {
+		t.Errorf("error %q does not identify the component", err.Error())
+	}
+	if count := strings.Count(err.Error(), "invalid structured image descriptor"); count != 1 {
+		t.Errorf("error %q repeats the descriptor summary %d times, want 1", err.Error(), count)
+	}
+
+	if len(renderer.inputs) != 1 {
+		t.Fatalf("renderer inputs = %d, want 1", len(renderer.inputs))
+	}
+	binder, ok := renderer.inputs[0].Values["binder"].(map[string]any)
+	if !ok {
+		t.Fatalf("binder values = %T, want map[string]any", renderer.inputs[0].Values["binder"])
+	}
+	image, ok := binder["image"].(map[string]any)
+	if !ok {
+		t.Fatalf("binder.image values = %T, want map[string]any", binder["image"])
+	}
+	if got := image["name"]; got != "null" {
+		t.Errorf("binder.image.name = %#v, want %q", got, "null")
+	}
+}
+
 // inMemoryDataProvider is a minimal recipe.DataProvider backed by an
 // in-memory map[path]content. Only ReadFile is exercised by extractManifestImages;
 // WalkDir and Source are implemented to satisfy the interface.
 type inMemoryDataProvider struct {
-	files map[string][]byte
+	files    map[string][]byte
+	readFile func(context.Context, string) ([]byte, error)
 }
 
 func (p *inMemoryDataProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if p.readFile != nil {
+		return p.readFile(ctx, path)
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -711,6 +880,120 @@ spec:
 		}
 	}
 }
+
+func TestDiscover_RejectsInvalidStructuredImageDescriptorInManifest(t *testing.T) {
+	const manifestPath = "components/kai-scheduler/manifests/invalid-image.yaml"
+	dp := &inMemoryDataProvider{files: map[string][]byte{
+		manifestPath: []byte(`
+apiVersion: kai.scheduler/v1
+kind: Config
+spec:
+  binder:
+    service:
+      image:
+        name: null
+        repository: ghcr.io/kai-scheduler/kai-scheduler
+        tag: v0.14.1
+`),
+	}}
+
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:          "kai-scheduler",
+				Type:          recipe.ComponentTypeHelm,
+				ManifestFiles: []string{manifestPath},
+			},
+		},
+	}
+	rec.BindDataProvider(dp)
+
+	_, err := NewLister(WithHelmRenderer(&helmtest.MockRenderer{})).
+		Discover(context.Background(), rec)
+	if err == nil {
+		t.Fatal("Discover() error = nil, want invalid structured image descriptor error")
+	}
+	if !bom.IsInvalidStructuredImageDescriptor(err) {
+		t.Errorf("IsInvalidStructuredImageDescriptor(%v) = false, want true", err)
+	}
+	if !strings.Contains(err.Error(), manifestPath) {
+		t.Errorf("error %q does not identify manifest %q", err.Error(), manifestPath)
+	}
+}
+
+func TestDiscover_PropagatesManifestReadCancellation(t *testing.T) {
+	const manifestPath = "components/test/manifests/canceled.yaml"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:          "test",
+				Type:          recipe.ComponentTypeHelm,
+				ManifestFiles: []string{manifestPath},
+			},
+		},
+	}
+	rec.BindDataProvider(&inMemoryDataProvider{
+		readFile: func(ctx context.Context, _ string) ([]byte, error) {
+			cancel()
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	_, err := NewLister(WithHelmRenderer(&helmtest.MockRenderer{})).Discover(ctx, rec)
+	if !stderrors.Is(err, context.Canceled) {
+		t.Fatalf("Discover() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDiscover_ChecksCancellationBetweenManifestReads(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const validManifest = `
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - image: example.com/test:v1
+`
+	readCount := 0
+	dp := &inMemoryDataProvider{
+		readFile: func(_ context.Context, _ string) ([]byte, error) {
+			readCount++
+			if readCount == 1 {
+				cancel()
+			}
+			return []byte(validManifest), nil
+		},
+	}
+	rec := &recipe.RecipeResult{
+		ComponentRefs: []recipe.ComponentRef{
+			{
+				Name:          "test",
+				Type:          recipe.ComponentTypeHelm,
+				ManifestFiles: []string{"first.yaml", "second.yaml"},
+			},
+		},
+	}
+	rec.BindDataProvider(dp)
+
+	_, err := NewLister(WithHelmRenderer(&helmtest.MockRenderer{})).Discover(ctx, rec)
+	if !stderrors.Is(err, context.Canceled) {
+		t.Fatalf("Discover() error = %v, want context.Canceled", err)
+	}
+	if readCount != 1 {
+		t.Errorf("manifest reads = %d, want 1", readCount)
+	}
+}
+
+// TestDiscover_NilDataProviderFallsBackToEmbedded confirms the back-compat
+// path: when a RecipeResult has no bound provider, extractManifestImages must
+// still resolve manifest paths via the package-global embedded provider
+// (recipe.GetManifestContentWithContext treats a nil dp as embedded fallback).
 
 func TestDiscover_OverrideAliasRegistryFailureIsFatal(t *testing.T) {
 	dp := &inMemoryDataProvider{files: map[string][]byte{

--- a/tools/bom/README.md
+++ b/tools/bom/README.md
@@ -2,7 +2,7 @@
 
 Generates an authoritative inventory of every container image AICR can deploy.
 Renders each Helm chart in `recipes/registry.yaml` at its pinned version,
-extracts every `image:` reference, walks embedded manifests under
+extracts recognized container-image references, walks embedded manifests under
 `recipes/components/<name>/manifests/`, and emits:
 
 - `bom.cdx.json` — CycloneDX 1.6 JSON (canonical, machine-readable)
@@ -72,8 +72,14 @@ supply-chain dashboards without conversion.
 - Charts that fail to render (missing required values, network unreachable)
   emit a warning property on the component and contribute zero images. Use
   `-strict` to make these fatal.
-- Image extraction looks for any `image:` scalar in the rendered YAML. False
-  positives are possible but rare in valid Kubernetes manifests; CRDs that
-  use `image` as an unrelated field would be flagged.
+- Image extraction recognizes scalar `image:` values and mapping-valued
+  `image:` or `scalingPodImage:` descriptors using the `name`, `repository`,
+  and `tag` fields. A present field must be a non-null, non-empty scalar.
+  Violations stop generation in all modes rather than publishing an incomplete
+  reference. Other fields are ignored. Descriptors that rely on separate
+  `registry` or `digest` fields are unsupported and can yield an incomplete or
+  incorrectly resolved reference.
+- False positives are possible but rare in valid Kubernetes manifests. CRDs
+  that use `image` as an unrelated scalar field may be flagged.
 - Unrendered Go template directives (`{{ .Values.image }}`) are skipped — they
   appear when the chart's values don't supply a required override.

--- a/tools/bom/main.go
+++ b/tools/bom/main.go
@@ -107,9 +107,9 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 
 	ctx := context.Background()
 
-	results := make([]bom.ComponentResult, 0, len(reg.Components))
-	for _, c := range reg.Components {
-		results = append(results, surveyComponent(ctx, repoRoot, c, renderer, skipHelm))
+	results, err := surveyComponents(ctx, repoRoot, reg.Components, renderer, skipHelm)
+	if err != nil {
+		return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "survey components")
 	}
 
 	// Version variants: explicit base/overlay/mixin Helm pins that differ
@@ -119,16 +119,28 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 	if err != nil {
 		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "load recipe sources")
 	}
-	byName := make(map[string]component, len(reg.Components))
-	for _, c := range reg.Components {
-		byName[c.Name] = c
-	}
+	byName := indexComponentsByName(reg.Components)
 	variants, err := deriveVariants(reg, sources)
 	if err != nil {
 		return errors.PropagateOrWrap(err, errors.ErrCodeInternal, "derive variants")
 	}
 	for i, v := range variants {
-		variants[i] = surveyVariant(ctx, repoRoot, v, byName[v.Name], renderer, skipHelm)
+		surveyed, surveyErr := surveyVariant(
+			ctx,
+			repoRoot,
+			v,
+			byName[v.Name],
+			renderer,
+			skipHelm,
+		)
+		if surveyErr != nil {
+			return errors.PropagateOrWrap(
+				surveyErr,
+				errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("survey component variant %q@%q", v.Name, v.Version),
+			)
+		}
+		variants[i] = surveyed
 	}
 
 	if strict {
@@ -225,6 +237,37 @@ func run(repoRoot, outDir, aicrVersion string, renderer helm.Renderer, skipHelm,
 	return nil
 }
 
+func indexComponentsByName(components []component) map[string]component {
+	byName := make(map[string]component, len(components))
+	for _, c := range components {
+		byName[c.Name] = c
+	}
+	return byName
+}
+
+func surveyComponents(
+	ctx context.Context,
+	repoRoot string,
+	components []component,
+	renderer helm.Renderer,
+	skipHelm bool,
+) ([]bom.ComponentResult, error) {
+
+	results := make([]bom.ComponentResult, 0, len(components))
+	for _, c := range components {
+		result, err := surveyComponent(ctx, repoRoot, c, renderer, skipHelm)
+		if err != nil {
+			return nil, errors.PropagateOrWrap(
+				err,
+				errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("survey component %q", c.Name),
+			)
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
 // renderHelmComponent shells out to `helm template` for c. The timeout
 // context is scoped to this call so its associated timer is canceled before
 // the manifests walk begins, regardless of how many components are surveyed.
@@ -259,7 +302,14 @@ func renderHelmComponent(ctx context.Context, repoRoot string, c component, r he
 
 // surveyComponent renders the component's chart (if any) and walks its
 // embedded manifests directory, returning the union of image refs.
-func surveyComponent(ctx context.Context, repoRoot string, c component, r helm.Renderer, skipHelm bool) bom.ComponentResult {
+func surveyComponent(
+	ctx context.Context,
+	repoRoot string,
+	c component,
+	r helm.Renderer,
+	skipHelm bool,
+) (bom.ComponentResult, error) {
+
 	version := pinnedVersion(c)
 	// Repository carries the Helm chart repo or, for a Kustomize component, its
 	// source; pkg/bom names the property by effective type. Chart/Namespace are
@@ -287,6 +337,13 @@ func surveyComponent(ctx context.Context, repoRoot string, c component, r helm.R
 		if len(out) > 0 {
 			imgs, parseErr := bom.ExtractImagesFromYAML(out)
 			if parseErr != nil {
+				if bom.IsInvalidStructuredImageDescriptor(parseErr) {
+					return res, wrapInvalidDescriptorSurveyError(
+						parseErr,
+						c.Name,
+						"",
+					)
+				}
 				res.Warnings = append(res.Warnings, "parse rendered yaml: "+parseErr.Error())
 			}
 			for _, i := range imgs {
@@ -313,6 +370,9 @@ func surveyComponent(ctx context.Context, repoRoot string, c component, r helm.R
 			}
 			imgs, perr := bom.ExtractImagesFromYAML(data)
 			if perr != nil {
+				if bom.IsInvalidStructuredImageDescriptor(perr) {
+					return wrapInvalidDescriptorSurveyError(perr, c.Name, path)
+				}
 				res.Warnings = append(res.Warnings, fmt.Sprintf("parse %s: %v", path, perr))
 				return nil
 			}
@@ -322,6 +382,13 @@ func surveyComponent(ctx context.Context, repoRoot string, c component, r helm.R
 			return nil
 		})
 		if walkErr != nil {
+			if bom.IsInvalidStructuredImageDescriptor(walkErr) {
+				return res, errors.PropagateOrWrap(
+					walkErr,
+					errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("survey component %q manifests", c.Name),
+				)
+			}
 			res.Warnings = append(res.Warnings, "walk manifests: "+walkErr.Error())
 		}
 	}
@@ -331,5 +398,27 @@ func surveyComponent(ctx context.Context, repoRoot string, c component, r helm.R
 		res.Images = append(res.Images, i)
 	}
 	sort.Strings(res.Images)
-	return res
+	return res, nil
+}
+
+func wrapInvalidDescriptorSurveyError(err error, componentName, manifestPath string) error {
+	errContext := map[string]any{"component": componentName}
+	message := fmt.Sprintf(
+		"invalid structured image descriptor in component %q rendered chart",
+		componentName,
+	)
+	if manifestPath != "" {
+		errContext["manifest"] = manifestPath
+		message = fmt.Sprintf(
+			"invalid structured image descriptor in component %q manifest %q",
+			componentName,
+			manifestPath,
+		)
+	}
+	return errors.WrapWithContext(
+		errors.ErrCodeInvalidRequest,
+		message,
+		err,
+		errContext,
+	)
 }

--- a/tools/bom/main_test.go
+++ b/tools/bom/main_test.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/bom"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/helm/helmtest"
 )
@@ -210,7 +212,10 @@ func TestSurveyComponentHelm(t *testing.T) {
 		},
 	}
 
-	res := surveyComponent(context.Background(), root, c, mock, false)
+	res, surveyErr := surveyComponent(context.Background(), root, c, mock, false)
+	if surveyErr != nil {
+		t.Fatalf("surveyComponent() error = %v", surveyErr)
+	}
 	if res.Name != "gpu-operator" {
 		t.Errorf("Name = %q, want %q", res.Name, "gpu-operator")
 	}
@@ -253,7 +258,10 @@ func TestSurveyComponentSkipHelm(t *testing.T) {
 		},
 	}
 
-	res := surveyComponent(context.Background(), root, c, mock, true)
+	res, surveyErr := surveyComponent(context.Background(), root, c, mock, true)
+	if surveyErr != nil {
+		t.Fatalf("surveyComponent() error = %v", surveyErr)
+	}
 	// With skipHelm, no images should come from the renderer.
 	if len(res.Images) != 0 {
 		t.Errorf("expected 0 images with skipHelm, got %d: %v", len(res.Images), res.Images)
@@ -278,7 +286,10 @@ func TestSurveyComponentRendererError(t *testing.T) {
 		},
 	}
 
-	res := surveyComponent(context.Background(), root, c, mock, false)
+	res, surveyErr := surveyComponent(context.Background(), root, c, mock, false)
+	if surveyErr != nil {
+		t.Fatalf("surveyComponent() error = %v", surveyErr)
+	}
 	if len(res.Warnings) == 0 {
 		t.Fatal("expected warnings from renderer error, got none")
 	}
@@ -298,7 +309,10 @@ func TestSurveyComponentKustomize(t *testing.T) {
 		},
 	}
 
-	res := surveyComponent(context.Background(), root, c, mock, false)
+	res, surveyErr := surveyComponent(context.Background(), root, c, mock, false)
+	if surveyErr != nil {
+		t.Fatalf("surveyComponent() error = %v", surveyErr)
+	}
 	if res.Type != "kustomize" {
 		t.Errorf("Type = %q, want %q", res.Type, "kustomize")
 	}
@@ -335,7 +349,10 @@ spec:
 		DisplayName: "My Component",
 	}
 
-	res := surveyComponent(context.Background(), root, c, mock, false)
+	res, surveyErr := surveyComponent(context.Background(), root, c, mock, false)
+	if surveyErr != nil {
+		t.Fatalf("surveyComponent() error = %v", surveyErr)
+	}
 	if res.Type != "manifest" {
 		t.Errorf("Type = %q, want %q", res.Type, "manifest")
 	}
@@ -344,6 +361,50 @@ spec:
 	}
 	if res.Images[0] != "docker.io/library/nginx:1.27" {
 		t.Errorf("Images[0] = %q, want %q", res.Images[0], "docker.io/library/nginx:1.27")
+	}
+}
+
+func TestSurveyComponentRejectsInvalidStructuredImageDescriptorInManifest(t *testing.T) {
+	root := writeTestRegistry(t, testRegistryHelm)
+	manifestPath := filepath.Join(
+		root,
+		"recipes",
+		"components",
+		"my-comp",
+		"manifests",
+		"config.yaml",
+	)
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("mkdir manifests: %v", err)
+	}
+	manifest := `apiVersion: example.com/v1
+kind: Config
+spec:
+  operand:
+    image:
+      name: null
+      repository: nvcr.io/nvidia
+      tag: v25.3.0
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	_, err := surveyComponent(
+		context.Background(),
+		root,
+		component{Name: "my-comp"},
+		&helmtest.MockRenderer{},
+		true,
+	)
+	if err == nil {
+		t.Fatal("surveyComponent() error = nil, want invalid structured image descriptor error")
+	}
+	if !bom.IsInvalidStructuredImageDescriptor(err) {
+		t.Errorf("IsInvalidStructuredImageDescriptor(%v) = false, want true", err)
+	}
+	if !strings.Contains(err.Error(), manifestPath) {
+		t.Errorf("error %q does not identify manifest %q", err, manifestPath)
 	}
 }
 
@@ -384,7 +445,10 @@ spec:
 		},
 	}
 
-	res := surveyComponent(context.Background(), root, c, mock, false)
+	res, surveyErr := surveyComponent(context.Background(), root, c, mock, false)
+	if surveyErr != nil {
+		t.Fatalf("surveyComponent() error = %v", surveyErr)
+	}
 	// 2 from helm + 1 from manifests = 3 unique images.
 	if len(res.Images) != 3 {
 		t.Fatalf("expected 3 images (helm + manifests), got %d: %v", len(res.Images), res.Images)
@@ -623,6 +687,44 @@ func TestRunStrictWithWarnings(t *testing.T) {
 	}
 }
 
+func TestRunRejectsInvalidStructuredImageDescriptorWithoutStrict(t *testing.T) {
+	root := writeTestRegistry(t, testRegistryHelm)
+	outDir := t.TempDir()
+	mock := &helmtest.MockRenderer{
+		Rendered: map[string][]byte{
+			"gpu-operator": []byte(`
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - image: nvcr.io/nvidia/gpu-operator:v25.3.0
+---
+apiVersion: example.com/v1
+kind: Config
+spec:
+  operand:
+    image:
+      name: null
+      repository: nvcr.io/nvidia
+      tag: v25.3.0
+`),
+		},
+	}
+
+	err := run(root, outDir, "test-v1", mock, false, false, true, true)
+	if err == nil {
+		t.Fatal("run() error = nil, want invalid structured image descriptor error")
+	}
+	if !bom.IsInvalidStructuredImageDescriptor(err) {
+		t.Errorf("IsInvalidStructuredImageDescriptor(%v) = false, want true", err)
+	}
+	for _, name := range []string{"bom.cdx.json", "bom.md"} {
+		if _, statErr := os.Stat(filepath.Join(outDir, name)); !os.IsNotExist(statErr) {
+			t.Errorf("%s was written despite fatal extraction error: %v", name, statErr)
+		}
+	}
+}
+
 func TestRunSkipHelm(t *testing.T) {
 	root := writeTestRegistry(t, testRegistryHelm)
 	outDir := t.TempDir()
@@ -729,7 +831,10 @@ func TestSurveyComponentSourceOnlyChartFallback(t *testing.T) {
 		},
 	}
 
-	res := surveyComponent(context.Background(), root, c, mock, false)
+	res, surveyErr := surveyComponent(context.Background(), root, c, mock, false)
+	if surveyErr != nil {
+		t.Fatalf("surveyComponent() error = %v", surveyErr)
+	}
 	if len(res.Warnings) != 0 {
 		t.Fatalf("unexpected warnings: %v", res.Warnings)
 	}

--- a/tools/bom/variants.go
+++ b/tools/bom/variants.go
@@ -357,11 +357,26 @@ func deriveVariants(reg *registry, sources []recipeSource) ([]bom.VariantResult,
 // parity, not deployment fidelity. Variant image sets are rendered, never
 // copied from the default entry: the two versions may ship different images,
 // and a mixed Helm+manifest component contributes its manifest images too.
-func surveyVariant(ctx context.Context, repoRoot string, v bom.VariantResult, base component, r helm.Renderer, skipHelm bool) bom.VariantResult {
+func surveyVariant(
+	ctx context.Context,
+	repoRoot string,
+	v bom.VariantResult,
+	base component,
+	r helm.Renderer,
+	skipHelm bool,
+) (bom.VariantResult, error) {
+
 	variantComponent := base
 	variantComponent.Helm.DefaultVersion = v.Version
-	res := surveyComponent(ctx, repoRoot, variantComponent, r, skipHelm)
+	res, err := surveyComponent(ctx, repoRoot, variantComponent, r, skipHelm)
+	if err != nil {
+		return v, errors.PropagateOrWrap(
+			err,
+			errors.ErrCodeInvalidRequest,
+			"survey variant images",
+		)
+	}
 	v.Images = res.Images
 	v.Warnings = append(v.Warnings, res.Warnings...)
-	return v
+	return v, nil
 }

--- a/tools/bom/variants_test.go
+++ b/tools/bom/variants_test.go
@@ -236,7 +236,10 @@ spec:
 	}
 	v := bom.VariantResult{Name: "kube-prometheus-stack", Version: "83.7.0", Sources: []string{"aks"}}
 
-	got := surveyVariant(context.Background(), root, v, base, mock, false)
+	got, surveyErr := surveyVariant(context.Background(), root, v, base, mock, false)
+	if surveyErr != nil {
+		t.Fatalf("surveyVariant() error = %v", surveyErr)
+	}
 	if len(got.Images) != 1 || got.Images[0] != "quay.io/prometheus/prometheus:v2.83.0" {
 		t.Errorf("images = %v, want the rendered image", got.Images)
 	}
@@ -250,7 +253,10 @@ spec:
 
 	// skipHelm leaves the variant unrendered (no images, no renderer call).
 	mock2 := &helmtest.MockRenderer{}
-	got2 := surveyVariant(context.Background(), root, v, base, mock2, true)
+	got2, surveyErr := surveyVariant(context.Background(), root, v, base, mock2, true)
+	if surveyErr != nil {
+		t.Fatalf("surveyVariant(skipHelm) error = %v", surveyErr)
+	}
 	if len(got2.Images) != 0 || len(mock2.Inputs) != 0 {
 		t.Errorf("skipHelm variant should not render, got images=%v calls=%d", got2.Images, len(mock2.Inputs))
 	}
@@ -404,7 +410,17 @@ spec:
 
 	// With -skip-helm the variant must still pick up manifest images, exactly
 	// like the default survey path.
-	got := surveyVariant(context.Background(), root, v, base, &helmtest.MockRenderer{}, true)
+	got, surveyErr := surveyVariant(
+		context.Background(),
+		root,
+		v,
+		base,
+		&helmtest.MockRenderer{},
+		true,
+	)
+	if surveyErr != nil {
+		t.Fatalf("surveyVariant(skipHelm) error = %v", surveyErr)
+	}
 	if len(got.Images) != 1 || got.Images[0] != "nvcr.io/nvidia/extra:v1.0.0" {
 		t.Errorf("skip-helm variant images = %v, want the embedded manifest image", got.Images)
 	}


### PR DESCRIPTION
## Summary

Extend BOM and mirror image discovery to recognize operator-style `image: {name, repository, tag}` mappings and KAI’s `scalingPodImage` descriptor. Fail closed on invalid recognized descriptors so BOM and mirror output cannot succeed while omitting a runtime-defaulted image.

## Motivation / Context

KAI Scheduler declares operator-managed operand images as mapping-valued descriptors, while the shared extractor recognized only scalar `image:` values. The committed BOM therefore listed only the operator and CRD upgrader, and air-gap outputs omitted binder, scheduler, podgrouper, admission, scalingpod, and the other rendered operands.

The KAI operator defaults a missing binder image name at runtime. A `binder.image.name=null` override previously caused AICR to omit binder silently even though the deployment still pulled it.

This is separate from the incomplete chart-reference report in #1954. It supersedes the scheduler downgrade proposed by draft #1958, which would not fix that integration. Unsupported descriptor shapes discovered during review are tracked separately in #1961.

Fixes: N/A
Related: #1954, #1961

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: BOM and mirror image discovery

## Implementation Notes

- Recognize allowlisted mapping-valued `image` and `scalingPodImage` nodes using `name`, `repository`, and `tag` fields.
- Preserve repository-only descriptors only when `name` is absent. A present null, empty, or non-scalar recognized member returns a structured invalid-request error.
- Make invalid structured descriptors fatal for `mirror list` and the BOM generator, including non-strict scheduled generation, instead of publishing a known-incomplete image set.
- Preserve cancellation while scanning manifest lists and between individual reads.
- Reuse existing image-reference combination and validation paths so scalar and mapping descriptors share filtering and deduplication behavior.
- Reject a present `registry` or `digest` member in a recognized descriptor instead of silently dropping it, so a partially-combined reference cannot resolve against the wrong registry or lose a digest pin. #1961 remains open for actually combining these members.
- Treat a null or empty `tag` (the Helm appVersion idiom) like an absent tag instead of failing the survey; a non-scalar tag still fails closed.
- Trim a trailing repository slash in the name-absent fallback, matching the name-present path.
- Blank out directive-only Helm lines instead of deleting them so descriptor-error line numbers index the original file.
- Use an override-aware KAI test renderer so the autoscaling and null-name assertions are causally tied to their `--set` values.
- Regenerate `docs/user/container-images.md`; the KAI inventory expands from 2 to 11 images and the repository-wide unique count from 87 to 96.

## Testing

```bash
make bom-docs
make bom-check
GOFLAGS="-mod=vendor" go test ./pkg/bom ./pkg/mirror ./tools/bom
GOFLAGS="-mod=vendor" go test -race ./pkg/bom/... ./pkg/mirror/... ./tools/bom/...
golangci-lint run -c .golangci.yaml ./pkg/bom/... ./pkg/mirror/... ./tools/bom/...
GOFLAGS="-mod=vendor" go test -coverprofile=<current> ./pkg/bom/...
GOFLAGS="-mod=vendor" go test -coverprofile=<current> ./pkg/mirror/...
GOFLAGS="-mod=vendor" go test -coverprofile=<current> ./tools/bom/...
GOFLAGS="-mod=vendor" go test -coverprofile=<baseline> ./pkg/bom/...
GOFLAGS="-mod=vendor" go test -coverprofile=<baseline> ./pkg/mirror/...
GOFLAGS="-mod=vendor" go test -coverprofile=<baseline> ./tools/bom/...
go run ./cmd/aicr mirror list --service eks --accelerator h100 --intent training --os ubuntu --set kaischeduler:global.clusterAutoscaling=true --format json
go run ./cmd/aicr mirror list --service eks --accelerator h100 --intent training --os ubuntu --set kaischeduler:binder.image.name=null --format json
```

All focused gates passed. Coverage changed as follows:

- `pkg/bom`: 95.8% → 96.1%
- `pkg/mirror`: 80.7% → 81.6% (rebased baseline; #1933 rewrote the mirror override machinery, so `TestSetNestedValue`/`splitPath` were dropped with the removed helper and the manifest-only test refs use Helm type per the new component-ref coherence rules)
- `tools/bom`: 83.0% → 83.1%

The autoscaling reproduction includes `scalingpod:v0.14.1`. The null-name reproduction exits 2, identifies `kai-scheduler` and the invalid `name` field, and writes no mirror output.

Full `make qualify` was run locally: test-coverage (with `-race`, 80.8% vs the 80% floor), lint, tuning-check, e2e, scan, and license-check all passed. The only local failures were `tests/releasepolicy` script-deadline timeouts that reproduce only under full-suite parallel load on the dev machine, pass in isolation on both this branch and `origin/main`, and touch a tree with zero diff from `main` that imports none of this PR's packages.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Regenerate mirror manifests or bundles to include the newly discovered KAI operand images. Invalid mapping-valued image overrides now fail instead of producing an incomplete mirror list; no configuration migration is required for valid descriptors.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)


