### PR TITLE
fix(validator): re-establish Job watch after apiserver idle-stream closure

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -185,6 +185,16 @@ const (
 	// Must exceed the default Kubernetes terminationGracePeriodSeconds (30s).
 	K8sPodTerminationWaitTimeout = 60 * time.Second
 
+	// K8sJobWatchResumeBackoff paces each watch re-establishment after a Job
+	// watch channel closes without the Job being terminal. Routine closures
+	// (apiserver --min-request-timeout expiry) are isolated, but a flapping
+	// load balancer or an apiserver rollout can close the stream immediately
+	// on every reconnect; without pacing the resume loop would re-fire
+	// Get+Watch back-to-back and hammer an already-degraded API server. A
+	// small fixed delay bounds that call rate while staying negligible against
+	// the multi-hour validator budgets the resume logic protects.
+	K8sJobWatchResumeBackoff = 2 * time.Second
+
 	// PodAffinitySelectorLookupTimeout bounds the per-namespace List call
 	// the deployer makes to verify a dependencyAffinity selector matches at
 	// least one running pod. Short because the lookup is a best-effort
@@ -946,6 +956,12 @@ const (
 	// number of dropped characters. Prevents oversized report output from
 	// inline JSON payloads (e.g., Prometheus metric scrapes).
 	ValidatorMaxStdoutLineLength = 512
+
+	// ValidatorMaxTerminationMsgBytes bounds the container termination message
+	// copied into a validator result. kubelet caps the message at 4 KiB
+	// upstream, but the result flows into ConfigMaps and rendered reports, so
+	// this bounds it defensively at the source regardless of upstream behavior.
+	ValidatorMaxTerminationMsgBytes = 4096
 
 	// ValidatorDefaultCPU is the default CPU request/limit for validator containers
 	// when not specified in the catalog entry.

--- a/pkg/k8s/pod/job.go
+++ b/pkg/k8s/pod/job.go
@@ -16,15 +16,122 @@ package pod
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
+
+// jobWatchResumeBackoff paces each watch re-establishment in rewatchJob. It is
+// a package var (not the constant directly) only so tests can drop it to a
+// negligible value and exercise the resume path without a real sleep;
+// production code never reassigns it.
+var jobWatchResumeBackoff = defaults.K8sJobWatchResumeBackoff
+
+// jobWatchResumeJitterFactor spreads the resume backoff by up to +20% so that
+// many validators whose watches were all closed by the same apiserver rollout
+// do not reconnect in lockstep and produce a synchronized thundering herd.
+const jobWatchResumeJitterFactor = 0.2
+
+// resumeContext builds the structured-error context shared by the resume
+// helper so a resume failure names the Job, mirroring the sibling pod-wait
+// helpers.
+func resumeContext(namespace, name string) map[string]any {
+	return map[string]any{keyNamespace: namespace, keyName: name}
+}
+
+// isRetryableWatchError reports whether a watch.Error event is a routine,
+// resumable signal (HTTP 410 Gone / ResourceExpired — the apiserver compacted
+// past the watch's ResourceVersion) rather than a fatal stream error. Callers
+// treat a retryable error like a channel close and re-establish the watch;
+// anything else aborts the wait.
+//
+// Against a real apiserver this is the *common* shape of a stale-ResourceVersion
+// rejection: the Watch call itself succeeds and the 410 arrives as the stream's
+// first ERROR event, not as a synchronous call error.
+func isRetryableWatchError(event watch.Event) bool {
+	if event.Type != watch.Error {
+		return false
+	}
+	err := apierrors.FromObject(event.Object)
+	return apierrors.IsResourceExpired(err) || apierrors.IsGone(err)
+}
+
+// resumeJobWatch reconnects a Job watch that ended — the channel closed or the
+// apiserver emitted a retryable 410 — before the Job reached a terminal state.
+//
+// It resyncs via a field-selected List rather than a Get, which is load-bearing:
+//   - The List's collection ResourceVersion (metadata.resourceVersion) is the
+//     current cluster revision, so the re-established watch always starts from a
+//     live RV. Re-watching from the Job's own object ResourceVersion is unsafe:
+//     a Job that runs untouched past the apiserver's watch-cache window keeps
+//     reporting the same aged-out object RV, so every watch from it 410s
+//     immediately and the wait degrades to paced polling for the rest of the run
+//     (the exact long-running-validator case issue #1966 targets).
+//   - The List still returns the Job, so a terminal transition that landed while
+//     the watch was down is observed here and not missed. Because the new watch
+//     starts from the List's collection RV, any transition after the List is
+//     replayed by the watch — there is no List-to-Watch gap (an empty
+//     ResourceVersion would reopen that gap and is deliberately not used).
+//
+// A jittered bounded backoff precedes every attempt so a stream that keeps
+// ending immediately (flapping LB, apiserver rollout) cannot make the loop spin,
+// and fleets sharing one apiserver do not reconnect in lockstep. The backoff
+// honors ctx cancellation, so the caller's context deadline remains the sole
+// give-up authority.
+//
+// It returns exactly one of:
+//   - terminal != nil: the Job was terminal in the resync List; the caller
+//     returns it (w is nil, nothing to continue).
+//   - w != nil: a fresh watch to continue consuming (terminal is nil).
+//   - err != nil: give up. Transient List/Watch failures are classified as
+//     ErrCodeUnavailable (vs ErrCodeTimeout when the context is done) via
+//     classifyReGetError, matching the sibling pod-wait helpers.
+func resumeJobWatch(ctx context.Context, client kubernetes.Interface, namespace, name string) (terminal *batchv1.Job, w watch.Interface, err error) {
+	select {
+	case <-time.After(wait.Jitter(jobWatchResumeBackoff, jobWatchResumeJitterFactor)):
+	case <-ctx.Done():
+		return nil, nil, errors.WrapWithContext(errors.ErrCodeTimeout,
+			"context canceled before Job watch resume", ctx.Err(), resumeContext(namespace, name))
+	}
+
+	// Resync via List: its collection ResourceVersion is current, and its result
+	// lets us catch a terminal transition that landed while the watch was down.
+	list, listErr := client.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + name,
+	})
+	if listErr != nil {
+		return nil, nil, classifyReGetError(ctx, "job watch closed and Job re-list failed", listErr)
+	}
+	if len(list.Items) == 0 {
+		// The Job no longer exists — deleted while the watch was down.
+		return nil, nil, errors.NewWithContext(errors.ErrCodeInternal,
+			"Job not found during watch resume", resumeContext(namespace, name))
+	}
+	job := &list.Items[0]
+	if isJobTerminal(job) {
+		return job, nil, nil
+	}
+
+	// Re-establish the watch from the current collection ResourceVersion so it
+	// starts from a live revision and replays any change after the List.
+	w, watchErr := client.BatchV1().Jobs(namespace).Watch(ctx, metav1.ListOptions{
+		FieldSelector:   "metadata.name=" + name,
+		ResourceVersion: list.ResourceVersion,
+	})
+	if watchErr != nil {
+		return nil, nil, classifyReGetError(ctx, "failed to re-establish Job watch after resync", watchErr)
+	}
+	return nil, w, nil
+}
 
 // WaitForJobCompletion waits for a Kubernetes Job to complete successfully or fail.
 // Returns nil if job completes successfully, error if job fails or context deadline exceeded.
