### PR TITLE
fix(api): require selector on v1 query GET

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -646,9 +646,10 @@ paths:
                     useOpenKernelModules: true
         "400":
           description: >
-            Invalid request: malformed criteria, allowlist violation, a resolved
-            profile (which requires `/v2/query`), or a stated criteria dimension
-            not honored by any applicable recipe overlay (uncovered dimension).
+            Invalid request: an omitted selector, malformed criteria, allowlist
+            violation, a resolved profile (which requires `/v2/query`), or a stated
+            criteria dimension not honored by any applicable recipe overlay
+            (uncovered dimension).
             Uncovered-dimension errors carry a machine-readable
             `details.uncovered` array (dimension, requestedValue,
             validCompletions). Snapshot-driven resolution (CLI `--snapshot` / Go
@@ -663,6 +664,16 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
               examples:
+                missingSelector:
+                  summary: Required selector omitted
+                  value:
+                    code: INVALID_REQUEST
+                    message: "Invalid query criteria"
+                    details:
+                      error: "[INVALID_REQUEST] selector is required on /v1/query"
+                    requestId: "550e8400-e29b-41d4-a716-446655440000"
+                    timestamp: "2025-01-15T10:30:00Z"
+                    retryable: false
                 invalidParameter:
                   summary: Invalid query parameter
                   value:

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -346,6 +346,8 @@ All GET /v1/recipe parameters are supported, plus:
 
 **Error Responses:**
 
+Omitting `selector` returns `400 Bad Request` with code `INVALID_REQUEST`. An explicitly empty `selector=` remains valid and returns the entire hydrated recipe.
+
 `GET /v1/query` and `POST /v1/query` resolve a recipe through the same engine as `/v1/recipe`, so a stated criteria dimension not honored by any applicable overlay fails the same way: `400 Bad Request` with the `details.uncovered` array described in the [POST /v1/recipe error responses](#post-v1recipe) above.
 
 **Examples:**

--- a/pkg/server/recipe_handler.go
+++ b/pkg/server/recipe_handler.go
@@ -406,10 +406,17 @@ func (h *recipeHandler) handleQuery(w http.ResponseWriter, r *http.Request, v2 b
 			if err != nil {
 				break
 			}
-		} else if _, supplied := r.URL.Query()[keyProfile]; supplied {
-			err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-				"profile selection is available only on /v2/query")
-			break
+		} else {
+			if _, supplied := r.URL.Query()[keyProfile]; supplied {
+				err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+					"profile selection is available only on /v2/query")
+				break
+			}
+			if !r.URL.Query().Has("selector") {
+				err = aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+					"selector is required on /v1/query")
+				break
+			}
 		}
 		criteria, err = recipe.ParseCriteriaFromRequest(r, h.client.CriteriaRegistry())
 		if !v2 {

--- a/pkg/server/recipe_handler_test.go
+++ b/pkg/server/recipe_handler_test.go
@@ -1002,25 +1002,59 @@ func TestHandleQuery_SelectorNotFound(t *testing.T) {
 	}
 }
 
-// TestHandleQuery_NoSelector verifies a query with no selector returns the
-// entire hydrated recipe structure (as the legacy handler does).
-func TestHandleQuery_NoSelector(t *testing.T) {
+// TestHandleQuery_SelectorPresence verifies an omitted selector is rejected
+// while an explicitly empty selector returns the entire hydrated recipe.
+func TestHandleQuery_SelectorPresence(t *testing.T) {
 	h := newTestHandler(t, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/query?service=eks&accelerator=h100&intent=training", nil)
-	w := httptest.NewRecorder()
-
-	h.HandleQuery(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	tests := []struct {
+		name       string
+		target     string
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "missing selector",
+			target:     "/v1/query?service=eks&accelerator=h100&intent=training",
+			wantStatus: http.StatusBadRequest,
+			wantError:  "[INVALID_REQUEST] selector is required on /v1/query",
+		},
+		{
+			name:       "explicitly empty selector",
+			target:     "/v1/query?service=eks&accelerator=h100&intent=training&selector=",
+			wantStatus: http.StatusOK,
+		},
 	}
-	var hydrated map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &hydrated); err != nil {
-		t.Fatalf("failed to decode hydrated recipe: %v; body: %s", err, w.Body.String())
-	}
-	if _, ok := hydrated["components"]; !ok {
-		t.Errorf("expected hydrated recipe to contain a components key; got keys %v", keysOf(hydrated))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			w := httptest.NewRecorder()
+
+			h.HandleQuery(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantError != "" {
+				errResp := decodeErrorBody(t, w.Body.Bytes())
+				if errResp.Code != "INVALID_REQUEST" {
+					t.Errorf("code = %q, want INVALID_REQUEST", errResp.Code)
+				}
+				if got := errResp.Details[keyError]; got != tt.wantError {
+					t.Errorf("details.error = %q, want %q", got, tt.wantError)
+				}
+				return
+			}
+
+			var hydrated map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &hydrated); err != nil {
+				t.Fatalf("failed to decode hydrated recipe: %v; body: %s", err, w.Body.String())
+			}
+			if _, ok := hydrated["components"]; !ok {
+				t.Errorf("expected hydrated recipe to contain a components key; got keys %v", keysOf(hydrated))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Require the `selector` query parameter to be present on `GET /v1/query` while preserving the documented `selector=` behavior that returns the entire hydrated recipe. Update the OpenAPI error contract and API documentation to describe the distinction.

## Motivation / Context

The handler used `Query().Get("selector")`, which returns an empty string for both an omitted parameter and an explicitly empty value. As a result, requests that omitted the OpenAPI-required parameter returned `200 OK` with the full hydrated recipe instead of `400 INVALID_REQUEST`, diverging from both the published contract and CLI behavior.

Fixes: #1890
Related: #1531

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Check query-key presence with `r.URL.Query().Has("selector")` before recipe resolution.
- Return `400 INVALID_REQUEST` when the selector is omitted.
- Preserve explicit `selector=` as the supported request for returning the full hydrated recipe.
- Replace the legacy no-selector success test with table-driven coverage for both omitted and explicitly empty selectors.
- Document the error response in the OpenAPI schema and API reference.

## Testing

```bash
PATH=/opt/homebrew/bin:$PATH make qualify
GOFLAGS="-mod=vendor" go test -coverprofile=cover.out ./pkg/server/...
```

- `make qualify` passed after rebasing onto the latest `NVIDIA/aicr:main`, including race tests, coverage enforcement, `go vet`, golangci-lint, Chainsaw E2E tests, vulnerability scanning, and license checks.
- Repository coverage: 81.6% (80% required).
- `pkg/server` coverage: 82.5% on upstream main → 82.6% on this branch (+0.1%).
- No new exported functions or methods were added.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No migration or feature flag is required. Clients that omitted the already-required `selector` parameter will now receive the documented `400 INVALID_REQUEST`; clients that intentionally request the full hydrated recipe must continue to send `selector=`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)