### PR TITLE
fix(aiperf-bench): move runtime to NVIDIA distroless python

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -25,19 +25,21 @@ exclude:
   # scans a fresh checkout, so this path never exists there).
   - './.claude/worktrees/**'
 
-# CVE suppressions for the aiperf-bench base image (python:3.13-slim,
-# Debian trixie) are managed in `.openvex.json` and consumed by
-# scan-action via the `vex:` input in
+# CVE suppressions for the aiperf-bench image are managed in
+# `.openvex.json` and consumed by scan-action via the `vex:` input in
 # `.github/workflows/vuln-scan-images.yaml`. The OpenVEX document
 # carries the structured status + justification + per-CVE
 # reachability evidence and is self-sufficient for suppression.
+# The image builds on python:3.13-slim (Debian trixie) and ships on
+# nvcr.io/nvidia/distroless/python:3.13-v4.0.8, so suppressed findings
+# come from CPython, pillow, and Debian libraries in that runtime base.
 #
 # When scanning the aiperf-bench image locally, pass `--vex
 # .openvex.json` alongside `-c .grype.yaml`. Scans of the AICR Go
 # source tree (`make scan` → `grype dir:.`) don't need VEX since the
 # suppressed CVEs are all in Python / glibc / libcap2 / ncurses /
-# pillow and never surface against Go source.
-# Reviewed: 2026-06-01
+# pillow / libexpat1 and never surface against Go source.
+# Reviewed: 2026-08-03
 
 # Go-source suppressions (accepted risk, not "not affected").
 #

--- a/.openvex.json
+++ b/.openvex.json
@@ -3,9 +3,9 @@
   "@id": "https://github.com/NVIDIA/aicr/.openvex.json",
   "author": "NVIDIA AICR maintainers",
   "role": "document creator",