@@ -57,40 +164,46 @@ func WaitForJobCompletion(ctx context.Context, client kubernetes.Interface, name
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to watch Job", err)
 	}
-	defer watcher.Stop()
+	// Closure form so a re-established watch (reassigning watcher below) stops
+	// the current stream rather than leaking the original.
+	defer func() { watcher.Stop() }()
 
 	for {
 		select {
 		case <-timeoutCtx.Done():
 			return errors.Wrap(errors.ErrCodeTimeout, "job completion timeout", timeoutCtx.Err())
 		case event, ok := <-watcher.ResultChan():
-			if !ok {
+			// The watch stream ended when the channel closes or the apiserver
+			// emits a retryable 410 (it compacted past our ResourceVersion).
+			// kube-apiserver closes every watch after --min-request-timeout
+			// (30-60m); rolling restarts and LB drops close them early. Re-Get
+			// the Job to catch a terminal transition during the gap, then
+			// re-establish the watch and keep waiting — the context deadline
+			// remains the sole give-up authority.
+			if !ok || isRetryableWatchError(event) {
 				if ctxErr := timeoutCtx.Err(); ctxErr != nil {
 					return errors.Wrap(errors.ErrCodeTimeout, "job completion timeout", ctxErr)
 				}
-				// Watch channel closed without context cancellation —
-				// apiserver hiccups (rolling restart, LB drop) commonly
-				// cause this. Re-Get the Job directly to see whether it
-				// raced to a terminal state during the closure window.
-				recheck, recheckErr := client.BatchV1().Jobs(namespace).Get(timeoutCtx, name, metav1.GetOptions{})
-				if recheckErr != nil {
+				terminal, newWatcher, resumeErr := resumeJobWatch(timeoutCtx, client, namespace, name)
+				if resumeErr != nil {
 					if ctxErr := timeoutCtx.Err(); ctxErr != nil {
 						return errors.Wrap(errors.ErrCodeTimeout, "job completion timeout", ctxErr)
 					}
-					return errors.Wrap(errors.ErrCodeInternal,
-						"watch closed and Job re-check failed", recheckErr)
+					return resumeErr
 				}
-				if done, checkErr := checkJobStatus(recheck); done {
+				if terminal != nil {
+					_, checkErr := checkJobStatus(terminal)
 					return checkErr
 				}
-				return errors.New(errors.ErrCodeUnavailable,
-					"watch channel closed before Job reached terminal state")
+				slog.Debug("job watch closed before terminal state, re-established",
+					keyNamespace, namespace, keyName, name)
+				watcher.Stop()
+				watcher = newWatcher
+				continue
 			}
 			if event.Type == watch.Error {
-				if statusErr, isErr := event.Object.(error); isErr {
-					return errors.Wrap(errors.ErrCodeInternal, "watch stream error", statusErr)
-				}
-				return errors.New(errors.ErrCodeInternal, "watch stream error")
+				return errors.Wrap(errors.ErrCodeInternal, "watch stream error",
+					apierrors.FromObject(event.Object))
 			}
 
 			job, ok := event.Object.(*batchv1.Job)
@@ -116,9 +229,15 @@ func WaitForJobCompletion(ctx context.Context, client kubernetes.Interface, name
 // legitimate completions).
 //
 // Returns ErrCodeInternal if the initial Get or Watch call fails, or if the
-// Job is deleted while being watched. Returns ErrCodeTimeout on context
-// deadline exceeded. Returns ErrCodeUnavailable if the watch channel closes
-// without a terminal state being observed (after one re-Get fast-path retry).
+// Job is deleted while being watched. Returns ErrCodeUnavailable when a
+// re-check Get fails transiently while resuming a closed watch, and
+// ErrCodeTimeout on context deadline exceeded — the context deadline is the
+// sole give-up authority.
+//
+// When the watch ends without the Job being terminal (routine on kube-apiserver
+// --min-request-timeout expiry, rolling restarts, and LB drops), this resyncs
+// via a field-selected List and re-establishes the watch from the current
+// collection ResourceVersion, waiting through the closure rather than failing.
 //
 // Performs an initial Get to catch already-terminal Jobs, then uses the watch
 // API for efficient monitoring.
@@ -145,39 +264,46 @@ func WaitForJobTerminal(ctx context.Context, client kubernetes.Interface, namesp
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to watch Job", err)
 	}
-	defer watcher.Stop()
+	// Closure form so a re-established watch (reassigning watcher below) stops
+	// the current stream rather than leaking the original.
+	defer func() { watcher.Stop() }()
 
 	for {
 		select {
 		case <-timeoutCtx.Done():
 			return nil, errors.Wrap(errors.ErrCodeTimeout, "job terminal wait timeout", timeoutCtx.Err())
 		case event, ok := <-watcher.ResultChan():
-			if !ok {
+			// The watch stream ended when the channel closes or the apiserver
+			// emits a retryable 410 (it compacted past our ResourceVersion) —
+			// routine on --min-request-timeout expiry, rolling restarts, and LB
+			// drops. Re-check the Job, then re-establish the watch and keep
+			// waiting rather than declaring failure; the context deadline is the
+			// sole give-up authority.
+			if !ok || isRetryableWatchError(event) {
 				// If the parent context already expired, classify the
 				// failure as a timeout rather than a generic recheck error.
 				if ctxErr := timeoutCtx.Err(); ctxErr != nil {
 					return nil, errors.Wrap(errors.ErrCodeTimeout, "job terminal wait timeout", ctxErr)
 				}
-				// Watch channel closed — re-check Job status directly before giving up.
-				recheck, recheckErr := client.BatchV1().Jobs(namespace).Get(timeoutCtx, name, metav1.GetOptions{})
-				if recheckErr != nil {
+				terminal, newWatcher, resumeErr := resumeJobWatch(timeoutCtx, client, namespace, name)
+				if resumeErr != nil {
 					if ctxErr := timeoutCtx.Err(); ctxErr != nil {
 						return nil, errors.Wrap(errors.ErrCodeTimeout, "job terminal wait timeout", ctxErr)
 					}
-					return nil, errors.Wrap(errors.ErrCodeInternal,
-						"watch closed and Job re-check failed", recheckErr)
+					return nil, resumeErr
 				}
-				if isJobTerminal(recheck) {
-					return recheck, nil
+				if terminal != nil {
+					return terminal, nil
 				}
-				return nil, errors.New(errors.ErrCodeUnavailable,
-					"watch channel closed before Job reached terminal state")
+				slog.Debug("job watch closed before terminal state, re-established",
+					keyNamespace, namespace, keyName, name)
+				watcher.Stop()
+				watcher = newWatcher
+				continue
 			}
 			if event.Type == watch.Error {
-				if statusErr, isErr := event.Object.(error); isErr {
-					return nil, errors.Wrap(errors.ErrCodeInternal, "watch stream error", statusErr)
-				}
-				return nil, errors.New(errors.ErrCodeInternal, "watch stream error")
+				return nil, errors.Wrap(errors.ErrCodeInternal, "watch stream error",
+					apierrors.FromObject(event.Object))
 			}
 			if event.Type == watch.Deleted {
 				return nil, errors.New(errors.ErrCodeInternal, "Job was deleted before reaching terminal state")

--- a/pkg/k8s/pod/job_test.go
+++ b/pkg/k8s/pod/job_test.go
@@ -17,6 +17,7 @@ package pod_test
 import (
 	"context"
 	stderrors "errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,7 +25,9 @@ import (
 	"github.com/NVIDIA/aicr/pkg/k8s/pod"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -165,6 +168,356 @@ func TestWaitForJobCompletion_WatchError(t *testing.T) {
 	}
 	if sErr.Code != aicrerrors.ErrCodeInternal {
 		t.Errorf("error code = %v, want %v", sErr.Code, aicrerrors.ErrCodeInternal)
+	}
+}
+
+// TestWaitForJobCompletion_WatchClosureResumes proves the fix for issue #1966:
+// when the watch channel closes without the Job being terminal (as
+// kube-apiserver does on --min-request-timeout expiry), WaitForJobCompletion
+// re-establishes the watch and keeps waiting instead of returning
+// ErrCodeUnavailable. Reverting the re-watch line makes this test fail.
+func TestWaitForJobCompletion_WatchClosureResumes(t *testing.T) {
+	t.Parallel()
+
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"}}
+	client := fake.NewSimpleClientset(job) //nolint:staticcheck
+
+	var attempts atomic.Int32
+	first := watch.NewFake()
+	second := watch.NewFake()
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		switch attempts.Add(1) {
+		case 1:
+			return true, first, nil
+		case 2:
+			return true, second, nil
+		default:
+			return true, watch.NewFake(), nil
+		}
+	})
+
+	// Close the first watcher to trigger the resume path.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		first.Stop()
+	}()
+	// Deliver the terminal event on the re-established (second) watcher.
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		second.Modify(&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "2"},
+			Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			}},
+		})
+	}()
+
+	if err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 2*time.Second); err != nil {
+		t.Fatalf("expected nil after watch resume, got: %v", err)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Errorf("expected at least 2 watch attempts (resume), got %d", got)
+	}
+}
+
+const freshCollectionRV = "100"
+
+// staleRVWatchReactor models a real apiserver's stale-ResourceVersion
+// semantics: a watch requested from any RV other than freshCollectionRV (i.e.
+// the aged-out object RV) succeeds at the call level but immediately delivers a
+// 410 ERROR event, while a watch from the current collection RV becomes usable
+// and delivers onFresh. It records how many watches came from each so a test can
+// assert the resume used the collection RV, not the stale object RV.
+func staleRVWatchReactor(fromStale, fromFresh *atomic.Int32, onFresh *batchv1.Job) k8stesting.WatchReactionFunc {
+	return func(action k8stesting.Action) (bool, watch.Interface, error) {
+		rv := action.(k8stesting.WatchActionImpl).WatchRestrictions.ResourceVersion
+		fw := watch.NewFake()
+		if rv == freshCollectionRV {
+			fromFresh.Add(1)
+			go func() { fw.Modify(onFresh) }()
+		} else {
+			fromStale.Add(1)
+			go func() {
+				expired := apierrors.NewResourceExpired("too old resource version: " + rv)
+				fw.Error(&expired.ErrStatus)
+			}()
+		}
+		return true, fw, nil
+	}
+}
+
+// TestWaitForJobCompletion_StaleObjectRVResyncsViaList is the regression for the
+// long-running-validator defect: a Job whose object ResourceVersion has aged out
+// of the watch cache must resync via a field-selected List and re-watch from the
+// current *collection* ResourceVersion. Watching from the stale object RV would
+// 410 forever and degrade the wait to paced polling. If the fix regresses, the
+// wait never re-establishes a usable watch and this test times out.
+func TestWaitForJobCompletion_StaleObjectRVResyncsViaList(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	var lists atomic.Int32
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		lists.Add(1)
+		// The resync List reports the still-non-terminal Job and the CURRENT
+		// collection RV — the value a correct resume must watch from.
+		return true, &batchv1.JobList{
+			ListMeta: metav1.ListMeta{ResourceVersion: freshCollectionRV},
+			Items:    []batchv1.Job{{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"}}},
+		}, nil
+	})
+
+	var fromStale, fromFresh atomic.Int32
+	client.PrependWatchReactor("jobs", staleRVWatchReactor(&fromStale, &fromFresh, terminalJobRV("101", batchv1.JobComplete)))
+
+	if err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 3*time.Second); err != nil {
+		t.Fatalf("expected completion via collection-RV watch, got: %v", err)
+	}
+	if lists.Load() == 0 {
+		t.Error("expected a resync List after the stale-RV watch 410ed")
+	}
+	if fromFresh.Load() == 0 {
+		t.Error("expected a watch re-established from the fresh collection RV")
+	}
+}
+
+// terminalJobRV builds the "j" Job at a given ResourceVersion carrying a single
+// terminal condition. Distinct from the file-level jobWithCondition helper,
+// which uses the "test-job" name and omits the ResourceVersion the resume tests
+// need.
+func terminalJobRV(rv string, condType batchv1.JobConditionType) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: rv},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+			{Type: condType, Status: corev1.ConditionTrue},
+		}},
+	}
+}
+
+// TestWaitForJobCompletion_ResyncListCatchesTerminal covers the closure-race
+// branch: the Job goes terminal while the watch is down, so the resync List
+// observes the terminal (Complete) state and the wait returns without
+// re-establishing a watch at all.
+func TestWaitForJobCompletion_ResyncListCatchesTerminal(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &batchv1.JobList{
+			ListMeta: metav1.ListMeta{ResourceVersion: freshCollectionRV},
+			Items:    []batchv1.Job{*terminalJobRV("2", batchv1.JobComplete)},
+		}, nil
+	})
+
+	var watches atomic.Int32
+	first := watch.NewFake()
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		if watches.Add(1) == 1 {
+			return true, first, nil
+		}
+		t.Error("watch must not be re-established once the resync List observes terminal")
+		return true, watch.NewFake(), nil
+	})
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		first.Stop()
+	}()
+
+	if err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 2*time.Second); err != nil {
+		t.Fatalf("expected nil when resync List catches terminal, got: %v", err)
+	}
+	if got := watches.Load(); got != 1 {
+		t.Errorf("expected exactly 1 watch attempt (no rewatch), got %d", got)
+	}
+}
+
+// TestWaitForJobCompletion_ResyncListCatchesFailed asserts the Failed terminal
+// disposition observed by the resync List is surfaced as an error, not swallowed.
+func TestWaitForJobCompletion_ResyncListCatchesFailed(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &batchv1.JobList{
+			ListMeta: metav1.ListMeta{ResourceVersion: freshCollectionRV},
+			Items:    []batchv1.Job{*terminalJobRV("3", batchv1.JobFailed)},
+		}, nil
+	})
+
+	first := watch.NewFake()
+	client.PrependWatchReactor("jobs", k8stesting.DefaultWatchReactor(first, nil))
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		first.Stop()
+	}()
+
+	err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected job-failed error from resync-List-observed terminal state")
+	}
+	var sErr *aicrerrors.StructuredError
+	if !stderrors.As(err, &sErr) {
+		t.Fatalf("expected *errors.StructuredError, got %T", err)
+	}
+}
+
+// TestWaitForJobCompletion_ResumesTwice proves the loop resumes across more than
+// one closure: two successive watches close before terminal, and only the third
+// delivers the completion event.
+func TestWaitForJobCompletion_ResumesTwice(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	var watches atomic.Int32
+	first := watch.NewFake()
+	second := watch.NewFake()
+	third := watch.NewFake()
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		switch watches.Add(1) {
+		case 1:
+			return true, first, nil
+		case 2:
+			return true, second, nil
+		case 3:
+			return true, third, nil
+		default:
+			return true, watch.NewFake(), nil
+		}
+	})
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		first.Stop()
+		time.Sleep(20 * time.Millisecond)
+		second.Stop()
+		time.Sleep(20 * time.Millisecond)
+		third.Modify(terminalJobRV("4", batchv1.JobComplete))
+	}()
+
+	if err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 3*time.Second); err != nil {
+		t.Fatalf("expected nil after two resumes, got: %v", err)
+	}
+	if got := watches.Load(); got < 3 {
+		t.Errorf("expected at least 3 watch attempts (two resumes), got %d", got)
+	}
+}
+
+// TestWaitForJobCompletion_RetryableWatchErrorResumes covers the F1 path: a
+// mid-stream watch.Error carrying a 410 (Gone) status is treated as a resumable
+// signal — the watch is re-established rather than the wait failing.
+func TestWaitForJobCompletion_RetryableWatchErrorResumes(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	var watches atomic.Int32
+	first := watch.NewFake()
+	second := watch.NewFake()
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		switch watches.Add(1) {
+		case 1:
+			return true, first, nil
+		case 2:
+			return true, second, nil
+		default:
+			return true, watch.NewFake(), nil
+		}
+	})
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		// Emit a 410 Gone as a watch.Error event rather than closing the channel.
+		expired := apierrors.NewResourceExpired("compacted")
+		first.Error(&expired.ErrStatus)
+		time.Sleep(30 * time.Millisecond)
+		second.Modify(terminalJobRV("2", batchv1.JobComplete))
+	}()
+
+	if err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 2*time.Second); err != nil {
+		t.Fatalf("expected nil after retryable watch error resume, got: %v", err)
+	}
+	if got := watches.Load(); got < 2 {
+		t.Errorf("expected at least 2 watch attempts (resume after 410 error), got %d", got)
+	}
+}
+
+// TestWaitForJobCompletion_FatalWatchErrorReturns confirms a non-retryable
+// watch.Error still aborts the wait with ErrCodeInternal rather than resuming.
+func TestWaitForJobCompletion_FatalWatchErrorReturns(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"},
+	})
+	w := watch.NewFake()
+	client.PrependWatchReactor("jobs", k8stesting.DefaultWatchReactor(w, nil))
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		internal := apierrors.NewInternalError(stderrors.New("boom"))
+		w.Error(&internal.ErrStatus)
+	}()
+
+	err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error from fatal watch stream error")
+	}
+	var sErr *aicrerrors.StructuredError
+	if !stderrors.As(err, &sErr) {
+		t.Fatalf("expected *errors.StructuredError, got %T", err)
+	}
+	if sErr.Code != aicrerrors.ErrCodeInternal {
+		t.Errorf("error code = %v, want %v", sErr.Code, aicrerrors.ErrCodeInternal)
+	}
+}
+
+// TestWaitForJobCompletion_ResumeReListTransientUnavailable pins F5: when the
+// post-close resync List fails with a transient (non-context) error, the wait
+// surfaces ErrCodeUnavailable — distinguishing an apiserver hiccup from the
+// caller's own deadline.
+func TestWaitForJobCompletion_ResumeReListTransientUnavailable(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver down")
+	})
+
+	w := watch.NewFake()
+	client.PrependWatchReactor("jobs", k8stesting.DefaultWatchReactor(w, nil))
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		w.Stop()
+	}()
+
+	err := pod.WaitForJobCompletion(context.Background(), client, "default", "j", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error from transient resync List failure")
+	}
+	var sErr *aicrerrors.StructuredError
+	if !stderrors.As(err, &sErr) {
+		t.Fatalf("expected *errors.StructuredError, got %T", err)
+	}
+	if sErr.Code != aicrerrors.ErrCodeUnavailable {
+		t.Errorf("error code = %v, want %v", sErr.Code, aicrerrors.ErrCodeUnavailable)
 	}
 }
 

