### PR TITLE
feat(validator): carry redaction-safe CTRF extra outcome data

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -192,9 +192,93 @@ validators.Run(map[string]validators.CheckFunc{
 
 | Channel | Captured as |
 |---------|-------------|
-| **stdout** | CTRF `message` (human-readable evidence) — use `fmt.Printf` |
+| **stdout** | CTRF `stdout` (human-readable evidence) — use `fmt.Printf` |
 | **stderr** | Streamed live to the user — use `slog.*` |
 | `/dev/termination-log` | Failure reason (≤ 4096 bytes), written on `return error` |
+| **stdout sentinel lines** | Structured/side-channel data — see [Stdout sentinels](#stdout-sentinels) |
+
+### Stdout sentinels
+
+A check runs inside a pod; the only channels that reach the orchestrator are the
+exit code, `/dev/termination-log`, and the captured stdout (pod logs). To move
+*more* than a pass/fail verdict across that boundary, checks emit **sentinel
+lines** — stdout lines with a reserved prefix that a specific parser recognizes
+and pulls out. Plain (non-prefixed) stdout is unaffected and flows into the CTRF
+`stdout` array as before.
+
+Two sentinels exist today, with deliberately different lifecycles:
+
+| Prefix | Emitted by | Parsed by | Payload | Kept in CTRF `stdout`? | Survives minimal redaction? |
+|--------|-----------|-----------|---------|------------------------|-----------------------------|
+| `RESULT:` + one space | any check (`fmt.Printf`) | `extractResultSummaries` (`pkg/validator/validator.go`) | free-form human text (throughput, bandwidth, TTFT…) | **yes** — line stays; trailing text is *also* echoed to the live CLI at INFO | **no** — dies with `stdout` under the default policy |
+| `##AICR-EXTRA##` + one space | `validators.EmitExtra` | `parseExtraSentinels` (`pkg/validator/job/result.go`) | one JSON object → `TestResult.Extra` (counts / enum codes) | **no** — stripped as transport, not evidence | **yes** — allowlisted keys are published (see below) |
+
+Both are parsed with `strings.CutPrefix` and both parsers are pure, unit-tested
+functions. They are separate channels on purpose: `RESULT:` surfaces live
+metrics to a human watching a run, so it carries unbounded free-form text and is
+correctly redacted with the rest of `stdout`; `##AICR-EXTRA##` carries structured
+data that must *outlive* redaction, so it is low-cardinality, allowlisted, and
+stripped from the human evidence. Do not route structured outcome data through
+`RESULT:` (it would not survive publication) or human prose through
+`##AICR-EXTRA##` (it would be dropped by the allowlist or leak identifiers).
+
+### Structured evidence that survives redaction
+
+`stdout` and `message` are free-form log text: they can leak node names, IPs,
+DNS names, and secret/cert names, so the default **minimal** redaction policy
+(`pkg/evidence/redact`) strips them from a published, signed evidence bundle —
+only `--full` keeps them. A check that reports on `stdout` alone therefore shows
+as `passed` with no detail in the artifact a downstream consumer verifies by
+default: a 1-of-2-node pass is indistinguishable from 2-of-2, and a skip loses
+its reason.
+
+To carry outcome data that *does* survive minimal redaction, emit it into the
+CTRF `extra` map (`ctrf.TestResult.Extra`, mirroring the CTRF spec's `extra`
+object) via `validators.EmitExtra`:
+
+```go
+// Emit failures are non-fatal — warn, but never flip the check's verdict on a
+// failed stdout write (checkNvidiaSMI wraps this as the emitExtraOrWarn helper):
+emit := func(extra map[string]string) {
+    if err := validators.EmitExtra(extra); err != nil {
+        slog.Warn("failed to emit validator extra", "error", err)
+    }
+}
+// Success path — coverage disclosure (counts only, never node names/IPs):
+emit(map[string]string{"nodesValidated": "1", "nodesTotal": "2"})
+// Skip path — reason enum code:
+emit(map[string]string{"skipReason": "no-gpu-nodes"})
+```
+
+**Transport.** `EmitExtra` marshals the map to one JSON line prefixed with
+`ctrf.ExtraLinePrefix` (`##AICR-EXTRA##` followed by one space) on stdout — the
+only channel that crosses the pod boundary besides the exit code and termination
+log. The orchestrator (`pkg/validator/job.ExtractResult`) parses each sentinel
+line, keeps the **last valid non-empty** payload as `TestResult.Extra`, and
+strips every sentinel line from the stored `stdout` (transport, not human
+evidence). A malformed line is non-fatal: it is logged and skipped without
+discarding an earlier valid payload — a garbled line never flips a pass to an
+error, nor clears a coverage line that preceded it. Keep the human `fmt.Printf`
+lines too; they still feed `--full` and live `aicr validate` output.
+
+**Low-cardinality + allowlist contract.** `extra` values MUST be counts or enum
+codes only (`"2"`, `"no-schedulable-gpu-nodes"`) — never node names, IPs, or hostnames.
+`pkg/evidence/redact`'s `ctrfExtraAllowlist` enforces this at the **publication
+boundary** (not just at emission, which raw prefixed stdout could bypass) with a
+fail-closed **key _and_ value** check: only the listed keys (`nodesValidated`,
+`nodesTotal`, `skipReason`) survive, and each surviving value must pass its key's
+validator — a non-negative decimal count for the `nodes*` keys, and for
+`skipReason` a **closed set** of known codes (`ctrfSkipReasons`, currently
+`no-gpu-nodes`, `no-schedulable-gpu-nodes`, `nodes-busy`). A closed set rather
+than a shape regex is deliberate: a kebab-case regex would still pass an
+arbitrary low-cardinality identifier like `customer-prod-cluster`. A value that
+is ill-shaped or unlisted (an IP under `nodesTotal`, a hostname or unminted code
+under `skipReason`) is dropped even though its key is allowed. Every other key is
+dropped too, and if nothing survives the map ships as absent (no empty
+`extra: {}`). Adding a new key (with its value validator) or a new `skipReason`
+code means adding it to that allowlist (and bumping `redact.PolicyVersion`) in
+the same change; there is no CTRF schema in `api/`, so the `pkg/validator/ctrf`
+godoc and this page are the contract.
 
 **Mounted data:** `/data/snapshot/snapshot.yaml`, `/data/validation/validation.yaml`
 (override via `AICR_SNAPSHOT_PATH`, `AICR_VALIDATION_PATH`).

--- a/docs/user/artifact-verification.md
+++ b/docs/user/artifact-verification.md
@@ -209,7 +209,12 @@ Bundles are **minimized by default**: the published `snapshot.yaml` keeps only
 an allowlisted set of fields and the CTRF reports omit per-test stdout/message,
 keeping sensitive operational detail (node names, provider instance IDs, the
 node label/taint set, OS tuning, raw container logs) out of the published
-artifact. The predicate records the applied policy in a `redaction` block, which
+artifact. A small allowlisted set of structured, low-cardinality per-test
+outcome fields (the CTRF `extra` object — coverage counts and skip-reason codes,
+never node names or IPs) is *preserved* so a signed bundle still shows e.g. a
+reduced-node pass; see [Structured evidence that survives
+redaction](../contributor/validator.md#structured-evidence-that-survives-redaction).
+The predicate records the applied policy in a `redaction` block, which
 `aicr evidence verify` surfaces. Minimal bundles self-verify exactly like full
 ones — the digests cover whatever bytes shipped. Pass `--full` to
 `aicr validate --emit-attestation` to publish the raw payloads instead.

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -721,9 +721,12 @@ After the command finishes:
 The bundle is **minimized by default**: `snapshot.yaml` keeps only an
 allowlisted set of fields (dropping node names, provider instance IDs, the
 node label/taint set, OS tuning, loaded modules, and systemd config) and the
-CTRF reports omit per-test stdout/message. The signed predicate records the
-applied policy in a `redaction` block, and the bundle self-verifies exactly
-like a full one. Pass `--full` to publish the raw payloads instead.
+CTRF reports omit per-test stdout/message — while *preserving* a small
+allowlisted set of structured, low-cardinality outcome fields (the CTRF `extra`
+object: coverage counts and skip-reason codes, never node names or IPs) so a
+signed bundle still distinguishes e.g. a reduced-node pass. The signed predicate
+records the applied policy in a `redaction` block, and the bundle self-verifies
+exactly like a full one. Pass `--full` to publish the raw payloads instead.
 
 Commit `pointer.yaml` to its per-source path
 `recipes/evidence/<recipe>/<src>/<digest>.yaml` — the emit output prints

--- a/pkg/evidence/attestation/emit_test.go
+++ b/pkg/evidence/attestation/emit_test.go
@@ -120,7 +120,7 @@ func TestEmit_MinimalByDefault_RedactsSnapshotAndRecordsPolicy(t *testing.T) {
 	if res.Bundle.Predicate.Redaction == nil {
 		t.Fatalf("minimal bundle must record a redaction policy")
 	}
-	if res.Bundle.Predicate.Redaction.Policy != "minimal" || res.Bundle.Predicate.Redaction.Version != "v1" {
+	if res.Bundle.Predicate.Redaction.Policy != "minimal" || res.Bundle.Predicate.Redaction.Version != "v2" {
 		t.Errorf("unexpected redaction provenance: %+v", res.Bundle.Predicate.Redaction)
 	}
 	if len(res.Bundle.Predicate.Redaction.Applied) == 0 {

--- a/pkg/evidence/redact/redact.go
+++ b/pkg/evidence/redact/redact.go
@@ -33,7 +33,19 @@
 //     service config are dropped.
 //   - CTRF: per-test Stdout and Message (free-form log text that can leak IPs,
 //     DNS names, secret/cert names, internal URLs) are omitted; the pass/fail
-//     signal (name, status, duration, suite, summary counts) is preserved.
+//     signal (name, status, duration, suite, summary counts) is preserved. The
+//     structured per-test Extra map is rebuilt against a fail-closed key AND
+//     value allowlist (ctrfExtraAllowlist): only enumerated low-cardinality
+//     keys survive, and each surviving value must additionally pass its key's
+//     validator (non-negative decimal count, or a closed set of known skip
+//     codes) — so an identifier smuggled under an allowed key (e.g. an IP in
+//     nodesTotal, a hostname or unminted code in skipReason) is dropped, not
+//     published. This is
+//     the publication boundary: emission-side validation alone is bypassable
+//     via raw prefixed stdout. A signed bundle can still distinguish a
+//     1-of-2-node pass from 2-of-2 and preserve a skip reason without shipping
+//     free-form log text. An Extra map that retains nothing is dropped rather
+//     than shipped as an empty object.
 //
 // Both functions are pure and non-mutating: they build fresh structures and
 // never alter their inputs, so the full (unredacted) artifacts remain
@@ -42,6 +54,9 @@
 package redact
 
 import (
+	"regexp"
+	"strconv"
+
 	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/measurement"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
@@ -54,7 +69,11 @@ const (
 
 	// PolicyVersion is the allowlist/scrub-rule version. Bump on any change
 	// to what survives redaction so verifiers can tell which rules ran.
-	PolicyVersion = "v1"
+	//
+	// v2 added the per-test CTRF Extra allowlist (ctrfExtraAllowlist):
+	// allowlisted structured keys whose values match the key's canonical shape
+	// (count / enum code) now survive minimal redaction.
+	PolicyVersion = "v2"
 )
 
 // headerMetadataAllowlist is the fail-closed set of snapshot header metadata
@@ -145,8 +164,59 @@ var snapshotAppliedRules = []string{
 	"snapshot.measurements.allowlist",
 }
 
+// ctrfExtraValidator reports whether v is a safe published value for its key.
+// It is the value half of the fail-closed contract: an allowlisted key alone is
+// not enough — the value must also match the key's canonical shape, so a value
+// that structurally looks like an identifier (IP, hostname, FQDN, free text)
+// never survives under an allowed key.
+type ctrfExtraValidator func(v string) bool
+
+// maxCountDigits bounds a published count value. Five digits (up to 99,999)
+// comfortably covers realistic node/GPU counts while keeping the attacker-
+// chosen numeric channel narrow — the premise is that only LOW-cardinality
+// counts cross the publication boundary, and EmitExtra itself does no value
+// validation, so this allowlist regex is the defense.
+const maxCountDigits = 5
+
+// ctrfCountValue matches a bare non-negative decimal count — no sign, dot, or
+// separator — so an IP or instance id smuggled into a count key (e.g.
+// "10.0.0.5") fails closed. The digit bound (maxCountDigits) caps the value.
+var ctrfCountValue = regexp.MustCompile(`^[0-9]{1,` + strconv.Itoa(maxCountDigits) + `}$`)
+
+func isCountValue(v string) bool { return ctrfCountValue.MatchString(v) }
+
+// ctrfSkipReasons is the CLOSED set of skipReason codes safe to publish. A
+// regex on kebab-case shape is not enough — it would still pass an arbitrary
+// low-cardinality identifier like "customer-prod-cluster". Only codes minted by
+// a check (see validators/deployment/nvidia_smi.go's skipReason* constants) are
+// listed; any other value, including a well-formed but unlisted code, is dropped
+// fail-closed. A new skip code must be added here in the same change that emits
+// it — same discipline as the key allowlist.
+var ctrfSkipReasons = map[string]struct{}{
+	"no-gpu-nodes":             {}, // cluster has no GPU nodes at all
+	"no-schedulable-gpu-nodes": {}, // GPU nodes exist but all cordoned/unschedulable
+	"nodes-busy":               {}, // schedulable GPU nodes exist but are busy with workloads
+}
+
+func isSkipReason(v string) bool { _, ok := ctrfSkipReasons[v]; return ok }
+
+// ctrfExtraAllowlist is the fail-closed set of TestResult.Extra keys safe to
+// publish in a minimal (default) evidence bundle, each paired with the
+// validator its value must pass. Every key carries only low-cardinality counts
+// or a closed-set enum code — never node names, IPs, or other operator-
+// identifying text — because unlike Stdout/Message these values are NOT stripped
+// by default. A key a future check adds is dropped until listed here; a value
+// that fails its validator is dropped even under an allowed key. Keep the map
+// keys mirrored in the ctrf godoc and docs/contributor/validator.md.
+var ctrfExtraAllowlist = map[string]ctrfExtraValidator{
+	"nodesValidated": isCountValue, // count of nodes a coverage check actually verified
+	"nodesTotal":     isCountValue, // count of candidate nodes (validated + skipped/cordoned)
+	"skipReason":     isSkipReason, // closed-set code for why a check skipped
+}
+
 // ctrfAppliedRules is the static, sorted description of the CTRF scrub.
 var ctrfAppliedRules = []string{
+	"ctrf.tests.extra.allowlist",
 	"ctrf.tests.omit:message",
 	"ctrf.tests.omit:stdout",
 }
@@ -240,8 +310,9 @@ func redactHeader(h header.Header) header.Header {
 }
 
 // CTRF returns a redacted deep copy of in with per-test Stdout and Message
-// omitted, and the sorted list of applied rule identifiers. It never mutates
-// in. Returns (nil, nil) when in is nil.
+// omitted and each per-test Extra map rebuilt against ctrfExtraAllowlist, plus
+// the sorted list of applied rule identifiers. It never mutates in. Returns
+// (nil, nil) when in is nil.
 func CTRF(in *ctrf.Report) (*ctrf.Report, []string) {
 	if in == nil {
 		return nil, nil
@@ -257,10 +328,34 @@ func CTRF(in *ctrf.Report) (*ctrf.Report, []string) {
 		for i, tr := range in.Results.Tests {
 			tr.Stdout = nil
 			tr.Message = ""
+			tr.Extra = allowlistExtra(tr.Extra)
 			tests[i] = tr
 		}
 		out.Results.Tests = tests
 	}
 
 	return &out, append([]string(nil), ctrfAppliedRules...)
+}
+
+// allowlistExtra returns a fresh map containing only the ctrfExtraAllowlist
+// entries of in whose value also passes the key's validator — every other key
+// (including any a future check adds) and every ill-shaped value (an identifier
+// smuggled under an allowed key) is dropped fail-closed. Returns nil when in is
+// empty or nothing survives, so no empty `extra: {}` ships. It never mutates in.
+func allowlistExtra(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	var out map[string]string
+	for k, v := range in {
+		validate, ok := ctrfExtraAllowlist[k]
+		if !ok || !validate(v) {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string, len(ctrfExtraAllowlist))
+		}
+		out[k] = v
+	}
+	return out
 }

--- a/pkg/evidence/redact/redact_test.go
+++ b/pkg/evidence/redact/redact_test.go
@@ -364,9 +364,13 @@ func sampleReport() *ctrf.Report {
 			Summary: ctrf.Summary{Tests: 2, Passed: 1, Failed: 1},
 			Tests: []ctrf.TestResult{
 				{Name: "t1", Status: ctrf.StatusPassed, Duration: 10, Suite: []string{"deploy"},
-					Stdout: []string{"connected to 10.0.0.5", "https://internal.example.com"}},
+					Stdout: []string{"connected to 10.0.0.5", "https://internal.example.com"},
+					// Mix of allowlisted counts and an unknown, node-identifying key.
+					Extra: map[string]string{"nodesValidated": "1", "nodesTotal": "2", "podName": "nvidia-smi-verify-ip-10-0-0-5"}},
 				{Name: "t2", Status: ctrf.StatusFailed, Duration: 20,
-					Message: "cert secret my-tls-secret not found", Stdout: []string{"line"}},
+					Message: "cert secret my-tls-secret not found", Stdout: []string{"line"},
+					// Only non-allowlisted keys → must drop to nil (no empty extra:{}).
+					Extra: map[string]string{"internalIP": "10.0.0.5"}},
 			},
 		},
 	}
@@ -404,11 +408,127 @@ func TestCTRFPreservesSignal(t *testing.T) {
 	}
 }
 
+func TestCTRFAllowlistsExtra(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string // nil means Extra must drop to nil (no empty map)
+	}{
+		{
+			name: "allowlisted counts survive, unknown key dropped",
+			in:   map[string]string{"nodesValidated": "1", "nodesTotal": "2", "podName": "nvidia-smi-verify-ip-10-0-0-5"},
+			want: map[string]string{"nodesValidated": "1", "nodesTotal": "2"},
+		},
+		{
+			name: "valid skip reason enum survives",
+			in:   map[string]string{"skipReason": "no-gpu-nodes"},
+			want: map[string]string{"skipReason": "no-gpu-nodes"},
+		},
+		{
+			name: "another listed skip code survives",
+			in:   map[string]string{"skipReason": "no-schedulable-gpu-nodes"},
+			want: map[string]string{"skipReason": "no-schedulable-gpu-nodes"},
+		},
+		{
+			name: "well-formed but unlisted skip code is dropped",
+			in:   map[string]string{"skipReason": "customer-prod-cluster"},
+			want: nil,
+		},
+		{
+			name: "only non-allowlisted keys drop to nil",
+			in:   map[string]string{"internalIP": "10.0.0.5"},
+			want: nil,
+		},
+		{
+			name: "IP smuggled under a count key is dropped",
+			in:   map[string]string{"nodesValidated": "1", "nodesTotal": "10.0.0.5"},
+			want: map[string]string{"nodesValidated": "1"},
+		},
+		{
+			name: "hostname smuggled under skipReason is dropped",
+			in:   map[string]string{"skipReason": "node-a.example"},
+			want: nil,
+		},
+		{
+			name: "negative and non-decimal counts are dropped",
+			in:   map[string]string{"nodesValidated": "-1", "nodesTotal": "1.5"},
+			want: nil,
+		},
+		{
+			name: "over-long count exceeding the digit bound is dropped",
+			in:   map[string]string{"nodesValidated": "2", "nodesTotal": "123456"},
+			want: map[string]string{"nodesValidated": "2"},
+		},
+		{
+			name: "uppercase / free-text enum code is dropped",
+			in:   map[string]string{"skipReason": "No GPU Nodes"},
+			want: nil,
+		},
+		{
+			name: "all allowed keys with invalid values drop to nil (no empty map)",
+			in:   map[string]string{"nodesTotal": "1.5", "skipReason": "10.0.0.5"},
+			want: nil,
+		},
+		{
+			name: "empty extra drops to nil",
+			in:   map[string]string{},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := redact.CTRF(reportWithExtra(tt.in))
+			got := out.Results.Tests[0].Extra
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("redacted Extra = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// reportWithExtra builds a minimal one-test CTRF report carrying extra, for
+// exercising the Extra allowlist in isolation.
+func reportWithExtra(extra map[string]string) *ctrf.Report {
+	return &ctrf.Report{
+		ReportFormat: ctrf.ReportFormatCTRF,
+		SpecVersion:  ctrf.SpecVersion,
+		GeneratedBy:  "aicr",
+		Results: ctrf.Results{
+			Tool:    ctrf.Tool{Name: "chainsaw", Version: "0.2.0"},
+			Summary: ctrf.Summary{Tests: 1, Passed: 1},
+			Tests: []ctrf.TestResult{
+				{Name: "t", Status: ctrf.StatusPassed, Suite: []string{"deploy"}, Extra: extra},
+			},
+		},
+	}
+}
+
+func TestCTRFAppliedRulesIncludeExtraAllowlist(t *testing.T) {
+	_, rules := redact.CTRF(sampleReport())
+	found := false
+	for _, r := range rules {
+		if r == "ctrf.tests.extra.allowlist" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("applied rules must include ctrf.tests.extra.allowlist, got %v", rules)
+	}
+}
+
 func TestCTRFDoesNotMutateInput(t *testing.T) {
 	in := sampleReport()
 	_, _ = redact.CTRF(in)
 	if in.Results.Tests[0].Stdout == nil || in.Results.Tests[1].Message == "" {
 		t.Errorf("CTRF must not mutate its input")
+	}
+	// The input Extra maps must be untouched (rebuilt fresh, not filtered in place).
+	if _, ok := in.Results.Tests[0].Extra["podName"]; !ok {
+		t.Errorf("CTRF must not mutate input Extra: podName was removed from t1")
+	}
+	if in.Results.Tests[1].Extra["internalIP"] != "10.0.0.5" {
+		t.Errorf("CTRF must not mutate input Extra: t2 internalIP altered")
 	}
 }
 

--- a/pkg/validator/ctrf/builder.go
+++ b/pkg/validator/ctrf/builder.go
@@ -37,6 +37,13 @@ type ValidatorResult struct {
 	// Stdout contains the standard output lines from the container.
 	Stdout []string
 
+	// Extra carries structured, low-cardinality outcome data parsed from the
+	// container's EmitExtra sentinel line (see ctrf.ExtraLinePrefix). It maps
+	// into TestResult.Extra and, unlike Stdout/TerminationMsg, survives the
+	// minimal redaction policy for allowlisted keys. Values are counts/enum
+	// codes only — never node names or IPs.
+	Extra map[string]string
+
 	// Duration is the wall-clock execution time.
 	Duration time.Duration
 
@@ -157,6 +164,16 @@ func (b *Builder) AddResult(r *ValidatorResult) {
 
 	if len(r.Stdout) > 0 {
 		tr.Stdout = r.Stdout
+	}
+
+	if len(r.Extra) > 0 {
+		// Defensive copy: r.Extra is caller-owned mutable state, so aliasing it
+		// would let a later mutation of ValidatorResult.Extra alter the built
+		// report after AddResult returns.
+		tr.Extra = make(map[string]string, len(r.Extra))
+		for key, value := range r.Extra {
+			tr.Extra[key] = value
+		}
 	}
 
 	b.tests = append(b.tests, tr)

--- a/pkg/validator/ctrf/ctrf_test.go
+++ b/pkg/validator/ctrf/ctrf_test.go
@@ -482,6 +482,77 @@ func TestIsFailingStatus(t *testing.T) {
 	}
 }
 
+func TestBuilderAddResultCopiesExtra(t *testing.T) {
+	b := NewBuilder("aicr", "1.0.0", testPhase)
+	// Caller-owned map that we mutate AFTER AddResult to prove the builder took
+	// a defensive copy rather than aliasing it.
+	src := map[string]string{"nodesValidated": "1", "nodesTotal": "2"}
+	b.AddResult(&ValidatorResult{
+		Name:     "check-nvidia-smi",
+		Phase:    testPhase,
+		ExitCode: 0,
+		Extra:    src,
+	})
+	// A result with no Extra must leave TestResult.Extra nil (omitempty).
+	b.AddResult(&ValidatorResult{
+		Name:     "no-extra",
+		Phase:    testPhase,
+		ExitCode: 0,
+	})
+
+	// Mutating the source after insertion must not reach into the built report.
+	src["nodesValidated"] = "999"
+	src["injected"] = "10.0.0.5"
+	delete(src, "nodesTotal")
+
+	report := b.Build()
+
+	got := report.Results.Tests[0].Extra
+	if got["nodesValidated"] != "1" || got["nodesTotal"] != "2" {
+		t.Errorf("Extra = %v, want {nodesValidated:1 nodesTotal:2} (defensive copy not taken?)", got)
+	}
+	if _, ok := got["injected"]; ok {
+		t.Errorf("post-insert key injection leaked into report: %v", got)
+	}
+	if report.Results.Tests[1].Extra != nil {
+		t.Errorf("Extra should be nil when ValidatorResult carries none, got %v", report.Results.Tests[1].Extra)
+	}
+}
+
+func TestTestResultExtraJSONRoundTrip(t *testing.T) {
+	b := NewBuilder("aicr", "1.0.0", testPhase)
+	b.AddResult(&ValidatorResult{
+		Name:     "check-nvidia-smi",
+		Phase:    testPhase,
+		ExitCode: 2,
+		Extra:    map[string]string{"skipReason": "no-gpu-nodes"},
+	})
+	b.AddResult(&ValidatorResult{Name: "plain", Phase: testPhase, ExitCode: 0})
+
+	data, err := json.Marshal(b.Build())
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var decoded Report
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if decoded.Results.Tests[0].Extra["skipReason"] != "no-gpu-nodes" {
+		t.Errorf("Extra survived round-trip incorrectly: %v", decoded.Results.Tests[0].Extra)
+	}
+
+	// extra must be omitted entirely when empty.
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	tests := raw["results"].(map[string]any)["tests"].([]any)
+	if _, exists := tests[1].(map[string]any)["extra"]; exists {
+		t.Error("extra should be omitted when empty")
+	}
+}
+
 func TestBuilderStdoutNotCapturedWhenEmpty(t *testing.T) {
 	b := NewBuilder("aicr", "1.0.0", testPhase)
 	b.AddResult(&ValidatorResult{

--- a/pkg/validator/ctrf/types.go
+++ b/pkg/validator/ctrf/types.go
@@ -37,6 +37,16 @@ const (
 
 	// StatusOther indicates an unexpected outcome (crash, OOM, timeout, etc.).
 	StatusOther = "other"
+
+	// ExtraLinePrefix marks a single stdout line as the transport for a check's
+	// structured TestResult.Extra map. An in-pod check emits one such line via
+	// EmitExtra; pkg/validator/job.ExtractResult parses the last one and strips
+	// all prefixed lines from the human-readable Stdout evidence.
+	//
+	// The prefix lives here (not in validators/ or pkg/validator/job) because it
+	// is the shared contract between the in-pod producer and the orchestrator
+	// consumer, and both packages import ctrf.
+	ExtraLinePrefix = "##AICR-EXTRA## "
 )
 
 // IsFailingStatus reports whether a check or phase status must block progress
@@ -141,6 +151,21 @@ type TestResult struct {
 
 	// Stdout contains standard output lines from test execution.
 	Stdout []string `json:"stdout,omitempty"`
+
+	// Extra carries structured, low-cardinality outcome data that survives the
+	// default "minimal" redaction policy (unlike Stdout and Message, which are
+	// free-form log text stripped by default). It mirrors the CTRF spec's
+	// `extra` object.
+	//
+	// CONTRACT: values MUST be low-cardinality counts or enum codes only —
+	// e.g. "1", "2", "no-schedulable-gpu-nodes", "no-gpu-nodes". NEVER node names, IPs,
+	// hostnames, or any operator-identifying free text; those belong in Stdout,
+	// which is redacted by default. The redact package enforces this at the
+	// publication boundary with a fail-closed key AND value allowlist: only
+	// listed keys survive, and only values matching the key's canonical shape
+	// (decimal count / kebab-case enum code) — so an identifier smuggled under
+	// an allowed key is dropped, not published (see pkg/evidence/redact).
+	Extra map[string]string `json:"extra,omitempty"`
 }
 
 // Environment describes the execution environment and build context.

--- a/pkg/validator/job/result.go
+++ b/pkg/validator/job/result.go
@@ -16,6 +16,7 @@ package job
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"log/slog"
@@ -101,13 +102,56 @@ func (d *Deployer) ExtractResult(ctx context.Context) *ctrf.ValidatorResult {
 		slog.Warn("failed to capture pod logs", "pod", jobPod.Name, "error", logErr)
 		// Not fatal — we still have exit code and termination message
 	} else if logs != "" {
-		result.Stdout = filterStdoutLines(
-			truncateLogLines(logs, defaults.ValidatorMaxStdoutLines),
-			defaults.ValidatorMaxStdoutLineLength,
-		)
+		result.Extra, result.Stdout = processValidatorLogs(logs)
 	}
 
 	return result
+}
+
+// processValidatorLogs turns raw pod logs into the structured Extra map and the
+// human-readable Stdout lines. Order matters and is the invariant both call
+// sites rely on: the Extra sentinel is parsed from the FULL logs BEFORE any
+// tail-truncation, so a sentinel emitted after more than ValidatorMaxStdoutLines
+// of output still survives; only then is the sentinel-stripped remainder
+// truncated and length-capped for human display.
+func processValidatorLogs(logs string) (extra map[string]string, stdout []string) {
+	cleaned, extra := parseExtraSentinels(logs)
+	stdout = filterStdoutLines(
+		truncateLogLines(cleaned, defaults.ValidatorMaxStdoutLines),
+		defaults.ValidatorMaxStdoutLineLength,
+	)
+	return extra, stdout
+}
+
+// parseExtraSentinels scans the raw pod logs for ctrf.ExtraLinePrefix sentinel
+// lines (the transport for a check's structured Extra map) and returns the logs
+// with every sentinel line removed plus the LAST VALID non-empty payload.
+//
+// Each sentinel is parsed as it is encountered: a malformed one is logged at
+// WARN and skipped WITHOUT discarding an earlier valid payload, so a valid
+// coverage/skip line followed by a garbled line still yields the valid map. A
+// merged/garbled line must never flip a passing check to an error — the exit
+// code, not this map, is the verdict. Returns (logs, nil) when no sentinel is
+// present, and extra is nil unless some line parsed to a non-empty object.
+func parseExtraSentinels(logs string) (cleaned string, extra map[string]string) {
+	if !strings.Contains(logs, ctrf.ExtraLinePrefix) {
+		return logs, nil
+	}
+	lines := strings.Split(logs, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if payload, ok := strings.CutPrefix(line, ctrf.ExtraLinePrefix); ok {
+			var parsed map[string]string
+			if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+				slog.Warn("failed to parse validator extra sentinel; dropping", "error", err)
+			} else if len(parsed) > 0 {
+				extra = parsed // keep the last VALID non-empty payload
+			}
+			continue // transport, not human evidence — strip it
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n"), extra
 }
 
 // HandleTimeout extracts whatever result is available when the orchestrator's
@@ -144,12 +188,11 @@ func (d *Deployer) HandleTimeout(ctx context.Context, waitCause error) *ctrf.Val
 		return result
 	}
 
-	// Try to get logs from "validator" container
+	// Try to get logs from "validator" container. Parse and strip the Extra
+	// sentinel here too: a check that emits coverage counts before hitting the
+	// timeout still yields structured evidence.
 	if logs, logErr := pod.GetPodLogs(ctx, d.config.Clientset, d.config.Namespace, jobPod.Name, ValidatorContainerName); logErr == nil && logs != "" {
-		result.Stdout = filterStdoutLines(
-			truncateLogLines(logs, defaults.ValidatorMaxStdoutLines),
-			defaults.ValidatorMaxStdoutLineLength,
-		)
+		result.Extra, result.Stdout = processValidatorLogs(logs)
 	}
 
 	if cs.State.Terminated != nil {

--- a/pkg/validator/job/result_test.go
+++ b/pkg/validator/job/result_test.go
@@ -17,6 +17,7 @@ package job
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -596,6 +597,111 @@ func TestHandleTimeoutSidecarOnlyNoValidator(t *testing.T) {
 	}
 	if !strings.Contains(result.TerminationMsg, "not found") {
 		t.Errorf("TerminationMsg = %q, want message containing 'not found'", result.TerminationMsg)
+	}
+}
+
+func TestParseExtraSentinels(t *testing.T) {
+	const p = ctrf.ExtraLinePrefix
+	tests := []struct {
+		name        string
+		logs        string
+		wantCleaned string
+		wantExtra   map[string]string
+	}{
+		{
+			name:        "no sentinel leaves logs intact and extra nil",
+			logs:        "Found 2 GPU node(s):\nAll OK",
+			wantCleaned: "Found 2 GPU node(s):\nAll OK",
+			wantExtra:   nil,
+		},
+		{
+			name:        "valid sentinel populates extra and is stripped",
+			logs:        "Found 2 GPU node(s):\n" + p + `{"nodesValidated":"1","nodesTotal":"2"}` + "\nSuccessfully verified",
+			wantCleaned: "Found 2 GPU node(s):\nSuccessfully verified",
+			wantExtra:   map[string]string{"nodesValidated": "1", "nodesTotal": "2"},
+		},
+		{
+			name:        "malformed sentinel drops extra but is still stripped",
+			logs:        "line before\n" + p + `{"nodesValidated":` + "\nline after",
+			wantCleaned: "line before\nline after",
+			wantExtra:   nil,
+		},
+		{
+			name:        "multiple sentinels: last wins",
+			logs:        p + `{"skipReason":"stale"}` + "\nwork\n" + p + `{"skipReason":"nodes-busy"}`,
+			wantCleaned: "work",
+			wantExtra:   map[string]string{"skipReason": "nodes-busy"},
+		},
+		{
+			name:        "valid then malformed: last valid payload is kept",
+			logs:        p + `{"nodesValidated":"1","nodesTotal":"2"}` + "\nwork\n" + p + `{"nodesValidated":`,
+			wantCleaned: "work",
+			wantExtra:   map[string]string{"nodesValidated": "1", "nodesTotal": "2"},
+		},
+		{
+			name:        "empty-object sentinel yields nil extra",
+			logs:        "work\n" + p + `{}`,
+			wantCleaned: "work",
+			wantExtra:   nil,
+		},
+		{
+			// Prefix mid-line (not line-initial) is human stdout, never parsed.
+			name:        "prefix mid-line is kept, not stripped",
+			logs:        "note: " + p + "appears mid-line\nreal",
+			wantCleaned: "note: " + p + "appears mid-line\nreal",
+			wantExtra:   nil,
+		},
+		{
+			// The prefix requires its trailing space: a line-initial "##AICR-EXTRA##"
+			// without the space is not a sentinel and stays in stdout.
+			name:        "prefix without trailing space is not a sentinel",
+			logs:        p + `{"skipReason":"nodes-busy"}` + "\n" + `##AICR-EXTRA##nospace`,
+			wantCleaned: `##AICR-EXTRA##nospace`,
+			wantExtra:   map[string]string{"skipReason": "nodes-busy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned, extra := parseExtraSentinels(tt.logs)
+			if cleaned != tt.wantCleaned {
+				t.Errorf("cleaned = %q, want %q", cleaned, tt.wantCleaned)
+			}
+			if len(extra) != len(tt.wantExtra) {
+				t.Fatalf("extra = %v, want %v", extra, tt.wantExtra)
+			}
+			for k, v := range tt.wantExtra {
+				if extra[k] != v {
+					t.Errorf("extra[%q] = %q, want %q", k, extra[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessValidatorLogs(t *testing.T) {
+	const p = ctrf.ExtraLinePrefix
+	// Emit the sentinel AFTER more than ValidatorMaxStdoutLines of output: the
+	// invariant is that Extra is parsed from the full logs before truncation, so
+	// a parse-after-truncate regression would silently drop this evidence.
+	var b strings.Builder
+	for i := 0; i < defaults.ValidatorMaxStdoutLines+100; i++ {
+		fmt.Fprintf(&b, "log line %d\n", i)
+	}
+	b.WriteString(p + `{"nodesValidated":"1","nodesTotal":"2"}`)
+
+	extra, stdout := processValidatorLogs(b.String())
+
+	if extra["nodesValidated"] != "1" || extra["nodesTotal"] != "2" {
+		t.Fatalf("late sentinel beyond truncation window was lost: extra=%v", extra)
+	}
+	if len(stdout) > defaults.ValidatorMaxStdoutLines {
+		t.Errorf("stdout not truncated: %d lines > max %d", len(stdout), defaults.ValidatorMaxStdoutLines)
+	}
+	for _, line := range stdout {
+		if strings.Contains(line, p) {
+			t.Errorf("sentinel transport line leaked into stdout: %q", line)
+		}
 	}
 }
 

--- a/validators/deployment/nvidia_smi.go
+++ b/validators/deployment/nvidia_smi.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
@@ -33,6 +34,17 @@ const (
 	nvidiaSMIPodTemplateFile = "testdata/nvidia-smi-verify-pod.yaml"
 	gpuCheckSuccessMsg       = "GPU_CHECK_SUCCESS"
 	nvidiaSMILogContextLines = 20
+
+	// skipReason* are the low-cardinality enum codes emitted via EmitExtra when
+	// the check skips. Unlike the human-readable RESULT/enumeration stdout lines
+	// (which the default redaction policy strips), these survive minimal
+	// redaction (see pkg/evidence/redact), so a signed bundle records WHY a check
+	// was skipped. Each must accurately describe the observed condition and be
+	// mirrored in redact.ctrfSkipReasons — a code missing from that closed set is
+	// dropped from the published bundle.
+	skipReasonNoGPUNodes            = "no-gpu-nodes"             // cluster has no GPU nodes at all
+	skipReasonNoSchedulableGPUNodes = "no-schedulable-gpu-nodes" // GPU nodes exist but all cordoned/unschedulable
+	skipReasonNodesBusy             = "nodes-busy"               // schedulable GPU nodes exist but are busy with workloads
 )
 
 // gpuNodeCoverage partitions check-nvidia-smi's discovered GPU nodes into the
@@ -126,18 +138,26 @@ func checkNvidiaSMI(ctx *validators.Context) error {
 
 	if len(allNodes) == 0 {
 		printLines(coverage.coverageLine(0))
+		emitExtraOrWarn(nvidiaSMISkipExtra(skipReasonNoGPUNodes))
 		return validators.Skip("no GPU nodes found in the cluster")
 	}
 
 	gpuNodes := coverage.schedulable
 	if len(gpuNodes) == 0 {
 		printLines(coverage.coverageLine(0))
+		// GPU nodes exist but all cordoned — a distinct, accurate code, never a
+		// false "no-gpu-nodes" in the signed evidence.
+		emitExtraOrWarn(nvidiaSMISkipExtra(skipReasonNoSchedulableGPUNodes))
 		return validators.Skip(fmt.Sprintf(
 			"all %d GPU node(s) are cordoned; nothing to verify", len(coverage.cordoned)))
 	}
 
 	// Check if any nodes are busy
+	// A probe error is treated as busy (fail-safe: don't run on a node we can't
+	// clear), but tracked separately from CONFIRMED occupancy so an all-errors
+	// skip is not signed as "nodes-busy".
 	var busyNodes []string
+	confirmedBusy := false
 	for _, node := range gpuNodes {
 		busy, busyErr := helper.IsNodeGpuBusy(ctx.Ctx, ctx.Clientset, node.Name)
 		if busyErr != nil {
@@ -147,11 +167,18 @@ func checkNvidiaSMI(ctx *validators.Context) error {
 		}
 		if busy {
 			busyNodes = append(busyNodes, node.Name)
+			confirmedBusy = true
 		}
 	}
 
 	if len(busyNodes) > 0 {
 		printLines(coverage.coverageLine(0))
+		// Only sign nodes-busy when at least one node was CONFIRMED occupied; a
+		// skip driven solely by probe errors must not masquerade as occupancy in
+		// the signed evidence (the error is already logged above).
+		if confirmedBusy {
+			emitExtraOrWarn(nvidiaSMISkipExtra(skipReasonNodesBusy))
+		}
 		return validators.Skip(fmt.Sprintf("GPU nodes busy with existing workloads: %v", busyNodes))
 	}
 
@@ -181,6 +208,11 @@ func checkNvidiaSMI(ctx *validators.Context) error {
 		validated++
 	}
 
+	// Emit the structured coverage disclosure (survives minimal redaction)
+	// alongside the human RESULT line, on BOTH the pass and fail paths, so a
+	// signed bundle records how many of the cluster's GPU nodes were verified.
+	emitExtraOrWarn(nvidiaSMICoverageExtra(validated, coverage.total))
+
 	if len(failedNodes) > 0 {
 		printLines(coverage.coverageLine(validated))
 		return errors.New(errors.ErrCodeInternal,
@@ -191,6 +223,31 @@ func checkNvidiaSMI(ctx *validators.Context) error {
 	printLines(coverage.coverageLine(validated))
 	fmt.Printf("Successfully verified GPU on all %d schedulable node(s)\n", len(gpuNodes))
 	return nil
+}
+
+// nvidiaSMICoverageExtra builds the structured coverage disclosure: how many GPU
+// nodes passed verification (validated) out of the total present incl. cordoned
+// (from the same node snapshot). Unlike the RESULT stdout line it survives
+// minimal redaction. Values are counts only — never node names or IPs.
+func nvidiaSMICoverageExtra(validated, total int) map[string]string {
+	return map[string]string{
+		"nodesValidated": strconv.Itoa(validated),
+		"nodesTotal":     strconv.Itoa(total),
+	}
+}
+
+// nvidiaSMISkipExtra builds the structured skip disclosure carrying only the
+// low-cardinality reason enum code.
+func nvidiaSMISkipExtra(reason string) map[string]string {
+	return map[string]string{"skipReason": reason}
+}
+
+// emitExtraOrWarn emits structured extra evidence, logging (never failing) on
+// error — a failed stdout write must not flip the check's verdict.
+func emitExtraOrWarn(extra map[string]string) {
+	if err := validators.EmitExtra(extra); err != nil {
+		slog.Warn("failed to emit validator extra", "error", err)
+	}
 }
 
 func verifySingleGPUNode(ctx *validators.Context, nodeName string) error {

--- a/validators/deployment/nvidia_smi_test.go
+++ b/validators/deployment/nvidia_smi_test.go
@@ -16,15 +16,74 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
 	"github.com/NVIDIA/aicr/validators"
 	"github.com/NVIDIA/aicr/validators/helper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+func TestNvidiaSMICoverageExtra(t *testing.T) {
+	tests := []struct {
+		name          string
+		validated     int
+		total         int
+		wantValidated string
+		wantTotal     string
+	}{
+		{"full coverage", 2, 2, "2", "2"},
+		{"reduced coverage one cordoned", 1, 2, "1", "2"},
+		{"single node", 1, 1, "1", "1"},
+		{"partial failure", 1, 2, "1", "2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extra := nvidiaSMICoverageExtra(tt.validated, tt.total)
+			if extra["nodesValidated"] != tt.wantValidated {
+				t.Errorf("nodesValidated = %q, want %q", extra["nodesValidated"], tt.wantValidated)
+			}
+			if got := extra["nodesTotal"]; got != tt.wantTotal {
+				t.Errorf("nodesTotal = %q, want %q", got, tt.wantTotal)
+			}
+			if len(extra) != 2 {
+				t.Errorf("coverage extra must carry exactly the two count keys, got %v", extra)
+			}
+			// The emitted transport line must be valid low-cardinality JSON that
+			// the orchestrator can parse back — mirror the EmitExtra contract.
+			data, err := json.Marshal(extra)
+			if err != nil {
+				t.Fatalf("coverage extra must marshal to JSON: %v", err)
+			}
+			payload, ok := strings.CutPrefix(ctrf.ExtraLinePrefix+string(data), ctrf.ExtraLinePrefix)
+			if !ok {
+				t.Fatalf("emitted line missing sentinel prefix")
+			}
+			var got map[string]string
+			if err := json.Unmarshal([]byte(payload), &got); err != nil {
+				t.Fatalf("emitted payload is not valid JSON: %v", err)
+			}
+		})
+	}
+}
+
+func TestNvidiaSMISkipExtra(t *testing.T) {
+	for _, reason := range []string{skipReasonNoGPUNodes, skipReasonNoSchedulableGPUNodes, skipReasonNodesBusy} {
+		t.Run(reason, func(t *testing.T) {
+			extra := nvidiaSMISkipExtra(reason)
+			if extra["skipReason"] != reason {
+				t.Errorf("skipReason = %q, want %q", extra["skipReason"], reason)
+			}
+			if len(extra) != 1 {
+				t.Errorf("skip extra must carry exactly skipReason, got %v", extra)
+			}
+		})
+	}
+}
 
 func TestVerifyNvidiaSMILogs(t *testing.T) {
 	t.Parallel()

--- a/validators/extras.go
+++ b/validators/extras.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
+)
+
+// extrasOut is the destination for EmitExtra's sentinel line. It is stdout in
+// production (the pod-boundary transport the orchestrator reads back); tests
+// redirect it to capture the emitted line.
+var extrasOut io.Writer = os.Stdout
+
+// EmitExtra marshals a check's structured, low-cardinality outcome data to a
+// single JSON line prefixed with ctrf.ExtraLinePrefix and writes it to stdout.
+// The orchestrator (pkg/validator/job.ExtractResult) parses this line back into
+// ctrf.TestResult.Extra, which — unlike the free-form Stdout/Message evidence —
+// survives the default "minimal" redaction policy for allowlisted keys.
+//
+// CONTRACT: values MUST be counts or enum codes only (e.g. "2", "no-gpu-nodes"),
+// never node names, IPs, or hostnames. Anything operator-identifying belongs in
+// fmt.Printf stdout, which is redacted by default. Emitting an empty map is a
+// no-op. Key order in the JSON is not significant — the line is re-parsed
+// structurally, and only redact-allowlisted keys are published.
+func EmitExtra(extra map[string]string) error {
+	if len(extra) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(extra)
+	if err != nil {
+		return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to marshal validator extra", err)
+	}
+	if _, err := fmt.Fprintln(extrasOut, ctrf.ExtraLinePrefix+string(data)); err != nil {
+		return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to write validator extra", err)
+	}
+	return nil
+}

--- a/validators/extras_test.go
+++ b/validators/extras_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"bytes"
+	"encoding/json"
+	stderrors "errors"
+	"io"
+	"strings"
+	"testing"
+
+	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/ctrf"
+)
+
+// errWriter always fails, to exercise EmitExtra's write-error branch.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestEmitExtra(t *testing.T) {
+	tests := []struct {
+		name       string
+		extra      map[string]string
+		wantLine   bool // whether a sentinel line is expected
+		wantParsed map[string]string
+	}{
+		{
+			name:       "coverage counts",
+			extra:      map[string]string{"nodesValidated": "1", "nodesTotal": "2"},
+			wantLine:   true,
+			wantParsed: map[string]string{"nodesValidated": "1", "nodesTotal": "2"},
+		},
+		{
+			name:       "skip reason",
+			extra:      map[string]string{"skipReason": "no-gpu-nodes"},
+			wantLine:   true,
+			wantParsed: map[string]string{"skipReason": "no-gpu-nodes"},
+		},
+		{
+			name:     "empty map is a no-op",
+			extra:    map[string]string{},
+			wantLine: false,
+		},
+		{
+			name:     "nil map is a no-op",
+			extra:    nil,
+			wantLine: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			orig := extrasOut
+			extrasOut = &buf
+			defer func() { extrasOut = orig }()
+
+			if err := EmitExtra(tt.extra); err != nil {
+				t.Fatalf("EmitExtra() error = %v", err)
+			}
+
+			out := buf.String()
+			if !tt.wantLine {
+				if out != "" {
+					t.Errorf("expected no output, got %q", out)
+				}
+				return
+			}
+
+			if !strings.HasPrefix(out, ctrf.ExtraLinePrefix) {
+				t.Fatalf("output %q missing prefix %q", out, ctrf.ExtraLinePrefix)
+			}
+			if !strings.HasSuffix(out, "\n") {
+				t.Errorf("output %q must end in newline (single line contract)", out)
+			}
+			payload := strings.TrimSuffix(strings.TrimPrefix(out, ctrf.ExtraLinePrefix), "\n")
+			var got map[string]string
+			if err := json.Unmarshal([]byte(payload), &got); err != nil {
+				t.Fatalf("payload %q is not valid JSON: %v", payload, err)
+			}
+			if len(got) != len(tt.wantParsed) {
+				t.Fatalf("parsed %v, want %v", got, tt.wantParsed)
+			}
+			for k, v := range tt.wantParsed {
+				if got[k] != v {
+					t.Errorf("parsed[%q] = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestEmitExtraWriteError covers the sink-write failure branch: a failed write
+// must surface a wrapped ErrCodeInternal (which emitExtraOrWarn callers then
+// swallow so a check's verdict is never flipped by a stdout write error).
+func TestEmitExtraWriteError(t *testing.T) {
+	orig := extrasOut
+	extrasOut = errWriter{}
+	defer func() { extrasOut = orig }()
+
+	err := EmitExtra(map[string]string{"nodesValidated": "1"})
+	if err == nil {
+		t.Fatal("EmitExtra() = nil, want error when the sink write fails")
+	}
+	if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInternal, "")) {
+		t.Errorf("EmitExtra() error = %v, want ErrCodeInternal", err)
+	}
+}


### PR DESCRIPTION
## Summary

Carry validator coverage disclosure (per-check node counts, skip-reason codes) in a structured CTRF `extra` field that survives the default "minimal" redaction policy, instead of overloading `Stdout`/`Message` (which are correctly stripped from signed evidence bundles by default).

## Motivation / Context

`#1936` added `nodesValidated: <schedulable>/<total>` (plus per-node cordoned-skip disclosure) to `check-nvidia-smi` stdout, so a pass on a reduced node set is visible rather than silent (`#1668`). But that disclosure only reaches `TestResult.Stdout`/`.Message`, which `pkg/evidence/redact`'s default "minimal" policy omits from a published, signed bundle. So in the default signed-bundle path a 1-of-2-node pass was indistinguishable from a 2-of-2 pass, and an all-cordoned skip lost its reason — for the very artifact a downstream consumer verifies by default.

Fixes: #1951
Related: #1936, #1668

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/redact`, `validators/`

## Implementation Notes

- **`ctrf.TestResult.Extra` (`map[string]string`)** mirrors the CTRF spec's `extra` object. `ctrf.ExtraLinePrefix` (`##AICR-EXTRA## `) is the shared transport contract between the in-pod producer and the orchestrator consumer; it lives in `pkg/validator/ctrf` because both sides import it.
- **Producer** — `validators.EmitExtra(map[string]string)` marshals a check's outcome data to one prefixed stdout line. **Consumer** — `pkg/validator/job.ExtractResult` parses the last such line into `TestResult.Extra` and strips all prefixed lines from human-readable `Stdout`.
- **Redaction** — `redact.CTRF` rebuilds `Extra` against a fail-closed allowlist (`ctrfExtraAllowlist`: `nodesValidated`, `nodesTotal`, `skipReason`). Unknown keys (including any a future check adds) are dropped; an empty result ships no `extra: {}`. `PolicyVersion` bumps `v1` → `v2`.
- **`checkNvidiaSMI`** now populates `Extra` with its coverage counts / skip code; `validators/helper.FindAllGpuNodes` computes the candidate-node total.
- **Contract** (enforced by godoc + the allowlist): `Extra` values must be low-cardinality counts or enum codes only — never node names, IPs, or hostnames. The default treatment of free-form `Stdout`/`Message` is unchanged (a stated non-goal of the issue).

## Testing

```bash
make qualify
```

- `golangci-lint` on all changed packages — **0 issues**
- `go test -race ./pkg/validator/... ./pkg/evidence/... ./validators/...` — **PASS**
- `make test-coverage` — **80.8%** (threshold 80%) PASS
- `make qualify` — PASS end-to-end (chainsaw e2e 23/0/0; grype: only pre-existing Low/Unknown transitive advisories, non-gating)

New exported funcs covered: `EmitExtra` 75.0%, `FindAllGpuNodes` 87.5%.

## Risk Assessment

- [x] **Low** — Additive, fail-closed, well-tested, easy to revert.

**Rollout notes:** Backwards compatible. `Extra` is `omitempty`; existing checks that don't emit it are unaffected. Redaction fails closed, so no new data leaks into signed bundles. `PolicyVersion` bump (`v2`) lets verifiers tell which rules ran.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
