### PR TITLE
fix(releasepolicy): derive per-script deadline from t.Deadline()

### DIFF
--- a/tests/releasepolicy/release_scripts_test.go
+++ b/tests/releasepolicy/release_scripts_test.go
@@ -165,7 +165,7 @@ func TestReleaseSbomSignaturesAreAllowlisted(t *testing.T) {
 // allowlist rather than a copy of it.
 func shellReleaseAssetNames(t *testing.T, tag string) []string {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), scriptDeadline(t))
 	defer cancel()
 	text := string(readFile(t, ".github/scripts/release-images.sh"))
 	const marker = "expected_release_asset_names() {"
@@ -1679,7 +1679,7 @@ type scriptResult struct {
 
 func runScript(t *testing.T, environment []string, relative string, args ...string) scriptResult {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), scriptDeadline(t))
 	defer cancel()
 	command := exec.CommandContext(ctx, repositoryPath(t, relative), args...)
 	command.Env = environment
@@ -1689,6 +1689,31 @@ func runScript(t *testing.T, environment []string, relative string, args ...stri
 	}
 	return scriptResult{output: string(output), err: err}
 }
+
+// scriptDeadline returns the per-script wall-clock budget for shelled-out
+// helpers in this package. The value guards against genuine hangs (infinite
+// loops, stuck prompts) while tolerating CPU starvation when the full test
+// suite runs concurrently with -race + coverage.
+//
+// Hangs and slow-but-progressing runs differ by orders of magnitude, so a
+// tight constant catches no additional hangs while producing false positives
+// under contention (see issue #1974). We cap at scriptDeadlineCap and shrink
+// only if the outer test binary's own deadline is closer, leaving
+// scriptDeadlineMargin so t.Fatalf can report cleanly before Go reaps the run.
+func scriptDeadline(t *testing.T) time.Duration {
+	t.Helper()
+	if d, ok := t.Deadline(); ok {
+		if remaining := time.Until(d) - scriptDeadlineMargin; remaining > 0 && remaining < scriptDeadlineCap {
+			return remaining
+		}
+	}
+	return scriptDeadlineCap
+}
+
+const (
+	scriptDeadlineCap    = 90 * time.Second
+	scriptDeadlineMargin = 30 * time.Second
+)
 
 func sortedImages() []string {
 	images := make([]string, 0, len(releaseImages))

--- a/tests/releasepolicy/release_workflow_test.go
+++ b/tests/releasepolicy/release_workflow_test.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -589,7 +588,7 @@ func TestReleaseOpenVEXValidation(t *testing.T) {
 // annotations and the GITHUB_OUTPUT contents) alongside the exit status.
 func runOpenVEXGuard(t *testing.T, script, workspace string) (string, error) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), scriptDeadline(t))
 	defer cancel()
 	outputs := filepath.Join(t.TempDir(), "outputs")
 	command := exec.CommandContext(ctx, "bash", "-c", script)


### PR DESCRIPTION
## Summary

Replace the hardcoded 10s per-script wall-clock deadline in `tests/releasepolicy` with a `t.Deadline()`-derived budget (90s cap, 30s margin off the outer test-binary deadline) so shelled-out release-script tests survive CPU starvation under full-suite `make qualify` load without losing hang detection.

## Motivation / Context

Under full-suite `make qualify` runs (`-race`, coverage, ~96 packages concurrent) the reporter observed a ~50% flake rate in `tests/releasepolicy`, always the `script exceeded test deadline: context deadline exceeded` sentinel, always a different subtest each time. In-isolation timings: p50=0.49s, p90=4.52s, max=5.54s per script; under contention wall times hit 12–30s against the 10s constant. Never observed on CI.

A tight constant conflates *hangs* (minutes) with *slow-but-progressing* runs (single-digit seconds under contention) — differ by orders of magnitude, so the 10s bound catches no additional hangs while producing false positives that erode trust in the documented pre-push gate.

Fixes: #1974
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tests/releasepolicy` (release-script test helpers)

## Implementation Notes

- New helper `scriptDeadline(t)` in `release_scripts_test.go`:
  - Returns `scriptDeadlineCap` (90s) when the outer test binary has no deadline (`-timeout 0`) or plenty of headroom.
  - Otherwise shrinks to `t.Deadline() - scriptDeadlineMargin` (30s) so `t.Fatalf` can report cleanly before Go reaps the run.
  - Positive-remaining guard prevents a degenerate near-expired deadline from returning a zero/negative budget.
- Applied to both call sites in the package: `runScript` (`release_scripts_test.go:1682`) and `runOpenVEXGuard` (`release_workflow_test.go:592`) — same hardcoded 10s pattern, same package, same starvation vulnerability class.
- Perf assertions using `time.Since(started) > 4*time.Second` at lines 1346/1388 are **intentionally left alone**: they assert that the script's own `AICR_NETWORK_TIMEOUT_SECONDS=1` bound fires — a real regression signal, not a harness deadline.

**Alternatives considered:**
- Raise the constant to 60–90s: works, leaves a constant to re-tune per-environment.
- Serialize `tests/releasepolicy` into its own `-p` slot in `make test`: addresses root-cause contention but requires Makefile restructure, slows total wall time, and doesn't protect future subprocess-heavy tests in the same package. Adaptive deadline is a superset.

## Testing

```bash
# Package in isolation with the gate's exact flags — zero deadline sentinels
unset GITLAB_TOKEN && AICR_CRITERIA_STRICT=1 go test -short -count=1 -race ./tests/releasepolicy/...

# Mandatory Go lint gate on affected package
GOFLAGS="-mod=vendor" golangci-lint run -c .golangci.yaml ./tests/releasepolicy/...
```

Results on the development machine:
- `go build ./tests/releasepolicy/...` — clean
- `go vet ./tests/releasepolicy/...` — clean
- `golangci-lint run` on affected package — **0 issues**
- `go test -race -short ./tests/releasepolicy/...` — **zero `script exceeded test deadline` occurrences** (the sentinel this fix targets). Some subtests fail on this specific Mac because `timeout` (GNU coreutils) is not installed and system bash is 3.2 — pre-existing environment issues, orthogonal to this change, would fail identically on `origin/main`.
- Full `make test`: only failing package was `validators/performance` (`env: bash: No such file or directory` shebang issue) — also unrelated to this change.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A. Test-file-only change. Reverting is a single-file diff.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — affected package's target sentinel no longer fires; unrelated pre-existing env failures noted above
- [x] Linter passes (`make lint`) — `golangci-lint run` on affected package is clean; `yamllint` N/A (no YAML changes)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, this is a test-harness fix; the subject-under-test is the test-suite behavior itself
- [ ] I updated docs if user-facing behavior changed — N/A, no user-visible behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)