--- a/pkg/k8s/pod/wait_internal_test.go
+++ b/pkg/k8s/pod/wait_internal_test.go
@@ -18,11 +18,115 @@ import (
 	"context"
 	stderrors "errors"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+// The watch-resume backoff paces reconnects against a degraded API server in
+// production, but a multi-second sleep would blow the sub-second deadlines the
+// resume tests use to drive the fake watcher. Shrink it to a negligible value
+// for the whole test binary — a single pre-test write, so no race with the
+// parallel resume tests that only read it.
+func init() {
+	jobWatchResumeBackoff = time.Millisecond
+}
+
+// TestResumeJobWatch_ContextCanceledDuringBackoff pins the backoff guard: when
+// the context is already done, resumeJobWatch must abandon the resume during the
+// backoff wait and report ErrCodeTimeout rather than issuing a List/Watch
+// against an apiserver the caller has already given up on.
+func TestResumeJobWatch_ContextCanceledDuringBackoff(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: fake.NewSimpleClientset is sufficient for tests
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		t.Error("List must not be attempted once the context is canceled")
+		return true, &batchv1.JobList{}, nil
+	})
+
+	terminal, w, err := resumeJobWatch(canceledCtx, client, "default", "j")
+	if w != nil || terminal != nil {
+		t.Fatalf("expected no watcher/terminal on canceled context, got w=%v terminal=%v", w, terminal)
+	}
+	assertStructuredCode(t, err, errors.ErrCodeTimeout)
+}
+
+// TestResumeJobWatch_ListFailsTransient covers the resync-List failure branch:
+// a transient (non-context) List error is classified ErrCodeUnavailable so an
+// apiserver hiccup is not mistaken for a defect.
+func TestResumeJobWatch_ListFailsTransient(t *testing.T) {
+	client := fake.NewSimpleClientset() //nolint:staticcheck
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver down")
+	})
+
+	terminal, w, err := resumeJobWatch(context.Background(), client, "default", "j")
+	if w != nil || terminal != nil {
+		t.Fatalf("expected no watcher/terminal on List failure, got w=%v terminal=%v", w, terminal)
+	}
+	assertStructuredCode(t, err, errors.ErrCodeUnavailable)
+}
+
+// TestResumeJobWatch_JobDeleted covers the empty-List branch: the Job vanished
+// while the watch was down, so the resume reports it is gone rather than
+// re-establishing a watch on a nonexistent object.
+func TestResumeJobWatch_JobDeleted(t *testing.T) {
+	client := fake.NewSimpleClientset() //nolint:staticcheck
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &batchv1.JobList{ListMeta: metav1.ListMeta{ResourceVersion: "9"}}, nil
+	})
+
+	terminal, w, err := resumeJobWatch(context.Background(), client, "default", "j")
+	if w != nil || terminal != nil {
+		t.Fatalf("expected no watcher/terminal when Job is gone, got w=%v terminal=%v", w, terminal)
+	}
+	assertStructuredCode(t, err, errors.ErrCodeInternal)
+}
+
+// TestResumeJobWatch_WatchFailsTransient covers the re-establish-Watch failure
+// branch: a transient Watch error after a successful resync List is classified
+// ErrCodeUnavailable, consistent with the List path (CodeRabbit job.go:98).
+func TestResumeJobWatch_WatchFailsTransient(t *testing.T) {
+	client := fake.NewSimpleClientset() //nolint:staticcheck
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &batchv1.JobList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "42"},
+			Items:    []batchv1.Job{{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "default", ResourceVersion: "1"}}},
+		}, nil
+	})
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver down")
+	})
+
+	terminal, w, err := resumeJobWatch(context.Background(), client, "default", "j")
+	if w != nil || terminal != nil {
+		t.Fatalf("expected no watcher/terminal on Watch failure, got w=%v terminal=%v", w, terminal)
+	}
+	assertStructuredCode(t, err, errors.ErrCodeUnavailable)
+}
+
+// assertStructuredCode fails the test unless err is a *StructuredError with the
+// wanted code.
+func assertStructuredCode(t *testing.T, err error, want errors.ErrorCode) {
+	t.Helper()
+	var se *errors.StructuredError
+	if !stderrors.As(err, &se) {
+		t.Fatalf("error is not StructuredError: %v", err)
+	}
+	if se.Code != want {
+		t.Errorf("code = %q, want %q", se.Code, want)
+	}
+}
 
 // TestClassifyReGetError pins the wait-loop re-Get classifier so a deadline
 // race between watch-channel close and the re-Get surfaces as ErrCodeTimeout,

