### PR TITLE
fix: reject recipes where both gpu-operator and gpu-operator-ocp are enabled

### DIFF
--- a/docs/design/015-recipe-configuration-profiles.md
+++ b/docs/design/015-recipe-configuration-profiles.md
@@ -890,6 +890,15 @@ any check runs. This ADR therefore **amends the #1327 model**:
   `devicePlugin.enabled=false`, preserving #1327's fail-closed posture for
   recipes without the declaration (the non-goal narrows from "externally
   managed advertisers" to "*inferring* externally managed advertisers").
+- The device-plugin advertiser selection itself was tightened (#1685): a
+  recipe with both `gpu-operator` and `gpu-operator-ocp` enabled is
+  rejected (`ErrCodeInvalidRequest`) at resolution — profile or not,
+  where the resolver previously warned and preferred `gpu-operator`. Two
+  GPU operators collide at the operand level, and failing closed beats
+  silently preferring one (a divergent `devicePlugin.enabled` across the
+  two would otherwise slip through). The external-advertiser branch's
+  OR-aggregation across both operator components therefore sees at most
+  one enabled operator — the reject above narrows it.
 - Resolution counts a declared external advertiser as **the** advertiser
   in the exactly-one invariant. The dual-advertisement gates extend
   accordingly, fail closed: `advertiser: external` +

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -550,23 +550,32 @@ The `nvidia-dra-driver-gpu` value `resources.gpus.enabled` is the switch:
 absent or disabled — resolves `device-plugin-extended-resource`. On an
 **enabled** DRA component the switch must be explicitly set: the upstream
 chart's declared default is `true`, so an absent value would diverge from
-what Helm deploys. Three configurations are rejected at resolution time with
-an invalid-request error: an enabled `nvidia-dra-driver-gpu` component with
+what Helm deploys. These configurations are rejected at resolution time with
+an invalid-request error:
+
+* an enabled `nvidia-dra-driver-gpu` component with
 `resources.gpus.enabled` absent (pin it explicitly in the recipe; stock
-recipes always do), `gpus.enabled=true` without
-`gpuResourcesEnabledOverride=true` (the upstream chart install guard refuses
-it), and no whole-GPU advertiser remaining — `gpus.enabled` off with the GPU
-operator component (`gpu-operator`, or `gpu-operator-ocp` on OpenShift
-recipes) absent, disabled, or carrying `devicePlugin.enabled=false`. Two
-further states are likewise rejected (they warned during the transition to
-the device-plugin production default and are errors since the flip): dual
-advertisement (both mechanisms enabled — exactly one whole-GPU advertiser is
-required) and an inert `gpuResourcesEnabledOverride=true` with
-`gpus.enabled=false` (the waiver would disarm the upstream chart's
-install-guard tripwire). Stock recipes ship the production default:
-`gpus.enabled=false`, `gpuResourcesEnabledOverride=false`, and
-`devicePlugin.enabled=true`; the experimental DRA opt-in flips all three
-together in a recipe overlay.
+recipes always do).
+* `gpus.enabled=true` without `gpuResourcesEnabledOverride=true` (the upstream
+chart install guard refuses it), and no whole-GPU advertiser remaining.
+* `gpus.enabled` off with the GPU operator component (`gpu-operator`, or
+`gpu-operator-ocp` on OpenShift recipes) absent, disabled, or carrying
+`devicePlugin.enabled=false`.
+* A recipe enabling both `gpu-operator` and `gpu-operator-ocp`; two GPU
+operators collide at the operand level; enable exactly one (OpenShift recipes
+disable gpu-operator and carry gpu-operator-ocp).
+
+Two further states are likewise rejected (they warned during the transition to
+the device-plugin production default and are errors since the flip):
+
+* dual advertisement (both mechanisms enabled — exactly one whole-GPU advertiser
+is required)
+* an inert `gpuResourcesEnabledOverride=true` with `gpus.enabled=false` (the
+waiver would disarm the upstream chart's install-guard tripwire).
+
+Stock recipes ship the production default: `gpus.enabled=false`,
+`gpuResourcesEnabledOverride=false`, and `devicePlugin.enabled=true`; the
+experimental DRA opt-in flips all three together in a recipe overlay.
 
 **Upgrading a cluster from the dual-advertised (pre-flip) configuration:**
 applying the flipped bundle does not drain existing workloads — a running

--- a/pkg/allocpolicy/allocpolicy.go
+++ b/pkg/allocpolicy/allocpolicy.go
@@ -165,9 +165,13 @@ type Observation struct {
 // CheckCoherence is the single shared evaluator of the #1327 tuple-coherence
 // rules for every advertiser shape, failing closed (ErrCodeInvalidRequest).
 // The hydrating artifact gate (pkg/recipe) and the validation-time resolver
-// (pkg/validator/v1 ResolveGPUAllocationPolicy) both delegate their verdicts
-// here, so an artifact the gate emits is exactly an artifact validation
-// accepts — gate/resolver symmetry (ADR-015).
+// (pkg/validator/v1 ResolveGPUAllocationPolicy) both delegate their tuple
+// verdicts here, so over these #1327 tuple rows an artifact the gate emits is
+// exactly an artifact validation accepts — gate/resolver symmetry (ADR-015).
+// The #1685 dual-operator rejection is resolution-time-only and deliberately
+// not part of this evaluator: it is a resolver-side check on the recipe's
+// component set, not a tuple reading, and bundle-time rejection is a separate
+// follow-up.
 //
 // Under a declared external advertiser (ADR-015 GKE amendment), the external
 // plugin is THE advertiser in the exactly-one invariant:

--- a/pkg/recipe/profile.go
+++ b/pkg/recipe/profile.go
@@ -824,15 +824,18 @@ func (r *RecipeResult) validateProfileValuesWithContext(
 // against the hydrated advertiser components for EVERY closure-triggering
 // profile — a declared external advertiser AND the empty (operator-advertised)
 // advertiser shape alike. The verdicts come from the single shared
-// evaluator (allocpolicy.CheckCoherence), which mirrors the validation-time
-// resolver (pkg/validator/v1 ResolveGPUAllocationPolicy) verdict-for-verdict
-// — gate/resolver symmetry (ADR-015): an artifact this gate emits is
-// exactly an artifact validation accepts. The gate is gated on the profile
-// owning advertisement: an AKS-shaped profile performs no evaluation here,
-// and the conflicting toggle typically lives in a component values file —
-// which is exactly why this runs at the hydration boundary rather than
-// only at resolution (disk-loaded, POSTed, and direct-bundler recipes
-// bypass resolution).
+// evaluator (allocpolicy.CheckCoherence), which applies the same #1327
+// tuple-coherence rows as the validation-time resolver (pkg/validator/v1
+// ResolveGPUAllocationPolicy) — gate/resolver symmetry over the shared
+// tuple verdicts (ADR-015): for those tuple rows, an artifact this gate
+// emits is exactly an artifact validation accepts. The #1685 dual-operator
+// rejection is resolution-time-only and deliberately not mirrored here
+// (it is outside #1685's scope); bundle-time rejection is a separate
+// follow-up. The gate is gated on the profile owning advertisement: an
+// AKS-shaped profile performs no evaluation here, and the conflicting
+// toggle typically lives in a component values file — which is exactly
+// why this runs at the hydration boundary rather than only at resolution
+// (disk-loaded, POSTed, and direct-bundler recipes bypass resolution).
 func (r *RecipeResult) checkAdvertiserCoherence(hydrated map[string]map[string]any) error {
 	if !r.profileClosureTriggered() {
 		return nil
@@ -843,12 +846,15 @@ func (r *RecipeResult) checkAdvertiserCoherence(hydrated map[string]map[string]a
 	// hydrated above. An absent devicePlugin.enabled on an enabled
 	// operator component follows the upstream chart default (true) — the
 	// same reading the #1327 resolver applies. The aggregation mirrors the
-	// resolver's per-advertiser reading exactly: under a declared external
-	// advertiser EVERY enabled operator component is a potential second
-	// advertiser (OR semantics); under an empty advertiser the resolver
-	// reads the preferred component only (gpu-operator wins over
-	// gpu-operator-ocp when both are enabled) — diverging here would emit
-	// artifacts validation resolves differently.
+	// resolver's per-advertiser reading for the shared tuple verdicts:
+	// under a declared external advertiser EVERY enabled operator
+	// component is a potential second advertiser (OR semantics); under an
+	// empty advertiser the gate reads the first present operator component
+	// (gpu-operator before gpu-operator-ocp in the iteration). The
+	// resolver's #1685 rejection of a recipe with both operators enabled
+	// is resolution-time-only and deliberately not mirrored here —
+	// diverging on the shared tuple rows would emit artifacts validation
+	// resolves differently.
 	for _, component := range []string{allocpolicy.ComponentGPUOperator, allocpolicy.ComponentGPUOperatorOCP} {
 		values, ok := hydrated[component]
 		if !ok {

--- a/pkg/recipe/profile_gke_test.go
+++ b/pkg/recipe/profile_gke_test.go
@@ -314,15 +314,17 @@ func TestCoherenceGateRejectsExternalWithDevicePluginEnabled(t *testing.T) {
 }
 
 // TestCoherenceGateRejectsDriverInstallerIncoherentTuples pins the
-// empty-advertiser (driver-installer) side of the gate/resolver symmetry:
-// the artifact gate applies the full #1327 tuple verdicts for EVERY
-// closure-triggering profile, not only a declared external advertiser. A
-// forged driver-installer artifact whose overrides enable DRA whole-GPU
-// advertisement next to the operator's device plugin (dual advertisement),
-// or leave an inert chart-guard waiver, must fail
-// PrepareAndValidateWithContext — the same recipes
+// empty-advertiser (driver-installer) side of the gate/resolver symmetry
+// over the shared #1327 tuple rows: the artifact gate applies the full
+// tuple verdicts for EVERY closure-triggering profile, not only a declared
+// external advertiser. A forged driver-installer artifact whose overrides
+// enable DRA whole-GPU advertisement next to the operator's device plugin
+// (dual advertisement), or leave an inert chart-guard waiver, must fail
+// PrepareAndValidateWithContext — the same tuple rows
 // ResolveGPUAllocationPolicy rejects at validation time must never reach an
 // output writer, because validation is not guaranteed to run before deploy.
+// (The #1685 dual-operator rejection is resolver-side only and not mirrored
+// here; it is outside the tuple rows this test covers.)
 func TestCoherenceGateRejectsDriverInstallerIncoherentTuples(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/validator/v1/allocation_policy.go
+++ b/pkg/validator/v1/allocation_policy.go
@@ -93,26 +93,40 @@ const (
 //
 // The device-plugin advertiser is read from an enabled gpu-operator OR
 // gpu-operator-ocp componentRef (OCP recipes disable the former and carry the
-// latter); if both are enabled, gpu-operator wins with a warning. When
-// NEITHER is present and enabled, there is no device-plugin advertiser at all
-// — INFERRING an externally managed advertiser from that absence is an
-// explicit #1327 non-goal. An advertiser declared explicitly via
-// metadata.selectedProfile.advertiser: external (ADR-015 GKE amendment) IS
-// supported and handled by the external-advertiser branch below.
+// latter); if both are enabled then ErrCodeInvalidRequest (#1685) — two GPU
+// operators collide at the operand level regardless of allocation policy,
+// and failing closed beats silently preferring one (a divergent
+// devicePlugin.enabled across the two would otherwise slip through).
+//
+// When NEITHER is present and enabled, there is
+// no device-plugin advertiser at all — INFERRING an externally managed
+// advertiser from that absence is an explicit #1327 non-goal. An advertiser
+// declared explicitly via metadata.selectedProfile.advertiser: external
+// (ADR-015 GKE amendment) IS supported and handled by the external-advertiser
+// branch below.
 //
 // Validity gates (ErrCodeInvalidRequest, fail closed at resolution time):
+//
+//   - an ENABLED gpu-operator and an ENABLED gpu-operator-ocp causes
+//     automatic rejection. Both GPU operators enabled: reject (#1685) — two
+//     operators collide at the operand level.
+//
 //   - an ENABLED nvidia-dra-driver-gpu component with resources.gpus.enabled
 //     ABSENT: the chart's declared default (true) would diverge from any
 //     silent resolution — the switch must be explicitly true or false.
+//
 //   - gpus.enabled=true with gpuResourcesEnabledOverride=false: the upstream
 //     chart install guard rejects this combination.
+//
 //   - no whole-GPU advertiser: gpus.enabled explicitly false (or the DRA
 //     component absent/disabled) AND no usable device-plugin advertiser
 //     (devicePlugin.enabled=false, or no enabled GPU operator component).
+//
 //   - gpus.enabled=true with devicePlugin.enabled=true: dual advertisement —
 //     both mechanisms advertising whole GPUs on the same nodes risks GPU
 //     over-admission; exactly one advertiser is required. (Transitional
 //     warning until the production-default flip; an error since.)
+//
 //   - gpus.enabled=false with gpuResourcesEnabledOverride=true: the inert
 //     waiver disarms the chart-guard tripwire that protects the
 //     device-plugin default. (Transitional warning until the
@@ -204,23 +218,23 @@ func ResolveGPUAllocationPolicy(parent context.Context, r *recipe.RecipeResult) 
 	// gpu-operator-ocp, and error guidance must name the component actually
 	// carrying devicePlugin.enabled.
 	operatorName := gpuOperatorComponentName
-	// A declared external advertiser takes the dedicated branch below, which
-	// aggregates devicePlugin.enabled across BOTH operator components with OR
-	// semantics — nothing is "ignored" there, so the warn-and-prefer
-	// diagnostic below would be misleading; suppress it on that path.
+	// A declared external advertiser takes the dedicated branch below.
+	// The #1685 rejection above guarantees at most one operator component
+	// is enabled by the time either path reads devicePlugin.enabled.
 	externalAdvertiser := r.Metadata.SelectedProfile != nil &&
 		r.Metadata.SelectedProfile.Advertiser == allocpolicy.AdvertiserExternal
 	opRef := enabledComponentRef(r, gpuOperatorComponentName)
-	if ocpRef := enabledComponentRef(r, gpuOperatorOCPComponentName); ocpRef != nil {
+	ocpRef := enabledComponentRef(r, gpuOperatorOCPComponentName)
+	if ocpRef != nil {
 		if opRef != nil {
-			if !externalAdvertiser {
-				slog.Warn("both gpu-operator and gpu-operator-ocp are enabled in the recipe; resolving devicePlugin.enabled from gpu-operator",
-					"preferred", gpuOperatorComponentName, "ignored", gpuOperatorOCPComponentName)
-			}
-		} else {
-			opRef = ocpRef
-			operatorName = gpuOperatorOCPComponentName
+			// Both GPU operators enabled: reject (#1685) — two operators collide at the operand level.
+			return "", errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf(
+				"invalid GPU allocation configuration: components %q and %q are both enabled — two GPU operators collide at the operand level; enable exactly one (OpenShift recipes disable %q and carry %q) (issue #1685)",
+				gpuOperatorComponentName, gpuOperatorOCPComponentName,
+				gpuOperatorComponentName, gpuOperatorOCPComponentName))
 		}
+		opRef = ocpRef
+		operatorName = gpuOperatorOCPComponentName
 	}
 	if opRef != nil {
 		values, err := r.GetValuesForComponentWithContext(ctx, opRef.Name)
@@ -244,32 +258,13 @@ func ResolveGPUAllocationPolicy(parent context.Context, r *recipe.RecipeResult) 
 	// only metadata.selectedProfile.advertiser produces this branch.
 	if externalAdvertiser {
 		// Under a declared external advertiser EVERY enabled operator
-		// component is a potential second advertiser, so the reading
-		// aggregates across gpu-operator AND gpu-operator-ocp with OR
-		// semantics (mirroring checkAdvertiserCoherence in
-		// pkg/recipe/profile.go) instead of the diagnostic warn-and-prefer
-		// selection above — preferring one component would let the other
-		// component's live plugin slip past the dual-advertisement gate.
-		externalDevicePluginEnabled := false
-		for _, name := range []string{gpuOperatorComponentName, gpuOperatorOCPComponentName} {
-			ref := enabledComponentRef(r, name)
-			if ref == nil {
-				continue
-			}
-			values, err := r.GetValuesForComponentWithContext(ctx, ref.Name)
-			if err != nil {
-				return "", err
-			}
-			// Key absent → true: the upstream chart default, same as the
-			// preferred-component reading above.
-			enabled, err := lookupBoolValue(values, ref.Name, valuePathDevicePluginEnabled, true)
-			if err != nil {
-				return "", err
-			}
-			if enabled {
-				externalDevicePluginEnabled = true
-			}
-		}
+		// component is a potential second advertiser, so the reading is
+		// the devicePlugin.enabled of any enabled operator component. The
+		// #1685 reject above guarantees at most one operator component is
+		// enabled here, so devicePluginEnabled — read from the surviving
+		// opRef above — already carries the aggregation the pre-#1685
+		// code performed across both components.
+		externalDevicePluginEnabled := devicePluginEnabled
 
 		observation := allocpolicy.Observation{
 			Advertiser:          allocpolicy.AdvertiserExternal,
@@ -288,9 +283,11 @@ func ResolveGPUAllocationPolicy(parent context.Context, r *recipe.RecipeResult) 
 	// Verdicts (chart guard, dual advertisement, no advertiser, inert
 	// waiver) come from the single shared #1327 tuple evaluator, so the
 	// hydrating artifact gate (pkg/recipe checkAdvertiserCoherence) and
-	// this resolver cannot drift: an artifact the gate emits is exactly an
-	// artifact this resolver accepts (ADR-015 gate/resolver symmetry).
-	// Only the policy SELECTION below stays here.
+	// this resolver apply the same #1327 tuple verdicts — an artifact the
+	// gate emits passes the same tuple rows this resolver accepts
+	// (ADR-015 gate/resolver symmetry over the shared tuple rows; the
+	// #1685 dual-operator rejection above is resolver-side only and not
+	// mirrored at the gate). Only the policy SELECTION below stays here.
 	observation := allocpolicy.Observation{
 		DevicePluginEnabled:  &devicePluginEnabled,
 		GPUOperatorComponent: operatorName,

--- a/pkg/validator/v1/allocation_policy_test.go
+++ b/pkg/validator/v1/allocation_policy_test.go
@@ -243,8 +243,12 @@ func TestResolveGPUAllocationPolicy(t *testing.T) {
 			want: GPUAllocationPolicyDevicePluginExtendedResource,
 		},
 		{
-			// Both operator components enabled: gpu-operator wins (warn).
-			name: "both gpu-operator and gpu-operator-ocp enabled: gpu-operator resolves the advertiser",
+			// Two GPU operators on one cluster collide at the operand level
+			// regardless of devicePlugin enablement at any operator level or external
+			// advertisers presence, so enabling both fails closed.
+			// (ErrCodeInvalidRequest) instead of silently preferring one (#1685
+			// and #1327).
+			name: "both gpu-operator and gpu-operator-ocp enabled: invalid (rejected)",
 			recipe: &recipe.RecipeResult{ComponentRefs: []recipe.ComponentRef{
 				gpuOperatorRef(true),
 				{
@@ -254,7 +258,31 @@ func TestResolveGPUAllocationPolicy(t *testing.T) {
 					},
 				},
 			}},
-			want: GPUAllocationPolicyDevicePluginExtendedResource,
+			wantErr: true,
+			wantMsg: "invalid GPU allocation configuration: components \"gpu-operator\" and \"gpu-operator-ocp\" are both enabled",
+		},
+		{
+			// Regression for the #1685 orientation gap: a custom recipe with
+			// gpu-operator devicePlugin.enabled=false and gpu-operator-ocp
+			// devicePlugin.enabled=true previously resolved dra-resource-claim
+			// (gpu-operator won) while the OCP ClusterPolicy still rendered an
+			// enabled device plugin — the dual-advertisement state #1327
+			// rejects. Enabling both operators must fail closed before any
+			// policy is derived, regardless of which side carries the
+			// divergent pin.
+			name: "both operators enabled with divergent devicePlugin pins: invalid (orientation gap)",
+			recipe: &recipe.RecipeResult{ComponentRefs: []recipe.ComponentRef{
+				draDriverRef(true, true),
+				gpuOperatorRef(false),
+				{
+					Name: "gpu-operator-ocp",
+					Overrides: map[string]any{
+						"devicePlugin": map[string]any{"enabled": true},
+					},
+				},
+			}},
+			wantErr: true,
+			wantMsg: "invalid GPU allocation configuration: components \"gpu-operator\" and \"gpu-operator-ocp\" are both enabled",
 		},
 		{
 			// OCP recipes carry the DRA driver under its -ocp alias; the
@@ -556,13 +584,12 @@ func TestResolveGPUAllocationPolicyExternalAdvertiser(t *testing.T) {
 			wantMsg: "devicePlugin.enabled=true",
 		},
 		{
-			// Under a declared external advertiser the reading aggregates
-			// across EVERY enabled operator component (OR semantics,
-			// mirroring the recipe-side checkAdvertiserCoherence): the
-			// warn-and-prefer selection used for diagnostics elsewhere must
-			// not let gpu-operator-ocp's live plugin slip past the gate
-			// behind a disabled gpu-operator.
-			name: "external advertiser with gpu-operator plugin off but gpu-operator-ocp plugin on is dual advertisement",
+			// Two GPU operators on one cluster collide at the operand level
+			// regardless of devicePlugin enablement on any operator level or external
+			// advertisers presence, so enabling both fails closed.
+			// (ErrCodeInvalidRequest) instead of silently preferring one (#1685
+			// and #1327).
+			name: "external advertiser with gpu-operator plugin off but gpu-operator-ocp plugin on is dual advertisement (rejected)",
 			recipe: externalProfileRecipe(
 				draDriverRef(false, false),
 				gpuOperatorRef(false),
@@ -574,13 +601,15 @@ func TestResolveGPUAllocationPolicyExternalAdvertiser(t *testing.T) {
 				},
 			),
 			wantErr: true,
-			wantMsg: "devicePlugin.enabled=true",
+			wantMsg: "invalid GPU allocation configuration: components \"gpu-operator\" and \"gpu-operator-ocp\" are both enabled",
 		},
 		{
-			// Both operator components enabled with the plugin off on each:
-			// the OR-aggregate stays false and external remains the sole
-			// advertiser.
-			name: "external advertiser with both operator components' plugins off resolves",
+			// Two GPU operators on one cluster collide at the operand level
+			// regardless of devicePlugin enablement on any operator level or external
+			// advertisers presence, so enabling both fails closed.
+			// (ErrCodeInvalidRequest) instead of silently preferring one (#1685
+			// and #1327).
+			name: "external advertiser with both operator components' plugins off (rejected)",
 			recipe: externalProfileRecipe(
 				draDriverRef(false, false),
 				gpuOperatorRef(false),
@@ -591,19 +620,23 @@ func TestResolveGPUAllocationPolicyExternalAdvertiser(t *testing.T) {
 					},
 				},
 			),
-			want: GPUAllocationPolicyDevicePluginExtendedResource,
+			wantErr: true,
+			wantMsg: "invalid GPU allocation configuration: components \"gpu-operator\" and \"gpu-operator-ocp\" are both enabled",
 		},
 		{
-			// An enabled operator component with the key ABSENT follows the
-			// upstream chart default (true) in the aggregate too.
-			name: "external advertiser with gpu-operator-ocp missing the devicePlugin key is dual advertisement",
+			// Two GPU operators on one cluster collide at the operand level
+			// regardless of devicePlugin enablement on any operator level or external
+			// advertisers presence, so enabling both fails closed.
+			// (ErrCodeInvalidRequest) instead of silently preferring one (#1685
+			// and #1327).
+			name: "external advertiser with gpu-operator-ocp missing the devicePlugin key is dual advertisement (rejected)",
 			recipe: externalProfileRecipe(
 				draDriverRef(false, false),
 				gpuOperatorRef(false),
 				recipe.ComponentRef{Name: "gpu-operator-ocp"},
 			),
 			wantErr: true,
-			wantMsg: "devicePlugin.enabled=true",
+			wantMsg: "invalid GPU allocation configuration: components \"gpu-operator\" and \"gpu-operator-ocp\" are both enabled",
 		},
 		{
 			name:    "external advertiser with DRA gpus enabled is dual advertisement",


### PR DESCRIPTION
## Summary

ResolveGPUAllocationPolicy would previously resolve incorrect policy when both `gpu-operator` and `gpu-operator-ocp` were enabled. Having two gpu operator is also an invalid recipe and should not be enabled at the same time. This PR now rejects when a recipe has both of the operators enabled.

## Motivation / Context

<!-- Why is this change needed? Link issues/discussions. -->

Fixes: #1685 
Related: #1327 #1664 #1671

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

<!-- Key decisions, trade-offs, and any non-obvious behavior changes. Delete if not applicable. -->

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
```

<!-- Summarize test results or paste relevant output -->

## Risk Assessment

<!-- Select one and explain -->

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** <!-- Migration steps, feature flags, backwards compatibility, or N/A -->

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
