### PR TITLE
ci(sdk): gate client API compatibility

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -13,6 +13,20 @@ executable bits or `./script.sh` invocation.
 
 ### Core CI/CD Actions
 
+#### `go-test/`
+
+**Purpose**: Set up Go and Helm, verify vendored dependencies, and run unit tests with race detection and coverage
+**When to use**: Go CI workflows that use the repository's `make test` target
+**Inputs**:
+- `go_version` (required): Go version to install
+- `coverage_report` (optional): Whether to generate a coverage report (default: "false")
+- `coverage_threshold` (optional): Minimum coverage percentage (default: empty)
+- `helm_version` (required): Helm version from `load-versions`
+- `apidiff_version` (optional): apidiff version from `load-versions`; when set, installs apidiff and runs `make api-diff` (default: empty, which skips both steps)
+
+Callers that set `apidiff_version` must check out full history with
+`fetch-depth: 0` so `make api-diff` can resolve a reachable stable release tag.
+
 #### `security-scan/`
 **Purpose**: Anchore/Grype vulnerability scanning with SARIF upload
 **When to use**: Security validation in CI/CD pipelines
@@ -339,12 +353,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/load-versions
         id: versions
       - uses: ./.github/actions/go-test
         with:
           go_version: ${{ steps.versions.outputs.go }}
           helm_version: ${{ steps.versions.outputs.helm }}
+          apidiff_version: ${{ steps.versions.outputs.apidiff }}
           coverage_report: 'true'
       - uses: ./.github/actions/go-lint
         with:
@@ -360,12 +377,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/load-versions
         id: versions
       - uses: ./.github/actions/go-test
         with:
           go_version: ${{ steps.versions.outputs.go }}
           helm_version: ${{ steps.versions.outputs.helm }}
+          apidiff_version: ${{ steps.versions.outputs.apidiff }}
       - uses: ./.github/actions/go-build-release
         id: release
         with:
@@ -437,3 +457,7 @@ To use these actions in other repositories:
     helm_version: 'v4.2.2'
     coverage_report: 'true'
 ```
+
+The cross-repository example intentionally omits `apidiff_version`. Repositories
+without AICR's `make api-diff` target retain the original test behavior because
+an empty `apidiff_version` skips the API compatibility steps.

--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -30,6 +30,10 @@ inputs:
   helm_version:
     description: 'Helm version pinned in .settings.yaml (testing_tools.helm, via load-versions) — required by the argocd-helm live-render tests, which fail (not skip) in CI when helm is missing'
     required: true
+  apidiff_version:
+    description: 'Optional apidiff version pinned in .settings.yaml (linting.apidiff, via load-versions); leave empty to skip the SDK API compatibility check'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -71,9 +75,23 @@ runs:
       shell: bash
       run: make test
 
+    - name: Install API-diff tool
+      if: inputs.apidiff_version != ''
+      shell: bash
+      env:
+        APIDIFF_VERSION: ${{ inputs.apidiff_version }}
+      run: |
+        set -euo pipefail
+        GOFLAGS= go install "golang.org/x/exp/cmd/apidiff@${APIDIFF_VERSION}"
+
     - name: Coverage Report
       if: inputs.coverage_report == 'true'
       uses: ./.github/actions/go-coverage
       with:
         coverage_file: ./coverage.out
         threshold: ${{ inputs.coverage_threshold }}
+
+    - name: Check SDK API compatibility
+      if: inputs.apidiff_version != ''
+      shell: bash
+      run: make api-diff

--- a/.github/actions/install-e2e-tools/action.yml
+++ b/.github/actions/install-e2e-tools/action.yml
@@ -49,8 +49,16 @@ runs:
         chmod +x tools/setup-tools
         AUTO_MODE=true ./tools/setup-tools --skip-go --skip-docker
 
-    - name: Verify tool installations
+    - name: Report tool installations
       shell: bash
       run: |
         echo "=== Installed Tools ==="
-        make tools-check
+        # This action reports the shared development-tool state, but E2E owns
+        # its required-tool contract. Do not make future strict_exact tools
+        # outside that contract a prerequisite for every E2E workflow.
+        if make tools-check; then
+          tools_check_rc=0
+        else
+          tools_check_rc=$?
+          printf '%s\n' "::warning title=Non-gating tool check failed::make tools-check exited with status ${tools_check_rc}; E2E continues because its required-tool contract is narrower."
+        fi

--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -31,6 +31,9 @@ outputs:
   golangci_lint:
     description: 'golangci-lint version'
     value: ${{ steps.versions.outputs.golangci_lint }}
+  apidiff:
+    description: 'API-diff version pinned in .settings.yaml'
+    value: ${{ steps.versions.outputs.apidiff }}
   addlicense:
     description: 'addlicense version'
     value: ${{ steps.versions.outputs.addlicense }}
@@ -171,6 +174,7 @@ runs:
 
         # Linting
         echo "golangci_lint=$(yq eval '.linting.golangci_lint' .settings.yaml)" >> $GITHUB_OUTPUT
+        echo "apidiff=$(yq eval '.linting.apidiff' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "yamllint=$(yq eval '.linting.yamllint' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "addlicense=$(yq eval '.linting.addlicense' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "go_licenses=$(yq eval '.linting.go_licenses' .settings.yaml)" >> $GITHUB_OUTPUT
@@ -230,6 +234,7 @@ runs:
         echo "  ko: ${{ steps.versions.outputs.ko }}"
         echo "  crane: ${{ steps.versions.outputs.crane }}"
         echo "  golangci_lint: ${{ steps.versions.outputs.golangci_lint }}"
+        echo "  apidiff: ${{ steps.versions.outputs.apidiff }}"
         echo "  yamllint: ${{ steps.versions.outputs.yamllint }}"
         echo "  addlicense: ${{ steps.versions.outputs.addlicense }}"
         echo "  go_licenses: ${{ steps.versions.outputs.go_licenses }}"

--- a/.github/workflows/qualification.yaml
+++ b/.github/workflows/qualification.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ inputs.ref || '' }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Load versions
@@ -64,6 +65,7 @@ jobs:
           coverage_report: ${{ inputs.coverage_report }}
           coverage_threshold: ${{ steps.versions.outputs.coverage_threshold }}
           helm_version: ${{ steps.versions.outputs.helm }}
+          apidiff_version: ${{ steps.versions.outputs.apidiff }}
 
   lint:
     name: Lint

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -29,6 +29,8 @@ build_tools:
 
 # Linting
 linting:
+  # renovate: datasource=go depName=golang.org/x/exp depType=linting
+  apidiff: 'v0.0.0-20260727155853-b88d891fe743'
   # renovate: datasource=github-releases depName=golangci/golangci-lint depType=linting
   golangci_lint: 'v2.12.2'
   # renovate: datasource=pypi depName=yamllint depType=linting

--- a/Makefile
+++ b/Makefile
@@ -288,8 +288,12 @@ scan: ## Scans for vulnerabilities with grype
 	echo "Running vulnerability scan..."; \
 	grype dir:. --config .grype.yaml --fail-on high --quiet
 
+.PHONY: api-diff
+api-diff: ## Checks pkg/client/v1 compatibility against the latest stable release
+	@bash tools/api-diff
+
 .PHONY: qualify
-qualify: test-coverage lint tuning-check e2e scan license-check ## Qualifies the codebase (test-coverage, lint, tuning-check, e2e, scan)
+qualify: test-coverage lint tuning-check e2e scan license-check api-diff ## Qualifies the codebase (test-coverage, lint, tuning-check, e2e, scan, API compatibility)
 	@echo "Codebase qualification completed"
 
 .PHONY: bom

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -27,6 +27,48 @@ The short form:
 
 Bi-weekly cadence; hotfix between cycles when a fix is critical.
 
+### SDK API Compatibility
+
+`make api-diff` compares the exported `pkg/client/v1` surface to the latest
+stable release tag. It runs through `make qualify` and the qualification
+workflow; additive changes are reported, while removals and incompatible type
+changes fail the gate.
+
+Local runs require the repository-pinned `apidiff` and `yq`; install them with
+`make tools-setup`. They also require full tag history and a stable release tag
+reachable from `HEAD`. The gate checks out that baseline in a temporary
+detached worktree, so it leaves the current working tree unchanged but adds
+checkout and filesystem I/O cost to `make qualify`.
+
+The gate compares declarations exported by `pkg/client/v1`. For external named
+types reached through transparent aliases, `apidiff` matches the target's
+package path and type name but does not recursively compare its definition. A
+change to such a target can therefore alter the facade contract without failing
+the gate. Reviewers must manually assess changes to aliased target types as
+changes to the stable facade until
+[#2019](https://github.com/NVIDIA/aicr/issues/2019) resolves this gap.
+
+To acknowledge an intentional break, first run `make api-diff`. Add a
+baseline-scoped entry to `pkg/client/v1/api-diff-exceptions.yaml` containing the
+reported baseline plus non-empty `issue`, `summary`, and `rationale` fields.
+Exactly one acknowledgement entry is allowed per baseline. Copy every reported
+incompatible line that begins with `- ` into `incompatible_changes`, omitting
+the `- ` prefix. The `incompatible_changes` list must exactly and completely
+match the command output; omissions and extras both fail the gate.
+
+The acknowledgement authorizes a break only for the active baseline, so keep it
+in place through the release that ships that break — it is what keeps the gate
+green until the release tag lands. Once the tag advances the baseline, the entry
+is obsolete and should be pruned. The gate is deliberately asymmetric about
+this. When the diff against the new baseline is clean there is nothing for a
+stale entry to authorize, so the gate only warns that the entry is prunable and
+still exits successfully; this is what lets the release pipeline and open pull
+requests stay green while the cleanup lands. When the diff is *not* clean, a
+stale entry is a hard failure: an acknowledgement scoped to an older baseline
+must never be accepted for a break against the current one. Prune the entry in a
+follow-up change after the release; Git history retains the release-notes record
+of the breaking change.
+
 ### Common Release Breakages
 
 **`goreleaser` fails with auth conflict.** `goreleaser` panics if both

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -483,6 +483,8 @@ half of the pipeline and skips deploy-side assertions.
 - `e2e` — the end-to-end pipeline runner.
 - `scan` — Grype vulnerability scan.
 - `license-check` — license header / dependency-license sweep.
+- `api-diff` — exported `pkg/client/v1` compatibility against the latest stable
+  release.
 
 CI runs the equivalent. If `make qualify` passes locally on the
 current branch, push CI will pass.

--- a/docs/integrator/public-api.md
+++ b/docs/integrator/public-api.md
@@ -56,6 +56,13 @@ The `github.com/NVIDIA/aicr/pkg/client/v1` package is Public (stable). Types
 reachable from this surface are either facade-owned structs or transparent
 aliases — the table below documents which.
 
+Transparent aliases extend that stable contract to their target types. The
+automated API-diff gate matches an external named target by package path and
+type name, but does not recursively compare the target's definition. Until
+[#2019](https://github.com/NVIDIA/aicr/issues/2019) resolves this limitation,
+changes to those definitions require manual compatibility review because they
+can affect facade consumers without failing the gate.
+
 | Facade symbol | Translates to/from | Notes |
 |---|---|---|
 | `aicr.Snapshot` | `pkg/snapshotter.Snapshot` | **Facade-owned struct**. Public fields are identifying metadata; full measurement payload is preserved in an unexported field for round-trip through `ValidateState`. Use `aicr.WrapSnapshot` to lift a `*snapshotter.Snapshot` loaded externally. |

--- a/pkg/client/v1/api-diff-exceptions.yaml
+++ b/pkg/client/v1/api-diff-exceptions.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Intentional API compatibility breaks. Each entry is tied to the active release
+# baseline and must be removed when that baseline advances; stale entries fail the gate.
+acknowledgements:
+  - baseline: v0.18.0
+    issue: '#1891, #2095'
+    summary: BundleOptions and Snapshot gained []byte fields, making both structs non-comparable.
+    rationale: BinaryAttestation enables verified in-image provenance; Raw preserves agent-emitted snapshots without dropping fields unknown to the client.
+    incompatible_changes:
+      - 'BundleOptions: old is comparable, new is not'
+      - 'Snapshot: old is comparable, new is not'

--- a/tools/api-diff
+++ b/tools/api-diff
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# api-diff compares pkg/client/v1 with the most recent stable release. The
+# current working tree is never modified: the release source is materialized in
+# a temporary detached worktree and apidiff consumes its export data.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/common
+. "${DIR}/common"
+
+if command -v go >/dev/null 2>&1; then
+    if ! go_path="$(go env GOPATH)" || [[ -z "${go_path}" ]]; then
+        err "Could not determine GOPATH with 'go env GOPATH'."
+    fi
+    export PATH="${go_path}/bin:${PATH}"
+fi
+
+has_tools apidiff git yq
+
+# apidiff resolves the new side from its working directory. Anchor it to this
+# checkout so callers outside the module cannot accidentally compare releases
+# from the module cache instead of the current source tree.
+cd "${REPO_ROOT}"
+
+readonly PACKAGE='github.com/NVIDIA/aicr/pkg/client/v1'
+readonly VERSIONS_FILE="${REPO_ROOT}/.settings.yaml"
+readonly EXCEPTIONS_FILE="${API_DIFF_EXCEPTIONS_FILE:-${REPO_ROOT}/pkg/client/v1/api-diff-exceptions.yaml}"
+readonly EXIT_NO_BASELINE=10
+readonly EXIT_EXCEPTIONS_FILE_MISSING=11
+readonly EXIT_EXCEPTIONS_EVALUATION_FAILED=12
+readonly EXIT_EXCEPTIONS_MALFORMED=13
+readonly EXIT_STALE_ACKNOWLEDGEMENT=14
+readonly EXIT_DUPLICATE_ACKNOWLEDGEMENT=15
+readonly EXIT_INCOMPATIBLE_CHANGES=16
+readonly EXIT_APIDIFF_VERSION_MISMATCH=17
+
+# These statuses are part of the decision-flow test contract. They prevent a
+# failure in an earlier branch from satisfying an assertion for a later one.
+api_diff_err() {
+    local status=$1
+    local message=$2
+
+    printf "${COLOR_RED}[ERR]${COLOR_RESET} %s\n" "${message}" >&2
+    exit "${status}"
+}
+
+if ! required_apidiff_version="$(yq eval -r '.linting.apidiff' "${VERSIONS_FILE}")"; then
+    api_diff_err "${EXIT_APIDIFF_VERSION_MISMATCH}" "Could not read the pinned apidiff version from ${VERSIONS_FILE}."
+fi
+if [[ -z "${required_apidiff_version}" || "${required_apidiff_version}" == "null" ]]; then
+    api_diff_err "${EXIT_APIDIFF_VERSION_MISMATCH}" "No apidiff version is pinned in ${VERSIONS_FILE}."
+fi
+
+if ! installed_apidiff_version="$(go_binary_module_version "$(command -v apidiff)" golang.org/x/exp)"; then
+    api_diff_err "${EXIT_APIDIFF_VERSION_MISMATCH}" "Could not verify the module version of apidiff; run make tools-setup to install ${required_apidiff_version}."
+fi
+if [[ "${installed_apidiff_version}" != "${required_apidiff_version}" ]]; then
+    api_diff_err "${EXIT_APIDIFF_VERSION_MISMATCH}" "apidiff version mismatch: installed ${installed_apidiff_version}, required ${required_apidiff_version}; run make tools-setup."
+fi
+
+baseline="${API_DIFF_BASELINE:-}"
+if [[ -z "${baseline}" ]]; then
+    tags="$(git tag --merged HEAD -l 'v*' --sort=-v:refname)"
+    while IFS= read -r tag; do
+        if [[ "${tag}" != *-* ]]; then
+            baseline="${tag}"
+            break
+        fi
+    done <<< "${tags}"
+fi
+if [[ -z "${baseline}" ]]; then
+    api_diff_err "${EXIT_NO_BASELINE}" "No stable release tag reachable from HEAD; cannot check ${PACKAGE} compatibility."
+fi
+
+if [[ ! -f "${EXCEPTIONS_FILE}" ]]; then
+    api_diff_err "${EXIT_EXCEPTIONS_FILE_MISSING}" "API-diff exceptions file not found: ${EXCEPTIONS_FILE}"
+fi
+
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/aicr-api-diff.XXXXXX")"
+release_worktree="${temp_dir}/release"
+release_export="${temp_dir}/release.export"
+
+cleanup() {
+    git worktree remove "${release_worktree}" >/dev/null 2>&1 || true
+    rm -rf "${temp_dir}"
+}
+trap cleanup EXIT
+
+msg "Comparing ${PACKAGE} against ${baseline}"
+git worktree prune
+git worktree add --detach "${release_worktree}" "${baseline}" >/dev/null
+(
+    cd "${release_worktree}"
+    apidiff -w "${release_export}" "${PACKAGE}"
+)
+
+# Additions are informational and intentionally do not fail the gate. Capture
+# the complete report once, then extract its incompatible section for
+# acknowledgement decisions. A second apidiff invocation would reload the
+# working-tree package and its dependency graph.
+report="$(apidiff "${release_export}" "${PACKAGE}")"
+incompatible="$(printf '%s\n' "${report}" | awk '
+    $0 == "Incompatible changes:" { in_incompatible = 1; next }
+    $0 == "Compatible changes:" { in_incompatible = 0 }
+    in_incompatible { print }
+')"
+if [[ -n "${report}" ]]; then
+    printf '%s\n' "${report}"
+fi
+
+if ! acknowledgements_valid="$(yq eval -r '
+    (.acknowledgements | tag == "!!seq") and
+    (.acknowledgements | all_c(
+        (tag == "!!map") and
+        (.baseline | tag == "!!str" and length > 0) and
+        (.issue | tag == "!!str" and length > 0) and
+        (.summary | tag == "!!str" and length > 0) and
+        (.rationale | tag == "!!str" and length > 0) and
+        (.incompatible_changes | tag == "!!seq" and length > 0) and
+        (.incompatible_changes | all_c(tag == "!!str" and length > 0))
+    ))
+' "${EXCEPTIONS_FILE}")"; then
+    api_diff_err "${EXIT_EXCEPTIONS_EVALUATION_FAILED}" "Could not validate API-diff acknowledgements in ${EXCEPTIONS_FILE}."
+fi
+if [[ "${acknowledgements_valid}" != "true" ]]; then
+    api_diff_err "${EXIT_EXCEPTIONS_MALFORMED}" "Malformed API-diff acknowledgements in ${EXCEPTIONS_FILE}: acknowledgements must be an array of entries with non-empty baseline, issue, summary, and rationale strings plus a non-empty incompatible_changes string array."
+fi
+
+stale_baselines="$(BASELINE="${baseline}" yq eval -r '[.acknowledgements[] | select(.baseline != strenv(BASELINE)) | .baseline] | unique | sort | join(", ")' "${EXCEPTIONS_FILE}")"
+acknowledgement_count="$(BASELINE="${baseline}" yq eval -r '[.acknowledgements[] | select(.baseline == strenv(BASELINE))] | length' "${EXCEPTIONS_FILE}")"
+if (( acknowledgement_count > 1 )); then
+    api_diff_err "${EXIT_DUPLICATE_ACKNOWLEDGEMENT}" "Duplicate API-diff acknowledgements for baseline ${baseline} in ${EXCEPTIONS_FILE}; exactly one entry is allowed."
+fi
+
+# A clean diff has nothing to adjudicate, so a stale acknowledgement cannot
+# authorize anything: it is merely obsolete bookkeeping. Failing here would
+# deadlock releases, because an entry that is required before the release tag
+# exists becomes stale the moment that tag advances the baseline. Warn instead
+# so the maintainer can prune it on a green build.
+if [[ -z "${incompatible}" ]]; then
+    msg "No incompatible ${PACKAGE} changes since ${baseline}."
+    if [[ -n "${stale_baselines}" ]]; then
+        log_warning "Prunable API-diff acknowledgement baseline(s) in ${EXCEPTIONS_FILE}: ${stale_baselines}; active baseline is ${baseline} and its diff is clean. Remove the acknowledgement(s) for non-active baselines."
+    fi
+    exit 0
+fi
+
+# There are incompatible changes to adjudicate: a stale acknowledgement must
+# never stand in for one scoped to the active baseline.
+if [[ -n "${stale_baselines}" ]]; then
+    api_diff_err "${EXIT_STALE_ACKNOWLEDGEMENT}" "Stale API-diff acknowledgement baseline(s) in ${EXCEPTIONS_FILE}: ${stale_baselines}; active baseline is ${baseline}. Remove acknowledgements for non-active baselines."
+fi
+
+actual_changes="$(printf '%s\n' "${incompatible}" | sed -n 's/^- //p' | sort)"
+
+if (( acknowledgement_count == 1 )); then
+    issue="$(BASELINE="${baseline}" yq eval -r '.acknowledgements[] | select(.baseline == strenv(BASELINE)) | .issue' "${EXCEPTIONS_FILE}")"
+    summary="$(BASELINE="${baseline}" yq eval -r '.acknowledgements[] | select(.baseline == strenv(BASELINE)) | .summary' "${EXCEPTIONS_FILE}")"
+    acknowledged_changes="$(BASELINE="${baseline}" yq eval -r '.acknowledgements[] | select(.baseline == strenv(BASELINE)) | .incompatible_changes[]' "${EXCEPTIONS_FILE}" | sort)"
+    if [[ "${actual_changes}" == "$(printf '%s\n' "${acknowledged_changes}" | sort)" ]]; then
+        log_warning "Allowing acknowledged incompatible API change(s) for ${baseline}: ${issue}: ${summary}"
+        exit 0
+    fi
+    log_error "The incompatible API changes do not exactly match the acknowledgement for ${baseline}."
+    log_error "Acknowledged changes: ${acknowledged_changes}"
+fi
+
+api_diff_err "${EXIT_INCOMPATIBLE_CHANGES}" "Incompatible ${PACKAGE} changes since ${baseline}. Add a baseline-scoped acknowledgement to ${EXCEPTIONS_FILE} only for an intentional breaking change."

--- a/tools/api-diff_test.sh
+++ b/tools/api-diff_test.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Decision-flow tests for tools/api-diff. Git, Go, and apidiff are stubbed so no
+# worktree is created and no network access is needed. yq is intentionally not
+# stubbed: these tests exercise the real structural parser supplied by the
+# repository's pinned toolchain, so mikefarah/yq is the one required tool.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIFF="${SCRIPT_DIR}/api-diff"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Without yq every assertion below fails inside has_tools, which reads as dozens
+# of unrelated defects rather than one missing tool. Skip with a single clear
+# message locally; fail in CI, where the gate must actually be exercised.
+# The variant check mirrors setup-tools: Python yq wraps jq and emits
+# JSON-quoted strings, which would corrupt the comparisons rather than error.
+yq_unavailable=""
+if ! command -v yq >/dev/null 2>&1; then
+    yq_unavailable="yq is not installed"
+elif ! yq --version 2>/dev/null | grep -q "mikefarah/yq"; then
+    yq_unavailable="yq at $(command -v yq) is not mikefarah/yq (Go-based)"
+fi
+if [[ -n "${yq_unavailable}" ]]; then
+    if [[ -n "${CI:-}" ]]; then
+        echo "FAIL: ${yq_unavailable}; the API-diff gate cannot be verified in CI" >&2
+        exit 1
+    fi
+    echo "SKIP: ${yq_unavailable}; run 'make tools-setup' to install the pinned version"
+    exit 0
+fi
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+
+cat >"${STUB_DIR}/go" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "env" && "$2" == "GOPATH" ]]; then
+    if [[ "${GOPATH_SCENARIO:-correct}" == "failure" ]]; then
+        echo "mock go env GOPATH failure" >&2
+        exit 42
+    fi
+    dirname "${STUB_DIR}"
+    exit 0
+fi
+if [[ "$1" == "version" && "$2" == "-m" ]]; then
+    case "${APIDIFF_VERSION_SCENARIO:-correct}" in
+        correct)
+            printf '%s: go1.26.0\n\tmod\tgolang.org/x/exp\t%s\th1:stub\n' "$3" "${PINNED_APIDIFF_VERSION}"
+            exit 0
+            ;;
+        mismatch)
+            printf '%s: go1.26.0\n\tmod\tgolang.org/x/exp\tv0.0.0-mismatch\th1:stub\n' "$3"
+            exit 0
+            ;;
+        unreadable)
+            exit 1
+            ;;
+    esac
+fi
+exit 1
+STUB
+
+cat >"${STUB_DIR}/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "tag" ]]; then
+    printf 'tag\n' >>"${GIT_LOG}"
+    case "${GIT_SCENARIO}" in
+        no-tags)
+            ;;
+        no-stable)
+            printf '%s\n' v2.0.0-rc.1 v1.9.0-beta.1
+            ;;
+        failure)
+            echo "mock git tag failure" >&2
+            exit 42
+            ;;
+        *)
+            echo "unexpected Git scenario: ${GIT_SCENARIO}" >&2
+            exit 2
+            ;;
+    esac
+    exit 0
+fi
+if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+    printf 'baseline=%s\n' "$5" >>"${GIT_LOG}"
+    mkdir -p "$4"
+    exit 0
+fi
+if [[ "$1" == "worktree" && "$2" == "prune" ]]; then
+    printf 'prune\n' >>"${GIT_LOG}"
+    exit 0
+fi
+if [[ "$1" == "worktree" && "$2" == "remove" ]]; then
+    exit 0
+fi
+echo "unexpected git invocation: $*" >&2
+exit 2
+STUB
+
+cat >"${STUB_DIR}/apidiff" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-w" ]]; then
+    : >"$2"
+    exit 0
+fi
+if [[ "${1:-}" == "-incompatible" ]]; then
+    echo "unexpected redundant apidiff -incompatible invocation" >&2
+    exit 99
+fi
+
+printf 'mode=report cwd=%s\n' "$(pwd)" >>"${APIDIFF_LOG}"
+if [[ -n "${APIDIFF_REPORT:-}" ]]; then
+    printf '%s' "${APIDIFF_REPORT}"
+elif [[ -n "${APIDIFF_INCOMPATIBLE:-}" ]]; then
+    printf 'Incompatible changes:\n%s' "${APIDIFF_INCOMPATIBLE}"
+else
+    exit 0
+fi
+STUB
+
+chmod +x "${STUB_DIR}/go" "${STUB_DIR}/git" "${STUB_DIR}/apidiff"
+export STUB_DIR
+export PATH="${STUB_DIR}:${PATH}"
+PINNED_APIDIFF_VERSION="$(yq eval -r '.linting.apidiff' "${SCRIPT_DIR}/../.settings.yaml")"
+export PINNED_APIDIFF_VERSION
+
+EMPTY_EXCEPTIONS="${STUB_DIR}/empty.yaml"
+EXACT_EXCEPTIONS="${STUB_DIR}/exact.yaml"
+MISMATCHED_EXCEPTIONS="${STUB_DIR}/mismatched.yaml"
+MALFORMED_EXCEPTIONS="${STUB_DIR}/malformed.yaml"
+WRONG_BASELINE_EXCEPTIONS="${STUB_DIR}/wrong-baseline.yaml"
+MIXED_BASELINE_EXCEPTIONS="${STUB_DIR}/mixed-baseline.yaml"
+NULL_FIELDS_EXCEPTIONS="${STUB_DIR}/null-fields.yaml"
+DUPLICATE_BASELINE_EXCEPTIONS="${STUB_DIR}/duplicate-baseline.yaml"
+REINDENTED_EXCEPTIONS="${STUB_DIR}/reindented.yaml"
+MISSING_EXCEPTIONS="${STUB_DIR}/missing.yaml"
+
+cat >"${EMPTY_EXCEPTIONS}" <<'YAML'
+acknowledgements: []
+YAML
+
+cat >"${EXACT_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+  - baseline: v9.8.7
+    issue: '#1234'
+    summary: Remove the legacy method.
+    rationale: The replacement has been available for two releases.
+    incompatible_changes:
+      - 'Client.Legacy: removed'
+YAML
+
+cat >"${MISMATCHED_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+  - baseline: v9.8.7
+    issue: '#1234'
+    summary: Remove the legacy method.
+    rationale: The replacement has been available for two releases.
+    incompatible_changes:
+      - 'Client.Other: removed'
+YAML
+
+cat >"${MALFORMED_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+  - baseline: v9.8.7
+    issue: '#1234'
+    summary: Remove the legacy method.
+    incompatible_changes:
+      - 'Client.Legacy: removed'
+YAML
+
+cat >"${WRONG_BASELINE_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+  - baseline: v9.8.6
+    issue: '#1234'
+    summary: Remove the legacy method.
+    rationale: The replacement has been available for two releases.
+    incompatible_changes:
+      - 'Client.Legacy: removed'
+YAML
+
+cat >"${MIXED_BASELINE_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+  - baseline: v9.8.7
+    issue: '#1234'
+    summary: Remove the legacy method.
+    rationale: The replacement has been available for two releases.
+    incompatible_changes:
+      - 'Client.Legacy: removed'
+  - baseline: v8.0.0
+    issue: '#1000'
+    summary: Unrelated historical change.
+    rationale: Records a change against a different release baseline.
+    incompatible_changes:
+      - 'Client.Historical: removed'
+YAML
+
+cat >"${NULL_FIELDS_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+  - baseline: v9.8.7
+    issue: null
+    summary: Remove the legacy method.
+    rationale: The replacement has been available for two releases.
+    incompatible_changes:
+      - 'Client.Legacy: removed'
+YAML
+
+cat >"${DUPLICATE_BASELINE_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+  - baseline: v9.8.7
+    issue: '#1234'
+    summary: Remove the legacy method.
+    rationale: The replacement has been available for two releases.
+    incompatible_changes:
+      - 'Client.Legacy: removed'
+  - baseline: v9.8.7
+    issue: '#1235'
+    summary: Duplicate acknowledgement.
+    rationale: This duplicate must be rejected as ambiguous.
+    incompatible_changes:
+      - 'Client.Legacy: removed'
+YAML
+
+cat >"${REINDENTED_EXCEPTIONS}" <<'YAML'
+acknowledgements:
+    - baseline: v9.8.7
+      issue: '#1234'
+      summary: Remove the legacy method.
+      rationale: The replacement has been available for two releases.
+      incompatible_changes:
+        - 'Client.Legacy: removed'
+YAML
+
+OUT=""
+RC=0
+GIT_LOG=""
+APIDIFF_LOG=""
+run() {
+    local scenario=$1
+    local baseline=${2:-}
+    local incompatible=${3:-}
+    local exceptions_file=${4:-${EMPTY_EXCEPTIONS}}
+    local version_scenario=${5:-correct}
+    local caller_dir=${6:-${SCRIPT_DIR}}
+    local gopath_scenario=${7:-correct}
+
+    GIT_LOG="${STUB_DIR}/${scenario}.git.log"
+    APIDIFF_LOG="${STUB_DIR}/${scenario}.apidiff.log"
+    : >"${GIT_LOG}"
+    : >"${APIDIFF_LOG}"
+    export GIT_LOG APIDIFF_LOG
+    if [[ -n "${baseline}" ]]; then
+        OUT="$(cd "${caller_dir}" && GIT_SCENARIO="${scenario}" API_DIFF_BASELINE="${baseline}" \
+            APIDIFF_INCOMPATIBLE="${incompatible}" \
+            APIDIFF_REPORT="${APIDIFF_REPORT:-}" \
+            API_DIFF_EXCEPTIONS_FILE="${exceptions_file}" \
+            APIDIFF_VERSION_SCENARIO="${version_scenario}" \
+            GOPATH_SCENARIO="${gopath_scenario}" "${API_DIFF}" 2>&1)"
+    else
+        OUT="$(cd "${caller_dir}" && GIT_SCENARIO="${scenario}" APIDIFF_INCOMPATIBLE="${incompatible}" \
+            APIDIFF_REPORT="${APIDIFF_REPORT:-}" \
+            API_DIFF_EXCEPTIONS_FILE="${exceptions_file}" \
+            APIDIFF_VERSION_SCENARIO="${version_scenario}" \
+            GOPATH_SCENARIO="${gopath_scenario}" "${API_DIFF}" 2>&1)"
+    fi
+    RC=$?
+}
+
+fails=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1 — $2"; fails=$((fails + 1)); }
+check_rc() {
+    if [[ "${RC}" == "$2" ]]; then pass "$1"; else fail "$1" "want rc=$2 got rc=${RC}"; fi
+}
+check_contains() {
+    if [[ "${OUT}" == *"$2"* ]]; then pass "$1"; else fail "$1" "expected to contain: $2"; fi
+}
+check_absent() {
+    if [[ "${OUT}" != *"$2"* ]]; then pass "$1"; else fail "$1" "expected not to contain: $2"; fi
+}
+check_log_contains() {
+    local contents
+    contents="$(<"${GIT_LOG}")"
+    if [[ "${contents}" == *"$2"* ]]; then pass "$1"; else fail "$1" "expected Git log to contain: $2"; fi
+}
+check_log_absent() {
+    local contents
+    contents="$(<"${GIT_LOG}")"
+    if [[ "${contents}" != *"$2"* ]]; then pass "$1"; else fail "$1" "expected Git log not to contain: $2"; fi
+}
+check_apidiff_log_equals() {
+    local contents
+    contents="$(<"${APIDIFF_LOG}")"
+    if [[ "${contents}" == "$2" ]]; then pass "$1"; else fail "$1" "expected apidiff log: $2 got: ${contents}"; fi
+}
+check_occurrences() {
+    local occurrences
+    occurrences="$(grep -F -o -- "$2" <<<"${OUT}" | wc -l | tr -d ' ')"
+    if [[ "${occurrences}" == "$3" ]]; then pass "$1"; else fail "$1" "want $3 occurrence(s) of: $2 got ${occurrences}"; fi
+}
+
+run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" correct "${SCRIPT_DIR}" failure
+check_rc "gopath-lookup-failure-fails" 1
+check_contains "gopath-lookup-failure-is-diagnostic" "Could not determine GOPATH"
+check_log_absent "gopath-lookup-failure-stops-before-git" "prune"
+
+run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" mismatch
+check_rc "mismatched-apidiff-version-fails" 17
+check_contains "mismatched-apidiff-version-is-diagnostic" "apidiff version mismatch"
+check_log_absent "mismatched-apidiff-version-stops-before-git" "prune"
+
+run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" unreadable
+check_rc "unverifiable-apidiff-version-fails" 17
+check_contains "unverifiable-apidiff-version-is-diagnostic" "Could not verify the module version of apidiff"
+check_log_absent "unverifiable-apidiff-version-stops-before-git" "prune"
+
+run no-tags
+check_rc "empty-tag-list-fails" 10
+check_contains "empty-tag-list-is-diagnostic" "No stable release tag reachable from HEAD"
+
+run no-stable
+check_rc "prerelease-only-tag-list-fails" 10
+check_contains "prerelease-only-tag-list-is-diagnostic" "No stable release tag reachable from HEAD"
+
+run failure
+check_rc "git-tag-failure-preserves-status" 42
+check_contains "git-tag-failure-is-preserved" "mock git tag failure"
+check_absent "git-tag-failure-is-not-no-match" "No stable release tag reachable from HEAD"
+
+run failure v9.8.7
+check_rc "explicit-baseline-succeeds" 0
+check_log_absent "explicit-baseline-skips-tag-discovery" "tag"
+check_log_contains "explicit-baseline-is-honored" "baseline=v9.8.7"
+check_log_contains "stale-worktrees-are-pruned-before-add" $'prune\nbaseline=v9.8.7'
+
+outside_module_dir="${STUB_DIR}/outside-module"
+mkdir -p "${outside_module_dir}"
+run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" correct "${outside_module_dir}"
+check_rc "new-side-from-outside-module-succeeds" 0
+check_apidiff_log_equals "new-side-loads-once-from-repository-root" \
+    "mode=report cwd=${REPO_ROOT}"
+
+run decision v9.8.7 "" "${MISSING_EXCEPTIONS}"
+check_rc "missing-exceptions-file-fails" 11
+check_contains "missing-exceptions-file-is-diagnostic" "API-diff exceptions file not found"
+
+removed_method=$'- Client.Legacy: removed\n'
+report_with_incompatible_and_compatible=$'Incompatible changes:\n- Client.Legacy: removed\nCompatible changes:\n- Client.New: added\n'
+
+APIDIFF_REPORT="${report_with_incompatible_and_compatible}"
+run decision v9.8.7 "${removed_method}" "${EMPTY_EXCEPTIONS}"
+unset APIDIFF_REPORT
+check_rc "unacknowledged-method-removal-fails" 16
+check_contains "unacknowledged-method-removal-is-reported" "Client.Legacy: removed"
+check_contains "plain-report-keeps-incompatible-header" "Incompatible changes:"
+check_contains "plain-report-keeps-compatible-header" "Compatible changes:"
+check_contains "plain-report-keeps-compatible-change" "Client.New: added"
+check_occurrences "incompatible-change-is-not-printed-twice" "Client.Legacy: removed" 1
+check_apidiff_log_equals "plain-report-loads-new-side-once" \
+    "mode=report cwd=${REPO_ROOT}"
+check_contains "unacknowledged-method-removal-is-diagnostic" "Add a baseline-scoped acknowledgement"
+
+compatible_only_report=$'Compatible changes:\n- Client.New: added\n'
+APIDIFF_REPORT="${compatible_only_report}"
+run decision v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset APIDIFF_REPORT
+check_rc "compatible-only-report-succeeds" 0
+check_contains "compatible-only-change-is-reported" "Client.New: added"
+check_contains "compatible-only-report-is-clean" "No incompatible"
+check_apidiff_log_equals "compatible-only-report-loads-new-side-once" \
+    "mode=report cwd=${REPO_ROOT}"
+
+run decision v9.8.7 "${removed_method}" "${EXACT_EXCEPTIONS}"
+check_rc "exact-baseline-acknowledgement-succeeds" 0
+check_contains "exact-baseline-acknowledgement-is-diagnostic" "Allowing acknowledged incompatible API change(s) for v9.8.7: #1234"
+
+run decision v9.8.7 "${removed_method}" "${MISMATCHED_EXCEPTIONS}"
+check_rc "mismatched-change-list-fails" 16
+check_contains "mismatched-change-list-is-diagnostic" "do not exactly match the acknowledgement"
+check_contains "mismatched-change-list-reports-acknowledged-value" "Client.Other: removed"
+
+run decision v9.8.7 "${removed_method}" "${MALFORMED_EXCEPTIONS}"
+check_rc "malformed-acknowledgement-fails" 13
+check_contains "malformed-acknowledgement-is-diagnostic" "Malformed API-diff acknowledgements"
+
+run decision v9.8.7 "${removed_method}" "${WRONG_BASELINE_EXCEPTIONS}"
+check_rc "wrong-baseline-fails" 14
+check_contains "wrong-baseline-is-stale-diagnostic" "Stale API-diff acknowledgement baseline(s)"
+check_contains "wrong-baseline-reports-active-baseline" "active baseline is v9.8.7"
+check_contains "wrong-baseline-reports-stale-baseline" "v9.8.6"
+
+run decision v9.8.7 "${removed_method}" "${MIXED_BASELINE_EXCEPTIONS}"
+check_rc "mixed-current-and-stale-baselines-fail" 14
+check_contains "mixed-baselines-are-stale-diagnostic" "Stale API-diff acknowledgement baseline(s)"
+check_contains "mixed-baselines-report-stale-baseline" "v8.0.0"
+
+run decision v9.8.7 "" "${WRONG_BASELINE_EXCEPTIONS}"
+check_rc "stale-baseline-with-clean-diff-succeeds" 0
+check_contains "clean-diff-reports-stale-baseline-as-prunable" "Prunable API-diff acknowledgement baseline(s)"
+check_contains "clean-diff-names-prunable-baseline" "v9.8.6"
+check_absent "clean-diff-does-not-fail-on-stale-baseline" "Stale API-diff acknowledgement baseline(s)"
+
+run decision v9.8.7 "${removed_method}" "${NULL_FIELDS_EXCEPTIONS}"
+check_rc "null-required-field-fails" 13
+check_contains "null-required-field-is-diagnostic" "Malformed API-diff acknowledgements"
+
+run decision v9.8.7 "${removed_method}" "${DUPLICATE_BASELINE_EXCEPTIONS}"
+check_rc "duplicate-baseline-fails" 15
+check_contains "duplicate-baseline-is-diagnostic" "Duplicate API-diff acknowledgements for baseline v9.8.7"
+
+run decision v9.8.7 "" "${DUPLICATE_BASELINE_EXCEPTIONS}"
+check_rc "duplicate-baseline-with-clean-diff-fails" 15
+check_contains "duplicate-baseline-with-clean-diff-is-diagnostic" "Duplicate API-diff acknowledgements for baseline v9.8.7"
+
+run decision v9.8.7 "${removed_method}" "${REINDENTED_EXCEPTIONS}"
+check_rc "reindented-valid-yaml-succeeds" 0
+check_contains "reindented-valid-yaml-is-diagnostic" "Allowing acknowledged incompatible API change(s) for v9.8.7: #1234"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All API-diff decision-flow tests passed"

--- a/tools/apidiff-version_test.sh
+++ b/tools/apidiff-version_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Hermetic tests for apidiff's module-version pin. The Go binary metadata and
+# .settings.yaml reads are stubbed; no tool installation or network is needed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_TOOLS="${SCRIPT_DIR}/check-tools"
+# shellcheck source=tools/common
+. "${SCRIPT_DIR}/common"
+# The helper's failure path is part of the test matrix, so capture it instead
+# of inheriting common's errexit setting.
+set +e
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+
+PINNED_VERSION="v0.0.0-20260727155853-b88d891fe743"
+MISMATCH_VERSION="v0.0.0-20260701000000-deadbeefdead"
+export PINNED_VERSION MISMATCH_VERSION
+
+cat >"${STUB_DIR}/go" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" != "version" || "${2:-}" != "-m" ]]; then
+    exit 2
+fi
+
+case "${APIDIFF_SCENARIO:-}" in
+    correct)
+        version="${PINNED_VERSION}"
+        ;;
+    mismatch)
+        version="${MISMATCH_VERSION}"
+        ;;
+    unreadable)
+        exit 1
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+
+printf '%s: go1.26.0\n' "$3"
+printf '\tpath\tgolang.org/x/exp/cmd/apidiff\n'
+printf '\tmod\tgolang.org/x/exp\t%s\th1:stub\n' "${version}"
+STUB
+
+cat >"${STUB_DIR}/yq" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+    'keys | .[]')
+        echo linting
+        ;;
+    '.linting | keys | .[]')
+        echo apidiff
+        ;;
+    '.linting.apidiff')
+        echo "${PINNED_VERSION}"
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+STUB
+
+cat >"${STUB_DIR}/apidiff" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+chmod +x "${STUB_DIR}/go" "${STUB_DIR}/yq" "${STUB_DIR}/apidiff"
+export PATH="${STUB_DIR}:${PATH}"
+
+fails=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1 — $2"; fails=$((fails + 1)); }
+
+check_helper() {
+    local name="$1"
+    local scenario="$2"
+    local want_rc="$3"
+    local want_output="$4"
+    local output
+    local rc
+
+    output=$(APIDIFF_SCENARIO="${scenario}" \
+        go_binary_module_version "${STUB_DIR}/apidiff" golang.org/x/exp)
+    rc=$?
+    if [[ "${rc}" == "${want_rc}" && "${output}" == "${want_output}" ]]; then
+        pass "${name}"
+    else
+        fail "${name}" "want rc=${want_rc} output='${want_output}', got rc=${rc} output='${output}'"
+    fi
+}
+
+check_tools_row() {
+    local name="$1"
+    local scenario="$2"
+    local want_rc="$3"
+    local want_row="$4"
+    local check_path="${CHECK_TOOLS_PATH:-${PATH}}"
+    local output
+    local rc
+    local row
+
+    output=$(PATH="${check_path}" APIDIFF_SCENARIO="${scenario}" \
+        bash "${CHECK_TOOLS}" 2>&1)
+    rc=$?
+    row=$(printf '%s\n' "${output}" | awk '$1 == "apidiff" { print $2 "|" $3 "|" $4 }')
+    if [[ "${rc}" == "${want_rc}" && "${row}" == "${want_row}" ]]; then
+        pass "${name}"
+    else
+        fail "${name}" "want rc=${want_rc} row='${want_row}', got rc=${rc} row='${row}'"
+    fi
+}
+
+check_helper "extracts-exact-module-version" correct 0 "${PINNED_VERSION}"
+check_helper "extracts-mismatched-module-version" mismatch 0 "${MISMATCH_VERSION}"
+check_helper "rejects-unreadable-build-metadata" unreadable 1 ""
+
+check_tools_row "check-tools-accepts-exact-version" correct 0 \
+    "${PINNED_VERSION}|${PINNED_VERSION}|✓"
+check_tools_row "check-tools-rejects-mismatch" mismatch 1 \
+    "${PINNED_VERSION}|${MISMATCH_VERSION}|⚠"
+check_tools_row "check-tools-rejects-unreadable-metadata" unreadable 1 \
+    "${PINNED_VERSION}|unknown|⚠"
+
+mv "${STUB_DIR}/apidiff" "${STUB_DIR}/apidiff.unavailable"
+CHECK_TOOLS_PATH="${STUB_DIR}:/usr/bin:/bin" \
+    check_tools_row "check-tools-rejects-missing-binary" missing 1 \
+    "${PINNED_VERSION}|-|✗"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All apidiff version-pin tests passed"

--- a/tools/check-tools
+++ b/tools/check-tools
@@ -50,6 +50,7 @@ fi
 # version_cmd: Command to extract version
 # match_strategy: How to compare versions
 #   - exact: Full version must match
+#   - strict_exact: Full version must match; missing/unverifiable/mismatch fails the check
 #   - major: Only major version must match
 #   - major_minor: Major.minor must match
 #   - presence: Only check if installed (no version comparison)
@@ -83,6 +84,9 @@ get_tool_metadata() {
         # Linting
         golangci_lint)
             echo "golangci-lint:::golangci-lint version --short 2>/dev/null:::major"
+            ;;
+        apidiff)
+            echo "apidiff:::go_binary_module_version \"\$(command -v apidiff)\" golang.org/x/exp:::strict_exact"
             ;;
         yamllint)
             echo "yamllint:::yamllint --version 2>/dev/null | awk '{print \$2}':::major"
@@ -168,7 +172,7 @@ compare_versions() {
     local strategy="$3"
 
     case "$strategy" in
-        exact)
+        exact|strict_exact)
             [[ "$installed" == "$expected" ]]
             ;;
         major)
@@ -225,6 +229,9 @@ check_tool() {
     # Check if command exists
     if ! command -v "$cmd_name" &>/dev/null; then
         print_row "$cmd_name" "$expected_version" "-" "✗"
+        if [[ "$match_strategy" == "strict_exact" ]]; then
+            CHECK_FAILED=1
+        fi
         return
     fi
 
@@ -243,10 +250,14 @@ check_tool() {
         print_row "$cmd_name" "$expected_version" "$installed_version" "✓"
     else
         print_row "$cmd_name" "$expected_version" "$installed_version" "⚠"
+        if [[ "$match_strategy" == "strict_exact" ]]; then
+            CHECK_FAILED=1
+        fi
     fi
 }
 
 # Main
+CHECK_FAILED=0
 echo "=== Tool Version Check ==="
 echo ""
 print_row "Tool" "Expected" "Installed" "Status"
@@ -283,3 +294,4 @@ fi
 
 echo ""
 echo "Legend: ✓ = installed, ⚠ = version mismatch or warning, ✗ = missing"
+exit "${CHECK_FAILED}"

--- a/tools/common
+++ b/tools/common
@@ -84,3 +84,25 @@ has_tools() {
         fi
     done
 }
+
+# Print the module version embedded in a Go binary's build metadata.
+# Returns non-zero when the binary metadata is unreadable or the requested
+# module is absent. Compatible with the Bash 3.x shipped by macOS.
+go_binary_module_version() {
+    local binary_path="$1"
+    local module_path="$2"
+    local build_info
+    local module_version
+
+    if ! build_info=$(go version -m "${binary_path}" 2>/dev/null); then
+        return 1
+    fi
+
+    module_version=$(printf '%s\n' "${build_info}" | awk -v module="${module_path}" \
+        '$1 == "mod" && $2 == module { print $3; exit }')
+    if [[ -z "${module_version}" ]]; then
+        return 1
+    fi
+
+    printf '%s\n' "${module_version}"
+}

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -273,6 +273,7 @@ cd "${REPO_ROOT}"
 
 GO_VERSION=$(yq '.languages.go' .settings.yaml)
 GOLANGCI_LINT_VERSION=$(yq '.linting.golangci_lint' .settings.yaml)
+APIDIFF_VERSION=$(yq '.linting.apidiff' .settings.yaml)
 YAMLLINT_VERSION=$(yq '.linting.yamllint' .settings.yaml)
 ADDLICENSE_VERSION=$(yq '.linting.addlicense' .settings.yaml)
 GO_LICENSES_VERSION=$(yq '.linting.go_licenses' .settings.yaml)
@@ -301,6 +302,7 @@ echo ""
 log_info "Target Versions:"
 echo "  Go:              ${GO_VERSION}"
 echo "  golangci-lint:   ${GOLANGCI_LINT_VERSION}"
+echo "  apidiff:         ${APIDIFF_VERSION}"
 echo "  grype:           ${GRYPE_VERSION}"
 echo "  cosign:          ${COSIGN_VERSION}"
 echo "  syft:            ${SYFT_VERSION}"
@@ -785,7 +787,7 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
                 brew install tilt-dev/tap/ctlptl
             elif [[ "${OS}" == "linux" ]]; then
                 if command_exists go; then
-                    go install github.com/tilt-dev/ctlptl/cmd/ctlptl@v"${CTLPTL_VERSION}"
+                    GOFLAGS= go install github.com/tilt-dev/ctlptl/cmd/ctlptl@v"${CTLPTL_VERSION}"
                     sudo cp "$(go env GOPATH)/bin/ctlptl" /usr/local/bin/
                 else
                     log_warning "Go not installed, skipping ctlptl"
@@ -929,7 +931,7 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
                 brew install goreleaser
             elif [[ "${OS}" == "linux" ]]; then
                 if command_exists go; then
-                    go install github.com/goreleaser/goreleaser/v2@"${GORELEASER_VERSION}"
+                    GOFLAGS= go install github.com/goreleaser/goreleaser/v2@"${GORELEASER_VERSION}"
                     sudo cp "$(go env GOPATH)/bin/goreleaser" /usr/local/bin/
                 else
                     log_warning "Go not installed, skipping goreleaser"
@@ -995,13 +997,37 @@ if [[ "${SKIP_TOOLS}" == "false" ]] && command_exists go; then
         fi
     fi
 
+    # apidiff
+    APIDIFF_CURRENT_VERSION=""
+    if command_exists apidiff && [[ "${UPGRADE}" != "true" ]]; then
+        APIDIFF_PATH=$(command -v apidiff)
+        APIDIFF_CURRENT_VERSION=$(go_binary_module_version "${APIDIFF_PATH}" golang.org/x/exp || true)
+    fi
+
+    if [[ "${UPGRADE}" != "true" && "${APIDIFF_CURRENT_VERSION}" == "${APIDIFF_VERSION}" ]]; then
+        log_success "apidiff ${APIDIFF_VERSION} already installed"
+    else
+        if command_exists apidiff && [[ "${UPGRADE}" != "true" ]]; then
+            if [[ -n "${APIDIFF_CURRENT_VERSION}" ]]; then
+                log_warning "apidiff version mismatch at ${APIDIFF_PATH} (installed: ${APIDIFF_CURRENT_VERSION}, required: ${APIDIFF_VERSION}); reinstalling pinned version"
+            else
+                log_warning "Unable to verify apidiff module version at ${APIDIFF_PATH}; reinstalling pinned version ${APIDIFF_VERSION}"
+            fi
+        fi
+        log_info "Installing apidiff ${APIDIFF_VERSION}..."
+        if prompt_continue; then
+            GOFLAGS= go install golang.org/x/exp/cmd/apidiff@"${APIDIFF_VERSION}"
+            log_success "apidiff ${APIDIFF_VERSION} installed"
+        fi
+    fi
+
     # addlicense
     if command_exists addlicense && [[ "${UPGRADE}" != "true" ]]; then
         log_success "addlicense already installed"
     else
         log_info "Installing addlicense ${ADDLICENSE_VERSION}..."
         if prompt_continue; then
-            go install github.com/google/addlicense@"${ADDLICENSE_VERSION}"
+            GOFLAGS= go install github.com/google/addlicense@"${ADDLICENSE_VERSION}"
             log_success "addlicense installed"
         fi
     fi
@@ -1012,7 +1038,7 @@ if [[ "${SKIP_TOOLS}" == "false" ]] && command_exists go; then
     else
         log_info "Installing go-licenses ${GO_LICENSES_VERSION}..."
         if prompt_continue; then
-            go install github.com/google/go-licenses/v2@"${GO_LICENSES_VERSION}"
+            GOFLAGS= go install github.com/google/go-licenses/v2@"${GO_LICENSES_VERSION}"
             log_success "go-licenses installed"
         fi
     fi

--- a/tools/setup-tools_test.sh
+++ b/tools/setup-tools_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify versioned Go tool installs do not inherit an exported vendor mode.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_TOOLS="${SCRIPT_DIR}/setup-tools"
+
+bash -n "${SETUP_TOOLS}"
+
+expected_installs=(
+    'github.com/tilt-dev/ctlptl/cmd/ctlptl@v"${CTLPTL_VERSION}"'
+    'github.com/goreleaser/goreleaser/v2@"${GORELEASER_VERSION}"'
+    'golang.org/x/exp/cmd/apidiff@"${APIDIFF_VERSION}"'
+    'github.com/google/addlicense@"${ADDLICENSE_VERSION}"'
+    'github.com/google/go-licenses/v2@"${GO_LICENSES_VERSION}"'
+)
+
+for install_target in "${expected_installs[@]}"; do
+    if ! grep -Fq "GOFLAGS= go install ${install_target}" "${SETUP_TOOLS}"; then
+        echo "FAIL: versioned go install does not clear GOFLAGS: ${install_target}" >&2
+        exit 1
+    fi
+done
+
+echo "All versioned Go tool installs clear GOFLAGS"


### PR DESCRIPTION
## Summary

Adds a release-baseline API compatibility gate for `pkg/client/v1` to local
qualification and CI, with fail-closed acknowledgements for intentional breaks.

## Motivation / Context

The public SDK facade is consumed by out-of-tree Go callers, but the existing
hand-maintained stability test cannot reliably detect every removed export or
incompatible signature change. This adds a mechanical comparison against the
latest stable release.

Fixes: #2018
Related: #1891, #2016, #2019

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK compatibility CI and developer tooling

## Implementation Notes

- Pins and verifies `apidiff`, then compares `pkg/client/v1` with the latest
  reachable stable tag in a temporary detached worktree.
- Reports compatible additions and blocks incompatible changes unless exactly
  acknowledged for the active baseline. Malformed, duplicate, mismatched, and
  stale acknowledgements fail closed.
- Keeps the reusable `go-test` action backward-compatible by making the API-diff
  input optional; AICR qualification always supplies the pin and runs the gate.
- Documents the transparent-alias limitation and manual review requirement
  tracked by #2019.

## Testing

```bash
unset GITLAB_TOKEN
make qualify
```

Passed. This includes race-enabled tests, coverage, lint, e2e, vulnerability
scan, license checks, and the new API-diff decision and tool-version tests.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Contributors should rerun `make tools-setup` and use a clone
with full tag history. Existing cross-repository `go-test` consumers remain
compatible.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