--- a/pkg/k8s/pod/wait_termination_test.go
+++ b/pkg/k8s/pod/wait_termination_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/k8s/pod"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -381,6 +382,106 @@ func TestWaitForJobTerminal(t *testing.T) {
 	}
 }
 
+// TestWaitForJobTerminal_WatchClosureResumes proves the fix for issue #1966 on
+// the terminal-wait path: a watch channel that closes without the Job being
+// terminal (kube-apiserver --min-request-timeout expiry) is followed by a
+// re-established watch that delivers the terminal event, and the observed Job is
+// returned rather than ErrCodeUnavailable. Reverting the re-watch line fails it.
+func TestWaitForJobTerminal_WatchClosureResumes(t *testing.T) {
+	t.Parallel()
+
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default", ResourceVersion: "1"}}
+	client := fake.NewSimpleClientset(job) //nolint:staticcheck
+
+	var attempts atomic.Int32
+	first := watch.NewFake()
+	second := watch.NewFake()
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		switch attempts.Add(1) {
+		case 1:
+			return true, first, nil
+		case 2:
+			return true, second, nil
+		default:
+			return true, watch.NewFake(), nil
+		}
+	})
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		first.Stop()
+	}()
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		second.Modify(jobWithCondition(batchCond("Failed")))
+	}()
+
+	got, err := pod.WaitForJobTerminal(context.Background(), client, "default", "test-job", 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected nil error after watch resume, got: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil terminal job after resume")
+	}
+	if n := attempts.Load(); n < 2 {
+		t.Errorf("expected at least 2 watch attempts (resume), got %d", n)
+	}
+}
+
+// TestWaitForJobTerminal_StaleObjectRVResyncsViaList is the terminal-wait mirror
+// of the long-running-validator regression: a watch from the aged-out object RV
+// 410s, so the resume must resync via a field-selected List and re-watch from
+// the current collection RV. Regressing to the object RV would 410-loop until
+// this test's deadline.
+func TestWaitForJobTerminal_StaleObjectRVResyncsViaList(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	const freshCollectionRV = "100"
+	var lists, fromStale, fromFresh atomic.Int32
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		lists.Add(1)
+		return true, &batchv1.JobList{
+			ListMeta: metav1.ListMeta{ResourceVersion: freshCollectionRV},
+			Items:    []batchv1.Job{{ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default", ResourceVersion: "1"}}},
+		}, nil
+	})
+	client.PrependWatchReactor("jobs", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		rv := action.(k8stesting.WatchActionImpl).WatchRestrictions.ResourceVersion
+		fw := watch.NewFake()
+		if rv == freshCollectionRV {
+			fromFresh.Add(1)
+			terminal := jobWithCondition(batchCond("Complete"))
+			terminal.ResourceVersion = "101"
+			go func() { fw.Modify(terminal) }()
+		} else {
+			fromStale.Add(1)
+			go func() {
+				expired := apierrors.NewResourceExpired("too old resource version: " + rv)
+				fw.Error(&expired.ErrStatus)
+			}()
+		}
+		return true, fw, nil
+	})
+
+	got, err := pod.WaitForJobTerminal(context.Background(), client, "default", "test-job", 3*time.Second)
+	if err != nil {
+		t.Fatalf("expected terminal job via collection-RV watch, got: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil terminal job after List resync")
+	}
+	if lists.Load() == 0 {
+		t.Error("expected a resync List after the stale-RV watch 410ed")
+	}
+	if fromFresh.Load() == 0 {
+		t.Error("expected a watch re-established from the fresh collection RV")
+	}
+}
+
 func TestWaitForJobTerminal_WatchError(t *testing.T) {
 	t.Parallel()
 
@@ -412,6 +513,95 @@ func TestWaitForJobTerminal_WatchError(t *testing.T) {
 	}
 	if sErr.Code != errors.ErrCodeInternal {
 		t.Errorf("error code = %v, want %v", sErr.Code, errors.ErrCodeInternal)
+	}
+}
+
+// TestWaitForJobTerminal_RetryableWatchErrorResumes mirrors the F1 fix on the
+// terminal-wait path: a mid-stream 410 (Gone) watch.Error resumes the watch
+// instead of aborting.
+func TestWaitForJobTerminal_RetryableWatchErrorResumes(t *testing.T) {
+	t.Parallel()
+
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default", ResourceVersion: "1"}}
+	client := fake.NewSimpleClientset(job) //nolint:staticcheck
+
+	var attempts atomic.Int32
+	first := watch.NewFake()
+	second := watch.NewFake()
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		switch attempts.Add(1) {
+		case 1:
+			return true, first, nil
+		case 2:
+			return true, second, nil
+		default:
+			return true, watch.NewFake(), nil
+		}
+	})
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		expired := apierrors.NewResourceExpired("compacted")
+		first.Error(&expired.ErrStatus)
+		time.Sleep(30 * time.Millisecond)
+		second.Modify(jobWithCondition(batchCond("Complete")))
+	}()
+
+	got, err := pod.WaitForJobTerminal(context.Background(), client, "default", "test-job", 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected nil error after retryable watch error resume, got: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil terminal job after resume")
+	}
+	if n := attempts.Load(); n < 2 {
+		t.Errorf("expected at least 2 watch attempts (resume after 410 error), got %d", n)
+	}
+}
+
+// TestWaitForJobTerminal_ResyncListCatchesTerminal covers the closure-race
+// branch on the terminal-wait path: the Job goes terminal while the watch is
+// down, so the resync List observes it and no watch is re-established.
+func TestWaitForJobTerminal_ResyncListCatchesTerminal(t *testing.T) {
+	t.Parallel()
+
+	client := fake.NewSimpleClientset(&batchv1.Job{ //nolint:staticcheck
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default", ResourceVersion: "1"},
+	})
+
+	terminal := jobWithCondition(batchCond("Complete"))
+	terminal.ResourceVersion = "2"
+	client.PrependReactor("list", "jobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &batchv1.JobList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "100"},
+			Items:    []batchv1.Job{*terminal},
+		}, nil
+	})
+
+	var watches atomic.Int32
+	first := watch.NewFake()
+	client.PrependWatchReactor("jobs", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		if watches.Add(1) == 1 {
+			return true, first, nil
+		}
+		t.Error("watch must not be re-established once the resync List observes terminal")
+		return true, watch.NewFake(), nil
+	})
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		first.Stop()
+	}()
+
+	got, err := pod.WaitForJobTerminal(context.Background(), client, "default", "test-job", 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected nil when resync List catches terminal, got: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil terminal job from resync List")
+	}
+	if n := watches.Load(); n != 1 {
+		t.Errorf("expected exactly 1 watch attempt (no rewatch), got %d", n)
 	}
 }
 

