### PR TITLE
fix(ci): break orphaned TF state lock before UAT teardown

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -891,6 +891,14 @@ jobs:
           set -euo pipefail
           yq -i '.deployment.destroy = true' "$CLUSTER_CONFIG"
           cat "$CLUSTER_CONFIG"
+          # NOTE: unlike the GCP and Azure teardowns, there is deliberately no
+          # stale-lock break here. The EKS actuator's S3 backend runs WITHOUT
+          # state locking — its `terraform init -backend-config` passes only
+          # bucket/key/region/prefix/encrypt (no `dynamodb_table`, no
+          # `use_lockfile`), so a cancel mid-bringup cannot orphan a lock that
+          # would block this destroy. If the actuator ever adds S3-native
+          # locking (a `<key>.tflock` object) or a DynamoDB lock table, add the
+          # equivalent best-effort break here (see uat-gcp.yaml / uat-azure.yaml).
           destroyed=false
           attempts=3
           for attempt in 1 2 3; do

--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -885,12 +885,82 @@ jobs:
           set -euxo pipefail
           yq -i '.deployment.id = strenv(DEPLOYMENT_ID) | .deployment.destroy = true' "$CLUSTER_CONFIG"
           cat "$CLUSTER_CONFIG"
+          # Break any orphaned Terraform state-blob lease before each destroy
+          # attempt. The azurerm backend holds an INFINITE lease on the state
+          # blob for the duration of the Bringup apply; a run cancelled
+          # mid-bringup SIGKILLs that apply before Terraform can release it,
+          # leaving the lease held. Every destroy attempt then fails to acquire
+          # the state lock and the retry loop cannot recover — the GPU node
+          # leaks. This always()-gated step runs only after the Bringup
+          # container has exited, so the lease has no live holder and is safe to
+          # break. State layout (infra/uat-azure-account): RG cluster-state-rg,
+          # account clst<sub-hex> (discovered — the setup tool derives the hex),
+          # container tfstate, blob deployments/<location>/<id>/terraform.tfstate.
+          #
+          # Auth is the account key, handed to `az` through AZURE_STORAGE_KEY
+          # rather than --account-key so it never appears in argv (which is
+          # world-readable via /proc/<pid>/cmdline), with xtrace off across the
+          # whole helper so it cannot reach the build log either. `--auth-mode
+          # login` is not an option: the pipeline identity holds subscription
+          # Contributor, which grants listKeys but no data-plane blob role, and
+          # the ABAC condition on its RBAC Administrator grant permits exactly
+          # three role definitions — none of them a Storage Blob Data role — so
+          # it cannot self-assign one (infra/uat-azure-account/README.md). Key
+          # auth is also how the actuator's own azurerm backend reaches this
+          # same blob.
+          #
+          # Only "no lease held" (and a state blob that was never written) is
+          # the happy path. Account lookup, key retrieval, and lease-break
+          # failures are reported as warnings instead of being swallowed by
+          # `|| true`, and are retried by virtue of running inside the destroy
+          # loop. Deliberately not fatal: aborting here would skip the destroy
+          # entirely and guarantee the leak this step exists to prevent, so the
+          # loop's terminal `exit 1` stays the gate on a real teardown failure.
+          STATE_RG="cluster-state-rg"
+          STATE_LOCATION="$(yq -r '.deployment.location' "$CLUSTER_CONFIG")"
+          STATE_BLOB="deployments/${STATE_LOCATION}/${DEPLOYMENT_ID}/terraform.tfstate"
+          break_stale_state_lease() {
+            local errf sa key rc
+            errf="$(mktemp)"
+            sa="$(az storage account list -g "$STATE_RG" --subscription "$AZURE_SUBSCRIPTION_ID" --query "[?starts_with(name, 'clst')].name | [0]" -o tsv 2>"$errf")" && rc=0 || rc=$?
+            if [ "$rc" -ne 0 ]; then
+              echo "::warning::state storage account lookup failed (rc=${rc}); cannot clear a stale state-blob lease: $(cat "$errf")"
+              rm -f "$errf"
+              return 0
+            fi
+            if [ -z "$sa" ]; then
+              echo "::warning::no clst* state storage account under ${STATE_RG}; cannot clear a stale state-blob lease"
+              rm -f "$errf"
+              return 0
+            fi
+            key="$(az storage account keys list -g "$STATE_RG" -n "$sa" --subscription "$AZURE_SUBSCRIPTION_ID" --query '[0].value' -o tsv 2>"$errf")" && rc=0 || rc=$?
+            if [ "$rc" -ne 0 ] || [ -z "$key" ]; then
+              echo "::warning::state storage account key retrieval failed (rc=${rc}); cannot clear a stale state-blob lease: $(cat "$errf")"
+              rm -f "$errf"
+              return 0
+            fi
+            echo "Clearing any stale Terraform state-blob lease: ${sa}/tfstate/${STATE_BLOB}"
+            AZURE_STORAGE_ACCOUNT="$sa" AZURE_STORAGE_KEY="$key" \
+              az storage blob lease break --account-name "$sa" \
+                --container-name tfstate --blob-name "$STATE_BLOB" >/dev/null 2>"$errf" && rc=0 || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "broke stale state-blob lease"
+            elif grep -qiE 'LeaseNotPresent|there is currently no lease|BlobNotFound|does not exist' "$errf"; then
+              echo "no stale state-blob lease to break (expected on the happy path)"
+            else
+              echo "::warning::state-blob lease break failed (rc=${rc}); a held lease will block this destroy: $(cat "$errf")"
+            fi
+            rm -f "$errf"
+          }
           # Same writable-copy mount as Bringup Infra (container uid cannot
           # write a directly-mounted ~/.azure). Fresh copy per attempt so a
           # partially-mutated context cannot poison the retries.
           destroyed=false
           for attempt in 1 2 3; do
             echo "Destroy attempt ${attempt}..."
