### PR TITLE
fix(kwok): fail closed on unmapped profiles; skip in batch

### DIFF
--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -92,7 +92,14 @@ jobs:
           fetch-depth: 0
 
       - name: Script unit tests (kwok/scripts/lib)
-        run: bash kwok/scripts/lib/sync-budget_test.sh
+        run: |
+          # yq is required by profile-select_test.sh; fail closed here so a
+          # runner image without yq cannot silently skip the assertions and
+          # let the CI light lie about coverage (#1997).
+          command -v yq >/dev/null || { echo "::error::yq is required for kwok/scripts/lib tests"; exit 1; }
+          bash kwok/scripts/lib/sync-budget_test.sh
+          bash kwok/scripts/lib/profile-select_test.sh
+          bash kwok/scripts/run-all-recipes_test.sh
 
       - name: Classify recipes into tiers
         id: classify
@@ -101,6 +108,64 @@ jobs:
           DISPATCH_RECIPE: ${{ github.event.inputs.recipe }}
         run: |
           set -euo pipefail
+
+          # Shared profile-selection helpers. Discovery filters out any
+          # recipe whose (service, accelerator) has no matching KWOK profile
+          # on disk, so the matrix never dispatches a job that would silently
+          # "SKIP" and return green without validating anything (#1997).
+          # shellcheck source=kwok/scripts/lib/profile-select.sh
+          source kwok/scripts/lib/profile-select.sh
+          PROFILES_ROOT="${GITHUB_WORKSPACE}/kwok/profiles"
+
+          # read_overlay_field <overlay> <yq_expr> — prints the resolved
+          # value on stdout (or "" when the field is absent/null). yq
+          # evaluation failures — a malformed overlay YAML — surface as
+          # a ::error:: annotation and return 1 rather than being
+          # swallowed by `|| true` and collapsed to an empty string,
+          # which the downstream filter would misread as "non-testable,
+          # skip". Same silent-swallow class the rest of the PR is
+          # closing.
+          #
+          # Diagnostics go to stderr so they don't get captured into the
+          # caller's variable via $(...) and become an annotation only in
+          # the step log. Caller MUST use `|| exit 1` — an inner exit
+          # inside command substitution only kills the subshell.
+          read_overlay_field() {
+            local overlay="$1" expr="$2" value
+            if ! value=$(yq eval "${expr} // \"\"" "${overlay}" 2>/dev/null); then
+              echo "::error file=${overlay}::yq failed to parse overlay (reading ${expr})" >&2
+              yq eval "${expr}" "${overlay}" >&2 || true
+              return 1
+            fi
+            echo "${value}"
+          }
+
+          # profile_status <overlay> — prints 0 to stdout if a profile exists
+          # for the recipe's (service, accelerator), PROFILE_SELECT_RC_NO_MATCH
+          # (2) if no profile exists (recipe is not in scope for this
+          # checkout), or exits 1 with an ::error:: annotation on any other
+          # selector failure (malformed criteria, malformed profile,
+          # ambiguous match — the tree is broken and must not be masked by
+          # dropping the recipe from the matrix).
+          profile_status() {
+            local overlay="$1" criteria svc accel rc=0
+            if ! criteria=$(resolve_recipe_criteria "${overlay}" 2>/dev/null); then
+              echo "::error file=${overlay}::resolve_recipe_criteria failed"
+              resolve_recipe_criteria "${overlay}" >&2 || true
+              exit 1
+            fi
+            read -r svc accel <<< "${criteria}"
+            select_profiles "${svc}" "${accel}" "${PROFILES_ROOT}" >/dev/null 2>&1 || rc=$?
+            if (( rc == 0 || rc == PROFILE_SELECT_RC_NO_MATCH )); then
+              echo "${rc}"
+              return 0
+            fi
+            echo "::error file=${overlay}::select_profiles failed (rc=${rc}) for service=${svc} accelerator=${accel} — see stderr"
+            select_profiles "${svc}" "${accel}" "${PROFILES_ROOT}" >&2 || true
+            exit 1
+          }
+
+          dropped="[]"   # recipes filtered out of the matrix (no profile)
 
           # --- Deployer list: single source of truth (#1172) ---
           # Defined once, here (before dispatch, since dispatch also needs it).
@@ -112,6 +177,25 @@ jobs:
 
           # --- workflow_dispatch: test exactly the requested recipe ---
           if [[ -n "${DISPATCH_RECIPE}" ]]; then
+            dispatch_overlay="recipes/overlays/${DISPATCH_RECIPE}.yaml"
+            if [[ ! -f "${dispatch_overlay}" ]]; then
+              echo "::error::Dispatch recipe '${DISPATCH_RECIPE}' has no overlay at ${dispatch_overlay}"
+              exit 1
+            fi
+            # workflow_dispatch is an explicit ask; an unmapped recipe here
+            # must fail (not silently produce an empty matrix) so the
+            # operator knows their request cannot be validated.
+            # Capture rc separately: an exit 1 inside profile_status only
+            # kills the $(...) subshell, so a fatal path (malformed
+            # profile / ambiguous match) would otherwise be swallowed
+            # and misread as the unmapped-skip case below.
+            status=$(profile_status "${dispatch_overlay}") || exit 1
+            if [[ "${status}" == "${PROFILE_SELECT_RC_NO_MATCH}" ]]; then
+              echo "::error::Dispatch recipe '${DISPATCH_RECIPE}' has no KWOK profile for its"
+              echo "::error::(service, accelerator). Add one under kwok/profiles/<service>/ or"
+              echo "::error::dispatch a different recipe."
+              exit 1
+            fi
             single=$(jq -cn --arg r "${DISPATCH_RECIPE}" --argjson deployers "$deployers" \
               '[ $deployers[] as $d | {recipe: $r, deployer: $d} ]')
             echo "tier1_pairs=${single}" >> "$GITHUB_OUTPUT"