--- a/pkg/validator/job/result.go
+++ b/pkg/validator/job/result.go
@@ -16,11 +16,15 @@ package job
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
+	"unicode/utf8"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/k8s/pod"
 	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
 	corev1 "k8s.io/api/core/v1"
@@ -71,7 +75,7 @@ func (d *Deployer) ExtractResult(ctx context.Context) *ctrf.ValidatorResult {
 	switch {
 	case cs.State.Terminated != nil:
 		result.ExitCode = cs.State.Terminated.ExitCode
-		result.TerminationMsg = cs.State.Terminated.Message
+		result.TerminationMsg = boundTerminationMsg(cs.State.Terminated.Message, defaults.ValidatorMaxTerminationMsgBytes)
 		if cs.State.Terminated.Reason == "OOMKilled" {
 			result.TerminationMsg = "Container OOMKilled"
 		}
@@ -107,8 +111,18 @@ func (d *Deployer) ExtractResult(ctx context.Context) *ctrf.ValidatorResult {
 }
 
 // HandleTimeout extracts whatever result is available when the orchestrator's
-// wait has timed out. Uses a fresh context since the parent may be canceled.
-func (d *Deployer) HandleTimeout(ctx context.Context) *ctrf.ValidatorResult {
+// wait returned an error. Uses a fresh context since the parent may be
+// canceled.
+//
+// waitCause is the error returned by WaitForCompletion. It classifies the
+// failure so the rendered TerminationMsg reflects the ACTUAL cause: a genuine
+// context-deadline expiry (stdlib DeadlineExceeded or a pkg/errors
+// ErrCodeTimeout) renders the "timeout: validator did not complete within
+// <configured>" wording, while any other cause (e.g. an infra/unavailable
+// error) renders "validation failed: <cause>" so a mid-run infra failure is
+// not misreported as the full catalog timeout (see issue #1966). A nil
+// waitCause is treated as a timeout for backward compatibility.
+func (d *Deployer) HandleTimeout(ctx context.Context, waitCause error) *ctrf.ValidatorResult {
 	result := &ctrf.ValidatorResult{
 		Name:  d.config.Entry.Name,
 		Phase: d.config.Entry.Phase,
@@ -126,7 +140,7 @@ func (d *Deployer) HandleTimeout(ctx context.Context) *ctrf.ValidatorResult {
 	cs, found := findContainerStatus(jobPod.Status.ContainerStatuses, ValidatorContainerName)
 	if !found {
 		result.ExitCode = -1
-		result.TerminationMsg = fmt.Sprintf("timeout: validator did not complete within %s (container %q not found - validator package contract)", d.config.Entry.Timeout, ValidatorContainerName)
+		result.TerminationMsg = fmt.Sprintf("timeout: validator did not complete within %s (container %q not found - validator package contract)", effectiveTimeout(d.config.Entry.Timeout), ValidatorContainerName)
 		return result
 	}
 
@@ -140,16 +154,53 @@ func (d *Deployer) HandleTimeout(ctx context.Context) *ctrf.ValidatorResult {
 
 	if cs.State.Terminated != nil {
 		result.ExitCode = cs.State.Terminated.ExitCode
-		result.TerminationMsg = cs.State.Terminated.Message
+		result.TerminationMsg = boundTerminationMsg(cs.State.Terminated.Message, defaults.ValidatorMaxTerminationMsgBytes)
 		result.StartTime = cs.State.Terminated.StartedAt.Time
 		result.CompletionTime = cs.State.Terminated.FinishedAt.Time
 		result.Duration = result.CompletionTime.Sub(result.StartTime)
 	} else {
 		result.ExitCode = -1
-		result.TerminationMsg = fmt.Sprintf("timeout: validator did not complete within %s", d.config.Entry.Timeout)
+		result.TerminationMsg = waitFailureMessage(waitCause, effectiveTimeout(d.config.Entry.Timeout))
 	}
 
 	return result
+}
+
+// effectiveTimeout mirrors the fallback runPhase applies before waiting: a
+// catalog entry with no explicit timeout is waited on for
+// defaults.ValidatorDefaultTimeout, so the rendered message must report that
+// same effective value rather than a bare "0s".
+func effectiveTimeout(configured time.Duration) time.Duration {
+	if configured == 0 {
+		return defaults.ValidatorDefaultTimeout
+	}
+	return configured
+}
+
+// waitFailureMessage renders the TerminationMsg for a validator whose container
+// never terminated. Only a genuine context-deadline expiry is reported as a
+// "timeout ... within <configured>" — any other cause (infra/unavailable) is
+// surfaced verbatim so diagnosis is not misdirected to the catalog timeout
+// (see issue #1966). A nil cause is treated as a timeout for backward
+// compatibility with callers that had no error to thread through.
+func waitFailureMessage(cause error, configured time.Duration) string {
+	if cause == nil || isDeadlineCause(cause) {
+		return fmt.Sprintf("timeout: validator did not complete within %s", configured)
+	}
+	return fmt.Sprintf("validation failed: %v", cause)
+}
+
+// isDeadlineCause reports whether err represents a genuine context-deadline
+// expiry — either the stdlib context.DeadlineExceeded sentinel or a pkg/errors
+// StructuredError carrying ErrCodeTimeout.
+func isDeadlineCause(err error) bool {
+	if err == nil {
+		return false
+	}
+	if stderrors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return stderrors.Is(err, errors.New(errors.ErrCodeTimeout, ""))
 }
 
 // truncateLogLines splits raw log output into lines and returns at most the
@@ -178,6 +229,23 @@ func filterStdoutLines(lines []string, maxLineLen int) []string {
 	}
 
 	return lines
+}
+
+// boundTerminationMsg defensively caps a container termination message at
+// maxBytes, appending a truncation suffix that reports the dropped byte count.
+// The kubelet already caps the message upstream, but bounding it at the source
+// keeps oversized messages out of ConfigMaps and rendered reports regardless.
+func boundTerminationMsg(msg string, maxBytes int) string {
+	if len(msg) <= maxBytes {
+		return msg
+	}
+	// Trim the cut back to a valid UTF-8 rune boundary so a multi-byte rune is
+	// never split into an invalid sequence in the emitted message.
+	head := msg[:maxBytes]
+	for len(head) > 0 && !utf8.ValidString(head) {
+		head = head[:len(head)-1]
+	}
+	return head + fmt.Sprintf("... [truncated %d bytes]", len(msg)-len(head))
 }
 
 // getPodForJob finds the pod created by the validator Job using the shared

--- a/pkg/validator/job/result_test.go
+++ b/pkg/validator/job/result_test.go
@@ -16,10 +16,14 @@ package job
 
 import (
 	"context"
+	stderrors "errors"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/validator/catalog"
 	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
 	corev1 "k8s.io/api/core/v1"
@@ -305,7 +309,7 @@ func TestHandleTimeoutPodNotFound(t *testing.T) {
 	ns := createUniqueNamespace(t)
 	d := deployTestJob(t, ns, testEntry())
 
-	result := d.HandleTimeout(context.Background())
+	result := d.HandleTimeout(context.Background(), context.DeadlineExceeded)
 
 	if result.ExitCode != -1 {
 		t.Errorf("ExitCode = %d, want -1", result.ExitCode)
@@ -315,26 +319,112 @@ func TestHandleTimeoutPodNotFound(t *testing.T) {
 	}
 }
 
+// TestHandleTimeoutContainerNotTerminated verifies that a validator whose
+// container never reached a terminal state renders a message reflecting the
+// ACTUAL wait cause: a genuine context-deadline expiry reports the configured
+// timeout, while an infra/unavailable cause reports that failure verbatim and
+// must NOT masquerade as the catalog timeout (issue #1966).
 func TestHandleTimeoutContainerNotTerminated(t *testing.T) {
-	ns := createUniqueNamespace(t)
-	d := deployTestJob(t, ns, testEntry())
+	tests := []struct {
+		name          string
+		cause         error
+		wantContains  []string // substrings that MUST all appear
+		wantExclusion string   // substring that must NOT appear
+	}{
+		{
+			name:         "genuine deadline (stdlib sentinel)",
+			cause:        context.DeadlineExceeded,
+			wantContains: []string{"timeout: validator did not complete within"},
+		},
+		{
+			name:         "genuine deadline (ErrCodeTimeout)",
+			cause:        errors.New(errors.ErrCodeTimeout, "wait deadline exceeded"),
+			wantContains: []string{"timeout: validator did not complete within"},
+		},
+		{
+			name:         "nil cause falls back to timeout wording",
+			cause:        nil,
+			wantContains: []string{"timeout: validator did not complete within"},
+		},
+		{
+			name:          "infra/unavailable cause is surfaced verbatim",
+			cause:         errors.New(errors.ErrCodeUnavailable, "apiserver watch closed: connection refused"),
+			wantContains:  []string{"validation failed:", "apiserver watch closed: connection refused"},
+			wantExclusion: "timeout: validator did not complete within",
+		},
+		{
+			// Production shape: WaitForJobTerminal wraps the context error under
+			// ErrCodeTimeout — isDeadlineCause must see through the wrap chain.
+			name:         "wrapped ErrCodeTimeout (production wait shape)",
+			cause:        errors.Wrap(errors.ErrCodeTimeout, "job terminal wait timeout", context.DeadlineExceeded),
+			wantContains: []string{"timeout: validator did not complete within"},
+		},
+		{
+			// Production shape: a transient re-check Get failure classified as
+			// ErrCodeUnavailable and wrapped by classifyReGetError — must render
+			// verbatim, not as the catalog timeout.
+			name:          "wrapped ErrCodeUnavailable (production resume shape)",
+			cause:         errors.Wrap(errors.ErrCodeUnavailable, "job watch closed and Job re-check failed", stderrors.New("connection refused")),
+			wantContains:  []string{"validation failed:", "connection refused"},
+			wantExclusion: "timeout: validator did not complete within",
+		},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := createUniqueNamespace(t)
+			d := deployTestJob(t, ns, testEntry())
+
+			createPodForJob(t, ns, d.JobName(), corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: ValidatorContainerName,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				}},
+			})
+
+			result := d.HandleTimeout(context.Background(), tt.cause)
+
+			if result.ExitCode != -1 {
+				t.Errorf("ExitCode = %d, want -1", result.ExitCode)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result.TerminationMsg, want) {
+					t.Errorf("TerminationMsg = %q, want substring %q", result.TerminationMsg, want)
+				}
+			}
+			if tt.wantExclusion != "" && strings.Contains(result.TerminationMsg, tt.wantExclusion) {
+				t.Errorf("TerminationMsg = %q, must NOT contain %q", result.TerminationMsg, tt.wantExclusion)
+			}
+		})
+	}
+}
+
+// TestHandleTimeoutZeroTimeoutRendersDefault verifies that a catalog entry with
+// no explicit timeout renders the effective default runPhase applies
+// (ValidatorDefaultTimeout), not a misleading "within 0s".
+func TestHandleTimeoutZeroTimeoutRendersDefault(t *testing.T) {
+	entry := testEntry()
+	entry.Timeout = 0
+
+	ns := createUniqueNamespace(t)
+	d := deployTestJob(t, ns, entry)
 	createPodForJob(t, ns, d.JobName(), corev1.PodStatus{
 		ContainerStatuses: []corev1.ContainerStatus{{
-			Name: ValidatorContainerName,
-			State: corev1.ContainerState{
-				Running: &corev1.ContainerStateRunning{},
-			},
+			Name:  ValidatorContainerName,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 		}},
 	})
 
-	result := d.HandleTimeout(context.Background())
+	result := d.HandleTimeout(context.Background(), context.DeadlineExceeded)
 
-	if result.ExitCode != -1 {
-		t.Errorf("ExitCode = %d, want -1", result.ExitCode)
+	wantTimeout := defaults.ValidatorDefaultTimeout.String()
+	if !strings.Contains(result.TerminationMsg, wantTimeout) {
+		t.Errorf("TerminationMsg = %q, want effective timeout %q", result.TerminationMsg, wantTimeout)
 	}
-	if result.TerminationMsg == "" {
-		t.Error("TerminationMsg should contain timeout message")
+	if strings.Contains(result.TerminationMsg, "within 0s") {
+		t.Errorf("TerminationMsg = %q, must not render a bare 0s timeout", result.TerminationMsg)
 	}
 }
 
@@ -358,7 +448,7 @@ func TestHandleTimeoutContainerTerminated(t *testing.T) {
 		}},
 	})
 