+            set +x  # keep the storage account key out of the xtrace log
+            break_stale_state_lease
+            set -x
             AZ_MOUNT=$(mktemp -d)
             cp -a "$HOME/.azure/." "$AZ_MOUNT/"
             chmod -R a+rwX "$AZ_MOUNT"

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -689,9 +689,41 @@ jobs:
           set -euo pipefail
           yq -i '.deployment.destroy = true' "$CLUSTER_CONFIG"
           cat "$CLUSTER_CONFIG"
+          # Break any orphaned Terraform state lock before each destroy attempt.
+          # The GCS backend takes a lock (default.tflock) for the duration of the
+          # Bringup apply; a run cancelled mid-bringup SIGKILLs that apply before
+          # Terraform can release it, orphaning the lock. Every destroy attempt
+          # then fails identically with HTTP 412 (conditionNotMet), so the retry
+          # loop cannot recover — the GPU node leaks. This always()-gated step
+          # runs only after the Bringup container has already exited, so any lock
+          # present has no live holder and is safe to remove. The teardown SA
+          # owns the state bucket (it writes state via the actuator), so the
+          # delete is authorized.
+          #
+          # Only a genuinely-absent object is the happy path (the apply released
+          # its lock). Every other failure — auth, permission, network, wrong
+          # URI — is reported as a warning rather than collapsed into "no lock",
+          # and is retried by virtue of running inside the destroy loop. It is
+          # deliberately not fatal: aborting here would skip the destroy
+          # entirely and guarantee the leak this step exists to prevent, so the
+          # loop's terminal `exit 1` stays the gate on a real teardown failure.
+          LOCK_URI="gs://cluster-state-${GCP_PROJECT_ID}/deployments/${GCP_REGION}/${DEPLOYMENT_ID}/default.tflock"
+          break_stale_state_lock() {
+            local err rc
+            echo "Clearing any stale Terraform state lock at ${LOCK_URI}"
+            err="$(gcloud storage rm "${LOCK_URI}" 2>&1 >/dev/null)" && rc=0 || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "removed stale state lock"
+            elif printf '%s' "$err" | grep -qiE 'matched no object|not found|notfound|404|does not exist'; then
+              echo "no stale state lock to remove (expected on the happy path)"
+            else
+              echo "::warning::stale state-lock cleanup failed (rc=${rc}); a held lock will block this destroy: ${err}"
+            fi
+          }
           destroyed=false
           for attempt in 1 2 3; do
             echo "Destroy attempt ${attempt}..."
