### PR TITLE
ci(e2e): drop the stale chainsaw binary from validator images

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -69,16 +69,6 @@ runs:
           CGO_ENABLED=0 go build -trimpath -o dist/validator/deployment ./validators/deployment &
           CGO_ENABLED=0 go build -trimpath -o dist/validator/performance ./validators/performance &
           CGO_ENABLED=0 go build -trimpath -o dist/validator/conformance ./validators/conformance &
-          # Download chainsaw binary for health check assertions.
-          (
-            CHAINSAW_VERSION=$(yq eval '.testing_tools.chainsaw' .settings.yaml | sed 's/^v//')
-            CHAINSAW_SHA256=$(yq eval '.testing_tools.chainsaw_checksums.linux_amd64' .settings.yaml)
-            curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --retry-max-time 60 -o dist/validator/chainsaw.tar.gz \
-              "https://github.com/kyverno/chainsaw/releases/download/v${CHAINSAW_VERSION}/chainsaw_linux_amd64.tar.gz"
-            echo "${CHAINSAW_SHA256}  dist/validator/chainsaw.tar.gz" | sha256sum -c
-            tar -xzf dist/validator/chainsaw.tar.gz -C dist/validator chainsaw
-            rm dist/validator/chainsaw.tar.gz
-          ) &
           wait
           # Build per-phase COPY-only images and push to local registry.
           # Ensure testdata dirs exist (conformance has none).
@@ -90,7 +80,6 @@ runs:
         FROM nvcr.io/nvidia/distroless/static:v4.0.0@sha256:d90158b69e250d2018f32622b5c622925202ee97224a990a54b63811cb1e3d69
         COPY dist/validator/${phase} /${phase}
         COPY validators/${phase}/testdata /app/testdata
-        COPY dist/validator/chainsaw /usr/local/bin/chainsaw
         WORKDIR /app
         USER nvs
         ENTRYPOINT ["/${phase}"]


### PR DESCRIPTION
## Summary

Removes the `kyverno/chainsaw` binary download and `COPY` from the validator images the e2e action builds. Nothing has used it since #1236.

## Motivation / Context

`.github/actions/e2e/action.yml` fetches a chainsaw release tarball, verifies its checksum, and copies the binary into all three locally built validator images (`deployment`, `performance`, `conformance`). No Go code execs a chainsaw binary — the deployment validator has evaluated Chainsaw `Test` format in-process since #1236, and `validators/deployment/Dockerfile` already carries a comment saying its chainsaw-fetch stage was removed then.

The consequence is worse than dead weight: the e2e lane builds validator images that differ from the ones that ship, so it has been exercising an artifact production does not have. #2038 removed the last *embedded* copy (the `aicr-gate` image); this removes the last *stale* one.

Fixes: N/A
Related: #2038, #1236

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/actions/e2e/action.yml`

## Implementation Notes

Deleted the download subshell and the `COPY dist/validator/chainsaw /usr/local/bin/chainsaw` line. The `wait` that joined the parallel build fan-out stays — it still joins the three `go build` jobs.

Deliberately **not** removed, because the host still runs the binary:

- `.settings.yaml` (`testing_tools.chainsaw` + checksums) — `tests/chainsaw` and `make check-health` use it.
- `tools/update-chainsaw-checksums`.
- The runner-level install in `.github/actions/setup-build-tools/action.yml`.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
```

Passed: unit tests with `-race` (81.8% total, floor 80%), golangci-lint (0 issues), yamllint, 23 chainsaw e2e tests, grype scan, license headers, agents sync.

The load-bearing check is this PR's own **E2E** lane: it builds those validator images and runs the deployment phase against them. If the binary were still needed, that lane fails. `make qualify`'s local chainsaw tests do not cover it — they run chainsaw from the host, not from inside a validator image.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** CI-only; no shipped artifact changes. Revert is a single `git revert`. Side benefit: one less release download and checksum step per e2e run, and one less layer per validator image.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, removal only
- [x] I updated docs if user-facing behavior changed — N/A, no user-facing surface
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