-	result := d.HandleTimeout(context.Background())
+	result := d.HandleTimeout(context.Background(), context.DeadlineExceeded)
 
 	if result.ExitCode != 137 {
 		t.Errorf("ExitCode = %d, want 137", result.ExitCode)
@@ -471,7 +561,7 @@ func TestHandleTimeoutWithSidecar(t *testing.T) {
 		},
 	})
 
-	result := d.HandleTimeout(context.Background())
+	result := d.HandleTimeout(context.Background(), context.DeadlineExceeded)
 
 	if result.ExitCode != 137 {
 		t.Errorf("ExitCode = %d, want 137", result.ExitCode)
@@ -496,7 +586,7 @@ func TestHandleTimeoutSidecarOnlyNoValidator(t *testing.T) {
 		},
 	})
 
-	result := d.HandleTimeout(context.Background())
+	result := d.HandleTimeout(context.Background(), context.DeadlineExceeded)
 
 	if result.ExitCode != -1 {
 		t.Errorf("ExitCode = %d, want -1", result.ExitCode)
@@ -600,6 +690,59 @@ func TestFilterStdoutLines(t *testing.T) {
 				if got[i] != tt.want[i] {
 					t.Errorf("line[%d]:\n  got:  %q\n  want: %q", i, got[i], tt.want[i])
 				}
+			}
+		})
+	}
+}
+
+func TestBoundTerminationMsg(t *testing.T) {
+	tests := []struct {
+		name         string
+		msg          string
+		maxBytes     int
+		wantLen      int    // expected exact length, 0 = compute from msg
+		wantContains string // substring that must appear (empty = none)
+	}{
+		{
+			name:     "under limit passes through unchanged",
+			msg:      "container exited with code 1",
+			maxBytes: 4096,
+		},
+		{
+			name:     "exactly at limit passes through unchanged",
+			msg:      strings.Repeat("x", 100),
+			maxBytes: 100,
+		},
+		{
+			name:         "over limit is truncated with byte-count suffix",
+			msg:          strings.Repeat("y", 5000),
+			maxBytes:     4096,
+			wantContains: "... [truncated 904 bytes]",
+		},
+		{
+			// Cut lands mid-rune: "€" is 3 bytes, so a maxBytes that splits it
+			// must trim back to the rune boundary and never emit an invalid rune.
+			name:         "cut mid multibyte rune trims to boundary",
+			msg:          strings.Repeat("€", 10), // 30 bytes
+			maxBytes:     10,                      // splits the 4th rune (bytes 9-11)
+			wantContains: "... [truncated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := boundTerminationMsg(tt.msg, tt.maxBytes)
+			if len(tt.msg) <= tt.maxBytes {
+				if got != tt.msg {
+					t.Errorf("expected passthrough, got %q", got)
+				}
+				return
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncated output is not valid UTF-8: %q", got)
+			}
+			if tt.wantContains != "" && !strings.Contains(got, tt.wantContains) {
+				t.Errorf("output missing suffix %q, got %q", tt.wantContains, got)
 			}
 		})
 	}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -430,9 +430,12 @@ func (v *Validator) runPhase(
 
 		var result *ctrf.ValidatorResult
 		if waitErr != nil {
-			// Timeout or infra error — extract what we can with a fresh context
+			// Timeout or infra error — extract what we can with a fresh context.
+			// Thread waitErr so the rendered message reflects the ACTUAL cause
+			// (infra/unavailable vs a genuine deadline), not always the
+			// configured catalog timeout (issue #1966).
 			captureCtx, captureCancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout) //nolint:contextcheck // Fresh context: parent may be canceled
-			result = deployer.HandleTimeout(captureCtx)                                                        //nolint:contextcheck // Uses fresh context above
+			result = deployer.HandleTimeout(captureCtx, waitErr)                                               //nolint:contextcheck // Uses fresh context above
 			captureCancel()
 		} else {
 			// Normal completion — extract exit code, termination msg, stdout


### PR DESCRIPTION
## Summary

`aicr validate` waits on each validator Job with a single Kubernetes watch. kube-apiserver terminates every watch stream after `--min-request-timeout` (30–60 min, randomized), which clients are expected to survive by re-establishing the watch. `WaitForJobCompletion`/`WaitForJobTerminal` now re-Get the Job and re-establish the watch from the observed `ResourceVersion` instead of reporting the closure as a fatal wait failure.

## Motivation / Context

On a default-configured API server no validator can reliably run longer than ~30 min through `aicr validate`; completions in the 30–60 min band are jitter luck regardless of the catalog `timeout`. The healthy long-running validator is torn down mid-run and mislabeled as timed out.

Fixes: #1966
Related: #1632, #1192

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)

