### PR TITLE
feat(cli): support aicr verify via AICRConfig (spec.verify)

### DIFF
--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -314,8 +314,11 @@ an attested bundle whose binary attestation is absent, or one carrying external
 
 What no policy value can wave through: checksum failures, and attestations that
 are present but fail verification. Those are rejected regardless of the floor.
-`aicr verify` logs at INFO whenever config sets the floor to anything other than
-`max`.
+
+`aicr verify` logs the floor at INFO when config is what supplies it: that is,
+when `--min-trust-level` is absent and the configured value is anything other
+than `max`. An explicit flag takes precedence instead, and that override is
+logged separately by the flag-precedence path.
 
 Every field is a durable, non-secret reference or policy value; no private key
 material is part of the schema. Three `aicr verify` flags are deliberately

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -301,6 +301,15 @@ checked after verification runs, `trust` holds the material it verifies against.
 | `trust.key` | string | KMS key URI (`awskms://` \| `gcpkms://` \| `azurekms://` \| `hashivault://`) or local PEM public-key path; the verify counterpart to `spec.bundle.attestation.signingKey` |
 | `trust.trustRoot` | string | Path to a private Sigstore `trusted_root.json`, additive to the built-in public-good root |
 
+`policy.minTrustLevel` sets **operator policy, not an org-enforced guardrail**.
+A committed value lowers the effective floor as readily as it raises it
+(`unknown` makes the trust check a no-op, since every level meets it), so treat
+it as a reviewable choice rather than a control that cannot be relaxed. Its
+blast radius is bounded: verification still rejects checksum-failed and
+invalidly-signed bundles regardless of policy, so only checksum-valid *unsigned*
+bundles pass a lowered floor. `aicr verify` logs at INFO whenever config sets the
+floor to anything other than `max`.
+
 Every field is a durable, non-secret reference or policy value; no private key
 material is part of the schema. Three `aicr verify` flags are deliberately
 excluded: the bundle directory (a positional argument), `--format`

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -304,11 +304,18 @@ checked after verification runs, `trust` holds the material it verifies against.
 `policy.minTrustLevel` sets **operator policy, not an org-enforced guardrail**.
 A committed value lowers the effective floor as readily as it raises it
 (`unknown` makes the trust check a no-op, since every level meets it), so treat
-it as a reviewable choice rather than a control that cannot be relaxed. Its
-blast radius is bounded: verification still rejects checksum-failed and
-invalidly-signed bundles regardless of policy, so only checksum-valid *unsigned*
-bundles pass a lowered floor. `aicr verify` logs at INFO whenever config sets the
-floor to anything other than `max`.
+it as a reviewable choice rather than a control that cannot be relaxed.
+
+A lowered floor admits any bundle whose actual trust level reaches it, which is
+broader than unsigned bundles. It also covers chains that legitimately degraded:
+an attested bundle whose binary attestation is absent, or one carrying external
+`--data`, both report `attested` against a `verified` maximum, so the default
+`max` rejects them while a lowered floor does not.
+
+What no policy value can wave through: checksum failures, and attestations that
+are present but fail verification. Those are rejected regardless of the floor.
+`aicr verify` logs at INFO whenever config sets the floor to anything other than
+`max`.
 
 Every field is a durable, non-secret reference or policy value; no private key
 material is part of the schema. Three `aicr verify` flags are deliberately

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -1,24 +1,30 @@
 # CLI Configuration File (AICRConfig)
 
 `AICRConfig` is a Kubernetes-style YAML/JSON document that captures the inputs
-to the four workflow commands — `aicr snapshot`, `aicr recipe`, `aicr bundle`,
-and `aicr validate` — so an end-to-end run version-controls as a single file
-instead of a shell script full of flags. Each command accepts it through the
-same `--config` flag:
+to the five workflow commands — `aicr snapshot`, `aicr recipe`, `aicr bundle`,
+`aicr validate`, and `aicr verify` — so an end-to-end run version-controls as a
+single file instead of a shell script full of flags. Each command accepts it
+through the same `--config` flag:
 
 ```shell
 aicr snapshot --config aicr-config.yaml
 aicr recipe   --config aicr-config.yaml
 aicr bundle   --config aicr-config.yaml
 aicr validate --config aicr-config.yaml
+aicr verify   --config aicr-config.yaml
 ```