@@ -127,16 +211,30 @@ jobs:
 
           for overlay in recipes/overlays/*.yaml; do
             name=$(basename "$overlay" .yaml)
-            service=$(yq eval '.spec.criteria.service // ""' "$overlay" 2>/dev/null || true)
+            service=$(read_overlay_field "$overlay" '.spec.criteria.service') || exit 1
 
             # Skip non-testable overlays (no service, or OCP — needs OpenShift operators)
             if [[ -z "$service" || "$service" == "null" || "$service" == "any" || "$service" == "ocp" ]]; then
               continue
             fi
 
+            # Drop recipes with no matching KWOK profile so the matrix cell
+            # can't report green without running anything. Fatal selector
+            # errors (ambiguous match, malformed profile) inside
+            # profile_status call exit 1, but that only kills the $(...)
+            # subshell — the outer script has to check the substitution's
+            # rc explicitly and propagate it, otherwise a broken tree gets
+            # silently reclassified as an unmapped-skip and hidden.
+            status=$(profile_status "${overlay}") || exit 1
+            if [[ "${status}" == "${PROFILE_SELECT_RC_NO_MATCH}" ]]; then
+              dropped=$(echo "$dropped" | jq -c --arg r "$name" '. + [$r]')
+              echo "::notice file=${overlay}::${name} filtered from KWOK matrix — no profile for its (service, accelerator)"
+              continue
+            fi
+
             all=$(echo "$all" | jq -c --arg r "$name" '. + [$r]')
 
-            accel=$(yq eval '.spec.criteria.accelerator // ""' "$overlay" 2>/dev/null || true)
+            accel=$(read_overlay_field "$overlay" '.spec.criteria.accelerator') || exit 1
             if [[ -z "$accel" || "$accel" == "null" || "$accel" == "any" ]]; then
               tier1=$(echo "$tier1" | jq -c --arg r "$name" '. + [$r]')
             fi
@@ -165,14 +263,25 @@ jobs:
             # Build set of affected accelerator-specific overlays
             for overlay in recipes/overlays/*.yaml; do
               name=$(basename "$overlay" .yaml)
-              service=$(yq eval '.spec.criteria.service // ""' "$overlay" 2>/dev/null || true)
-              accel=$(yq eval '.spec.criteria.accelerator // ""' "$overlay" 2>/dev/null || true)
+              service=$(read_overlay_field "$overlay" '.spec.criteria.service') || exit 1
+              accel=$(read_overlay_field "$overlay" '.spec.criteria.accelerator') || exit 1
 
               # Only accelerator-specific, KWOK-testable overlays belong in Tier 2
               if [[ -z "$service" || "$service" == "null" || "$service" == "any" || "$service" == "ocp" ]]; then
                 continue
               fi
               if [[ -z "$accel" || "$accel" == "null" || "$accel" == "any" ]]; then
+                continue
+              fi
+
+              # Same profile-availability filter as the main loop — an
+              # unmapped accelerator recipe must not enter the matrix, or
+              # its Tier 2 cell reports green after skipping (#1997).
+              # Same subshell-exit trap as above: capture rc explicitly
+              # so fatal selector errors propagate instead of being
+              # silently reclassified as unmapped-skips.
+              status=$(profile_status "${overlay}") || exit 1
+              if [[ "${status}" == "${PROFILE_SELECT_RC_NO_MATCH}" ]]; then
                 continue
               fi
 
@@ -302,6 +411,10 @@ jobs:
           echo "Tier 1 (generic):      $(echo "$tier1" | jq 'length') recipe(s) × $(echo "$deployers" | jq 'length') deployer(s) = ${tier1_count} pair(s)"
           echo "Tier 2 (diff-aware):   $(echo "$tier2" | jq 'length') recipe(s) × 1 deployer (helm) = ${tier2_count} pair(s)"
           echo "Tier 3 (full matrix):  $(echo "$tier3" | jq 'length') recipe(s) × $(echo "$deployers" | jq 'length') deployer(s) = ${tier3_pairs} pair(s) in ${tier3_batch_count} batch(es)"
+          dropped_count=$(echo "$dropped" | jq 'length')
+          if (( dropped_count > 0 )); then
+            echo "Filtered from matrix: ${dropped_count} recipe(s) with no matching KWOK profile — $(echo "$dropped" | jq -r 'join(", ")')"
+          fi
   # Thin caller of the shared kwok-test-run.yaml reusable workflow (#1172).
   # tier1_pairs is well under 256 entries, so it's passed in a single call —
   # no batching needed.

--- a/kwok/README.md
+++ b/kwok/README.md
@@ -52,15 +52,55 @@ flowchart LR
 | Scripts | `kwok/scripts/` | Create nodes, validate scheduling |
 | CI Workflow | `.github/workflows/kwok-recipes.yaml` | Auto-discover and test recipes |
 
-## Profile Mapping
+## Profile Selection
 
-`apply-nodes.sh` reads recipe criteria and selects matching profiles:
+Selection happens in two steps: normalize the recipe criteria, then match
+profiles against the normalized values.
 
-| Service | Accelerator | GPU Profile |
-|---------|-------------|-------------|
-| eks | h100 (default) | `eks/p5-h100.yaml` |
-| eks | gb200 | `eks/p6-gb200.yaml` |
-| other | any | `eks/p5-h100.yaml` (fallback) |
+**1. Criteria normalization.** `resolve_recipe_criteria` in
+`kwok/scripts/lib/profile-select.sh` reads
+`spec.criteria.{service,accelerator}` from the overlay and applies:
+
+| Input value | Normalized to |
+|-------------|---------------|
+| missing / `null` — `service` | `eks` |
+| `any` — `service` | `eks` |
+| missing / `null` — `accelerator` | `h100` |
+| `any` — `accelerator` | `h100` |
+| any other value | passed through verbatim |
+
+Both `apply-nodes.sh` (direct path) and `run-all-recipes.sh` (batch path)
+call this same resolver, so the two entry points cannot drift on how
+placeholder values collapse.
+
+**2. Profile matching.** The normalized `(service, accelerator)` pair is
+then looked up under `kwok/profiles/<service>/` by matching each
+candidate's `metadata.labels`:
+
+| Role | Match rule |
+|------|------------|
+| system | `provider == <service>` and `nodeType == system` |
+| gpu | `provider == <service>` and `nodeType == accelerated` and `accelerator == <accelerator>` |
+
+Exactly one match per role is required. Zero or multiple matches — or an
+unknown service or accelerator — is a hard error; there is no silent
+fallback to another provider (see #1997). Selection is implemented in
+`kwok/scripts/lib/profile-select.sh` and unit-tested by the sibling
+`profile-select_test.sh` (wired into the `kwok-recipes.yaml` discover job).
+
+**Direct vs batch semantics.** `apply-nodes.sh <recipe>` (and
+`make kwok-e2e RECIPE=...`) fails closed with the full diagnostic when
+no profile matches. `run-all-recipes.sh` (and `make kwok-test-all`,
+plus the CI matrix) instead **skips** unmapped recipes with a WARN so
+batch coverage stays green while profiles are backfilled — a recipe
+you can't test isn't the same as a recipe that failed.
+
+Currently on disk:
+
+| Service | Accelerator | System profile | GPU profile |
+|---------|-------------|----------------|-------------|
+| eks | h100 | `eks/system-m7i.yaml` | `eks/p5-h100.yaml` |
+| eks | gb200 | `eks/system-m7i.yaml` | `eks/p6-gb200.yaml` |
 
 **Cluster defaults:** 2 system nodes, 4 GPU nodes (32 GPUs), Kubernetes v1.33.5, region `us-east-1`.
 
@@ -128,13 +168,27 @@ Test it: `unset GITLAB_TOKEN && make build && make kwok-e2e RECIPE=your-recipe-n
 
 ## Adding Node Profiles or Cloud Providers
 
-Copy an existing profile and modify, then update the mapping in `kwok/scripts/apply-nodes.sh` (`get_profiles()` around line 52):
+Profiles are discovered by label — no script edit is needed. Copy an
+existing profile, update `metadata.labels.{provider,nodeType,accelerator}`
+and `spec.*`, and drop it under `kwok/profiles/<provider>/`:
 
 ```bash
 cp kwok/profiles/eks/p5-h100.yaml kwok/profiles/eks/p5-a100.yaml
+# then edit metadata.labels.accelerator and spec.gpu.* to match the new instance type
 ```
 
-For new cloud providers, copy the `kwok/profiles/eks/` directory structure and update `apply-nodes.sh`.
+For a new cloud provider, create the `kwok/profiles/<provider>/` directory
+and add:
+
+- **exactly one** system profile with `metadata.labels.{provider: <provider>, nodeType: system}`, and
+- **exactly one** accelerated profile *per supported accelerator* with `metadata.labels.{provider: <provider>, nodeType: accelerated, accelerator: <accelerator>}`.
+
+`select_profiles` requires a unique match in each role and returns a
+fatal error (not a skip) on ambiguity, so a duplicate `nodeType: system`
+or two profiles carrying the same accelerator label will break both
+direct invocations and batch CI. The accelerator label is required —
+without it, a profile is silently skipped for GPU-role lookups.
+`apply-nodes.sh` picks up the new profiles on the next run.
 
 ## CI Integration
 

--- a/kwok/scripts/apply-nodes.sh
+++ b/kwok/scripts/apply-nodes.sh
@@ -17,8 +17,12 @@
 # Usage: ./apply-nodes.sh <recipe-name>
 #
 # Reads the recipe overlay to determine:
-#   - criteria.service → cloud provider (eks, gke)
-#   - criteria.accelerator → GPU type (h100 default, gb200)
+#   - criteria.service → cloud provider (matches kwok/profiles/<service>/)
+#   - criteria.accelerator → GPU type (matches metadata.labels.accelerator)
+#
+# Profile selection is fail-closed and driven by profile-declared labels;
+# see kwok/scripts/lib/profile-select.sh. Unknown or ambiguous
+# combinations abort with a diagnostic instead of falling back.
 #
 # Fixed defaults: 2 system nodes, 4 GPU nodes
 
@@ -29,6 +33,10 @@ KWOK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${KWOK_DIR}/.." && pwd)"
 TEMPLATE="${KWOK_DIR}/templates/nodes/node.yaml.tmpl"
 OVERLAYS_DIR="${REPO_ROOT}/recipes/overlays"
+PROFILES_ROOT="${KWOK_DIR}/profiles"
+
+# shellcheck source=lib/profile-select.sh
+source "${SCRIPT_DIR}/lib/profile-select.sh"
 
 # Fixed defaults
 SYSTEM_NODE_COUNT=2
@@ -46,43 +54,6 @@ check_deps() {
     for cmd in yq kubectl; do
         command -v "$cmd" &>/dev/null || { log_error "Missing: $cmd"; exit 1; }
     done
-}
-
-# Map service + accelerator to profile paths
-get_profiles() {
-    local service="$1"
-    local accelerator="$2"
-
-    # System profile: {service}/system-*.yaml
-    local system_profile=""
-    case "$service" in
-        eks) system_profile="eks/system-m7i.yaml" ;;
-        gke) system_profile="eks/system-m7i.yaml" ;;  # Fallback to EKS for now
-        *)   system_profile="eks/system-m7i.yaml" ;;  # Default
-    esac
-
-    # GPU profile: based on accelerator
-    local gpu_profile=""
-    case "$service" in
-        eks)
-            case "$accelerator" in
-                gb200) gpu_profile="eks/p6-gb200.yaml" ;;
-                *)     gpu_profile="eks/p5-h100.yaml" ;;  # h100 or default
-            esac
-            ;;
-        gke)
-            # GKE uses same profiles for now
-            case "$accelerator" in
-                gb200) gpu_profile="eks/p6-gb200.yaml" ;;
-                *)     gpu_profile="eks/p5-h100.yaml" ;;
-            esac
-            ;;
-        *)
-            gpu_profile="eks/p5-h100.yaml"  # Default to H100
-            ;;
-    esac
-
-    echo "${system_profile}:${gpu_profile}"
 }
 
 # Generate node YAML from template
@@ -139,30 +110,25 @@ create_nodes() {
     local recipe="$1"
     local overlay_file="${OVERLAYS_DIR}/${recipe}.yaml"
 
-    [[ -f "$overlay_file" ]] || { log_error "Recipe overlay not found: $overlay_file"; exit 1; }
-
-    # Extract criteria from overlay
-    local service accelerator
-    service=$(yq eval '.spec.criteria.service // "eks"' "$overlay_file")
-    accelerator=$(yq eval '.spec.criteria.accelerator // "h100"' "$overlay_file")
-
-    # Handle 'any' or empty values
-    [[ "$service" == "any" || "$service" == "null" ]] && service="eks"
-    [[ "$accelerator" == "any" || "$accelerator" == "null" ]] && accelerator="h100"
+    local criteria service accelerator
+    if ! criteria=$(resolve_recipe_criteria "$overlay_file"); then
+        exit 1
+    fi
+    read -r service accelerator <<< "${criteria}"
 
     log_info "Recipe: $recipe (service=$service, accelerator=$accelerator)"
 
-    # Get profile paths
+    # Discover profiles by matching metadata.labels; unmapped or ambiguous
+    # combinations fail closed here rather than falling back to defaults.
     local profiles system_profile gpu_profile
-    profiles=$(get_profiles "$service" "$accelerator")
+    if ! profiles=$(select_profiles "$service" "$accelerator" "$PROFILES_ROOT"); then
+        exit 1
+    fi
     system_profile="${profiles%%:*}"
     gpu_profile="${profiles##*:}"
 
-    local sys_profile_path="${KWOK_DIR}/profiles/${system_profile}"
-    local gpu_profile_path="${KWOK_DIR}/profiles/${gpu_profile}"
-
-    [[ -f "$sys_profile_path" ]] || { log_error "System profile not found: $sys_profile_path"; exit 1; }
-    [[ -f "$gpu_profile_path" ]] || { log_error "GPU profile not found: $gpu_profile_path"; exit 1; }
+    local sys_profile_path="${PROFILES_ROOT}/${system_profile}"
+    local gpu_profile_path="${PROFILES_ROOT}/${gpu_profile}"
 
     log_info "Profiles: system=$system_profile, gpu=$gpu_profile"
 

--- a/kwok/scripts/lib/profile-select.sh
+++ b/kwok/scripts/lib/profile-select.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Fail-closed KWOK profile selection driven by profile-declared labels.
+#
+# Sourced by apply-nodes.sh. Selects the (system, gpu) profile pair for
+# a given (service, accelerator) recipe criteria by scanning
+# kwok/profiles/<service>/ and matching each candidate's
+# metadata.labels. The selection is intrinsically validating: a profile
+# whose labels disagree with the recipe simply does not match, so the
+# fallback path that silently ran arm64 GB300 GKE lanes on amd64 H100
+# nodes (#1985) cannot recur.
+#
+# Match rules (all evaluated against metadata.labels):
+#   - provider   MUST equal <service>          (both roles)
+#   - nodeType   == "system"                    (system role)
+#   - nodeType   == "accelerated" AND
+#     accelerator == <accelerator>              (gpu role)
+#
+# A unique match in each role is required; zero or multiple matches in
+# either role is an error, and the diagnostic enumerates what was
+# actually found on disk. Requires yq on PATH.
+#
+# Source guard: constants and functions only, no side effects at source
+# time (same contract as lib/sync-budget.sh).
+
+# Dedicated exit code for "no matching profile" — the batch-mode skip
+# policy only applies to this outcome. Ambiguous matches, malformed
+# args, and other selector failures return 1 so the caller can
+# distinguish "recipe has no profile yet" (SKIP) from "something is
+# wrong with the profile tree" (FAIL). See run-all-recipes.sh
+# run_recipe_test.
+readonly PROFILE_SELECT_RC_NO_MATCH=2
+
+# resolve_recipe_criteria <overlay_file>
+#
+# Prints "<service> <accelerator>" to stdout after applying the same
+# defaulting apply-nodes.sh uses: missing/null → eks/h100, and the
+# "any" placeholder collapses to the same defaults so KWOK has a
+# concrete pair to look up. Kept here so run-all-recipes.sh and
+# apply-nodes.sh cannot drift on this policy. Requires yq.
+resolve_recipe_criteria() {
+    # Use :- default so a no-args call under caller `set -u` surfaces the
+    # intended diagnostic instead of an "unbound variable" error.
+    local overlay_file="${1:-}"
+    if [[ -z "${overlay_file}" ]]; then
+        echo "[ERROR] resolve_recipe_criteria: overlay_file is required" >&2
+        return 1
+    fi
+    if [[ ! -f "${overlay_file}" ]]; then
+        echo "[ERROR] Recipe overlay not found: ${overlay_file}" >&2
+        return 1
+    fi
+
+    local svc accel
+    svc=$(_read_criteria_field "${overlay_file}" service eks) || return 1
+    accel=$(_read_criteria_field "${overlay_file}" accelerator h100) || return 1
+
+    echo "${svc} ${accel}"
+}
+
+# _read_criteria_field <overlay_file> <field> <default>
+#
+# Reads .spec.criteria.<field> and normalizes by yq tag:
+#   - !!null / missing        -> <default>
+#   - !!str "any" or ""       -> <default>
+#   - !!str <other>           -> value verbatim
+#   - any other tag (bool, int, ...) -> error with the invalid type
+#
+# Also propagates yq evaluation failures (malformed YAML) as errors
+# instead of the alternative-operator (`//`) silently swallowing them
+# into the default value. `false` in particular is falsy under `//`, so
+# `service: false` used to collapse to "eks" without a warning.
+_read_criteria_field() {
+    local overlay_file="$1" field="$2" default="$3"
+    local expr=".spec.criteria.${field}"
+
+    local raw tag
+    if ! raw=$(yq eval "${expr}" "${overlay_file}" 2>/dev/null); then
+        echo "[ERROR] failed to read ${expr} from ${overlay_file} (malformed YAML?)" >&2
+        return 1
+    fi
+    if ! tag=$(yq eval "${expr} | tag" "${overlay_file}" 2>/dev/null); then
+        echo "[ERROR] failed to read tag of ${expr} from ${overlay_file}" >&2
+        return 1
+    fi
+
+    case "${tag}" in
+        '!!null')
+            echo "${default}"
+            ;;
+        '!!str')
+            if [[ -z "${raw}" || "${raw}" == "any" ]]; then
+                echo "${default}"
+            else
+                echo "${raw}"
+            fi
+            ;;
+        *)
+            echo "[ERROR] ${expr} in ${overlay_file}: invalid type ${tag} (expected a string; got '${raw}')" >&2
+            return 1
+            ;;
+    esac
+}
+
+# _read_profile_label <profile_path> <label_key> <profiles_root>
+#
+# Reads .metadata.labels.<label_key> from the profile and prints the
+# value (or "" if the label is absent) on stdout. On yq evaluation
+# failure — malformed YAML in the profile itself — prints a diagnostic
+# identifying the file and returns 1 so select_profiles can fail
+# closed instead of treating the broken file as a silent no-match
+# (which would let a typo'd profile hide behind a valid sibling).
+_read_profile_label() {
+    local profile="$1" label="$2" profiles_root="$3"
+    local value
+    if ! value=$(yq eval ".metadata.labels.${label} // \"\"" "${profile}" 2>/dev/null); then
+        echo "[ERROR] Malformed KWOK profile ${profile#"${profiles_root}"/}: yq failed reading .metadata.labels.${label}" >&2
+        return 1
+    fi
+    echo "${value}"
+}
+
+# select_profiles <service> <accelerator> <profiles_root>
+#
+# On unique match prints "<system_relpath>:<gpu_relpath>" to stdout
+# (paths relative to profiles_root). Otherwise prints a diagnostic to
+# stderr and returns:
+#   - PROFILE_SELECT_RC_NO_MATCH (2) when no profile exists for this
+#     (service, accelerator) — safe for batch mode to skip.
+#   - 1 for every other selector failure: missing/invalid args,
+#     missing profiles_root, or ambiguous matches (>1 system or GPU
+#     profile). Batch mode MUST NOT swallow these; a duplicate profile
+#     is a real fault the tree must surface.
+select_profiles() {
+    # Use :- defaults so a no-args call under caller `set -u` surfaces
+    # the intended diagnostic instead of an "unbound variable" error.
+    local service="${1:-}"
+    local accelerator="${2:-}"
+    local profiles_root="${3:-}"
+
+    if [[ -z "${service}" || -z "${accelerator}" || -z "${profiles_root}" ]]; then
+        echo "[ERROR] select_profiles: service, accelerator, and profiles_root are all required" >&2
+        return 1
+    fi
+
+    if [[ ! -d "${profiles_root}" ]]; then
+        echo "[ERROR] Profiles root does not exist: ${profiles_root}" >&2
+        return 1
+    fi
+
+    local service_dir="${profiles_root}/${service}"
+    if [[ ! -d "${service_dir}" ]]; then
+        echo "[ERROR] No KWOK profiles for service='${service}': ${service_dir} does not exist." >&2
+        local available="" d
+        for d in "${profiles_root}"/*/; do
+            [[ -d "${d}" ]] || continue
+            d="${d%/}"
+            if [[ -z "${available}" ]]; then
+                available="${d##*/}"
+            else
+                available="${available},${d##*/}"
+            fi
+        done
+        if [[ -n "${available}" ]]; then
+            echo "[ERROR] Services with profiles on disk: ${available}" >&2
+        fi
+        return "${PROFILE_SELECT_RC_NO_MATCH}"
+    fi
+
+    local system_matches=() gpu_matches=() available_accels=()
+    local profile
+    while IFS= read -r -d '' profile; do
+        local provider nodeType accel relpath
+        # yq failures inside the loop propagate — a malformed profile is a
+        # broken tree, not a silent no-match. Rc=1 (fatal), not the
+        # skippable no-match code.
+        provider=$(_read_profile_label "${profile}" provider "${profiles_root}") || return 1
+        nodeType=$(_read_profile_label "${profile}" nodeType "${profiles_root}") || return 1
+        relpath="${profile#"${profiles_root}"/}"
+        # Skip anything whose provider label disagrees with its directory —
+        # protects against a mis-copied file living under the wrong service.
+        if [[ "${provider}" != "${service}" ]]; then
+            continue
+        fi
+        case "${nodeType}" in
+            system)
+                system_matches+=("${relpath}")
+                ;;
+            accelerated)
+                accel=$(_read_profile_label "${profile}" accelerator "${profiles_root}") || return 1
+                available_accels+=("${accel}")
+                if [[ "${accel}" == "${accelerator}" ]]; then
+                    gpu_matches+=("${relpath}")
+                fi
+                ;;
+        esac
+    done < <(find "${service_dir}" -maxdepth 1 -name '*.yaml' -type f -print0)
+
+    if (( ${#system_matches[@]} == 0 )); then
+        echo "[ERROR] No system profile for service='${service}' (need metadata.labels.nodeType=system under ${service_dir})" >&2
+        return "${PROFILE_SELECT_RC_NO_MATCH}"
+    fi
+    if (( ${#system_matches[@]} > 1 )); then
+        echo "[ERROR] Multiple system profiles for service='${service}': ${system_matches[*]} — expected exactly one" >&2
+        return 1
+    fi
+
+    if (( ${#gpu_matches[@]} == 0 )); then
+        echo "[ERROR] No GPU profile for service='${service}' accelerator='${accelerator}' under ${service_dir}" >&2
+        if (( ${#available_accels[@]} > 0 )); then
+            local uniq_accels
+            uniq_accels=$(printf '%s\n' "${available_accels[@]}" | sort -u | paste -sd, -)
+            echo "[ERROR] Accelerators available for service='${service}': ${uniq_accels}" >&2
+        fi
+        return "${PROFILE_SELECT_RC_NO_MATCH}"
+    fi
+    if (( ${#gpu_matches[@]} > 1 )); then
+        echo "[ERROR] Multiple GPU profiles for service='${service}' accelerator='${accelerator}': ${gpu_matches[*]} — expected exactly one" >&2
+        return 1
+    fi
+
+    echo "${system_matches[0]}:${gpu_matches[0]}"
+}

--- a/kwok/scripts/lib/profile-select_test.sh
+++ b/kwok/scripts/lib/profile-select_test.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unit harness for lib/profile-select.sh (label-driven KWOK profile selection).
+# Run directly: bash kwok/scripts/lib/profile-select_test.sh
+# Wired into CI by the kwok-recipes discover job.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=profile-select.sh
+source "${SCRIPT_DIR}/profile-select.sh"
+
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not on PATH"; exit 0; }
+
+# Invariant: the SKIP rc must stay distinct from the FATAL rc (1) and
+# from success (0). Batch-mode CI relies on the split to swallow SKIP
+# but propagate FATAL; a collapse would resurface the false-pass class
+# this whole PR exists to eliminate.
+if [[ "${PROFILE_SELECT_RC_NO_MATCH}" == "0" || "${PROFILE_SELECT_RC_NO_MATCH}" == "1" ]]; then
+    echo "FAIL: PROFILE_SELECT_RC_NO_MATCH must not be 0 or 1 (got ${PROFILE_SELECT_RC_NO_MATCH})"
+    exit 1
+fi
+
+fails=0
+# check <name> <want_rc> <want_stdout> <want_stderr_substring> <got_rc> <got_stdout> <got_stderr>
+# want_stderr_substring: empty string means "do not check stderr".
+check() {
+    local name="$1" want_rc="$2" want_out="$3" want_err_sub="$4"
+    local got_rc="$5" got_out="$6" got_err="$7"
+    local ok=1
+    [[ "${got_rc}" == "${want_rc}" ]] || ok=0
+    [[ "${got_out}" == "${want_out}" ]] || ok=0
+    if [[ -n "${want_err_sub}" && "${got_err}" != *"${want_err_sub}"* ]]; then
+        ok=0
+    fi
+    if (( ok == 1 )); then
+        echo "PASS: ${name}"
+    else
+        echo "FAIL: ${name}"
+        echo "  want: rc=${want_rc} out='${want_out}' err~='${want_err_sub}'"
+        echo "  got : rc=${got_rc} out='${got_out}' err='${got_err}'"
+        fails=$((fails + 1))
+    fi
+}
+
+# Fixture root — a self-contained profiles/ tree the tests build up.
+FIXTURE_ROOT=$(mktemp -d)
+trap 'rm -rf "${FIXTURE_ROOT}"' EXIT
+
+write_profile() {
+    local path="$1" provider="$2" nodeType="$3" accelerator="${4:-}"
+    local name dir
+    name=$(basename "${path}" .yaml)
+    dir=$(dirname "${path}")
+    mkdir -p "${dir}"
+    {
+        echo "apiVersion: aicr.run/v1alpha2"
+        echo "kind: KWOKNodeProfile"
+        echo "metadata:"
+        echo "  name: ${name}"
+        echo "  labels:"
+        echo "    provider: ${provider}"
+        echo "    nodeType: ${nodeType}"
+        [[ -n "${accelerator}" ]] && echo "    accelerator: ${accelerator}"
+        echo "spec:"
+        echo "  instanceType: fake"
+    } > "${path}"
+}
+
+# Helper: run select_profiles and capture rc/stdout/stderr separately.
+# Sets got_rc, got_out, got_err.
+run_select() {
+    local err_file
+    err_file=$(mktemp)
+    got_out=$(select_profiles "$@" 2>"${err_file}")
+    got_rc=$?
+    got_err=$(cat "${err_file}")
+    rm -f "${err_file}"
+}
+
+# 1. Happy path: exactly one system + one gpu match.
+write_profile "${FIXTURE_ROOT}/eks/system-m7i.yaml" eks system
+write_profile "${FIXTURE_ROOT}/eks/p5-h100.yaml"   eks accelerated h100
+run_select eks h100 "${FIXTURE_ROOT}"
+check "happy-path-eks-h100" 0 "eks/system-m7i.yaml:eks/p5-h100.yaml" "" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 2. Happy path with multiple accelerators — still unique per accelerator.
+write_profile "${FIXTURE_ROOT}/eks/p6-gb200.yaml" eks accelerated gb200
+run_select eks gb200 "${FIXTURE_ROOT}"
+check "happy-path-eks-gb200-with-siblings" 0 "eks/system-m7i.yaml:eks/p6-gb200.yaml" "" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# Tests 3-5 and 8 assert the SKIP outcome (rc = PROFILE_SELECT_RC_NO_MATCH,
+# currently 2). Tests 6-7 assert the FATAL outcome (rc = 1) for ambiguous
+# matches. The distinction matters: batch-mode CI (run-all-recipes.sh)
+# swallows the SKIP rc but must propagate the FATAL rc, otherwise a
+# duplicate profile could silently pass CI green.
+
+# 3. Unmapped service — dir does not exist. SKIP outcome.
+run_select gke gb300 "${FIXTURE_ROOT}"
+check "unmapped-service-fails-and-lists-known-services" "${PROFILE_SELECT_RC_NO_MATCH}" "" "Services with profiles on disk: eks" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 4. Unmapped accelerator — SKIP outcome.
+run_select eks l40 "${FIXTURE_ROOT}"
+check "unmapped-accelerator-fails-and-lists-available" "${PROFILE_SELECT_RC_NO_MATCH}" "" "Accelerators available for service='eks': gb200,h100" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 5. Missing system profile — SKIP outcome.
+mkdir -p "${FIXTURE_ROOT}/gke"
+write_profile "${FIXTURE_ROOT}/gke/a4x-gb300.yaml" gke accelerated gb300
+run_select gke gb300 "${FIXTURE_ROOT}"
+check "missing-system-profile-fails" "${PROFILE_SELECT_RC_NO_MATCH}" "" "No system profile for service='gke'" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 6. Ambiguous system — two nodeType=system profiles. FATAL outcome (rc=1);
+# batch mode must NOT swallow this.
+write_profile "${FIXTURE_ROOT}/gke/system-n2.yaml"  gke system
+write_profile "${FIXTURE_ROOT}/gke/system-n2d.yaml" gke system
+run_select gke gb300 "${FIXTURE_ROOT}"
+check "ambiguous-system-profile-fails-fatal" 1 "" "Multiple system profiles for service='gke'" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 7. Ambiguous GPU — FATAL outcome (rc=1).
+#    Use a fresh fixture subtree so previous tests don't contaminate arity.
+CLEAN_ROOT=$(mktemp -d)
+write_profile "${CLEAN_ROOT}/eks/system-m7i.yaml" eks system
+write_profile "${CLEAN_ROOT}/eks/p5-h100.yaml"    eks accelerated h100
+write_profile "${CLEAN_ROOT}/eks/p5-h100-alt.yaml" eks accelerated h100
+run_select eks h100 "${CLEAN_ROOT}"
+check "ambiguous-gpu-profile-fails-fatal" 1 "" "Multiple GPU profiles for service='eks' accelerator='h100'" \
+    "${got_rc}" "${got_out}" "${got_err}"
+rm -rf "${CLEAN_ROOT}"
+
+# 8. Provider-label mismatch inside the directory — file is silently ignored
+#    (defense against a mis-copied file living under the wrong service dir).
+#    Net outcome is no GPU match → SKIP.
+CLEAN_ROOT=$(mktemp -d)
+write_profile "${CLEAN_ROOT}/gke/system-n2.yaml" gke system
+# This file lives under gke/ but declares provider: eks — must NOT be picked.
+write_profile "${CLEAN_ROOT}/gke/wrong-provider.yaml" eks accelerated gb300
+run_select gke gb300 "${CLEAN_ROOT}"
+check "mislabeled-provider-is-ignored" "${PROFILE_SELECT_RC_NO_MATCH}" "" "No GPU profile for service='gke' accelerator='gb300'" \
+    "${got_rc}" "${got_out}" "${got_err}"
+rm -rf "${CLEAN_ROOT}"
+
+# 9. Argument validation — empty strings.
+run_select "" "" ""
+check "missing-args-fails" 1 "" "service, accelerator, and profiles_root are all required" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 10. Argument validation — no args at all. This runs under the script's
+# set -u; the callee must surface its own diagnostic instead of blowing
+# up with "unbound variable" on the local="$1" assignment.
+run_select
+check "no-args-fails-with-diagnostic" 1 "" "service, accelerator, and profiles_root are all required" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 11. Nonexistent profiles root.
+run_select eks h100 "/nonexistent/${RANDOM}/profiles"
+check "nonexistent-profiles-root-fails" 1 "" "Profiles root does not exist" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# --- resolve_recipe_criteria ---
+
+# Helper: write a recipe overlay with given criteria. Missing values are
+# omitted from the YAML so we can exercise the null/default path.
+write_overlay() {
+    local path="$1" service="${2:-}" accelerator="${3:-}"
+    local dir
+    dir=$(dirname "${path}")
+    mkdir -p "${dir}"
+    {
+        echo "apiVersion: aicr.run/v1alpha2"
+        echo "kind: recipeMetadata"
+        echo "metadata:"
+        echo "  name: fixture"
+        echo "spec:"
+        echo "  criteria:"
+        [[ -n "${service}" ]] && echo "    service: ${service}"
+        [[ -n "${accelerator}" ]] && echo "    accelerator: ${accelerator}"
+    } > "${path}"
+}
+
+# 12. Explicit criteria pass through verbatim.
+OVERLAY_DIR=$(mktemp -d)
+trap 'rm -rf "${FIXTURE_ROOT}" "${OVERLAY_DIR}"' EXIT
+write_overlay "${OVERLAY_DIR}/explicit.yaml" gke gb200
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/explicit.yaml" 2>/dev/null)
+got_rc=$?
+check "resolve-explicit-criteria" 0 "gke gb200" "" "${got_rc}" "${got_out}" ""
+
+# 13. Missing fields default to eks/h100 (matches apply-nodes.sh policy).
+write_overlay "${OVERLAY_DIR}/missing.yaml"
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/missing.yaml" 2>/dev/null)
+got_rc=$?
+check "resolve-missing-defaults-to-eks-h100" 0 "eks h100" "" "${got_rc}" "${got_out}" ""
+
+# 14. 'any' placeholder collapses to the same defaults.
+write_overlay "${OVERLAY_DIR}/any.yaml" any any
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/any.yaml" 2>/dev/null)
+got_rc=$?
+check "resolve-any-collapses-to-defaults" 0 "eks h100" "" "${got_rc}" "${got_out}" ""
+
+# 15. Explicit null service + empty-string accelerator — the mixed shape
+# hits both normalization branches (!!null via bareword `null`, and !!str
+# "" via a quoted empty string). Both must still collapse to defaults;
+# write_overlay can't emit these forms so build the fixture directly.
+cat > "${OVERLAY_DIR}/null-and-empty.yaml" <<'EOF'
+apiVersion: aicr.run/v1alpha2
+kind: recipeMetadata
+metadata:
+  name: fixture
+spec:
+  criteria:
+    service: null
+    accelerator: ""
+EOF
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/null-and-empty.yaml" 2>/dev/null)
+got_rc=$?
+check "resolve-null-and-empty-collapse-to-defaults" 0 "eks h100" "" "${got_rc}" "${got_out}" ""
+
+# 16. Nonexistent overlay is an error.
+err_file=$(mktemp)
+got_out=$(resolve_recipe_criteria "/nonexistent/${RANDOM}.yaml" 2>"${err_file}")
+got_rc=$?
+got_err=$(cat "${err_file}"); rm -f "${err_file}"
+check "resolve-missing-overlay-fails" 1 "" "Recipe overlay not found" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 17. No-args call — must surface the argument-validation diagnostic
+# rather than triggering set -u "unbound variable" on $1.
+err_file=$(mktemp)
+got_out=$(resolve_recipe_criteria 2>"${err_file}")
+got_rc=$?
+got_err=$(cat "${err_file}"); rm -f "${err_file}"
+check "resolve-no-args-fails-with-diagnostic" 1 "" "overlay_file is required" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 18. Boolean `false` for service — must NOT collapse to "eks" (yq's `//`
+# alternative treated false as falsy; this is the false-pass class the
+# whole PR exists to eliminate).
+write_overlay "${OVERLAY_DIR}/bool-false.yaml" false h100
+err_file=$(mktemp)
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/bool-false.yaml" 2>"${err_file}")
+got_rc=$?
+got_err=$(cat "${err_file}"); rm -f "${err_file}"
+check "resolve-boolean-false-service-rejected" 1 "" "invalid type !!bool" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 19. Boolean `true` for accelerator — also rejected. Guards against the
+# other side of the falsy heuristic and confirms the type check, not the
+# value, is what gates.
+write_overlay "${OVERLAY_DIR}/bool-true.yaml" eks true
+err_file=$(mktemp)
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/bool-true.yaml" 2>"${err_file}")
+got_rc=$?
+got_err=$(cat "${err_file}"); rm -f "${err_file}"
+check "resolve-boolean-true-accelerator-rejected" 1 "" "invalid type !!bool" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 20. Integer for service — rejected with the invalid-type diagnostic.
+write_overlay "${OVERLAY_DIR}/int.yaml" 42 h100
+err_file=$(mktemp)
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/int.yaml" 2>"${err_file}")
+got_rc=$?
+got_err=$(cat "${err_file}"); rm -f "${err_file}"
+check "resolve-integer-service-rejected" 1 "" "invalid type !!int" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 21. Malformed YAML — yq evaluation failure propagates as an error rather
+# than silently defaulting to eks/h100.
+cat > "${OVERLAY_DIR}/malformed.yaml" <<'EOF'
+spec:
+  criteria:
+    service: eks
+     accelerator: [unclosed
+EOF
+err_file=$(mktemp)
+got_out=$(resolve_recipe_criteria "${OVERLAY_DIR}/malformed.yaml" 2>"${err_file}")
+got_rc=$?
+got_err=$(cat "${err_file}"); rm -f "${err_file}"
+check "resolve-malformed-yaml-fails" 1 "" "malformed YAML" \
+    "${got_rc}" "${got_out}" "${got_err}"
+
+# 22. Malformed profile YAML inside the service directory — must fail
+# fatally (rc=1) with a diagnostic identifying the bad file, rather
+# than silently treating it as a no-match while a valid sibling gets
+# selected. Placed under a fresh fixture root so the malformed file
+# only affects this test.
+BAD_ROOT=$(mktemp -d)
+write_profile "${BAD_ROOT}/eks/system-m7i.yaml" eks system
+write_profile "${BAD_ROOT}/eks/p5-h100.yaml"    eks accelerated h100
+cat > "${BAD_ROOT}/eks/broken.yaml" <<'EOF'
+metadata:
+  name: broken
+  labels:
+    provider: eks
+     nodeType: accelerated
+EOF
+run_select eks h100 "${BAD_ROOT}"
+check "malformed-profile-fails-fatal" 1 "" "Malformed KWOK profile eks/broken.yaml" \
+    "${got_rc}" "${got_out}" "${got_err}"
+rm -rf "${BAD_ROOT}"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All 22 tests passed"

--- a/kwok/scripts/run-all-recipes.sh
+++ b/kwok/scripts/run-all-recipes.sh
@@ -76,6 +76,12 @@ OVERLAYS_DIR="${REPO_ROOT}/recipes/overlays"
 # shellcheck source=lib/cleanup.sh
 source "${SCRIPT_DIR}/lib/cleanup.sh"
 
+# Shared profile-selection helpers (resolve_recipe_criteria,
+# select_profiles). Batch mode uses these to skip recipes with no
+# matching KWOK profile instead of hard-failing on them (#1997).
+# shellcheck source=lib/profile-select.sh
+source "${SCRIPT_DIR}/lib/profile-select.sh"
+
 CLUSTER_NAME="${KWOK_CLUSTER:-aicr-kwok-test}"
 CONTEXT="kind-${CLUSTER_NAME}"
 
@@ -242,6 +248,49 @@ run_recipe_test() {
     log_info "Testing recipe: ${recipe} (deployer=${DEPLOYER})"
     log_info "========================================"
 
+    # Skip recipes whose (service, accelerator) has no matching KWOK
+    # profile on disk. Direct `apply-nodes.sh <recipe>` still fails
+    # closed with the full diagnostic (#1997).
+    #
+    # Only PROFILE_SELECT_RC_NO_MATCH (rc=2 from select_profiles) is
+    # potentially skippable. Every other non-zero rc — ambiguous matches,
+    # invalid profiles root, malformed args — is a real fault the tree
+    # must surface; swallowing it would let a duplicate profile pass
+    # batch CI green, which is the false-pass class this PR exists to
+    # eliminate.
+    #
+    # For the no-match case the invocation mode decides. Implicit batch
+    # mode (get_recipes(), used by `make kwok-test-all` locally) keeps
+    # the historical SKIP-as-pass semantics so a partly-populated
+    # profile tree doesn't turn every dev-loop invocation red. Explicit
+    # invocation — the caller named this recipe on the command line, as
+    # every CI matrix cell does — fails: reporting green for a recipe
+    # the operator specifically asked about is the exact false-success
+    # the CI discovery filter also targets, and this is defense in
+    # depth if a caller ever bypasses that filter.
+    local overlay_file="${OVERLAYS_DIR}/${recipe}.yaml"
+    if [[ -f "${overlay_file}" ]]; then
+        local criteria svc accel
+        if criteria=$(resolve_recipe_criteria "${overlay_file}" 2>/dev/null); then
+            read -r svc accel <<< "${criteria}"
+            local sel_err select_rc=0
+            sel_err=$(select_profiles "${svc}" "${accel}" "${KWOK_DIR}/profiles" 2>&1 >/dev/null) || select_rc=$?
+            if (( select_rc == PROFILE_SELECT_RC_NO_MATCH )); then
+                if is_explicit_recipe "${recipe}"; then
+                    log_error "Recipe ${recipe} was explicitly requested but has no KWOK profile for service=${svc} accelerator=${accel}. Add a profile under kwok/profiles/${svc}/ or drop this recipe from the invocation (see #1997)."
+                    return 1
+                fi
+                log_warn "SKIP ${recipe}: no KWOK profile for service=${svc} accelerator=${accel} (add one under kwok/profiles/${svc}/ — see #1997)"
+                return 0
+            fi
+            if (( select_rc != 0 )); then
+                log_error "Profile selection failed for ${recipe} (service=${svc} accelerator=${accel}, rc=${select_rc}):"
+                [[ -n "${sel_err}" ]] && echo "${sel_err}" >&2
+                return "${select_rc}"
+            fi
+        fi
+    fi
+
     cleanup_between_tests
 
     # Create nodes (pass recipe name, script infers from overlay)
@@ -281,6 +330,21 @@ EOF
 # except the cleanup_between_tests system_ns allowlist gains two harmless
 # entries (argocd|aicr-registry) that never exist on the helm path.
 DEPLOYER="helm"
+
+# Space-separated list of recipes the caller explicitly named on the
+# command line. Populated in main() from positional args. Empty when the
+# recipe set came from get_recipes() (implicit batch mode). Used by
+# run_recipe_test to decide whether an unmapped-profile SKIP is a
+# recoverable batch outcome (rc=0) or a false-success that must be
+# surfaced as a failure (#1997): CI matrix cells always name a specific
+# recipe, so an unmapped recipe reaching them means every prior filter
+# was bypassed and the run has no coverage to report green about.
+EXPLICIT_RECIPES=""
+
+is_explicit_recipe() {
+    local recipe="$1"
+    [[ " ${EXPLICIT_RECIPES} " == *" ${recipe} "* ]]
+}
 
 main() {
     local recipes failed=() passed=()
@@ -332,6 +396,7 @@ main() {
 
     if [[ ${#positional[@]} -gt 0 ]]; then
         recipes="${positional[*]}"
+        EXPLICIT_RECIPES="${positional[*]}"
     else
         recipes=$(get_recipes)
     fi

--- a/kwok/scripts/run-all-recipes_test.sh
+++ b/kwok/scripts/run-all-recipes_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Regression harness for run-all-recipes.sh's unmapped-profile handling.
+# Proves the asymmetry required by #1997:
+#   - Explicit invocation (positional recipe args, as every CI matrix
+#     cell uses) must NOT report an unmapped recipe as passed.
+#   - Implicit batch invocation (no args, get_recipes() drives the set,
+#     as `make kwok-test-all` uses locally) may still SKIP an unmapped
+#     recipe with rc=0 so a partly-populated profile tree doesn't turn
+#     every dev-loop run red.
+#
+# Run directly: bash kwok/scripts/run-all-recipes_test.sh
+# Wired into CI by the kwok-recipes discover job.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not on PATH"; exit 0; }
+
+# Source run-all-recipes.sh without letting main() run. The script's
+# tail is the literal line `main "$@"`; strip it so we can source and
+# then invoke individual functions with stubs in place.
+SCRIPT_UNDER_TEST="${SCRIPT_DIR}/run-all-recipes.sh"
+# Keep the temp copy alongside the original so its ${SCRIPT_DIR} / lib
+# resolution (which uses BASH_SOURCE) points at the real lib directory.
+TMP_SOURCE=$(mktemp "${SCRIPT_DIR}/.run-all-recipes.test.XXXXXX.sh")
+trap 'rm -f "${TMP_SOURCE}"' EXIT
+grep -v '^main "\$@"$' "${SCRIPT_UNDER_TEST}" > "${TMP_SOURCE}"
+
+# shellcheck disable=SC1090
+source "${TMP_SOURCE}"
+
+# Stub cluster-touching helper AFTER sourcing so we win over the real
+# definition. Both test cases exit run_recipe_test at the SKIP branch
+# before cleanup_between_tests or apply-nodes.sh are reached; the stub
+# is defense-in-depth against a future change that shifts either call
+# above the SKIP check.
+# shellcheck disable=SC2329  # called indirectly via run_recipe_test
+cleanup_between_tests() { :; }
+
+# Point OVERLAYS_DIR at the real recipe tree so a known-unmapped recipe
+# resolves through resolve_recipe_criteria + select_profiles the same way
+# it would in production. Sourced run_recipe_test reads these globals.
+# shellcheck disable=SC2034  # read by sourced run_recipe_test
+OVERLAYS_DIR="${REPO_ROOT}/recipes/overlays"
+# shellcheck disable=SC2034  # read by sourced run_recipe_test
+KWOK_DIR="${REPO_ROOT}/kwok"
+# shellcheck disable=SC2034  # read by sourced run_recipe_test
+DEPLOYER="helm"
+
+# Pick a recipe known to be unmapped on the current tree. gb200-oke-training
+# has service=oke, and no oke profile ships on main.
+UNMAPPED_RECIPE="gb200-oke-training"
+if [[ ! -f "${OVERLAYS_DIR}/${UNMAPPED_RECIPE}.yaml" ]]; then
+    echo "FAIL: fixture recipe ${UNMAPPED_RECIPE} not found under ${OVERLAYS_DIR}"
+    exit 1
+fi
+
+fails=0
+check() {
+    local name="$1" want_rc_op="$2" want_rc="$3" got_rc="$4"
+    local ok=0
+    case "${want_rc_op}" in
+        eq) [[ "${got_rc}" == "${want_rc}" ]] && ok=1 ;;
+        ne) [[ "${got_rc}" != "${want_rc}" ]] && ok=1 ;;
+    esac
+    if (( ok == 1 )); then
+        echo "PASS: ${name}"
+    else
+        echo "FAIL: ${name} (want rc ${want_rc_op} ${want_rc}, got ${got_rc})"
+        fails=$((fails + 1))
+    fi
+}
+
+# 1. Explicit invocation — the operator named this recipe on the command
+# line, matching what every CI matrix cell does. An unmapped profile
+# must fail (rc != 0) rather than be reported as passed.
+# shellcheck disable=SC2034  # read by sourced run_recipe_test via is_explicit_recipe
+EXPLICIT_RECIPES="${UNMAPPED_RECIPE}"
+rc=0
+run_recipe_test "${UNMAPPED_RECIPE}" >/dev/null 2>&1 || rc=$?
+check "explicit-unmapped-recipe-is-not-reported-as-passed" ne 0 "${rc}"
+
+# 2. Implicit batch invocation — no positional args, recipe came from
+# get_recipes(). Historical dev-loop behavior (make kwok-test-all) is
+# preserved: unmapped recipes SKIP with rc=0 so a partly-populated
+# profile tree doesn't turn every local run red.
+# shellcheck disable=SC2034  # read by sourced run_recipe_test via is_explicit_recipe
+EXPLICIT_RECIPES=""
+rc=0
+run_recipe_test "${UNMAPPED_RECIPE}" >/dev/null 2>&1 || rc=$?
+check "implicit-batch-unmapped-recipe-is-still-skippable" eq 0 "${rc}"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All 2 tests passed"


### PR DESCRIPTION
Replace `apply-nodes.sh`'s hardcoded profile mapping with label-driven
discovery so unmapped `(service, accelerator)` combinations can no longer
silently fall back to `eks/p5-h100.yaml`.

## Motivation / Context

`get_profiles()` in `kwok/scripts/apply-nodes.sh` hardcoded a small
service+accelerator → profile map and defaulted everything else to
amd64 H100. #1985 hit the failure mode: four GB300 GKE lanes reported
green while the CI logs showed the simulated nodes were amd64 H100 —
the arm64 GB300 profiles the PR added were never exercised. The tests
said "your recipe schedules correctly" when they had actually tested
completely different hardware.

Fixes: #1997
Related: #1985

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: KWOK simulation scaffolding (`kwok/scripts/`, `kwok/README.md`, `.github/workflows/kwok-recipes.yaml`)

## Implementation Notes

Profile selection moves to `kwok/scripts/lib/profile-select.sh` and is
driven by profile-declared labels rather than a hardcoded case
statement. `select_profiles(service, accelerator, profiles_root)` walks
`kwok/profiles/<service>/` and matches:

| Role   | Match rule |
|--------|------------|
| system | `provider == <service>` and `nodeType == system` |
| gpu    | `provider == <service>` and `nodeType == accelerated` and `accelerator == <accelerator>` |

Exactly one match per role is required. Zero or multiple matches — or
an unknown service/accelerator — is an error, with a diagnostic that
enumerates what is on disk. Adding a profile now requires only a YAML
file with the right labels; no bash edit.

Direct-vs-batch semantics are intentionally different:

- **Direct** (`apply-nodes.sh <recipe>`, `make kwok-e2e RECIPE=…`) —
fails closed with the full diagnostic. If you explicitly ask about a
recipe, you get the honest answer.
- **Batch** (`run-all-recipes.sh`, `make kwok-test-all`, CI) — skips
unmapped recipes with a `WARN` and returns `rc=0`. Matrix coverage
stays green while profiles are backfilled in follow-up PRs; a recipe
that can't be simulated is not the same as a recipe that failed.

`resolve_recipe_criteria` is extracted alongside `select_profiles` so
`apply-nodes.sh` and `run-all-recipes.sh` share one defaulting policy
(`null`/`any` → `eks`/`h100`) and cannot drift.

Exposed by this change (currently silently passing, will `SKIP` after
merge until profiles are added): `a100-eks-*`, all `gke-*`, all `aks-*`,
all `oke-*`, all `bcm-*` recipes. Each is a candidate for a follow-up
profile PR.

## Testing

```bash
bash kwok/scripts/lib/profile-select_test.sh   # 14/14 pass
bash kwok/scripts/lib/sync-budget_test.sh      #  9/9 pass (unaffected)
shellcheck -x kwok/scripts/lib/profile-select*.sh kwok/scripts/apply-nodes.sh kwok/scripts/run-all-recipes.sh
yamllint .github/workflows/kwok-recipes.yaml
bash -n kwok/scripts/{apply-nodes.sh,run-all-recipes.sh,lib/profile-select.sh,lib/profile-select_test.sh}
```

New unit tests cover: happy paths (eks/h100, eks/gb200), unmapped
service, unmapped accelerator, missing system profile, ambiguous
system/gpu profiles, mislabeled provider in wrong directory, argument
validation, nonexistent roots, and resolve_recipe_criteria
explicit/default/any/missing-overlay paths. End-to-end skip logic
verified against the real overlay tree — 4 mapped recipes proceed,
7 unmapped ones skip cleanly.

Risk Assessment

- [x] Low — Isolated to KWOK scripts; no Go code touched, no
production code paths affected, purely CI/dev-loop scaffolding.

Rollout notes: No user-visible change. Recipes without matching
profiles will move from silent false-passes to explicit SKIP lines in
the CI logs; follow-up PRs add the missing profiles per provider/GPU.

Checklist

- [x] Tests pass locally (bash kwok/scripts/lib/profile-select_test.sh; no Go changes so make test is unchanged)
- [x] Linter passes (shellcheck, yamllint, bash -n)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (kwok/README.md)
- [x] Changes follow existing patterns in the codebase (mirrors lib/sync-budget.sh + sync-budget_test.sh)
- [x] Commits are cryptographically signed (git commit -S)