-  "timestamp": "2026-07-24T00:00:00Z",
-  "version": 9,
-  "tooling": "manual; aiperf-bench statements verified against aiperf v0.11.0 source (which pins pillow~=12.2.0) — the GHSA-whj4-6x5x-4v2j and GHSA-pwv6-vv43-88gr statements were dropped because their CVEs are fixed in pillow 12.2.0 and no longer present; aicr statement reachability verified by source inspection (CGO-free ko build, no libssl linkage); aicr-gate statements suppress CVEs in the embedded upstream kyverno/chainsaw binary (affected packages identified via vuln.go.dev), justified by chainsaw's ephemeral cluster-internal readiness-gate usage",
+  "timestamp": "2026-08-03T00:00:00Z",
+  "version": 10,
+  "tooling": "manual; aiperf-bench statements verified against aiperf v0.11.0 source (which pins pillow~=12.2.0); the aiperf-bench runtime base moved from python:3.13-slim to nvcr.io/nvidia/distroless/python:3.13-v4.0.8, adding 21 libexpat1 2.7.1-2 statements (4 High, 16 Medium, 1 Low) whose unreachability was verified by reading ELF DT_NEEDED across the built image (no binary links libexpat) and by confirming CPython's pyexpat statically bundles expat 2.8.1; aicr statement reachability verified by source inspection (CGO-free ko build, no libssl linkage); aicr-gate statements suppress CVEs in the embedded upstream kyverno/chainsaw binary (affected packages identified via vuln.go.dev), justified by chainsaw's ephemeral cluster-internal readiness-gate usage; v10 dropped 11 redundant aicr-gate statements (GO-2026-5005/5006/5013/5014/5015/5017/5018/5019/5020/5021/5023): the 2026-08-03 scan of ghcr.io/nvidia/aicr-gate reports each of those CVEs under its GHSA identifier instead of the go.dev one, and the GHSA-aliased statement for every one of them is retained here (e.g. GO-2026-5005 / CVE-2026-39833 is covered by GHSA-jppx-rxg9-jmrx), so no suppression coverage is lost — chainsaw is unchanged at v0.2.15 and the vulnerable golang.org/x/crypto/ssh code is still present in the embedded binary, so the retained GHSA statements must not be removed",
   "statements": [
     {
       "vulnerability": {
@@ -49,41 +49,7 @@
     },
     {
       "vulnerability": {
-        "name": "GO-2026-5005",
-        "description": "chainsaw (embedded kyverno binary): key constraints not enforced in golang.org/x/crypto/ssh/agent (CVE-2026-39833, GO-2026-5005)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
         "name": "GHSA-f5wc-c3c7-36mc",
-        "description": "chainsaw (embedded kyverno binary): agent constraints dropped when forwarding keys in golang.org/x/crypto/ssh/agent (CVE-2026-39832, GO-2026-5006)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
-        "name": "GO-2026-5006",
         "description": "chainsaw (embedded kyverno binary): agent constraints dropped when forwarding keys in golang.org/x/crypto/ssh/agent (CVE-2026-39832, GO-2026-5006)."
       },
       "products": [
@@ -117,41 +83,7 @@
     },
     {
       "vulnerability": {
-        "name": "GO-2026-5013",
-        "description": "chainsaw (embedded kyverno binary): byte arithmetic underflow and panic in golang.org/x/crypto/ssh (CVE-2026-46597, GO-2026-5013)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
         "name": "GHSA-vgwf-h737-ff37",
-        "description": "chainsaw (embedded kyverno binary): client can cause server deadlock on unexpected responses in golang.org/x/crypto/ssh (CVE-2026-39830, GO-2026-5017)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
-        "name": "GO-2026-5017",
         "description": "chainsaw (embedded kyverno binary): client can cause server deadlock on unexpected responses in golang.org/x/crypto/ssh (CVE-2026-39830, GO-2026-5017)."
       },
       "products": [
@@ -185,41 +117,7 @@
     },
     {
       "vulnerability": {
-        "name": "GO-2026-5018",
-        "description": "chainsaw (embedded kyverno binary): pathological RSA/DSA parameters may cause DoS in golang.org/x/crypto/ssh (CVE-2026-39829, GO-2026-5018)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
         "name": "GHSA-89gr-r52h-f8rx",
-        "description": "chainsaw (embedded kyverno binary): bypass of FIDO/U2F security key physical interaction in golang.org/x/crypto/ssh (CVE-2026-39831, GO-2026-5019)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
-        "name": "GO-2026-5019",
         "description": "chainsaw (embedded kyverno binary): bypass of FIDO/U2F security key physical interaction in golang.org/x/crypto/ssh (CVE-2026-39831, GO-2026-5019)."
       },
       "products": [
@@ -253,23 +151,6 @@
     },
     {
       "vulnerability": {
-        "name": "GO-2026-5020",
-        "description": "chainsaw (embedded kyverno binary): infinite loop on large channel writes in golang.org/x/crypto/ssh (CVE-2026-39834, GO-2026-5020)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
         "name": "GHSA-5cgq-3rg8-m6cv",
         "description": "chainsaw (embedded kyverno binary): auth bypass via unenforced @revoked status in golang.org/x/crypto/ssh/knownhosts (CVE-2026-42508, GO-2026-5021)."
       },
@@ -287,41 +168,7 @@
     },
     {
       "vulnerability": {
-        "name": "GO-2026-5021",
-        "description": "chainsaw (embedded kyverno binary): auth bypass via unenforced @revoked status in golang.org/x/crypto/ssh/knownhosts (CVE-2026-42508, GO-2026-5021)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
         "name": "GHSA-x527-x647-q7gg",
-        "description": "chainsaw (embedded kyverno binary): VerifiedPublicKeyCallback permissions skip enforcement in golang.org/x/crypto/ssh (CVE-2026-46595, GO-2026-5023)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) was built with an older Go toolchain and older golang.org/x/{crypto,net}; kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. chainsaw is a Kubernetes test runner and never establishes SSH client, server, or agent connections; the golang.org/x/crypto/ssh* code path is not reached during `chainsaw test`."
-    },
-    {
-      "vulnerability": {
-        "name": "GO-2026-5023",
         "description": "chainsaw (embedded kyverno binary): VerifiedPublicKeyCallback permissions skip enforcement in golang.org/x/crypto/ssh (CVE-2026-46595, GO-2026-5023)."
       },
       "products": [
@@ -882,41 +729,7 @@
     },
     {
       "vulnerability": {
-        "name": "GO-2026-5015",
-        "description": "chainsaw (embedded kyverno binary): server panic during CheckHostKey/Authenticate in golang.org/x/crypto/ssh (CVE-2026-39835, GO-2026-5015)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) bundles golang.org/x/crypto v0.49.0 (fixed in v0.52.0); kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. The affected code path is server-side golang.org/x/crypto/ssh handshake handling (CheckHostKey/Authenticate). chainsaw operates no SSH server and never invokes golang.org/x/crypto/ssh; the panic is reachable only by an SSH server processing a malicious client, which the gate's readiness-check workload does not present."
-    },
-    {
-      "vulnerability": {
         "name": "GHSA-45gg-vh54-h5m9",
-        "description": "chainsaw (embedded kyverno binary): bypass of certificate restrictions in golang.org/x/crypto/ssh (CVE-2026-39828, GO-2026-5014)."
-      },
-      "products": [
-        {
-          "@id": "pkg:oci/aicr-gate",
-          "identifiers": {
-            "purl": "pkg:oci/aicr-gate"
-          }
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (built with Go 1.26.5, golang.org/x/crypto v0.53.0, golang.org/x/net v0.56.0). chainsaw v0.2.15 (the latest release) bundles golang.org/x/crypto v0.49.0 (fixed in v0.52.0); kyverno has not yet shipped a rebuilt release. Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job: the bundler launches it to `chainsaw test` recipe-authored assertions, talking only to the trusted in-cluster Kubernetes API server. It exposes no network listener, accepts no untrusted ingress, and processes only operator-authored manifests and trusted API-server responses. The affected code path is golang.org/x/crypto/ssh certificate-restriction enforcement. chainsaw performs no SSH authentication and never invokes golang.org/x/crypto/ssh; with no SSH server or client in the gate's readiness-check workload, the restriction-bypass is not reachable."
-    },
-    {
-      "vulnerability": {
-        "name": "GO-2026-5014",
         "description": "chainsaw (embedded kyverno binary): bypass of certificate restrictions in golang.org/x/crypto/ssh (CVE-2026-39828, GO-2026-5014)."
       },
       "products": [
@@ -1211,6 +1024,489 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The aicr-gate image embeds the upstream, cosign-attested kyverno/chainsaw binary (/usr/local/bin/chainsaw, CHAINSAW_VERSION in .settings.yaml) alongside the AICR gate binary; see cmd/gate/Dockerfile. The vulnerable code is present ONLY in that embedded chainsaw binary -- the AICR gate binary is clean (this module pins google.golang.org/grpc v1.82.1, the fixed version). All three vulnerabilities are in gRPC SERVER-side components: the xDS RBAC authorization engine (internal/xds/rbac) and the HTTP/2 transport server stream-reset handling (internal/transport). chainsaw is a CLI Kubernetes test runner: it never instantiates a gRPC server (zero grpc.NewServer call sites in kyverno/chainsaw source; grpc is a transitive dependency of its Kubernetes client libraries) and never configures xDS-managed clients (no xDS bootstrap). Within AICR, chainsaw runs exclusively as an ephemeral, cluster-internal readiness-gate Job talking only to the trusted in-cluster Kubernetes API server; it exposes no network listener, so neither the RBAC fail-open, the RBAC parse panic, nor the Rapid Reset server DoS is reachable. Drop this statement when kyverno ships a chainsaw release built with grpc >= 1.82.1 and CHAINSAW_VERSION is bumped."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-59375",
+        "description": "libexpat before 2.7.2 allows attackers to trigger large dynamic memory allocations via a small document submitted for parsing (CVSS 3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H). Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Reaching the allocation amplification requires feeding a crafted XML document to expat's parser. The aiperf-bench runtime base moved to nvcr.io/nvidia/distroless/python:3.13-v4.0.8, which ships Debian libexpat1 2.7.1-2 (fixed upstream in 2.8.2-1~deb13u1). The package cannot be bumped from this repo: it comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io, so no base-image bump remediates it today. Two independent facts make the vulnerable build unreachable. (1) Nothing in the image links it: reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 (2.7.1-2) is never loaded. (2) The one XML path that does execute does not use it: CPython routes xml.parsers.expat through lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled at EXPAT_VERSION 2.8.1. So the 14 venv packages that import xml.* (PIL, matplotlib, pandas, fontTools, pyarrow, datasets, ...) exercise that bundled build, not the flagged 2.7.1-2 package. Whether 2.8.1 is itself patched varies by CVE and is stated per statement below. aiperf itself imports no XML module at all: scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits. AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP; no XML document from any source reaches a parser. The statically bundled expat is 2.8.1, above this CVE's 2.7.2 fix threshold, so even the reachable XML path is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45186",
+        "description": "libexpat before 2.8.1: the computational complexity of attribute name collision checks allows denial of service via moderately sized crafted XML input (CVSS 3.1 AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L). Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The trigger requires parsing crafted XML with colliding attribute names. The aiperf-bench runtime base moved to nvcr.io/nvidia/distroless/python:3.13-v4.0.8, which ships Debian libexpat1 2.7.1-2 (fixed upstream in 2.8.2-1~deb13u1). The package cannot be bumped from this repo: it comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io, so no base-image bump remediates it today. Two independent facts make the vulnerable build unreachable. (1) Nothing in the image links it: reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 (2.7.1-2) is never loaded. (2) The one XML path that does execute does not use it: CPython routes xml.parsers.expat through lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled at EXPAT_VERSION 2.8.1. So the 14 venv packages that import xml.* (PIL, matplotlib, pandas, fontTools, pyarrow, datasets, ...) exercise that bundled build, not the flagged 2.7.1-2 package. Whether 2.8.1 is itself patched varies by CVE and is stated per statement below. aiperf itself imports no XML module at all: scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits. AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP; no XML document from any source reaches a parser. The statically bundled expat is exactly 2.8.1, this CVE's fix threshold, so the reachable XML path is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41080",
+        "description": "libexpat before 2.8.0 uses insufficient entropy, allowing hash flooding via a crafted XML document (CVSS 3.1 AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L). Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Hash flooding requires the attacker to supply a crafted XML document to the parser. The aiperf-bench runtime base moved to nvcr.io/nvidia/distroless/python:3.13-v4.0.8, which ships Debian libexpat1 2.7.1-2 (fixed upstream in 2.8.2-1~deb13u1). The package cannot be bumped from this repo: it comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io, so no base-image bump remediates it today. Two independent facts make the vulnerable build unreachable. (1) Nothing in the image links it: reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 (2.7.1-2) is never loaded. (2) The one XML path that does execute does not use it: CPython routes xml.parsers.expat through lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled at EXPAT_VERSION 2.8.1. So the 14 venv packages that import xml.* (PIL, matplotlib, pandas, fontTools, pyarrow, datasets, ...) exercise that bundled build, not the flagged 2.7.1-2 package. Whether 2.8.1 is itself patched varies by CVE and is stated per statement below. aiperf itself imports no XML module at all: scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits. AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP; no XML document from any source reaches a parser. The statically bundled expat is 2.8.1, above this CVE's 2.8.0 fix threshold, so even the reachable XML path is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25210",
+        "description": "libexpat before 2.7.4: doContent does not correctly determine bufSize because the tag buffer reallocation lacks an integer overflow check (CVSS 3.1 AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L). Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Overflowing the tag buffer requires driving expat's doContent with crafted XML element content. The aiperf-bench runtime base moved to nvcr.io/nvidia/distroless/python:3.13-v4.0.8, which ships Debian libexpat1 2.7.1-2 (fixed upstream in 2.8.2-1~deb13u1). The package cannot be bumped from this repo: it comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io, so no base-image bump remediates it today. Two independent facts make the vulnerable build unreachable. (1) Nothing in the image links it: reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 (2.7.1-2) is never loaded. (2) The one XML path that does execute does not use it: CPython routes xml.parsers.expat through lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled at EXPAT_VERSION 2.8.1. So the 14 venv packages that import xml.* (PIL, matplotlib, pandas, fontTools, pyarrow, datasets, ...) exercise that bundled build, not the flagged 2.7.1-2 package. Whether 2.8.1 is itself patched varies by CVE and is stated per statement below. aiperf itself imports no XML module at all: scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits. AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP; no XML document from any source reaches a parser. The statically bundled expat is 2.8.1, above this CVE's 2.7.4 fix threshold, so even the reachable XML path is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-24515",
+        "description": "In libexpat before 2.7.4, XML_ExternalEntityParserCreate does not copy unknown encoding handler user data. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Independently, the statically bundled expat is EXPAT_VERSION 2.8.1, at or above this CVE's 2.7.4 fix threshold, so even the XML path that does execute is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32776",
+        "description": "libexpat before 2.7.5 allows a NULL pointer dereference with empty external parameter entity content. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Independently, the statically bundled expat is EXPAT_VERSION 2.8.1, at or above this CVE's 2.7.5 fix threshold, so even the XML path that does execute is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32777",
+        "description": "libexpat before 2.7.5 allows an infinite loop while parsing DTD content. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Independently, the statically bundled expat is EXPAT_VERSION 2.8.1, at or above this CVE's 2.7.5 fix threshold, so even the XML path that does execute is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32778",
+        "description": "libexpat before 2.7.5 allows a NULL pointer dereference in the function setContext on retry after an earlier ouf-of-memory condition. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Independently, the statically bundled expat is EXPAT_VERSION 2.8.1, at or above this CVE's 2.7.5 fix threshold, so even the XML path that does execute is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-50219",
+        "description": "libexpat before 2.8.2 lacks handler call depth tracking for calls to XML_GetBuffer, XML_Parse, XML_ParseBuffer, XML_ParserFree, or XML_ParserReset from within handlers in cases of a policy violation. Thus, a use-after-free can occur, Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56131",
+        "description": "libexpat before 2.8.2 lacks handler call depth tracking for calls to XML_ResumeParser from within handlers in cases of a policy violation. Thus, a use-after-free can occur (similar to the CVE-2026-50219 situation). Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56132",
+        "description": "In libexpat before 2.8.2, there is a heap-based buffer overflow in doProlog in xmlparse.c because scaffold backing array reallocation is mishandled when there is data-structure sharing across parsers. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56403",
+        "description": "libexpat before 2.8.2 has an integer overflow in storeAtts. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56404",
+        "description": "libexpat before 2.8.2 has an integer overflow in addBinding. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56405",
+        "description": "libexpat before 2.8.2 has an integer overflow in getAttributeId. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56406",
+        "description": "libexpat before 2.8.2 has an integer overflow in XML_ParseBuffer because it lacked a check that was present in XML_Parse. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56407",
+        "description": "libexpat before 2.8.2 has an integer overflow in doProlog that is related to storeEntityValue and entity textLen. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56408",
+        "description": "libexpat before 2.8.2 has an integer overflow in copyString. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56409",
+        "description": "xmlwf in libexpat before 2.8.2 has an integer overflow for the output filename when -d outputDir is used. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56410",
+        "description": "xmlwf in libexpat before 2.8.2 has an integer overflow in resolveSystemId. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56411",
+        "description": "xmlwf in libexpat before 2.8.2 has an integer overflow in endDoctypeDecl via NOTATION declarations. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56412",
+        "description": "libexpat before 2.8.2 does not consider XML_TOK_DATA_CHARS in doCdataSection and thus lacks handler call depth tracking for various calls from within handlers in cases of a policy violation. Thus, a use-after-free can occur. NOTE: this issue exists because of an incomplete fix for CVE-2026-50219. Present via Debian libexpat1 2.7.1-2 in the distroless runtime base; fixed in 2.8.2-1~deb13u1. CVSS: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L."
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/aicr-aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aicr-aiperf-bench"
+          }
+        },
+        {
+          "@id": "pkg:oci/aiperf-bench",
+          "identifiers": {
+            "purl": "pkg:oci/aiperf-bench"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flagged package is Debian libexpat1 2.7.1-2, shipped by the nvcr.io/nvidia/distroless/python:3.13-v4.0.8 runtime base and fixed upstream in 2.8.2-1~deb13u1. It cannot be bumped from this repo: the package comes from NVIDIA's published distroless image and 3.13-v4.0.8 is the newest 3.13 tag on nvcr.io. The vulnerable build is never executed because nothing in the image links it -- reading ELF DT_NEEDED entries for every binary under /usr/local/lib, /usr/lib, /lib, /opt/venv/lib, /usr/local/bin, and /usr/bin returns zero references to libexpat, so /usr/lib/x86_64-linux-gnu/libexpat.so.1 is dead weight on disk. CPython does not use it either: xml.parsers.expat resolves to lib-dynload/pyexpat.cpython-313-x86_64-linux-gnu.so, whose DT_NEEDED is ['libc.so.6'] only because expat is statically bundled. aiperf itself imports no XML module -- scanning its 682 .py files for '^(import|from) (xml|pyexpat|xmlrpc)' returns zero hits -- and AICR invokes the image only as `aiperf profile <text-LLM> --url <endpoint>` (buildAIPerfJob in validators/performance/inference_perf_constraint.go), exchanging JSON over HTTP. No XML document from any source reaches a parser. Note: CPython's statically bundled expat is 2.8.1 and this CVE is fixed in 2.8.2, so the bundled copy is not itself patched. That copy is invisible to package scanners and is not what this finding reports; the finding is scoped to the unused Debian libexpat1 package above. The bundled parser is unreachable for the separate reason that neither aiperf nor the benchmark workload parses XML from any source."
     }
   ]
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -182,7 +182,7 @@ Published to GitHub Container Registry (`ghcr.io/nvidia/aicr-validators/`):
 | `deployment` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Deployment validator |
 | `performance` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Performance validator |
 | `conformance` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Conformance validator |
-| `aiperf-bench` | `python:3.12-slim` | AIPerf benchmark runner |
+| `aiperf-bench` | `nvcr.io/nvidia/distroless/python:3.13-v4.0.8` | AIPerf benchmark runner (built from `python:3.13-slim`) |
 
 Stable releases promote `vX.Y.Z` and `latest`; prereleases promote their
 `vX.Y.Z-rcN` version tags but never `latest`. The release workflow also retains

--- a/validators/performance/aiperf-bench.Dockerfile
+++ b/validators/performance/aiperf-bench.Dockerfile
@@ -29,6 +29,18 @@
 # crick) and, on Python versions without cp3XX wheels yet, no wheel for
 # pyzmq/uvloop either. Compiling those in the builder means the arm64 image
 # never regresses regardless of aiperf's dependency set.
+#
+# The runtime stage is NVIDIA's distroless Python image. It ships no shell,
+# no package manager, and no login tooling, so it cannot host `RUN` steps —
+# that is exactly why the builder stays on python:3.13-slim. Two consequences
+# follow and are handled below:
+#   1. `useradd` is unavailable; the base already defines a non-root `nvs`
+#      user (uid 1000), which we adopt instead of minting our own.
+#   2. `/bin/sh` is absent, so the benchmark Job cannot frame its result JSON
+#      with `sh -c 'aiperf ...; echo; cat; echo'`. aiperf_entrypoint.py
+#      reproduces that framing with the standard library; buildAIPerfJob in
+#      validators/performance/inference_perf_constraint.go invokes it with
+#      exec-form argv.
 
 # Single global default so the builder install and the final-stage
 # io.aicr.aiperf.version label always move together on a bump; each stage
@@ -60,30 +72,54 @@ ENV PATH="/opt/venv/bin:${PATH}"
 RUN pip install --no-cache-dir --upgrade pip \
  && pip install --no-cache-dir "aiperf==${AIPERF_VERSION}"
 
-# ---- Final stage: runtime only, no toolchain ----
-FROM python:3.13-slim
+# Syntax-gate the framing wrapper here, where a shell and a compiler still
+# exist. The runtime stage has neither, and the repo runs no Python test
+# tooling, so without this a syntax regression would produce a perfectly valid
+# image and only surface when a benchmark Job execs the script — the most
+# expensive possible discovery point. py_compile is byte-compilation only; the
+# exit-code and framing contract is asserted by TestAIPerfEntrypointExitContract
+# and TestAIPerfEntrypointFramingFeedsParser in aiperf_entrypoint_test.go.
+COPY validators/performance/aiperf_entrypoint.py /opt/aicr/aiperf_entrypoint.py
+RUN python -m py_compile /opt/aicr/aiperf_entrypoint.py
+
+# ---- Final stage: runtime only, no toolchain, no shell ----
+# renovate: pinned by digest. The tag is retained for readability; the digest
+# is what actually resolves, so a retag upstream cannot silently change the
+# runtime. Bump both together.
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.8@sha256:89574a7b9524b7166ff3e0c547ad87a203437b3afe71dfb9878e279196254b76
 
 ARG AIPERF_VERSION
 
 # Copy the fully-installed venv from the builder; nothing is compiled here.
-# The venv's interpreter symlinks resolve against this stage's identical base
-# image, and PATH makes `aiperf` (and python) resolve to the venv.
+# Both stages put CPython 3.13 at /usr/local/bin, so the venv's interpreter
+# symlinks still resolve and its compiled extensions (pyzmq, uvloop, crick)
+# load unchanged. PATH makes `aiperf` (and python) resolve to the venv.
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
+# Sentinel-framing entrypoint used by the benchmark Job. Baked in rather than
+# generated at runtime so the image is self-contained and air-gap friendly.
+# Taken from the builder so the copy that ships is the one py_compile accepted.
+# This destination and the venv path above are mirrored by the Go constants
+# aiperfEntrypointScript and aiperfEntrypointPython;
+# TestAIPerfEntrypointPathsMatchDockerfile reads this file and fails on drift.
+COPY --from=builder /opt/aicr/aiperf_entrypoint.py /opt/aicr/aiperf_entrypoint.py
+
 # Drop privileges: the runtime benchmark pod only needs to exec
 # `aiperf profile ...` against an HTTP endpoint, no filesystem writes outside
-# /tmp, and no privileged ops — running as a dedicated non-root user hardens
-# the image for air-gap / multi-tenant deployments.
-RUN useradd --create-home --shell /usr/sbin/nologin --uid 10001 aiperf
-USER aiperf
-WORKDIR /home/aiperf
+# /tmp, and no privileged ops. The distroless base has no `useradd`, but it
+# already defines a non-root `nvs` user (uid 1000) with /home/nvs, so we adopt
+# that instead of minting a dedicated one.
+USER nvs
+WORKDIR /home/nvs
 
 # Runtime metadata so `docker inspect` surfaces what's baked in.
 LABEL org.opencontainers.image.description="AIPerf benchmark runner for AICR inference-perf validator"
 LABEL io.aicr.aiperf.version="${AIPERF_VERSION}"
 
 # Default entrypoint for direct use (e.g., `docker run <image> profile <model> --url ...`).
-# Kubernetes callers override Command to wrap invocation in a shell for the
-# sentinel-delimited log framing used by parseAIPerfOutput.
+# The base image sets its own ENTRYPOINT (/usr/bin/shelless_ulimit); override it
+# so direct `docker run` keeps behaving as before. Kubernetes callers override
+# Command to run aiperf_entrypoint.py for the sentinel-delimited log framing
+# used by parseAIPerfOutput — see buildAIPerfJob.
 ENTRYPOINT ["aiperf"]

--- a/validators/performance/aiperf_entrypoint.py
+++ b/validators/performance/aiperf_entrypoint.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sentinel-framing entrypoint for the AIPerf benchmark pod.
+
+The runtime image is distroless (no shell), so the benchmark Job cannot use
+`/bin/sh -c` to chain `aiperf` with the `echo`/`cat` calls that frame the
+result JSON. This wrapper reproduces that framing with the standard library
+only:
+
+    aiperf profile <argv[1:]>
+    <sentinel>
+    <contents of <artifact-dir>/profile_export_aiperf.json>
+    <sentinel>
+
+Contract notes:
+
+* This wrapper owns framing only. Every benchmark flag -- including --model --
+  is built by buildAIPerfJob in inference_perf_constraint.go and arrives as
+  argv, so the Go tests remain the single place that asserts flag correctness.
+* aiperf inherits this process's stdout/stderr, so progress and warnings
+  stream to the pod log unbuffered and in real time. Diagnostic output is
+  deliberately NOT captured or silenced -- swallowing it makes benchmark
+  failures undiagnosable.
+* Exit statuses match what the replaced `/bin/sh -c` script produced, so
+  existing runbooks and log triage keep working: a non-zero aiperf exit
+  propagates verbatim, death-by-signal N becomes 128+N (an OOMKilled run still
+  reports 137, not 247), and a missing or non-executable aiperf gives 127.
+* argv is handed to execvp directly. With no shell in the runtime image there
+  is nothing to re-scan a value, so a model name containing shell
+  metacharacters is inert without any quoting.
+* A missing result file after a successful run is a hard error rather than an
+  empty sentinel block, so parseAIPerfOutput reports the real cause instead of
+  a downstream JSON parse failure.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+
+AIPERF_BIN = "aiperf"
+RESULT_FILENAME = "profile_export_aiperf.json"
+_SIGNAL_NUMBERS = {s.value for s in signal.Signals}
+
+
+def _require_env(name: str) -> str:
+    """Return a required environment variable or fail closed."""
+    value = os.environ.get(name, "")
+    if not value:
+        print(f"aiperf-entrypoint: {name} is unset or empty", file=sys.stderr)
+        raise SystemExit(2)
+    return value
+
+
+def _report_failure(returncode: int) -> int:
+    """Log a failed aiperf run and return the status this process should exit with.
+
+    subprocess reports death-by-signal as a negative return code (-N). Returning
+    that verbatim would be truncated to eight bits by the interpreter -- SIGKILL
+    would surface as 247 rather than the conventional 137 -- so map it to 128+N
+    the way a shell does. This matters in practice: the benchmark is a load
+    generator, and an OOMKilled run must keep reporting 137 for pod-level triage
+    to classify it correctly.
+    """
+    if returncode < 0:
+        signum = -returncode
+        status = 128 + signum
+        name = signal.Signals(signum).name if signum in _SIGNAL_NUMBERS else "unknown"
+        print(
+            f"aiperf-entrypoint: {AIPERF_BIN} killed by signal {signum} ({name})",
+            file=sys.stderr,
+        )
+        return status
+    print(f"aiperf-entrypoint: {AIPERF_BIN} exited {returncode}", file=sys.stderr)
+    return returncode
+
+
+def main() -> int:
+    artifact_dir = _require_env("AICR_AIPERF_ARTIFACT_DIR")
+    sentinel = _require_env("AICR_RESULT_SENTINEL")
+
+    cmd = [AIPERF_BIN, "profile", *sys.argv[1:]]
+
+    # No shell: argv is passed straight to execvp, so no element is re-parsed.
+    # stdout/stderr are inherited so benchmark progress reaches the pod log.
+    try:
+        completed = subprocess.run(cmd, check=False)
+    except OSError as err:
+        # A missing or non-executable aiperf would otherwise surface as a raw
+        # Python traceback. Exit 127 matches what the `/bin/sh -c` predecessor
+        # returned for "command not found", so operator runbooks and any log
+        # triage keyed on that code keep working.
+        print(
+            f"aiperf-entrypoint: cannot execute {AIPERF_BIN}: {err}",
+            file=sys.stderr,
+        )
+        return 127
+    if completed.returncode != 0:
+        return _report_failure(completed.returncode)
+
+    result_path = os.path.join(artifact_dir, RESULT_FILENAME)
+    try:
+        with open(result_path, "r", encoding="utf-8") as handle:
+            payload = handle.read()
+    except OSError as err:
+        print(
+            f"aiperf-entrypoint: cannot read result file {result_path}: {err}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Flush inherited aiperf output before framing so the sentinels cannot
+    # interleave with trailing benchmark chatter.
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    out = sys.stdout
+    out.write(sentinel + "\n")
+    out.write(payload)
+    # Guarantee the closing sentinel starts on its own line even when the
+    # exported JSON has no trailing newline.
+    if not payload.endswith("\n"):
+        out.write("\n")
+    out.write(sentinel + "\n")
+    out.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validators/performance/aiperf_entrypoint_test.go
+++ b/validators/performance/aiperf_entrypoint_test.go
@@ -1,0 +1,416 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The benchmark pod's runtime contract lives in aiperf_entrypoint.py, outside
+// the Go build: the exit-code mapping, the sentinel framing, and the fail-closed
+// env checks are all Python. Nothing else in the repo runs Python, so without
+// these tests a regression there compiles, lints, builds a valid image, and only
+// surfaces when a live multi-GPU inference-perf run execs the script. These
+// tests execute the real file the Dockerfile bakes in, with a stub `aiperf`, and
+// feed its actual stdout to parseAIPerfOutput so the emitter and the parser
+// cannot drift apart silently.
+
+const (
+	// aiperfEntrypointSource is the wrapper's repo path, relative to this
+	// package. aiperf-bench.Dockerfile COPYs this exact path to
+	// aiperfEntrypointScript inside the image.
+	aiperfEntrypointSource = "aiperf_entrypoint.py"
+
+	aiperfBenchDockerfile = "aiperf-bench.Dockerfile"
+
+	// aiperfResultFilename is the export aiperf writes into its artifact dir
+	// and the wrapper frames; it is duplicated from RESULT_FILENAME in
+	// aiperf_entrypoint.py, which is the point — a rename on either side must
+	// break a test rather than a benchmark run.
+	aiperfResultFilename = "profile_export_aiperf.json"
+
+	wrapperRunTimeout = 60 * time.Second
+)
+
+// stubAIPerfProgram stands in for the real benchmark. It records the argv it was
+// handed — proving the wrapper prepends `profile` and forwards every flag
+// verbatim — then acts out one outcome selected by AICR_STUB_MODE.
+const stubAIPerfProgram = `import json, os, signal, sys
+
+with open(os.environ["AICR_STUB_ARGV_LOG"], "w", encoding="utf-8") as fh:
+    json.dump(sys.argv[1:], fh)
+
+print("stub-aiperf: progress chatter")
+
+mode = os.environ["AICR_STUB_MODE"]
+if mode == "signal":
+    os.kill(os.getpid(), signal.SIGKILL)
+if mode == "fail":
+    sys.exit(7)
+if mode == "ok":
+    path = os.path.join(os.environ["AICR_AIPERF_ARTIFACT_DIR"], "profile_export_aiperf.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        # No trailing newline: this is how aiperf writes the export.
+        fh.write(os.environ["AICR_STUB_RESULT"])
+sys.exit(0)
+`
+
+const stubResultJSON = `{
+	"output_token_throughput": {"unit": "tokens/sec", "avg": 5667.5},
+	"time_to_first_token": {"unit": "ms", "avg": 45.2, "p99": 84.1, "min": 20.0, "max": 95.3}
+}`
+
+// requirePython3 resolves the interpreter that runs the wrapper. CI must have it
+// — a silent skip there would mean the Python contract stopped being exercised
+// while the suite still reported green — but a dev box without python3 skips
+// rather than fails, matching requireHelm in pkg/bundler/deployer/argocdhelm.
+func requirePython3(t *testing.T) string {
+	t.Helper()
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		if os.Getenv("CI") != "" {
+			t.Fatal("python3 is required in CI but is not on PATH; the aiperf_entrypoint.py contract tests cannot run")
+		}
+		t.Skip("python3 not available; skipping aiperf_entrypoint.py contract tests")
+	}
+	return python
+}
+
+// stubAIPerfDir writes an executable `aiperf` shim into a temp dir and returns
+// the dir, ready to become the child's entire PATH.
+func stubAIPerfDir(t *testing.T, python string) string {
+	t.Helper()
+	dir := t.TempDir()
+	program := "#!" + python + "\n" + stubAIPerfProgram
+	if err := os.WriteFile(filepath.Join(dir, "aiperf"), []byte(program), 0o755); err != nil {
+		t.Fatalf("write stub aiperf: %v", err)
+	}
+	return dir
+}
+
+// wrapperResult captures everything the benchmark Job observes from a wrapper
+// run: the pod's exit status, the log stream parseAIPerfOutput consumes, and
+// the argv the stub actually received.
+type wrapperResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+}
+
+// runWrapper executes aiperf_entrypoint.py exactly as the Job does — the
+// interpreter, then the script path, then benchmark flags as discrete argv
+// elements — with a fully explicit environment so an ambient AICR_* value on the
+// developer's shell cannot change the outcome.
+func runWrapper(t *testing.T, python string, env map[string]string, args ...string) wrapperResult {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), wrapperRunTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, python, append([]string{aiperfEntrypointSource}, args...)...)
+	cmd.Env = make([]string, 0, len(env))
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	res := wrapperResult{}
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("run %s: %v (stderr: %s)", aiperfEntrypointSource, err, stderr.String())
+		}
+		res.exitCode = exitErr.ExitCode()
+	}
+	res.stdout = stdout.String()
+	res.stderr = stderr.String()
+	return res
+}
+
+// TestAIPerfEntrypointExitContract locks the exit statuses the wrapper inherited
+// from the `/bin/sh -c` script it replaced. These are not cosmetic: pod-level
+// triage classifies an OOMKilled load generator by exit 137, and a run that
+// produced no result file must fail loudly rather than emit an empty sentinel
+// block for parseAIPerfOutput to choke on later.
+func TestAIPerfEntrypointExitContract(t *testing.T) {
+	python := requirePython3(t)
+	stubDir := stubAIPerfDir(t, python)
+
+	tests := []struct {
+		name             string
+		mode             string
+		emptyPath        bool
+		dropEnv          string
+		wantExit         int
+		wantStderrSubstr string
+	}{
+		{
+			name:             "aiperf non-zero exit propagates verbatim",
+			mode:             "fail",
+			wantExit:         7,
+			wantStderrSubstr: "exited 7",
+		},
+		{
+			// subprocess reports death-by-signal as -9; returning that verbatim
+			// would truncate to 247 and misclassify an OOMKill.
+			name:             "death by SIGKILL maps to 128+N",
+			mode:             "signal",
+			wantExit:         137,
+			wantStderrSubstr: "killed by signal 9 (SIGKILL)",
+		},
+		{
+			name:             "missing aiperf binary gives 127",
+			mode:             "ok",
+			emptyPath:        true,
+			wantExit:         127,
+			wantStderrSubstr: "cannot execute aiperf",
+		},
+		{
+			name:             "successful run with no result file is a hard error",
+			mode:             "noresult",
+			wantExit:         1,
+			wantStderrSubstr: "cannot read result file",
+		},
+		{
+			name:             "unset artifact dir fails closed before exec",
+			mode:             "ok",
+			dropEnv:          envAIPerfArtifactDir,
+			wantExit:         2,
+			wantStderrSubstr: envAIPerfArtifactDir + " is unset or empty",
+		},
+		{
+			name:             "unset sentinel fails closed before exec",
+			mode:             "ok",
+			dropEnv:          envAIPerfResultMarker,
+			wantExit:         2,
+			wantStderrSubstr: envAIPerfResultMarker + " is unset or empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artifactDir := t.TempDir()
+			pathDir := stubDir
+			if tt.emptyPath {
+				pathDir = t.TempDir()
+			}
+			env := map[string]string{
+				"PATH":                pathDir,
+				"AICR_STUB_MODE":      tt.mode,
+				"AICR_STUB_RESULT":    stubResultJSON,
+				"AICR_STUB_ARGV_LOG":  filepath.Join(t.TempDir(), "argv.json"),
+				envAIPerfArtifactDir:  artifactDir,
+				envAIPerfResultMarker: aiperfResultSentinel,
+				envAIPerfModel:        "Qwen/Qwen3-32B",
+			}
+			delete(env, tt.dropEnv)
+
+			got := runWrapper(t, python, env, "--model", "Qwen/Qwen3-32B")
+
+			if got.exitCode != tt.wantExit {
+				t.Errorf("exit code = %d, want %d (stderr: %s)", got.exitCode, tt.wantExit, got.stderr)
+			}
+			if !strings.Contains(got.stderr, tt.wantStderrSubstr) {
+				t.Errorf("stderr missing %q; got:\n%s", tt.wantStderrSubstr, got.stderr)
+			}
+			// A failed run must not frame a result: parseAIPerfOutput keys off
+			// the sentinel, and an emitted-but-empty block would turn a clear
+			// benchmark failure into an opaque JSON parse error.
+			if strings.Contains(got.stdout, aiperfResultSentinel) {
+				t.Errorf("failed run emitted the result sentinel; stdout:\n%s", got.stdout)
+			}
+		})
+	}
+}
+
+// TestAIPerfEntrypointFramingFeedsParser closes the one seam between the Python
+// emitter and the Go parser by running the wrapper for real and handing its
+// actual stdout to parseAIPerfOutput. A hand-written approximation of the
+// framing would keep passing after the wrapper's output shape changed.
+func TestAIPerfEntrypointFramingFeedsParser(t *testing.T) {
+	python := requirePython3(t)
+
+	artifactDir := t.TempDir()
+	argvLog := filepath.Join(t.TempDir(), "argv.json")
+	// A model name carrying a command substitution. With no shell in the
+	// runtime image, argv reaches execvp unparsed, so this must arrive verbatim
+	// at the stub and must not execute. The canary is test-local rather than
+	// /tmp/pwned so a stale file from another run cannot fake either verdict.
+	canary := filepath.Join(t.TempDir(), "pwned")
+	model := "$(touch " + canary + ")"
+
+	got := runWrapper(t, python, map[string]string{
+		"PATH":                stubAIPerfDir(t, python),
+		"AICR_STUB_MODE":      "ok",
+		"AICR_STUB_RESULT":    stubResultJSON,
+		"AICR_STUB_ARGV_LOG":  argvLog,
+		envAIPerfArtifactDir:  artifactDir,
+		envAIPerfResultMarker: aiperfResultSentinel,
+		envAIPerfModel:        model,
+	}, "--model", model, "--streaming", "--request-count", "2000")
+
+	if got.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", got.exitCode, got.stderr)
+	}
+
+	// The wrapper owns only the `profile` subcommand; every benchmark flag is
+	// built in Go and must survive as its own argv element.
+	raw, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read stub argv log: %v", err)
+	}
+	var argv []string
+	if err = json.Unmarshal(raw, &argv); err != nil {
+		t.Fatalf("parse stub argv log: %v", err)
+	}
+	wantArgv := []string{"profile", "--model", model, "--streaming", "--request-count", "2000"}
+	if len(argv) != len(wantArgv) {
+		t.Fatalf("stub argv = %q, want %q", argv, wantArgv)
+	}
+	for i := range wantArgv {
+		if argv[i] != wantArgv[i] {
+			t.Errorf("stub argv[%d] = %q, want %q", i, argv[i], wantArgv[i])
+		}
+	}
+	if _, statErr := os.Stat(canary); statErr == nil {
+		t.Errorf("command substitution in the model executed (%s exists); argv must reach execvp unparsed", canary)
+	}
+
+	// Benchmark chatter must still reach the pod log: swallowing aiperf's
+	// stdout makes a failed run undiagnosable.
+	if !strings.Contains(got.stdout, "stub-aiperf: progress chatter") {
+		t.Errorf("aiperf stdout was not inherited; got:\n%s", got.stdout)
+	}
+
+	// The exported JSON has no trailing newline, so the closing sentinel would
+	// otherwise share a line with its final brace. parseAIPerfOutput is
+	// substring-based and tolerates that, but the pod log stays readable only
+	// if the wrapper's newline guard holds.
+	export, err := os.ReadFile(filepath.Join(artifactDir, aiperfResultFilename))
+	if err != nil {
+		t.Fatalf("stub did not write the export: %v", err)
+	}
+	if bytes.HasSuffix(export, []byte("\n")) {
+		t.Fatal("stub export ends in a newline; this case must exercise the wrapper's guard")
+	}
+	wantTail := aiperfResultSentinel + "\n" + string(export) + "\n" + aiperfResultSentinel + "\n"
+	if !strings.HasSuffix(got.stdout, wantTail) {
+		t.Errorf("stdout tail = %q, want %q", got.stdout, wantTail)
+	}
+
+	// The payoff: the bytes the wrapper actually emitted, parsed by the code
+	// that consumes the real pod log.
+	result, err := parseAIPerfOutput(got.stdout)
+	if err != nil {
+		t.Fatalf("parseAIPerfOutput() on real wrapper output: %v\nstdout:\n%s", err, got.stdout)
+	}
+	if result.throughput != 5667.5 {
+		t.Errorf("throughput = %v, want 5667.5", result.throughput)
+	}
+	if result.ttftP99Ms != 84.1 {
+		t.Errorf("ttftP99Ms = %v, want 84.1", result.ttftP99Ms)
+	}
+}
+
+// TestAIPerfEntrypointPathsMatchDockerfile binds the Go path constants to the
+// image layout. buildAIPerfJob builds container.Command from these same
+// constants, so asserting Command against them is constant-vs-constant and
+// passes by construction; the coupling that can actually break is between the
+// constants and the Dockerfile's COPY destination and venv layout. Without this
+// test, moving either one passes `make qualify` and then fails at pod start with
+// "python: can't open file '/opt/aicr/aiperf_entrypoint.py'".
+func TestAIPerfEntrypointPathsMatchDockerfile(t *testing.T) {
+	raw, err := os.ReadFile(aiperfBenchDockerfile)
+	if err != nil {
+		t.Fatalf("read %s: %v", aiperfBenchDockerfile, err)
+	}
+	lines := strings.Split(string(raw), "\n")
+
+	// The interpreter must live in the venv the builder creates and the final
+	// stage copies forward, e.g. /opt/venv/bin/python -> venv root /opt/venv.
+	const venvBin = "/bin/python"
+	if !strings.HasSuffix(aiperfEntrypointPython, venvBin) {
+		t.Fatalf("aiperfEntrypointPython = %q, want a path ending in %q", aiperfEntrypointPython, venvBin)
+	}
+	venvRoot := strings.TrimSuffix(aiperfEntrypointPython, venvBin)
+
+	var (
+		createsVenv     bool
+		copiesVenv      bool
+		copiesSource    bool
+		copiesToRuntime bool
+		compilesSource  bool
+	)
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || strings.HasPrefix(fields[0], "#") {
+			continue
+		}
+		switch fields[0] {
+		case "RUN":
+			joined := strings.Join(fields, " ")
+			if strings.Contains(joined, "-m venv "+venvRoot) {
+				createsVenv = true
+			}
+			if strings.Contains(joined, "-m py_compile "+aiperfEntrypointScript) {
+				compilesSource = true
+			}
+		case "COPY":
+			src, dst := fields[len(fields)-2], fields[len(fields)-1]
+			switch {
+			case src == venvRoot && dst == venvRoot:
+				copiesVenv = true
+			case src == "validators/performance/"+aiperfEntrypointSource && dst == aiperfEntrypointScript:
+				copiesSource = true
+			case src == aiperfEntrypointScript && dst == aiperfEntrypointScript:
+				copiesToRuntime = true
+			}
+		}
+	}
+
+	if !createsVenv {
+		t.Errorf("%s never creates the venv at %q, so aiperfEntrypointPython %q cannot resolve",
+			aiperfBenchDockerfile, venvRoot, aiperfEntrypointPython)
+	}
+	if !copiesVenv {
+		t.Errorf("%s never copies %q into the runtime stage, so aiperfEntrypointPython %q cannot resolve",
+			aiperfBenchDockerfile, venvRoot, aiperfEntrypointPython)
+	}
+	if !copiesSource {
+		t.Errorf("%s never copies validators/performance/%s to aiperfEntrypointScript %q",
+			aiperfBenchDockerfile, aiperfEntrypointSource, aiperfEntrypointScript)
+	}
+	if !copiesToRuntime {
+		t.Errorf("%s never copies %q into the runtime stage; the Job's Command would exec a missing file",
+			aiperfBenchDockerfile, aiperfEntrypointScript)
+	}
+	if !compilesSource {
+		t.Errorf("%s lost the `python -m py_compile %s` gate; a syntax error would ship in a valid image",
+			aiperfBenchDockerfile, aiperfEntrypointScript)
+	}
+}

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -137,6 +137,23 @@ const (
 	// aiperfArtifactDir is where AIPerf writes benchmark result files.
 	aiperfArtifactDir = "/tmp/aiperf"
 
+	// aiperfEntrypointPython and aiperfEntrypointScript locate the
+	// sentinel-framing wrapper baked into the aiperf-bench image. The runtime
+	// stage is distroless and ships no /bin/sh, so the Job cannot chain
+	// `aiperf`, `echo`, and `cat` in a shell; the wrapper does that framing in
+	// Python instead. Both paths are fixed by aiperf-bench.Dockerfile — keep
+	// them in sync with the COPY destination and venv layout there.
+	aiperfEntrypointPython = "/opt/venv/bin/python"
+	aiperfEntrypointScript = "/opt/aicr/aiperf_entrypoint.py"
+
+	// envAIPerfArtifactDir and envAIPerfResultMarker configure
+	// aiperf_entrypoint.py's framing. envAIPerfModel is informational only —
+	// the model reaches aiperf as an explicit --model argv element — and is
+	// kept so `kubectl describe pod` shows what a run benchmarked.
+	envAIPerfModel        = "AICR_MODEL"
+	envAIPerfArtifactDir  = "AICR_AIPERF_ARTIFACT_DIR"
+	envAIPerfResultMarker = "AICR_RESULT_SENTINEL"
+
 	// AICR_INFERENCE_PERF_* env vars let operators tune the benchmark without
 	// rebuilding the validator image. Each overrides the like-named constant
 	// above; set them on the inference-perf catalog entry's `env` (editable
@@ -2884,15 +2901,16 @@ type aiperfRunParams struct {
 
 // buildAIPerfJob constructs the Kubernetes Job spec for running AIPerf.
 // The image (aiperfBaseImage) has aiperf pre-installed at build time — no pip
-// install at runtime. The script wraps aiperf invocation in sentinel markers
-// so parseAIPerfOutput can locate the JSON unambiguously. Diagnostic output
+// install at runtime. The run is wrapped in sentinel markers so
+// parseAIPerfOutput can locate the JSON unambiguously. Diagnostic output
 // (aiperf progress, warnings) is kept in the pod logs — silencing it made
 // benchmark failures undiagnosable.
 //
-// Command overrides the image ENTRYPOINT (["aiperf"]) with a shell so we can
-// chain aiperf + echo + cat for sentinel framing. /bin/sh is POSIX-sufficient
-// for everything in the script (set -e, line continuation, echo, cat) and is
-// present in the python:3.12-slim base image, avoiding a bash dependency.
+// Command overrides the image ENTRYPOINT (["aiperf"]) with aiperf_entrypoint.py,
+// which performs that framing. It is a Python wrapper rather than a shell
+// pipeline because the runtime stage is NVIDIA's distroless Python image and
+// ships no /bin/sh — see the header of aiperf-bench.Dockerfile. Everything is
+// exec-form argv, so no element is shell-interpreted.
 func buildAIPerfJob(namespace, jobName, endpoint, model string, concurrency int, pullSecrets []v1.LocalObjectReference) (*batchv1.Job, aiperfRunParams, error) {
 	// AIPerf requires request_count >= concurrency. Scale the measured request
 	// count with concurrency so larger GPU counts still get a multi-wave
@@ -2930,44 +2948,35 @@ func buildAIPerfJob(namespace, jobName, endpoint, model string, concurrency int,
 	// were mutated between two calls (matters in tests; cheap in prod).
 	aiperfImage := resolveAiperfImage()
 
-	// The model is passed via the AICR_MODEL container env var and referenced as
-	// "$AICR_MODEL", not interpolated into the script text. A recipe /
-	// AICR_INFERENCE_PERF_MODEL value with shell metacharacters (e.g. $(...))
-	// would otherwise be command-substituted by /bin/sh -c even inside double
-	// quotes; "$AICR_MODEL" expands to the literal value without re-scanning it.
+	// Benchmark flags as exec-form argv. aiperf_entrypoint.py prepends
+	// `aiperf profile` and appends the sentinel-framed result JSON,
+	// reproducing what the previous `/bin/sh -c` script did. Every flag is
+	// built here so this file stays the single source of truth for the
+	// benchmark invocation.
 	//
-	// The model must be passed with the explicit --model flag: aiperf 0.11.0
-	// dropped support for a positional model argument, rejecting it with
-	// "Unused Tokens: ['<model>']" before the benchmark starts.
-	script := fmt.Sprintf(`set -e
-aiperf profile \
-  --model "$AICR_MODEL" \
-  --url %s \
-  --endpoint-type chat \
-  --streaming \
-  --concurrency %d \
-  --request-count %d \
-  --warmup-request-count %d \
-  --prompt-input-tokens-mean %d \
-  --prompt-input-tokens-stddev 0 \
-  --prompt-output-tokens-mean %d \
-  --prompt-output-tokens-stddev 0 \
-  --num-dataset-entries %d \
-  --random-seed %d \
-  --extra-inputs temperature:0 \
-  --output-artifact-dir %s \
-  --export-level summary
-echo '%s'
-cat %s/profile_export_aiperf.json
-echo '%s'`,
-		endpoint,
-		concurrency, requestCount, warmupCount,
-		inputTokensMean, outputTokensMean,
-		aiperfNumDatasetEntries, aiperfRandomSeed,
-		aiperfArtifactDir,
-		aiperfResultSentinel,
-		aiperfArtifactDir,
-		aiperfResultSentinel)
+	// The model is a discrete argv element handed to execvp, never spliced
+	// into a command string. The runtime image has no shell, so a model
+	// containing metacharacters cannot be command-substituted and needs no
+	// quoting. It must use the explicit --model flag: aiperf 0.11.0 dropped
+	// the positional form and aborts with "Unused Tokens: ['<model>']".
+	aiperfArgs := []string{
+		"--model", model,
+		"--url", endpoint,
+		"--endpoint-type", "chat",
+		"--streaming",
+		"--concurrency", strconv.Itoa(concurrency),
+		"--request-count", strconv.Itoa(requestCount),
+		"--warmup-request-count", strconv.Itoa(warmupCount),
+		"--prompt-input-tokens-mean", strconv.Itoa(inputTokensMean),
+		"--prompt-input-tokens-stddev", "0",
+		"--prompt-output-tokens-mean", strconv.Itoa(outputTokensMean),
+		"--prompt-output-tokens-stddev", "0",
+		"--num-dataset-entries", strconv.Itoa(aiperfNumDatasetEntries),
+		"--random-seed", strconv.Itoa(aiperfRandomSeed),
+		"--extra-inputs", "temperature:0",
+		"--output-artifact-dir", aiperfArtifactDir,
+		"--export-level", "summary",
+	}
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3006,12 +3015,21 @@ echo '%s'`,
 							// `:edge`, `:main`, and similar rolling tags
 							// on-push.yaml recreates on every merge.
 							ImagePullPolicy: validatorv1.ImagePullPolicy(aiperfImage, os.Getenv("AICR_VALIDATOR_IMAGE_TAG")),
-							// Model passed as env and referenced as "$AICR_MODEL"
-							// in the script so a value with shell metacharacters
-							// can't be command-substituted (see script above).
-							Env:     []v1.EnvVar{{Name: "AICR_MODEL", Value: model}},
-							Command: []string{shellBin, "-c"},
-							Args:    []string{script},
+							// The artifact dir and sentinel configure the framing
+							// wrapper. AICR_MODEL is not read by the wrapper (the
+							// model is an explicit --model argv element); it is
+							// retained so `kubectl describe pod` still shows which
+							// model a run benchmarked.
+							Env: []v1.EnvVar{
+								{Name: envAIPerfModel, Value: model},
+								{Name: envAIPerfArtifactDir, Value: aiperfArtifactDir},
+								{Name: envAIPerfResultMarker, Value: aiperfResultSentinel},
+							},
+							// Exec form, no shell: the runtime image is distroless
+							// and has no /bin/sh. Overrides the image ENTRYPOINT
+							// (["aiperf"]) with the framing wrapper.
+							Command: []string{aiperfEntrypointPython, aiperfEntrypointScript},
+							Args:    aiperfArgs,
 						},
 					},
 				},

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -290,8 +291,33 @@ func TestParseAIPerfOutput(t *testing.T) {
 			wantTTFT:       84.1,
 		},
 		{
+			// Shape emitted by aiperf_entrypoint.py: benchmark chatter, then
+			// sentinel, then the exported JSON, then sentinel. Sentinel lookup
+			// is substring-based, so the parser also tolerates the closing
+			// sentinel sharing a line with the JSON's final brace — the
+			// wrapper's newline guard is for log readability, not parseability.
+			// TestAIPerfEntrypointFramingFeedsParser asserts the real bytes;
+			// this case keeps the parser covered without python3 on PATH.
+			name: "wrapper framing with no trailing newline in export",
+			logs: "stub-aiperf: progress chatter\nstub-aiperf: done\n" +
+				aiperfResultSentinel + "\n" + validJSON + "\n" + aiperfResultSentinel + "\n",
+			wantThroughput: 5667.5,
+			wantTTFT:       84.1,
+		},
+		{
+			// The guard-absent shape, proving the claim above rather than
+			// asserting it in a comment: the closing sentinel glued to the
+			// final brace still parses.
+			name:           "closing sentinel glued to the JSON's final brace",
+			logs:           aiperfResultSentinel + "\n" + validJSON + aiperfResultSentinel + "\n",
+			wantThroughput: 5667.5,
+			wantTTFT:       84.1,
+		},
+		{
+			// A failed benchmark exits non-zero before the wrapper emits any
+			// sentinel, so the logs carry only diagnostics.
 			name:          "missing start sentinel — benchmark failed",
-			logs:          "pip install failed: unable to reach PyPI\n",
+			logs:          "aiperf-entrypoint: aiperf exited 7\n",
 			wantErrSubstr: "sentinel",
 		},
 		{
@@ -896,19 +922,64 @@ func TestBuildAIPerfJob_PrebuiltImageAndSentinel(t *testing.T) {
 		t.Errorf("aiperfBaseImage %q should be the pre-built ghcr image", aiperfBaseImage)
 	}
 
-	script := container.Args[0]
-	if strings.Contains(script, "pip install") {
-		t.Errorf("script should not pip install at runtime — aiperf is baked into the image; got:\n%s", script)
+	// The runtime image is distroless (no /bin/sh), so the Job must invoke the
+	// baked Python framing wrapper in exec form. A regression back to a shell
+	// would fail at pod start with "exec: /bin/sh: no such file or directory".
+	wantCommand := []string{aiperfEntrypointPython, aiperfEntrypointScript}
+	if !reflect.DeepEqual(container.Command, wantCommand) {
+		t.Errorf("container.Command = %v, want %v", container.Command, wantCommand)
 	}
-	if !strings.Contains(script, aiperfResultSentinel) {
-		t.Errorf("script missing result sentinel %q", aiperfResultSentinel)
+	assertNoShellIndicators(t, container, "the distroless runtime has none")
+
+	argv := strings.Join(container.Args, " ")
+	if strings.Contains(argv, "pip install") {
+		t.Errorf("args should not pip install at runtime — aiperf is baked into the image; got:\n%s", argv)
 	}
-	if strings.Contains(script, "2>&1") || strings.Contains(script, "> /dev/null") {
-		t.Errorf("script should not silence stderr/stdout — benchmark errors must surface in pod logs")
+	if strings.Contains(argv, "2>&1") || strings.Contains(argv, "> /dev/null") {
+		t.Errorf("args should not silence stderr/stdout — benchmark errors must surface in pod logs")
 	}
-	// /bin/sh is sufficient (POSIX) and avoids a bash install in the image.
-	if len(container.Command) == 0 || container.Command[0] != "/bin/sh" {
-		t.Errorf("container.Command[0] = %v, want /bin/sh", container.Command)
+	// The wrapper prepends `aiperf profile`, so Args must carry only flags —
+	// a leading subcommand would be passed twice.
+	if len(container.Args) == 0 || !strings.HasPrefix(container.Args[0], "-") {
+		t.Errorf("container.Args should start with a flag, got %v", container.Args)
+	}
+	for _, want := range []string{
+		"--output-artifact-dir " + aiperfArtifactDir,
+		"--export-level summary",
+		"--endpoint-type chat",
+	} {
+		if !strings.Contains(argv, want) {
+			t.Errorf("args missing %q; got:\n%s", want, argv)
+		}
+	}
+
+	// Sentinel framing moved from the shell script into env consumed by
+	// aiperf_entrypoint.py; parseAIPerfOutput still keys off this exact value.
+	env := map[string]string{}
+	for _, e := range container.Env {
+		env[e.Name] = e.Value
+	}
+	if env[envAIPerfResultMarker] != aiperfResultSentinel {
+		t.Errorf("%s = %q, want %q", envAIPerfResultMarker, env[envAIPerfResultMarker], aiperfResultSentinel)
+	}
+	if env[envAIPerfArtifactDir] != aiperfArtifactDir {
+		t.Errorf("%s = %q, want %q", envAIPerfArtifactDir, env[envAIPerfArtifactDir], aiperfArtifactDir)
+	}
+	// The artifact dir is double-sourced: argv tells aiperf where to write, env
+	// tells the wrapper where to read. They agree today because both resolve
+	// from one constant, but a future per-run subdirectory applied to only the
+	// argv side would leave the wrapper reading a stale path and returning 1
+	// ("cannot read result file") on an otherwise-successful benchmark.
+	argvArtifactDir, ok := argvFlagValue(container.Args, "--output-artifact-dir")
+	if !ok {
+		t.Fatalf("--output-artifact-dir missing from argv: %v", container.Args)
+	}
+	if argvArtifactDir != env[envAIPerfArtifactDir] {
+		t.Errorf("--output-artifact-dir = %q but %s = %q; aiperf would write where the wrapper does not read",
+			argvArtifactDir, envAIPerfArtifactDir, env[envAIPerfArtifactDir])
+	}
+	if env[envAIPerfModel] == "" {
+		t.Errorf("%s must be set so the wrapper can pass --model", envAIPerfModel)
 	}
 
 	// Pull secrets from the outer pod must propagate to the inner aiperf pod
@@ -1011,11 +1082,44 @@ func clearTuningEnvs(t *testing.T) {
 	}
 }
 
-// TestBuildAIPerfJob_ModelViaEnvNotShell verifies the model is passed through a
-// container env var and referenced as "$AICR_MODEL" in the script, never
-// interpolated into the /bin/sh -c text — so a model containing shell
-// metacharacters cannot be command-substituted before the benchmark runs.
-func TestBuildAIPerfJob_ModelViaEnvNotShell(t *testing.T) {
+// assertNoShellIndicators fails if any element of the container's full argv
+// looks like a shell invocation. The aiperf-bench runtime is distroless and
+// ships no /bin/sh, so a regression here fails at pod start rather than in a
+// test — and it is what keeps a metacharacter-bearing model inert. Shared by
+// every test that asserts the shell-free contract so the recognized set of
+// shell binaries stays in one place.
+func assertNoShellIndicators(t *testing.T, ctr v1.Container, why string) {
+	t.Helper()
+	for _, a := range append(append([]string{}, ctr.Command...), ctr.Args...) {
+		if strings.HasSuffix(a, "/sh") || strings.HasSuffix(a, "/bash") || a == "-c" {
+			t.Errorf("argv element %q implies a shell; %s", a, why)
+		}
+	}
+}
+
+// aiperfArgv renders the container's benchmark flags for substring assertions.
+// Args is exec-form argv (no shell), so joining on a space reproduces the
+// "--flag value" shape the older script-based assertions matched against.
+func aiperfArgv(job *batchv1.Job) string {
+	return strings.Join(job.Spec.Template.Spec.Containers[0].Args, " ")
+}
+
+// argvFlagValue returns the element following the named flag in argv.
+func argvFlagValue(args []string, flag string) (string, bool) {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+// TestBuildAIPerfJob_ModelCarriedAsDiscreteArgv verifies the model is handed to
+// execvp as its own argv element rather than spliced into a command string. The
+// runtime image is distroless with no shell, so a model containing shell
+// metacharacters must survive verbatim and inert — not be quoted, escaped, or
+// indirected through an env expansion that no longer has a shell to expand it.
+func TestBuildAIPerfJob_ModelCarriedAsDiscreteArgv(t *testing.T) {
 	clearTuningEnvs(t)
 	malicious := "$(touch /tmp/pwned)"
 	job, _, err := buildAIPerfJob("ns", "aicr-aiperf-run-0", "http://ep:8000", malicious, 16, nil)
@@ -1023,22 +1127,30 @@ func TestBuildAIPerfJob_ModelViaEnvNotShell(t *testing.T) {
 		t.Fatalf("buildAIPerfJob: %v", err)
 	}
 	ctr := job.Spec.Template.Spec.Containers[0]
-	script := ctr.Args[0]
-	if strings.Contains(script, malicious) {
-		t.Errorf("script must not interpolate the model verbatim (injection risk); script:\n%s", script)
+
+	// The value must appear as exactly one argv element, so execvp passes it
+	// as a single token with no re-parsing.
+	got, ok := argvFlagValue(ctr.Args, "--model")
+	if !ok {
+		t.Fatalf("--model flag missing from argv: %v", ctr.Args)
 	}
-	if !strings.Contains(script, `"$AICR_MODEL"`) {
-		t.Errorf("script must reference the model via \"$AICR_MODEL\"; script:\n%s", script)
+	if got != malicious {
+		t.Errorf("--model value = %q, want the raw model %q carried verbatim", got, malicious)
 	}
-	var got string
+
+	// No shell anywhere in the invocation means nothing can substitute it.
+	assertNoShellIndicators(t, ctr, "the model would become command-substitutable")
+
+	// Retained for operator visibility via `kubectl describe pod`.
+	var envVal string
 	found := false
 	for _, e := range ctr.Env {
-		if e.Name == "AICR_MODEL" {
-			got, found = e.Value, true
+		if e.Name == envAIPerfModel {
+			envVal, found = e.Value, true
 		}
 	}
-	if !found || got != malicious {
-		t.Errorf("AICR_MODEL env = %q (found=%v), want the raw model %q carried as data", got, found, malicious)
+	if !found || envVal != malicious {
+		t.Errorf("%s env = %q (found=%v), want the raw model %q", envAIPerfModel, envVal, found, malicious)
 	}
 }
 
@@ -1048,16 +1160,20 @@ func TestBuildAIPerfJob_ModelViaEnvNotShell(t *testing.T) {
 // regression here fails every inference-perf run on every cloud.
 func TestBuildAIPerfJob_ModelPassedWithFlag(t *testing.T) {
 	clearTuningEnvs(t)
-	job, _, err := buildAIPerfJob("ns", "aicr-aiperf-run-0", "http://ep:8000", "Qwen/Qwen3-8B", 16, nil)
+	const model = "Qwen/Qwen3-8B"
+	job, _, err := buildAIPerfJob("ns", "aicr-aiperf-run-0", "http://ep:8000", model, 16, nil)
 	if err != nil {
 		t.Fatalf("buildAIPerfJob: %v", err)
 	}
-	script := job.Spec.Template.Spec.Containers[0].Args[0]
-	if !strings.Contains(script, `--model "$AICR_MODEL"`) {
-		t.Errorf("script must pass the model as `--model \"$AICR_MODEL\"`; script:\n%s", script)
+	args := job.Spec.Template.Spec.Containers[0].Args
+	got, ok := argvFlagValue(args, "--model")
+	if !ok || got != model {
+		t.Errorf("argv must pass the model as `--model %s`; got %v", model, args)
 	}
-	if strings.Contains(script, `aiperf profile "$AICR_MODEL"`) {
-		t.Errorf("model must not be passed positionally (rejected by aiperf >= 0.11.0); script:\n%s", script)
+	// A bare positional would be argv[0] since the wrapper supplies only
+	// `aiperf profile` ahead of these args.
+	if len(args) > 0 && args[0] == model {
+		t.Errorf("model must not be passed positionally (rejected by aiperf >= 0.11.0); got %v", args)
 	}
 }
 
@@ -1074,7 +1190,7 @@ func TestBuildAIPerfJob_RequestCountFloor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			job := mustBuildAIPerfJob(t, "ns", "aicr-aiperf-run-0", "http://ep:8000", tt.concurrency, nil)
-			script := job.Spec.Template.Spec.Containers[0].Args[0]
+			script := aiperfArgv(job)
 			needle := fmt.Sprintf("--request-count %d", tt.wantMinReqs)
 			if !strings.Contains(script, needle) {
 				t.Errorf("script missing %q; script:\n%s", needle, script)
@@ -1099,7 +1215,7 @@ func TestBuildAIPerfJob_Warmup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			job := mustBuildAIPerfJob(t, "ns", "aicr-aiperf-run-0", "http://ep:8000", tt.concurrency, nil)
-			script := job.Spec.Template.Spec.Containers[0].Args[0]
+			script := aiperfArgv(job)
 			needle := fmt.Sprintf("--warmup-request-count %d", tt.concurrency*aiperfWarmupPerConcurrency)
 			if !strings.Contains(script, needle) {
 				t.Errorf("concurrency=%d: script missing %q; script:\n%s", tt.concurrency, needle, script)
@@ -1665,7 +1781,7 @@ func TestBuildAIPerfJob_EnvOverrides(t *testing.T) {
 	t.Setenv(envOutputTokensMean, "256")
 
 	job := mustBuildAIPerfJob(t, "ns", "run-0", "http://ep:8000", 100, nil)
-	script := job.Spec.Template.Spec.Containers[0].Args[0]
+	script := aiperfArgv(job)
 	for _, needle := range []string{
 		"--request-count 2000",
 		"--warmup-request-count 300",


### PR DESCRIPTION
## Summary

Move the `aiperf-bench` runtime stage from `python:3.13-slim` to `nvcr.io/nvidia/distroless/python:3.13-v4.0.8` (pinned by digest), and replace the `/bin/sh -c` benchmark invocation with a shell-free Python entrypoint since the distroless base ships no shell.

## Motivation / Context

Requested move to the NVIDIA distroless Python base for the AIPerf benchmark image. The swap is not drop-in: the base has no shell, no apt, no pip, and no `useradd`, which breaks both the builder stage and the benchmark Job's runtime contract. This PR does the work those constraints require and re-validates the vulnerability posture end to end.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Validator (`pkg/validator`) — `validators/performance` only
- [x] Other: `aiperf-bench` image, `.openvex.json`, `.grype.yaml`, `RELEASING.md`

## Implementation Notes

**Why only the runtime stage moved.** The distroless image has no shell, apt, or pip, so it cannot host `RUN` steps. The builder stage stays on `python:3.13-slim` and still compiles the venv; only the final stage changed. Both bases put CPython 3.13 at `/usr/local/bin`, so the venv's interpreter symlinks and compiled extensions (pyzmq, uvloop, crick) resolve unchanged.

**Replacing `/bin/sh -c`.** `buildAIPerfJob` chained `aiperf`, `echo`, and `cat` in a shell to produce the sentinel framing `parseAIPerfOutput` consumes. That framing moved to `validators/performance/aiperf_entrypoint.py` (stdlib only), invoked in exec form. Division of responsibility:

- **Go owns every benchmark flag.** The wrapper only prepends `aiperf profile` and appends the framed result. This keeps flag correctness — including the `--model` flag that aiperf 0.11.0 requires — asserted in Go tests rather than in an untested Python file.
- **The model is now a discrete argv element** instead of a `"$AICR_MODEL"` shell expansion. This is strictly safer: with no shell there is nothing to re-scan a metacharacter-bearing value. Verified by running the image with model `$(touch /tmp/pwned)` and confirming the payload arrives verbatim and does not execute.
- `AICR_MODEL` is still set on the container, now informational, so `kubectl describe pod` shows what a run benchmarked.

**Non-root user.** `RUN useradd` cannot run, so the image adopts the base's built-in `nvs` user (uid 1000) instead of minting uid 10001. Still non-root; verified `uid 1000` at runtime.

**Vulnerability posture.** The distroless base ships two Debian packages *older* than `python:3.13-slim`:

| | `python:3.13-slim` (before) | distroless (after, with VEX) |
|---|---|---|
| Critical | 0 | 0 |
| **High** | **2** | **2** |
| Medium | 14 | 15 |
| Low | 4 | 4 |
| VEX-suppressed | 11 | 32 |

- The 2 remaining Highs are the pre-existing CPython `CVE-2026-11940` / `CVE-2026-11972`. **The swap does not fix them** — both bases ship CPython 3.13.14.
- **libexpat1 2.7.1-2** contributes 21 findings (4 High). Suppressed in `.openvex.json` on two independently verified grounds: (1) *nothing in the image links it* — reading ELF `DT_NEEDED` for every binary under `/usr/local/lib`, `/usr/lib`, `/lib`, `/opt/venv/lib`, `/usr/local/bin`, `/usr/bin` returns zero references to libexpat; (2) CPython routes `xml.parsers.expat` through a `pyexpat` whose `DT_NEEDED` is `['libc.so.6']` only, with expat statically bundled at 2.8.1. aiperf itself has zero XML imports across its 682 `.py` files. Suppression is scoped to the unused system library; for the 13 CVEs fixed only in 2.8.2 the impact statement explicitly states the bundled 2.8.1 is *not* itself patched rather than overclaiming.
- **liblzma5 5.8.1-1 (`CVE-2026-34743`, Medium) is deliberately left unsuppressed.** `_lzma.so` genuinely links it, so the evidence is weaker than for expat, and `python:3.13-slim` already ships the fixed `5.8.1-1+deb13u1`. Leaving it visible preserves the signal that the base image is stale. **This is the one net-new finding in this PR.**

**Recommended follow-up:** file upstream with the NVIDIA distroless team to refresh the Debian layer — `3.13-v4.0.8` was built 2026-06-11 and both stale packages have fixes available in Debian trixie.

**VEX housekeeping.** Dropped 11 `aicr-gate` statements (`GO-2026-5005/5006/5013/5014/5015/5017/5018/5019/5020/5021/5023`) confirmed *entirely absent* from the current scan after a chainsaw bump — verified individually, not inferred from a count delta. Document bumped to version 10 with a refreshed timestamp and tooling note. The remaining `aicr-gate` statements still apply (count-neutral).

**Note for reviewers:** two unsuppressed Highs remain on `aicr-gate` — `GO-2026-5970` (x/text) and `GO-2026-5942` (x/net). Those want a dependency bump, not a VEX entry, and are out of scope here.

## Testing

```bash
make qualify   # exit 0
```

- `make qualify` passes clean on the final tree.
- `golangci-lint run -c .golangci.yaml ./validators/performance/...` → 0 issues.
- `go test -race ./validators/performance/` passes; coverage 56.4% (unchanged — `validators/` is excluded from the project floor per #1752).
- Image built for **both** `linux/amd64` and `linux/arm64`; `aiperf --version` → `0.11.0` in the distroless runtime.
- Wrapper exercised end-to-end inside the real distroless image with a stub `aiperf`:
  - happy path emits `sentinel / JSON / sentinel` and parses correctly;
  - the newline guard is covered (aiperf writes the export without a trailing newline, so without it the closing sentinel would share a line with the JSON);
  - non-zero aiperf exit propagates verbatim (exit 7) with no sentinel emitted;
  - missing result file is a hard error rather than an empty sentinel block;
  - missing required env fails closed;
  - runs as uid 1000.
- New regression test ties the wrapper's exact output shape to `parseAIPerfOutput`.
- Grype re-scan used the CI-pinned v0.110.0 with the same `--only-fixed --vex .openvex.json -c .grype.yaml` flags, against an image tagged so the PURL resolves to `pkg:oci/aicr-aiperf-bench`; all 4 new High suppressions confirmed landing under `appliedIgnoreRules` with `namespace = "vex"`.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** The benchmark Job's `Command`/`Args` shape changes, so a released `aicr` binary must run against a matching `aiperf-bench` image. The validator resolves the inner image from the same tag as the outer validator (`resolveAiperfImage` / `AICR_VALIDATOR_IMAGE_TAG`), so they move together in normal use. A pinned older `aiperf-bench` image combined with a new binary would fail at pod start on the missing `/opt/aicr/aiperf_entrypoint.py`. Revert is a straight rollback of the Dockerfile and Go change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