+
+The first four are the producer pipeline; `spec.verify` is the consumer side, so
+one document can carry both how an artifact is built and the trust floor a
+downstream consumer enforces against it.
 
 This page documents the complete document schema in one place. The
 [CLI Reference](cli-reference.md) shows per-command usage in its
 [Snapshot](cli-reference.md#snapshot-config-file-mode),
 [Recipe](cli-reference.md#config-file-mode-recommended),
-[Validate](cli-reference.md#validate-config-file-mode), and
-[Bundle](cli-reference.md#bundle-config-file-mode) config-file-mode sections.
+[Validate](cli-reference.md#validate-config-file-mode),
+[Bundle](cli-reference.md#bundle-config-file-mode), and
+[Verify](cli-reference.md#verify-config-file-mode) config-file-mode sections.
 The schema's source of truth is
 [`pkg/config`](https://github.com/NVIDIA/aicr/tree/main/pkg/config).
 
@@ -34,11 +40,12 @@ spec:
   recipe: {}                   # at least ONE must be present
   bundle: {}
   validate: {}
+  verify: {}
 ```
 
 Each `spec.*` section is optional and each command reads only its own section,
 so a file may carry just one section or any combination. A document with none
-of the four sections is rejected.
+of the five sections is rejected.
 
 ## Loading, Precedence, and Secrets
 
@@ -183,6 +190,15 @@ spec:
         push: ""                     # OCI ref to push the signed bundle
         plainHTTP: false
         insecureTLS: false
+  verify:                            # consumer side: policy for `aicr verify`
+    policy:                          # assertions checked after verification
+      minTrustLevel: verified        # unknown | unverified | attested | verified | max
+      requireCreator: ci@myorg.example.com
+      cliVersionConstraint: ">= 0.16.0"
+    trust:                           # material verification runs against
+      certificateIdentityRegexp: ""  # must contain NVIDIA/aicr when set
+      key: ""                        # KMS URI or local PEM public-key path
+      trustRoot: ""                  # private Sigstore trusted_root.json
 ```
 
 ## Field Reference
@@ -270,9 +286,31 @@ Inputs to `aicr validate`.
 | `evidence.attestation.bom` / `.push` | string | BOM input; OCI ref for the signed bundle push |
 | `evidence.attestation.plainHTTP` / `.insecureTLS` | bool (tri-state) | Push transport options |
 
+### spec.verify
+
+Verification policy for `aicr verify`, the one consumer-side section. The two
+sub-sections mirror how the command consumes them: `policy` holds assertions
+checked after verification runs, `trust` holds the material it verifies against.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `policy.minTrustLevel` | string | `unknown` \| `unverified` \| `attested` \| `verified`, or `max` (the CLI default) to auto-detect the highest level the bundle can reach |
+| `policy.requireCreator` | string | Pins the OIDC identity in the bundle attestation's signing certificate |
+| `policy.cliVersionConstraint` | string | Constrains the `aicr` version in the attestation predicate; supports `>=`, `>`, `<=`, `<`, `==`, `!=`, and a bare version means `>=` |
+| `trust.certificateIdentityRegexp` | string | Certificate identity pattern for binary attestation verification; must contain `NVIDIA/aicr` |
+| `trust.key` | string | KMS key URI (`awskms://` \| `gcpkms://` \| `azurekms://` \| `hashivault://`) or local PEM public-key path; the verify counterpart to `spec.bundle.attestation.signingKey` |
+| `trust.trustRoot` | string | Path to a private Sigstore `trusted_root.json`, additive to the built-in public-good root |
+
+Every field is a durable, non-secret reference or policy value; no private key
+material is part of the schema. Three `aicr verify` flags are deliberately
+excluded: the bundle directory (a positional argument), `--format`
+(presentation, not policy), and `--insecure-ignore-tlog`, which weakens the
+trust floor and so stays command-line-only rather than something a committed
+file can silently enable. It still composes with a config-supplied `trust.key`.
+
 ## Cross-Section Rules
 
-- At least one of the four `spec.*` sections must be present.
+- At least one of the five `spec.*` sections must be present.
 - `spec.recipe.criteria` and `spec.recipe.input.snapshot` are mutually
   exclusive.
 - When **both** `spec.recipe.output.path` and `spec.bundle.input.recipe` are

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -11,7 +11,7 @@ aicr snapshot --config aicr-config.yaml
 aicr recipe   --config aicr-config.yaml
 aicr bundle   --config aicr-config.yaml
 aicr validate --config aicr-config.yaml
-aicr verify   --config aicr-config.yaml
+aicr verify   ./my-bundle --config aicr-config.yaml   # bundle dir is positional
 ```
 
 The first four are the producer pipeline; `spec.verify` is the consumer side, so

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2833,6 +2833,63 @@ aicr verify <bundle-dir> [flags]
 | `--trust-root` | string | | Verify the bundle attestation against a private Sigstore trusted root (a `trusted_root.json` from a self-hosted Fulcio/Rekor). Additive to AICR's built-in public-good root, so NVIDIA-signed and privately-signed bundles both verify. Composes with `--key` and `--certificate-identity-regexp`. The verify counterpart to `bundle --fulcio-url`/`--rekor-url`. |
 | `--insecure-ignore-tlog` | bool | `false` | Offline/air-gapped verification: skip the transparency-log (and observer-timestamp) requirement so a bundle signed with `bundle --signing-key ... --tlog-upload=false` verifies against `--key` with no transparency-log network calls. A local PEM `--key` is then fully offline; a KMS `--key` URI still makes a live `GetPublicKey` call to resolve the key (export a PEM with `cosign public-key` for a truly offline verify). Requires `--key`; the air-gapped path is key-based, not keyless. Named "insecure" because, with no transparency log, there is no trusted timestamp proving when the signature was made. Does not affect the binary attestation, which always requires a transparency log. |
 | `--format` | string | `text` | Output format: `text` or `json`. |
+| `--config` | string | | Path or HTTP/HTTPS URL to an AICRConfig file (YAML/JSON) supplying verification policy from `spec.verify`. CLI flags override values from this file. See [Verify Config File Mode](#verify-config-file-mode). |
+
+#### Verify Config File Mode
+
+`aicr verify --config <path>` reads verification policy from an AICRConfig
+YAML/JSON file under `spec.verify`. CLI flags always override values loaded from
+`--config`; override events are logged at INFO so users can see which input won.
+
+This is the one consumer-side section of the schema, so a single committed
+document can carry both the settings that build an artifact and the trust floor
+a downstream consumer enforces against it.
+
+**Supported schema:**
+
+```yaml
+kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: prod-verify
+spec:
+  verify:
+    policy:                              # assertions checked after verification runs
+      minTrustLevel: verified            # or unknown | unverified | attested | max
+      requireCreator: ci@myorg.example.com
+      cliVersionConstraint: ">= 0.16.0"  # bare version means ">="
+    trust:                               # material verification runs against
+      certificateIdentityRegexp: "https://github.com/NVIDIA/aicr/.+"
+      key: gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k
+      trustRoot: ./trusted_root.json
+```
+
+Every field is a durable, non-secret reference or policy value, so the whole
+section is safe to commit. No private key material is part of the schema.
+
+Three `aicr verify` flags are deliberately **not** in the schema:
+
+- The bundle directory, which is a positional argument rather than a flag.
+- `--format`, which is presentation rather than policy.
+- `--insecure-ignore-tlog`, which weakens the trust floor by dropping the
+  transparency-log requirement. Keeping it command-line-only means a committed
+  file can never silently disable that check, and an air-gap override stays an
+  explicit operator act. It still composes with a config-supplied `key`.
+
+Values are validated when the document loads, so a typo fails with its spec path
+(for example `invalid spec.verify.policy.minTrustLevel`) rather than after a full
+verification run. One limit is worth knowing: `cliVersionConstraint` is checked
+at the operator level only, so `">="` with no version is rejected at load time
+while `">= not-a-version"` is accepted and fails later when the constraint is
+evaluated.
+
+```shell
+# Commit the verification policy, then gate a deploy on it.
+aicr verify ./my-bundle --config aicr-config.yaml
+
+# A CLI flag still wins over the committed policy.
+aicr verify ./my-bundle --config aicr-config.yaml --min-trust-level attested
+```
 
 #### Trust Levels
 

--- a/pkg/bundler/verifier/trust.go
+++ b/pkg/bundler/verifier/trust.go
@@ -236,7 +236,11 @@ func (r *VerifyResult) MaxAchievableTrustLevel() TrustLevel {
 // here and fails later at Evaluate.
 func ParseVersionConstraint(expr string) (*constraints.ParsedConstraint, error) {
 	expr = strings.TrimSpace(expr)
-	if !hasOperatorPrefix(expr) {
+	// A leading "!" is never a bare version. The shared parser rejects a bare
+	// "!" prefix outright (it means the user wanted "!=" or the node-set
+	// form), so prepending ">=" here would hide invalid syntax from that
+	// check and let it through as ">= !1.2.3".
+	if !hasOperatorPrefix(expr) && !strings.HasPrefix(expr, "!") {
 		expr = ">= " + expr
 	}
 	constraint, err := constraints.ParseConstraintExpression(expr)

--- a/pkg/bundler/verifier/trust.go
+++ b/pkg/bundler/verifier/trust.go
@@ -179,13 +179,9 @@ func (r *VerifyResult) CheckPolicy(p Policy) (string, error) {
 		if r.ToolVersion == "" {
 			return "tool version not available in attestation (bundle may be unattested)", nil
 		}
-		expr := strings.TrimSpace(p.VersionConstraint)
-		if !hasOperatorPrefix(expr) {
-			expr = ">= " + expr
-		}
-		constraint, err := constraints.ParseConstraintExpression(expr)
+		constraint, err := ParseVersionConstraint(p.VersionConstraint)
 		if err != nil {
-			return "", errors.Wrap(errors.ErrCodeInvalidRequest, "invalid tool version constraint", err)
+			return "", err
 		}
 		passed, err := constraint.Evaluate(r.ToolVersion)
 		if err != nil {
@@ -223,6 +219,31 @@ func (r *VerifyResult) MaxAchievableTrustLevel() TrustLevel {
 		return TrustAttested
 	}
 	return TrustVerified
+}
+
+// ParseVersionConstraint parses a CLI-version constraint expression using the
+// same grammar CheckPolicy enforces at verify time, applying the bare-version
+// default (e.g. "0.8.0" means ">= 0.8.0").
+//
+// Exported so configuration layers can reject a malformed constraint when the
+// document is loaded rather than after a full verification run. Sharing the
+// parser is what keeps the two entry points from drifting: a value that parses
+// at load time is guaranteed to parse when Policy is evaluated.
+//
+// Note the check is operator-level only. The underlying parser splits off a
+// leading comparison operator and rejects an empty remainder, but does not
+// verify that the remainder is version-shaped, so ">= not-a-version" parses
+// here and fails later at Evaluate.
+func ParseVersionConstraint(expr string) (*constraints.ParsedConstraint, error) {
+	expr = strings.TrimSpace(expr)
+	if !hasOperatorPrefix(expr) {
+		expr = ">= " + expr
+	}
+	constraint, err := constraints.ParseConstraintExpression(expr)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "invalid tool version constraint", err)
+	}
+	return constraint, nil
 }
 
 // hasOperatorPrefix returns true if the expression starts with a comparison operator.

--- a/pkg/bundler/verifier/trust_test.go
+++ b/pkg/bundler/verifier/trust_test.go
@@ -265,6 +265,10 @@ func TestParseVersionConstraint(t *testing.T) {
 		{name: "surrounding whitespace tolerated", expr: "  0.8.0  ", satisfied: "0.9.0", rejected: "0.7.0"},
 		{name: "empty expression rejected", expr: "", wantErr: true},
 		{name: "operator with no version rejected", expr: ">=", wantErr: true},
+		// A bare "!" is invalid syntax that the shared parser rejects
+		// outright. Prepending ">=" would hide it from that check, so the
+		// bare-version default must not apply to "!"-prefixed input.
+		{name: "bare ! prefix rejected, not coerced to >=", expr: "!0.8.0", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/bundler/verifier/trust_test.go
+++ b/pkg/bundler/verifier/trust_test.go
@@ -262,6 +262,8 @@ func TestParseVersionConstraint(t *testing.T) {
 		{name: "explicit ==", expr: "== 0.8.0", satisfied: "0.8.0", rejected: "0.8.1"},
 		{name: "explicit !=", expr: "!= 0.8.0", satisfied: "0.8.1", rejected: "0.8.0"},
 		{name: "explicit <", expr: "< 0.8.0", satisfied: "0.7.0", rejected: "0.8.0"},
+		{name: "explicit >", expr: "> 0.8.0", satisfied: "0.8.1", rejected: "0.8.0"},
+		{name: "explicit <=", expr: "<= 0.8.0", satisfied: "0.8.0", rejected: "0.9.0"},
 		{name: "surrounding whitespace tolerated", expr: "  0.8.0  ", satisfied: "0.9.0", rejected: "0.7.0"},
 		{name: "empty expression rejected", expr: "", wantErr: true},
 		{name: "operator with no version rejected", expr: ">=", wantErr: true},

--- a/pkg/bundler/verifier/trust_test.go
+++ b/pkg/bundler/verifier/trust_test.go
@@ -243,3 +243,57 @@ func TestGetTrustLevels(t *testing.T) {
 		}
 	}
 }
+
+// TestParseVersionConstraint covers the grammar shared by the CLI flag and
+// spec.verify.policy.cliVersionConstraint. The bare-version default is the
+// behavior worth pinning: "0.8.0" must mean ">= 0.8.0", not "== 0.8.0".
+func TestParseVersionConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+		// satisfied is a version the parsed constraint must accept.
+		satisfied string
+		// rejected is a version the parsed constraint must refuse.
+		rejected string
+	}{
+		{name: "bare version defaults to >=", expr: "0.8.0", satisfied: "0.9.0", rejected: "0.7.0"},
+		{name: "explicit >=", expr: ">= 0.8.0", satisfied: "0.8.0", rejected: "0.7.9"},
+		{name: "explicit ==", expr: "== 0.8.0", satisfied: "0.8.0", rejected: "0.8.1"},
+		{name: "explicit !=", expr: "!= 0.8.0", satisfied: "0.8.1", rejected: "0.8.0"},
+		{name: "explicit <", expr: "< 0.8.0", satisfied: "0.7.0", rejected: "0.8.0"},
+		{name: "surrounding whitespace tolerated", expr: "  0.8.0  ", satisfied: "0.9.0", rejected: "0.7.0"},
+		{name: "empty expression rejected", expr: "", wantErr: true},
+		{name: "operator with no version rejected", expr: ">=", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVersionConstraint(tt.expr)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseVersionConstraint(%q) error = nil, want an error", tt.expr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseVersionConstraint(%q) error = %v, want nil", tt.expr, err)
+			}
+
+			ok, evalErr := got.Evaluate(tt.satisfied)
+			if evalErr != nil {
+				t.Fatalf("Evaluate(%q) error = %v", tt.satisfied, evalErr)
+			}
+			if !ok {
+				t.Errorf("constraint %q rejected %q, want it satisfied", tt.expr, tt.satisfied)
+			}
+
+			ok, evalErr = got.Evaluate(tt.rejected)
+			if evalErr != nil {
+				t.Fatalf("Evaluate(%q) error = %v", tt.rejected, evalErr)
+			}
+			if ok {
+				t.Errorf("constraint %q accepted %q, want it rejected", tt.expr, tt.rejected)
+			}
+		})
+	}
+}

--- a/pkg/bundler/verifier/verifier.go
+++ b/pkg/bundler/verifier/verifier.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -215,6 +216,15 @@ func ValidateIdentityPattern(pattern string) error {
 
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("certificate identity pattern must contain %q to pin to the NVIDIA repository", requiredRepoPrefix))
+	}
+	// The anchor check above is a substring test, so a pattern can carry the
+	// required repository and still not be a valid regexp. Compile it here so
+	// callers that validate up-front report the failure against their own
+	// input (a CLI flag or a config field, with its spec path) rather than
+	// letting it surface later from the identity matcher.
+	if _, err := regexp.Compile(pattern); err != nil {
+		return errors.Wrap(errors.ErrCodeInvalidRequest,
+			"certificate identity pattern is not a valid regular expression", err)
 	}
 	return nil
 }

--- a/pkg/bundler/verifier/verifier_test.go
+++ b/pkg/bundler/verifier/verifier_test.go
@@ -1607,3 +1607,15 @@ func TestVerifyBinaryStep_PropagatesTimeout(t *testing.T) {
 		t.Errorf("TrustLevel = %s, want unset for propagated timeout", result.TrustLevel)
 	}
 }
+
+// TestValidateIdentityPattern_RejectsUncompilablePattern covers a pattern that
+// carries the required repository anchor (so the substring check passes) but is
+// not a valid regexp. Callers validate up-front precisely so a bad pattern is
+// reported against its own input rather than surfacing later from the identity
+// matcher, so the compile has to happen here.
+func TestValidateIdentityPattern_RejectsUncompilablePattern(t *testing.T) {
+	err := ValidateIdentityPattern("https://github.com/NVIDIA/aicr/[")
+	if err == nil {
+		t.Fatal("ValidateIdentityPattern() error = nil, want rejection of an uncompilable pattern")
+	}
+}

--- a/pkg/cli/bundle_verify.go
+++ b/pkg/cli/bundle_verify.go
@@ -188,6 +188,15 @@ func runBundleVerifyCmd(ctx context.Context, cmd *cli.Command) error {
 		RequireCreator:    stringFlagOrConfig(cmd, "require-creator", resolved.RequireCreator),
 		VersionConstraint: stringFlagOrConfig(cmd, "cli-version-constraint", resolved.VersionConstraint),
 	}
+	// A config-supplied floor can be *lower* than the "max" default, and
+	// stringFlagOrConfig only logs when a CLI flag overrides config, so that
+	// case would otherwise be silent. Surface it: the trust floor is the one
+	// setting here where a committed value quietly weakening the gate is worth
+	// an audit line.
+	if !cmd.IsSet("min-trust-level") && resolved.MinTrustLevel != "" && resolved.MinTrustLevel != "max" {
+		slog.Info("trust floor set by config", "minTrustLevel", resolved.MinTrustLevel,
+			"source", "spec.verify.policy.minTrustLevel")
+	}
 	policyFailure, policyErr := result.CheckPolicy(policy)
 	if policyErr != nil {
 		return policyErr

--- a/pkg/cli/bundle_verify.go
+++ b/pkg/cli/bundle_verify.go
@@ -65,6 +65,9 @@ Require a minimum CLI version (bare version defaults to >= semantics):
 Verify a privately-signed bundle against an org trusted root:
   aicr verify ./my-bundle --trust-root ./trusted_root.json
 
+Read the verification policy from a committed AICRConfig (spec.verify):
+  aicr verify ./my-bundle --config aicr-config.yaml
+
 Verify an offline/air-gapped bundle (no transparency-log network calls; use a
 local PEM key for fully offline operation, since a KMS URI still resolves remotely):
   aicr verify ./bundle --key ./bundle-signer.pub --insecure-ignore-tlog
@@ -112,6 +115,7 @@ Output as JSON:
 				Value: verifyFormatText,
 				Usage: "Output format: text, json",
 			}, func() []string { return []string{verifyFormatJSON, verifyFormatText} }),
+			configFlag(),
 		},
 		Action: runBundleVerifyCmd,
 	}
@@ -134,19 +138,32 @@ func runBundleVerifyCmd(ctx context.Context, cmd *cli.Command) error {
 		return errors.New(errors.ErrCodeInvalidRequest, "invalid --format: must be text or json")
 	}
 
+	// Load and resolve --config before any verification work so a malformed
+	// spec.verify fails immediately, with spec-path attribution, rather than
+	// after a full verification pass.
+	cfg, err := loadCmdConfig(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	resolved, err := cfg.Verification().Resolve()
+	if err != nil {
+		return err
+	}
+
 	slog.Info("verifying bundle", "dir", absDir)
 
-	// Build verify options
+	// Build verify options. Every field is CLI-flag-over-config, matching the
+	// precedence the other --config-aware commands use.
 	verifyOpts := &verifier.VerifyOptions{}
-	identityRegexp := cmd.String("certificate-identity-regexp")
+	identityRegexp := stringFlagOrConfig(cmd, "certificate-identity-regexp", resolved.CertificateIdentityRegexp)
 	if identityRegexp != "" {
 		if validErr := verifier.ValidateIdentityPattern(identityRegexp); validErr != nil {
 			return validErr
 		}
 		verifyOpts.CertificateIdentityRegexp = identityRegexp
 	}
-	verifyOpts.Key = cmd.String("key")
-	verifyOpts.TrustRoot = cmd.String("trust-root")
+	verifyOpts.Key = stringFlagOrConfig(cmd, "key", resolved.Key)
+	verifyOpts.TrustRoot = stringFlagOrConfig(cmd, "trust-root", resolved.TrustRoot)
 	verifyOpts.IgnoreTLog = cmd.Bool("insecure-ignore-tlog")
 
 	// Offline/air-gapped verification is key-based only: reject the flag combo up
@@ -167,9 +184,9 @@ func runBundleVerifyCmd(ctx context.Context, cmd *cli.Command) error {
 
 	// Check policy requirements
 	policy := verifier.Policy{
-		MinTrustLevel:     cmd.String("min-trust-level"),
-		RequireCreator:    cmd.String("require-creator"),
-		VersionConstraint: cmd.String("cli-version-constraint"),
+		MinTrustLevel:     stringFlagOrConfig(cmd, "min-trust-level", resolved.MinTrustLevel),
+		RequireCreator:    stringFlagOrConfig(cmd, "require-creator", resolved.RequireCreator),
+		VersionConstraint: stringFlagOrConfig(cmd, "cli-version-constraint", resolved.VersionConstraint),
 	}
 	policyFailure, policyErr := result.CheckPolicy(policy)
 	if policyErr != nil {

--- a/pkg/cli/bundle_verify_config_test.go
+++ b/pkg/cli/bundle_verify_config_test.go
@@ -65,8 +65,42 @@ func TestBundleVerifyCmd_ConfigKeyReachesKeyVerification(t *testing.T) {
 
 	out := runVerify(t, "verify", dir, "--config", cfg)
 
-	if !strings.Contains(out, "public key") {
+	// Assert on the config-supplied path name rather than the generic
+	// "public key" phrase: if the keyless path ever emits that phrase, a
+	// substring check on it would pass vacuously.
+	if !strings.Contains(out, "from-config.pem") {
 		t.Errorf("config key did not route to the key-verification path; got:\n%s", out)
+	}
+}
+
+// TestBundleVerifyCmd_MinTrustLevelFlagOverridesConfig covers the override
+// branch of stringFlagOrConfig for the policy fields. Config demands
+// "verified", which this unsigned fixture cannot reach, while the flag asks for
+// "unknown", which it does. The run must therefore not fail the trust check.
+func TestBundleVerifyCmd_MinTrustLevelFlagOverridesConfig(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t, "    policy:\n      minTrustLevel: verified\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg, "--min-trust-level", "unknown")
+
+	if strings.Contains(out, `does not meet minimum "verified"`) {
+		t.Errorf("config minTrustLevel won over an explicit --min-trust-level; got:\n%s", out)
+	}
+}
+
+// TestBundleVerifyCmd_PolicylessConfigKeepsMaxDefault guards against the
+// wiring regressing to pass an empty MinTrustLevel. CheckPolicy skips the trust
+// check entirely when the field is "", so a fail-open regression would be
+// silent. A config with no policy section must leave the flag's "max" default
+// intact, which this unsigned fixture fails.
+func TestBundleVerifyCmd_PolicylessConfigKeepsMaxDefault(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t, "    trust:\n      trustRoot: \"\"\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg)
+
+	if !strings.Contains(out, "maximum achievable") {
+		t.Errorf("policy-less config did not preserve the \"max\" default floor; got:\n%s", out)
 	}
 }
 

--- a/pkg/cli/bundle_verify_config_test.go
+++ b/pkg/cli/bundle_verify_config_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// verifyConfig builds an AICRConfig document carrying only a spec.verify
+// section, which is the shape a consumer-side config file takes.
+func verifyConfig(t *testing.T, body string) string {
+	t.Helper()
+	return writeYAML(t, "aicr-config.yaml",
+		"kind: AICRConfig\napiVersion: aicr.run/v1alpha2\nspec:\n  verify:\n"+body)
+}
+
+// runVerify runs the real verify command and returns stdout plus any error
+// text, so a test can assert on whichever surface the message lands in.
+func runVerify(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := bundleVerifyCmd()
+	var buf bytes.Buffer
+	cmd.Writer = &buf
+
+	err := cmd.Run(context.Background(), args)
+
+	// A flag-level failure means the command never reached its action, which
+	// would make any assertion below meaningless.
+	if err != nil {
+		for _, bad := range []string{"flag provided but not defined", "no such flag", "flag needs an argument"} {
+			if strings.Contains(err.Error(), bad) {
+				t.Fatalf("got flag-level error %q for args %v", err.Error(), args)
+			}
+		}
+	}
+	combined := buf.String()
+	if err != nil {
+		combined += " " + err.Error()
+	}
+	return combined
+}
+
+// TestBundleVerifyCmd_ConfigKeyReachesKeyVerification proves
+// spec.verify.trust.key is plumbed into VerifyOptions.Key. It reuses the
+// --key plumbing signal: a nonexistent PEM path drives the key branch to a
+// public-key resolution error that the keyless path does not produce.
+func TestBundleVerifyCmd_ConfigKeyReachesKeyVerification(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t, "    trust:\n      key: /nonexistent/from-config.pem\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg)
+
+	if !strings.Contains(out, "public key") {
+		t.Errorf("config key did not route to the key-verification path; got:\n%s", out)
+	}
+}
+
+// TestBundleVerifyCmd_ConfigKeyOverriddenByFlag locks in the documented
+// precedence: an explicit --key wins over spec.verify.trust.key. The config
+// points at a path whose name would appear in the error if it were used.
+func TestBundleVerifyCmd_ConfigKeyOverriddenByFlag(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t, "    trust:\n      key: /nonexistent/from-config.pem\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg, "--key", "/nonexistent/from-flag.pem")
+
+	if strings.Contains(out, "from-config.pem") {
+		t.Errorf("config key was used despite an explicit --key; got:\n%s", out)
+	}
+	if !strings.Contains(out, "from-flag.pem") {
+		t.Errorf("explicit --key did not reach verification; got:\n%s", out)
+	}
+}
+
+// TestBundleVerifyCmd_ConfigMinTrustLevelEnforced proves
+// spec.verify.policy.minTrustLevel reaches verifier.Policy. The fixture has no
+// verifiable attestation, so demanding "verified" must fail the policy check.
+//
+// The assertion targets the explicit-level branch of CheckPolicy ("does not
+// meet minimum") rather than the substring "verified", which the default "max"
+// branch also emits via the word "unverified".
+func TestBundleVerifyCmd_ConfigMinTrustLevelEnforced(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t, "    policy:\n      minTrustLevel: verified\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg)
+
+	if !strings.Contains(out, `does not meet minimum "verified"`) {
+		t.Errorf("config minTrustLevel was not enforced; got:\n%s", out)
+	}
+}
+
+// TestBundleVerifyCmd_ConfigRequireCreatorEnforced proves
+// spec.verify.policy.requireCreator reaches verifier.Policy: the fixture has no
+// bundle creator, so a pinned creator must be reported as unmet.
+//
+// minTrustLevel is pinned to "unknown" (the level this fixture reaches)
+// deliberately. CheckPolicy evaluates the trust floor first and returns on the
+// first failure, so under the default "max" the creator check is never reached
+// and this test would assert nothing.
+func TestBundleVerifyCmd_ConfigRequireCreatorEnforced(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t,
+		"    policy:\n      minTrustLevel: unknown\n      requireCreator: ci@example.com\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg)
+
+	if !strings.Contains(out, "ci@example.com") {
+		t.Errorf("config requireCreator was not enforced; got:\n%s", out)
+	}
+}
+
+// TestBundleVerifyCmd_IgnoreTLogSatisfiedByConfigKey guards the interaction
+// between the --insecure-ignore-tlog precondition and a config-supplied key.
+// The guard must run against the resolved key, otherwise a perfectly valid
+// config-driven offline verify is rejected as if --key were missing.
+func TestBundleVerifyCmd_IgnoreTLogSatisfiedByConfigKey(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t, "    trust:\n      key: /nonexistent/from-config.pem\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg, "--insecure-ignore-tlog")
+
+	if strings.Contains(out, "--insecure-ignore-tlog requires --key") {
+		t.Errorf("guard ignored the config-supplied key; got:\n%s", out)
+	}
+}
+
+// TestBundleVerifyCmd_InvalidConfigRejected proves the config is validated
+// before verification runs, so a typo fails with spec-path attribution rather
+// than after a full verification pass.
+func TestBundleVerifyCmd_InvalidConfigRejected(t *testing.T) {
+	dir := writeVerifiableKeyFixture(t)
+	cfg := verifyConfig(t, "    policy:\n      minTrustLevel: totally-bogus\n")
+
+	out := runVerify(t, "verify", dir, "--config", cfg)
+
+	if !strings.Contains(out, "spec.verify.policy.minTrustLevel") {
+		t.Errorf("invalid minTrustLevel was not rejected with spec-path attribution; got:\n%s", out)
+	}
+}

--- a/pkg/config/accessors.go
+++ b/pkg/config/accessors.go
@@ -49,6 +49,16 @@ func (c *AICRConfig) Validation() *ValidateSpec {
 	return c.Spec.Validate
 }
 
+// Verification returns the verify section, or nil if cfg or the section is
+// unset. Named Verification (not Verify) for symmetry with Validation, which
+// avoids colliding with (*AICRConfig).Validate.
+func (c *AICRConfig) Verification() *VerifySpec {
+	if c == nil {
+		return nil
+	}
+	return c.Spec.Verify
+}
+
 // Snapshot returns the snapshot section, or nil if cfg or the section is unset.
 func (c *AICRConfig) Snapshot() *SnapshotSpec {
 	if c == nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -384,11 +384,21 @@ type VerifyPolicySpec struct {
 	// value *lowers* the effective floor as readily as it raises it (for
 	// example "unknown" makes the trust check a no-op, since every level
 	// meets it). That is a deliberate, reviewable choice living in version
-	// control, and its blast radius is bounded — the separate result.Errors
-	// gate still rejects checksum-failed and invalidly-signed bundles
-	// regardless of policy, so only checksum-valid *unsigned* bundles pass
-	// a lowered floor. `aicr verify` logs at INFO whenever config sets the
-	// floor to anything other than "max".
+	// control.
+	//
+	// A lowered floor admits any bundle whose actual trust level reaches it.
+	// That is broader than unsigned bundles: it also covers chains that
+	// legitimately degraded, such as an attested bundle whose binary
+	// attestation is absent, or one carrying external --data. Both report
+	// "attested" against a "verified" maximum, so the default "max" rejects
+	// them while a lowered floor does not, and neither records an entry in
+	// result.Errors.
+	//
+	// What no policy value can wave through: checksum failures and
+	// attestations that are present but fail verification. Those populate
+	// result.Errors, which is gated separately from the trust floor.
+	// `aicr verify` logs at INFO whenever config sets the floor to anything
+	// other than "max".
 	MinTrustLevel string `yaml:"minTrustLevel,omitempty" json:"minTrustLevel,omitempty"`
 
 	// RequireCreator pins the OIDC identity in the bundle attestation's

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,7 @@ const Kind = "AICRConfig"
 const APIVersion = header.GroupVersion
 
 // AICRConfig is the top-level schema for the --config file accepted by
-// the aicr CLI's snapshot, recipe, bundle, and validate commands.
+// the aicr CLI's snapshot, recipe, bundle, validate, and verify commands.
 type AICRConfig struct {
 	Kind       string   `yaml:"kind" json:"kind"`
 	APIVersion string   `yaml:"apiVersion" json:"apiVersion"`
@@ -42,11 +42,16 @@ type Metadata struct {
 // Each section is optional: a config file used only with `aicr recipe` may
 // populate just Recipe; one used only with `aicr bundle` may populate just
 // Bundle. A single file may populate any combination for end-to-end workflows.
+//
+// Snapshot, Recipe, Bundle, and Validate are the producer pipeline; Verify is
+// the consumer side, so a single document can carry both the settings that
+// build an artifact and the policy a downstream consumer enforces against it.
 type Spec struct {
 	Snapshot *SnapshotSpec `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
 	Recipe   *RecipeSpec   `yaml:"recipe,omitempty" json:"recipe,omitempty"`
 	Bundle   *BundleSpec   `yaml:"bundle,omitempty" json:"bundle,omitempty"`
 	Validate *ValidateSpec `yaml:"validate,omitempty" json:"validate,omitempty"`
+	Verify   *VerifySpec   `yaml:"verify,omitempty" json:"verify,omitempty"`
 }
 
 // SnapshotSpec captures the inputs to `aicr snapshot`.
@@ -341,4 +346,70 @@ type ValidateExecutionSpec struct {
 	NoCluster bool   `yaml:"noCluster,omitempty" json:"noCluster,omitempty"`
 	NoCleanup bool   `yaml:"noCleanup,omitempty" json:"noCleanup,omitempty"`
 	Timeout   string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+}
+
+// VerifySpec captures the inputs to `aicr verify`, the one consumer-side
+// command in the schema. Every field is durable, non-secret verification
+// *policy* — a trust floor, a pinned creator identity, a KMS key reference,
+// a trusted-root path — so it belongs in the same version-controlled
+// document as the producer sections rather than being retyped on each
+// invocation. See issue #1567.
+//
+// The two sub-sections mirror how `aicr verify` consumes them: Policy feeds
+// verifier.Policy (assertions checked after verification runs) and Trust
+// feeds verifier.VerifyOptions (the material verification runs against).
+//
+// Three `aicr verify` flags are deliberately absent:
+//   - the bundle directory, which is a positional argument, not a flag
+//   - --format, which is presentation rather than policy
+//   - --insecure-ignore-tlog, which weakens the trust floor by dropping the
+//     transparency-log requirement; keeping it command-line-only means a
+//     checked-in file can never silently disable that check, and an air-gap
+//     override stays an explicit operator act
+type VerifySpec struct {
+	Policy *VerifyPolicySpec `yaml:"policy,omitempty" json:"policy,omitempty"`
+	Trust  *VerifyTrustSpec  `yaml:"trust,omitempty" json:"trust,omitempty"`
+}
+
+// VerifyPolicySpec captures the assertions `aicr verify` enforces against a
+// completed verification result (--min-trust-level / --require-creator /
+// --cli-version-constraint).
+type VerifyPolicySpec struct {
+	// MinTrustLevel is one of the verifier trust levels (unknown,
+	// unverified, attested, verified) or the meta-value "max", which
+	// auto-detects the highest level achievable for the bundle. Empty
+	// leaves the CLI flag's "max" default in place.
+	MinTrustLevel string `yaml:"minTrustLevel,omitempty" json:"minTrustLevel,omitempty"`
+
+	// RequireCreator pins the OIDC identity in the bundle attestation's
+	// signing certificate.
+	RequireCreator string `yaml:"requireCreator,omitempty" json:"requireCreator,omitempty"`
+
+	// CLIVersionConstraint constrains the aicr version recorded in the
+	// attestation predicate. Supports >=, >, <=, <, ==, != ; a bare
+	// version (e.g. "0.16.0") is treated as ">= 0.16.0".
+	CLIVersionConstraint string `yaml:"cliVersionConstraint,omitempty" json:"cliVersionConstraint,omitempty"`
+}
+
+// VerifyTrustSpec captures the trust material `aicr verify` verifies against
+// (--certificate-identity-regexp / --key / --trust-root).
+//
+// All three are references, not secrets: a public-key URI or path, a
+// certificate-identity pattern, and a path to a trusted_root.json. No private
+// key material is ever part of the schema.
+type VerifyTrustSpec struct {
+	// CertificateIdentityRegexp overrides the certificate identity pattern
+	// used for binary attestation verification. Must contain "NVIDIA/aicr".
+	CertificateIdentityRegexp string `yaml:"certificateIdentityRegexp,omitempty" json:"certificateIdentityRegexp,omitempty"`
+
+	// Key is a KMS key URI (awskms:// | gcpkms:// | azurekms:// |
+	// hashivault://) or a local PEM public-key path, used to verify a
+	// key-signed bundle attestation. The verify counterpart to
+	// spec.bundle.attestation.signingKey.
+	Key string `yaml:"key,omitempty" json:"key,omitempty"`
+
+	// TrustRoot is a path to a private Sigstore trusted_root.json, additive
+	// to AICR's built-in public-good root. The verify counterpart to
+	// spec.bundle.attestation.fulcioURL / rekorURL.
+	TrustRoot string `yaml:"trustRoot,omitempty" json:"trustRoot,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -397,8 +397,11 @@ type VerifyPolicySpec struct {
 	// What no policy value can wave through: checksum failures and
 	// attestations that are present but fail verification. Those populate
 	// result.Errors, which is gated separately from the trust floor.
-	// `aicr verify` logs at INFO whenever config sets the floor to anything
-	// other than "max".
+	//
+	// `aicr verify` logs the floor at INFO when config is what supplies it:
+	// when --min-trust-level is absent and the configured value is anything
+	// other than "max". An explicit flag wins instead, and that override is
+	// logged by the flag-precedence path rather than this one.
 	MinTrustLevel string `yaml:"minTrustLevel,omitempty" json:"minTrustLevel,omitempty"`
 
 	// RequireCreator pins the OIDC identity in the bundle attestation's

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -379,6 +379,16 @@ type VerifyPolicySpec struct {
 	// unverified, attested, verified) or the meta-value "max", which
 	// auto-detects the highest level achievable for the bundle. Empty
 	// leaves the CLI flag's "max" default in place.
+	//
+	// This is operator policy, not an org-enforced guardrail: a committed
+	// value *lowers* the effective floor as readily as it raises it (for
+	// example "unknown" makes the trust check a no-op, since every level
+	// meets it). That is a deliberate, reviewable choice living in version
+	// control, and its blast radius is bounded — the separate result.Errors
+	// gate still rejects checksum-failed and invalidly-signed bundles
+	// regardless of policy, so only checksum-valid *unsigned* bundles pass
+	// a lowered floor. `aicr verify` logs at INFO whenever config sets the
+	// floor to anything other than "max".
 	MinTrustLevel string `yaml:"minTrustLevel,omitempty" json:"minTrustLevel,omitempty"`
 
 	// RequireCreator pins the OIDC identity in the bundle attestation's

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -38,5 +38,6 @@
 // Sigstore endpoints (spec.bundle.attestation.fulcioURL / rekorURL), the
 // KMS signing-key reference (spec.bundle.attestation.signingKey), and their
 // verify-side counterparts (spec.verify.trust.key / trustRoot) all belong in
-// version-controlled config even though they configure signing.
+// version-controlled config even though they configure signing or its
+// verification.
 package config

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -13,16 +13,20 @@
 // limitations under the License.
 
 // Package config defines the AICRConfig file schema accepted by the
-// aicr CLI's --config flag on the snapshot, recipe, bundle, and validate
-// commands.
+// aicr CLI's --config flag on the snapshot, recipe, bundle, validate, and
+// verify commands.
 //
 // AICRConfig is a Kubernetes-style envelope (kind / apiVersion / metadata / spec)
 // that lets users capture flag values for these commands in a single YAML or
 // JSON document. Each per-command section under spec (snapshot, recipe,
-// bundle, validate) is optional, so a config file may populate just one
-// section or any combination for end-to-end workflows. CLI flags always
+// bundle, validate, verify) is optional, so a config file may populate just
+// one section or any combination for end-to-end workflows. CLI flags always
 // override values loaded from a config file; for slice/map flags, presence
 // on the command line replaces the file's value rather than appending.
+//
+// The first four sections are the producer pipeline; spec.verify is the
+// consumer side, so one committed document can describe both how an artifact
+// is built and the trust floor a downstream consumer enforces against it.
 //
 // Sources are restricted to local file paths and HTTP/HTTPS URLs.
 // ConfigMap (cm://) URIs are intentionally rejected: extract the data with
@@ -31,7 +35,8 @@
 // Secrets (notably the cosign identity token) are not part of the schema;
 // they must be supplied via environment variables or dedicated CLI flags.
 // Durable, non-secret references are in scope by contrast: the private
-// Sigstore endpoints (spec.bundle.attestation.fulcioURL / rekorURL) and the
-// KMS signing-key reference (spec.bundle.attestation.signingKey) all belong
-// in version-controlled config even though they configure signing.
+// Sigstore endpoints (spec.bundle.attestation.fulcioURL / rekorURL), the
+// KMS signing-key reference (spec.bundle.attestation.signingKey), and their
+// verify-side counterparts (spec.verify.trust.key / trustRoot) all belong in
+// version-controlled config even though they configure signing.
 package config

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	bundlercfg "github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/bundler/verifier"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/oci"
 	"github.com/NVIDIA/aicr/pkg/recipe"
@@ -491,6 +492,93 @@ func (v *ValidateSpec) Resolve() (*ValidateResolved, error) {
 				InsecureTLS: boolPtrOrFalse(a.InsecureTLS),
 			}
 		}
+	}
+
+	return out, nil
+}
+
+// VerifyResolved is the typed-domain projection of VerifySpec produced by
+// (*VerifySpec).Resolve. Field names mirror the verifier structs the CLI
+// hands them to (verifier.Policy and verifier.VerifyOptions) rather than the
+// wire path, so the CLI can layer flag overrides and pass them straight
+// through.
+//
+// Zero values mean "config did not set this field," letting each CLI flag's
+// own default flow through — notably MinTrustLevel, whose flag defaults to
+// "max".
+type VerifyResolved struct {
+	// MinTrustLevel is spec.verify.policy.minTrustLevel.
+	MinTrustLevel string
+
+	// RequireCreator is spec.verify.policy.requireCreator.
+	RequireCreator string
+
+	// VersionConstraint is spec.verify.policy.cliVersionConstraint.
+	VersionConstraint string
+
+	// CertificateIdentityRegexp is
+	// spec.verify.trust.certificateIdentityRegexp.
+	CertificateIdentityRegexp string
+
+	// Key is spec.verify.trust.key.
+	Key string
+
+	// TrustRoot is spec.verify.trust.trustRoot.
+	TrustRoot string
+}
+
+// minTrustLevelMax is the meta-value accepted by --min-trust-level (and
+// spec.verify.policy.minTrustLevel) that auto-detects the highest trust level
+// achievable for the bundle. It is not a real level, so
+// verifier.ParseTrustLevel rejects it and it must be special-cased here.
+const minTrustLevelMax = "max"
+
+// Resolve converts a VerifySpec from the wire form to a typed
+// VerifyResolved. It is nil-receiver tolerant and never returns a nil
+// pointer — callers reach into fields, so nil would just relocate the
+// nil-pointer dereference.
+//
+// Every value that has a parser is validated here against the same parser
+// `aicr verify` uses at verification time, so a typo in a committed config
+// fails at load with spec-path attribution instead of after a full
+// verification run. Key and TrustRoot are passed through unvalidated: they
+// are references whose resolution (KMS reachability, file contents) belongs
+// to the verifier, which reports far better errors than a syntactic check
+// here could.
+func (v *VerifySpec) Resolve() (*VerifyResolved, error) {
+	out := &VerifyResolved{}
+	if v == nil {
+		return out, nil
+	}
+
+	if v.Policy != nil {
+		if v.Policy.MinTrustLevel != "" && v.Policy.MinTrustLevel != minTrustLevelMax {
+			if _, err := verifier.ParseTrustLevel(v.Policy.MinTrustLevel); err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.verify.policy.minTrustLevel", err)
+			}
+		}
+		if v.Policy.CLIVersionConstraint != "" {
+			if _, err := verifier.ParseVersionConstraint(v.Policy.CLIVersionConstraint); err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.verify.policy.cliVersionConstraint", err)
+			}
+		}
+		out.MinTrustLevel = v.Policy.MinTrustLevel
+		out.RequireCreator = v.Policy.RequireCreator
+		out.VersionConstraint = v.Policy.CLIVersionConstraint
+	}
+
+	if v.Trust != nil {
+		if v.Trust.CertificateIdentityRegexp != "" {
+			if err := verifier.ValidateIdentityPattern(v.Trust.CertificateIdentityRegexp); err != nil {
+				return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+					"invalid spec.verify.trust.certificateIdentityRegexp", err)
+			}
+		}
+		out.CertificateIdentityRegexp = v.Trust.CertificateIdentityRegexp
+		out.Key = v.Trust.Key
+		out.TrustRoot = v.Trust.TrustRoot
 	}
 
 	return out, nil

--- a/pkg/config/resolve_verify_test.go
+++ b/pkg/config/resolve_verify_test.go
@@ -139,6 +139,17 @@ func TestVerifyResolve_InvalidValues(t *testing.T) {
 			wantSub: "spec.verify.policy.cliVersionConstraint",
 		},
 		{
+			// Contains the required anchor, so the substring check passes;
+			// only compiling the pattern catches it. Without this, an
+			// uncompilable regexp reaches the verifier and fails there
+			// instead of at load time with its spec path.
+			name: "identity regexp that is not a compilable regexp",
+			spec: &config.VerifySpec{
+				Trust: &config.VerifyTrustSpec{CertificateIdentityRegexp: "https://github.com/NVIDIA/aicr/["},
+			},
+			wantSub: "spec.verify.trust.certificateIdentityRegexp",
+		},
+		{
 			name: "identity regexp missing the required NVIDIA/aicr anchor",
 			spec: &config.VerifySpec{
 				Trust: &config.VerifyTrustSpec{CertificateIdentityRegexp: "https://example.com/.+"},

--- a/pkg/config/resolve_verify_test.go
+++ b/pkg/config/resolve_verify_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/config"
+)
+
+func TestVerifyResolve_NilReceiver(t *testing.T) {
+	var spec *config.VerifySpec
+
+	got, err := spec.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if got == nil {
+		t.Fatal("Resolve() returned nil; callers reach into fields")
+	}
+	if *got != (config.VerifyResolved{}) {
+		t.Errorf("Resolve() = %+v, want zero value", *got)
+	}
+}
+
+func TestVerifyResolve_EmptySpec(t *testing.T) {
+	got, err := (&config.VerifySpec{}).Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if *got != (config.VerifyResolved{}) {
+		t.Errorf("Resolve() = %+v, want zero value", *got)
+	}
+}
+
+func TestVerifyResolve_AllFieldsPopulated(t *testing.T) {
+	spec := &config.VerifySpec{
+		Policy: &config.VerifyPolicySpec{
+			MinTrustLevel:        "attested",
+			RequireCreator:       "ci@example.com",
+			CLIVersionConstraint: ">= 0.16.0",
+		},
+		Trust: &config.VerifyTrustSpec{
+			CertificateIdentityRegexp: "https://github.com/NVIDIA/aicr/.+",
+			Key:                       "gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k",
+			TrustRoot:                 "./trusted_root.json",
+		},
+	}
+
+	got, err := spec.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+
+	want := config.VerifyResolved{
+		MinTrustLevel:             "attested",
+		RequireCreator:            "ci@example.com",
+		VersionConstraint:         ">= 0.16.0",
+		CertificateIdentityRegexp: "https://github.com/NVIDIA/aicr/.+",
+		Key:                       "gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k",
+		TrustRoot:                 "./trusted_root.json",
+	}
+	if *got != want {
+		t.Errorf("Resolve() = %+v, want %+v", *got, want)
+	}
+}
+
+// TestVerifyResolve_AcceptsMaxMetaValue locks in that "max" survives Resolve.
+// It is the --min-trust-level default and a meta-value rather than a real
+// level, so verifier.ParseTrustLevel rejects it and it must be special-cased.
+func TestVerifyResolve_AcceptsMaxMetaValue(t *testing.T) {
+	spec := &config.VerifySpec{
+		Policy: &config.VerifyPolicySpec{MinTrustLevel: "max"},
+	}
+
+	got, err := spec.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil for the \"max\" meta-value", err)
+	}
+	if got.MinTrustLevel != "max" {
+		t.Errorf("MinTrustLevel = %q, want %q", got.MinTrustLevel, "max")
+	}
+}
+
+// TestVerifyResolve_BareVersionConstraintAccepted covers the bare-version form
+// documented on the flag, which ParseVersionConstraint normalizes to ">=".
+func TestVerifyResolve_BareVersionConstraintAccepted(t *testing.T) {
+	spec := &config.VerifySpec{
+		Policy: &config.VerifyPolicySpec{CLIVersionConstraint: "0.16.0"},
+	}
+
+	got, err := spec.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil for a bare version", err)
+	}
+	// The raw wire value is preserved; normalization happens at check time.
+	if got.VersionConstraint != "0.16.0" {
+		t.Errorf("VersionConstraint = %q, want %q", got.VersionConstraint, "0.16.0")
+	}
+}
+
+// TestVerifyResolve_InvalidValues asserts every rejected value names its own
+// spec path, so a typo in a committed config points at the offending field.
+func TestVerifyResolve_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.VerifySpec
+		wantSub string
+	}{
+		{
+			name: "unknown trust level",
+			spec: &config.VerifySpec{
+				Policy: &config.VerifyPolicySpec{MinTrustLevel: "totally-bogus"},
+			},
+			wantSub: "spec.verify.policy.minTrustLevel",
+		},
+		{
+			// The shared parser rejects an operator with no value. It does
+			// NOT check that the value is version-shaped, so a malformed
+			// version surfaces at evaluate time rather than at load time;
+			// see TestVerifyResolve_VersionConstraintValueNotVersionChecked.
+			name: "version constraint with operator but no version",
+			spec: &config.VerifySpec{
+				Policy: &config.VerifyPolicySpec{CLIVersionConstraint: ">="},
+			},
+			wantSub: "spec.verify.policy.cliVersionConstraint",
+		},
+		{
+			name: "identity regexp missing the required NVIDIA/aicr anchor",
+			spec: &config.VerifySpec{
+				Trust: &config.VerifyTrustSpec{CertificateIdentityRegexp: "https://example.com/.+"},
+			},
+			wantSub: "spec.verify.trust.certificateIdentityRegexp",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.spec.Resolve()
+			if err == nil {
+				t.Fatalf("Resolve() error = nil, want an error mentioning %q", tt.wantSub)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("Resolve() error = %q, want it to mention %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+// TestVerifyResolve_VersionConstraintValueNotVersionChecked pins a real limit
+// of load-time validation: the shared parser splits off the operator but never
+// checks the remainder is version-shaped, so a malformed version is accepted
+// here and only fails when the constraint is evaluated against a real bundle.
+//
+// This is deliberate. The config layer validates exactly what the consuming
+// parser validates rather than maintaining a parallel, stricter grammar that
+// could reject expressions `aicr verify` would otherwise accept.
+func TestVerifyResolve_VersionConstraintValueNotVersionChecked(t *testing.T) {
+	spec := &config.VerifySpec{
+		Policy: &config.VerifyPolicySpec{CLIVersionConstraint: ">= not-a-version"},
+	}
+
+	got, err := spec.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v; load-time validation is operator-level only", err)
+	}
+	if got.VersionConstraint != ">= not-a-version" {
+		t.Errorf("VersionConstraint = %q, want the value passed through verbatim", got.VersionConstraint)
+	}
+}
+
+// TestVerifyResolve_KeyAndTrustRootUnvalidated documents the deliberate
+// non-validation of these two: they are references whose resolution (KMS
+// reachability, file contents) belongs to the verifier, which reports far
+// better errors than a syntactic check here could.
+func TestVerifyResolve_KeyAndTrustRootUnvalidated(t *testing.T) {
+	spec := &config.VerifySpec{
+		Trust: &config.VerifyTrustSpec{
+			Key:       "not-a-real-scheme://whatever",
+			TrustRoot: "/nonexistent/trusted_root.json",
+		},
+	}
+
+	got, err := spec.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil (references are not validated here)", err)
+	}
+	if got.Key != "not-a-real-scheme://whatever" || got.TrustRoot != "/nonexistent/trusted_root.json" {
+		t.Errorf("Resolve() = %+v, want both references passed through verbatim", *got)
+	}
+}
+
+// TestVerifyOnlyConfigIsValid proves spec.verify alone satisfies the
+// at-least-one-section requirement, which is the whole point of a
+// consumer-side config file that carries no producer settings.
+func TestVerifyOnlyConfigIsValid(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Verify: &config.VerifySpec{
+				Policy: &config.VerifyPolicySpec{MinTrustLevel: "verified"},
+			},
+		},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want nil for a verify-only config", err)
+	}
+}
+
+// TestVerifyConfigValidationRejectsBadValue proves Validate reaches into the
+// verify section rather than only checking that it is present.
+func TestVerifyConfigValidationRejectsBadValue(t *testing.T) {
+	cfg := &config.AICRConfig{
+		Kind:       config.Kind,
+		APIVersion: config.APIVersion,
+		Spec: config.Spec{
+			Verify: &config.VerifySpec{
+				Policy: &config.VerifyPolicySpec{MinTrustLevel: "totally-bogus"},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want rejection of an unknown trust level")
+	}
+	if !strings.Contains(err.Error(), "spec.verify.policy.minTrustLevel") {
+		t.Errorf("Validate() error = %q, want it to name the offending field", err.Error())
+	}
+}
+
+func TestVerificationAccessor(t *testing.T) {
+	var nilCfg *config.AICRConfig
+	if got := nilCfg.Verification(); got != nil {
+		t.Errorf("Verification() on nil config = %+v, want nil", got)
+	}
+
+	if got := (&config.AICRConfig{}).Verification(); got != nil {
+		t.Errorf("Verification() with unset section = %+v, want nil", got)
+	}
+
+	spec := &config.VerifySpec{Policy: &config.VerifyPolicySpec{RequireCreator: "ci@example.com"}}
+	cfg := &config.AICRConfig{Spec: config.Spec{Verify: spec}}
+	if got := cfg.Verification(); got != spec {
+		t.Errorf("Verification() = %+v, want the populated section", got)
+	}
+}

--- a/pkg/config/resolve_verify_test.go
+++ b/pkg/config/resolve_verify_test.go
@@ -15,6 +15,9 @@
 package config_test
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -268,5 +271,28 @@ func TestVerificationAccessor(t *testing.T) {
 	cfg := &config.AICRConfig{Spec: config.Spec{Verify: spec}}
 	if got := cfg.Verification(); got != spec {
 		t.Errorf("Verification() = %+v, want the populated section", got)
+	}
+}
+
+// TestVerifyTrustRejectsIgnoreTlogField locks the flag-only design of
+// --insecure-ignore-tlog into a named test. The guarantee that a committed
+// config can never disable transparency-log verification rests on strict
+// decoding rejecting the unknown field; a future schema addition that
+// accidentally introduced it would otherwise silently weaken that promise.
+func TestVerifyTrustRejectsIgnoreTlogField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	doc := "kind: AICRConfig\napiVersion: aicr.run/v1alpha2\n" +
+		"spec:\n  verify:\n    trust:\n      ignoreTlog: true\n"
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	_, err := config.Load(context.Background(), path)
+	if err == nil {
+		t.Fatal("Load() error = nil, want rejection of spec.verify.trust.ignoreTlog")
+	}
+	if !strings.Contains(err.Error(), "ignoreTlog") {
+		t.Errorf("Load() error = %q, want it to name the unknown field", err.Error())
 	}
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -41,9 +41,11 @@ func (c *AICRConfig) Validate() error {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid apiVersion %q: expected %q", c.APIVersion, APIVersion))
 	}
-	if c.Spec.Snapshot == nil && c.Spec.Recipe == nil && c.Spec.Bundle == nil && c.Spec.Validate == nil {
+	if c.Spec.Snapshot == nil && c.Spec.Recipe == nil && c.Spec.Bundle == nil &&
+		c.Spec.Validate == nil && c.Spec.Verify == nil {
+
 		return errors.New(errors.ErrCodeInvalidRequest,
-			"config has none of spec.snapshot, spec.recipe, spec.bundle, spec.validate; at least one is required")
+			"config has none of spec.snapshot, spec.recipe, spec.bundle, spec.validate, spec.verify; at least one is required")
 	}
 	if err := c.Spec.Snapshot.validate(); err != nil {
 		return err
@@ -55,6 +57,9 @@ func (c *AICRConfig) Validate() error {
 		return err
 	}
 	if err := c.Spec.Validate.validate(); err != nil {
+		return err
+	}
+	if err := c.Spec.Verify.validate(); err != nil {
 		return err
 	}
 	if err := c.Spec.validateRecipeBundleHandoff(); err != nil {
@@ -132,6 +137,16 @@ func (b *BundleSpec) validate() error {
 }
 
 func (v *ValidateSpec) validate() error {
+	if v == nil {
+		return nil
+	}
+	if _, err := v.Resolve(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *VerifySpec) validate() error {
 	if v == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Adds an optional `spec.verify` section to `AICRConfig` and a `--config` flag to
`aicr verify`, so verification policy (trust floor, pinned creator, CLI-version
constraint, private trust root, KMS key) can be committed alongside the rest of
an end-to-end workflow instead of retyped as flags on every invocation.

## Motivation / Context

`AICRConfig` was scoped to the producer pipeline — `pkg/config/doc.go` stated it
was accepted "on the snapshot, recipe, bundle, and validate commands." `verify`
is the consumer side and had no `--config` support, so a `--config`-driven
workflow could build and validate reproducibly but still had to pass the
verification gate by hand every time.

This matters most where the verify step runs as a separate CI stage from the
build: that stage's trust floor now lives in version control next to the recipe.

Fixes: #1567
Related: #1149, #1152, #1153

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**Schema shape.** The issue sketched six flat fields. They are grouped into two
sub-sections instead, mirroring how `aicr verify` consumes them: `policy` feeds
`verifier.Policy` (assertions checked after verification runs) and `trust` feeds
`verifier.VerifyOptions` (the material verification runs against). This also
matches the nesting every other `spec.*` section already uses, and disambiguates
otherwise-bare names — `trust.key` reads clearly where a top-level `key:` would
not. Field names themselves are unchanged from the issue.

**Deliberate exclusions.** Three `verify` flags are not in the schema: the bundle
directory (a positional argument), `--format` (presentation, not policy), and
`--insecure-ignore-tlog`. The last is a policy *weakener* that drops the
transparency-log requirement, so keeping it command-line-only means a committed
file can never silently disable that check. It still composes with a
config-supplied `trust.key`, and the precondition guard now reads the resolved
key rather than the raw flag.

**Shared constraint parser.** `verifier.ParseVersionConstraint` is extracted and
exported so the config layer and `CheckPolicy` validate `cliVersionConstraint`
through one grammar rather than two that can drift. `CheckPolicy` now calls it.

**Spec-path attribution.** Validation happens at load time so a typo fails as
`invalid spec.verify.policy.minTrustLevel` rather than after a full verification
run. This initially did not work: `errors.PropagateOrWrap` passes the inner error
through untouched when it already carries `ErrCodeInvalidRequest`, which silently
discarded the spec path. Switched to plain `errors.Wrap`, matching the sibling
resolvers in the same file.

**A validation limit, documented rather than papered over.** The shared parser
splits off a leading comparison operator and rejects an empty remainder, but does
not check the remainder is version-shaped. So `">="` is rejected at load time
while `">= not-a-version"` is accepted and fails later at evaluate time. Pinned
by `TestVerifyResolve_VersionConstraintValueNotVersionChecked` and noted in the
godoc and the CLI reference. Tightening it would mean a stricter grammar in
config than `aicr verify` itself accepts, which this package explicitly avoids.

**`key` and `trustRoot` are passed through unvalidated.** They are references
whose resolution (KMS reachability, file contents) belongs to the verifier, which
reports far better errors than a syntactic check here could.

## Testing

```bash
go test ./pkg/config/... ./pkg/bundler/verifier/... ./pkg/cli/...   # all ok
golangci-lint -c .golangci.yaml run                                 # 0 issues
```

The CLI wiring was written test-first: the six `bundle_verify_config_test.go`
cases were added before the resolved values were applied in
`runBundleVerifyCmd`, five failed, and the implementation followed. That is what
surfaced the `PropagateOrWrap` defect above, which a tests-after pass would have
locked in as correct.

Coverage on changed packages: `pkg/config` 93.6%, `pkg/bundler/verifier` 76.3%,
`pkg/cli` 74.2%. Every new exported symbol (`ParseVersionConstraint`,
`VerifySpec.Resolve`, `AICRConfig.Verification`) is covered.

Note on `make qualify`: it does not pass on the contributor workstation used
here, for two pre-existing environmental reasons unrelated to this branch — local
`helm` is v4.2.0 against a v4.2.3 exact pin, and GNU `timeout` is absent on
macOS so the `.github/scripts` release tests abort. Both should pass on CI, which
provisions the pinned toolchain.

## Risk Assessment

- [x] **Low** — Additive only. The new `spec.verify` section is optional, every
  existing config document keeps validating, and with no `--config` the verify
  command behaves exactly as before (all pre-existing `bundle_verify` tests pass
  unchanged).

**Rollout notes:** N/A — no migration, no behavior change for existing callers.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