+            break_stale_state_lock
             if /usr/bin/docker run \
               -e CONFIG_CONTENT="$(base64 < "$CLUSTER_CONFIG")" \
               -e AUTO_APPROVE=true \


### PR DESCRIPTION
## Summary

Break the orphaned Terraform state lock/lease before the UAT `Destroy Cluster` retry loop, so a run cancelled mid-bringup can still tear down its cluster instead of leaking the GPU node.

## Motivation / Context

GKE UAT run [30948013962](https://github.com/NVIDIA/aicr/actions/runs/30948013962) was cancelled mid-bringup and then failed teardown with `Cluster aicr-30948013962 destroy failed after 3 attempts; GPU node may be leaking`, leaving a 5-node cluster + 9 VPC networks running (cleaned up manually).

Root cause: GitHub cancels a job by SIGKILLing the running step's process tree after a ~7.5s grace period. The **Bringup Infra** step's `terraform apply` (a multi-minute GKE/AKS provision inside the actuator container) is killed before Terraform can release its backend state lock, orphaning it. The `always()`-gated **Destroy Cluster** step then can never acquire the lock — and because a stale lock is *persistent*, all 3 retry attempts fail identically. The retry loop is designed for transient failures and cannot recover here.

Fix: by the time the teardown step runs, the Bringup container has already exited, so any lock present has no live holder and is safe to break. Clear it best-effort before the retry loop.

Fixes: N/A
Related: run 30948013962

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT teardown workflows (`.github/workflows/uat-{gcp,azure,aws}.yaml`)

## Implementation Notes

Handling differs per cloud because the backend lock mechanism differs — verified by inspecting the pinned actuator images' `terraform/backend.tf` and the `-backend-config` flags baked into each `cluster` binary:

- **GCP (GCS backend):** takes a `default.tflock` object lock; acquire fails with HTTP 412 `conditionNotMet`. Fix: `gcloud storage rm …/default.tflock` (teardown SA already owns the state bucket).
- **Azure (`azurerm` backend):** holds an **infinite blob lease** on the state blob (always on — not opt-in). Fix: `az storage blob lease break` on `deployments/<location>/<id>/terraform.tfstate` in the `clst<sub-hex>` account, using the account key (the actuator's backend authenticates the same way). `xtrace` is disabled around the key so it never lands in the build log.
- **AWS (S3 backend):** the EKS actuator's `-backend-config` sets **no `dynamodb_table` and no `use_lockfile`**, so the backend does **no state locking** and cannot orphan a lock. No code change — documented inline so the asymmetry is intentional, with a pointer to add an equivalent break if the actuator ever enables S3 locking.

All three breaks are best-effort no-ops on the happy path (the lock/lease is absent once a successful apply releases it) and are scoped to this run's own `deployment.id`, so they cannot disturb another run's state.

## Testing

```bash
yamllint .github/workflows/uat-{gcp,azure,aws}.yaml   # clean
actionlint .github/workflows/uat-{gcp,azure,aws}.yaml # no new findings (pre-existing info-level SC2016 only)
shellcheck -x <extracted Azure block>                 # clean
```

The GCP path is validated end-to-end: this exact `gcloud storage rm …/default.tflock` + actuator re-destroy sequence is what recovered the leaked cluster from run 30948013962 manually. The Azure lease-break is reasoned from the actuator's verified state layout/auth but has not yet been exercised against a live cancelled-mid-bringup Azure run.

## Risk Assessment

- [x] **Low** — Additive, best-effort, scoped to the run's own state object; no-op on the happy path and easy to revert.

**Rollout notes:** N/A — CI-only workflow change.

## Checklist

- [x] Linter passes (`make lint` — yamllint/actionlint clean on the edited steps)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