## Implementation Notes

- `pkg/k8s/pod/job.go` — `WaitForJobCompletion`/`WaitForJobTerminal` re-establish the watch from the observed `ResourceVersion` when the result channel closes without context cancellation; a `410 Gone` (stale ResourceVersion) triggers a fresh Get and restarts the watch from current state instead of returning `ErrCodeUnavailable`.
- The watcher `defer` is changed to closure form (`defer func() { watcher.Stop() }()`) so the re-established stream is stopped rather than leaking the original, now-superseded watcher.
- `pkg/validator/job/result.go` — `HandleTimeout` now threads the actual wait cause through, so an infrastructure failure renders `validation failed: <cause>` instead of the misleading `timeout … within <configured catalog timeout>` that misdirected operators toward the catalog knob.
- The context deadline and the Job's `activeDeadlineSeconds` remain the sole give-up authorities; hang detection is unchanged (approach A from the issue).

## Testing

```bash
make test        # -race, GREEN on pkg/k8s/pod and pkg/validator/...
make lint        # golangci-lint GREEN on affected packages
make test-coverage  # 79.6% total (threshold 75%) — PASS
```

Added tests for the re-watch/resume path (`pkg/k8s/pod/job_test.go`, `wait_termination_test.go`) and the cause-threading message (`pkg/validator/job/result_test.go`).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — no user-facing API, flag, or documented-behavior change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A (no user-facing behavior change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
