### PR TITLE
fix(ci): retry GKE UAT bringup on transient node-pool timeout

### DIFF
--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -454,11 +454,43 @@ jobs:
         if: inputs.lifecycle != 'daytime-down'
         run: |
           set -euo pipefail
-          /usr/bin/docker run \
-            -e CONFIG_CONTENT="$(base64 < "$CLUSTER_CONFIG")" \
-            -e AUTO_APPROVE=true \
-            -e KEY_CONTENT="$(base64 < ${{ steps.auth.outputs.credentials_file_path }})" \
-            ${{ env.GKE_ACTUATOR_IMAGE }} apply
+          # Retry the actuator apply once on a transient provisioning failure.
+          # The GKE actuator hardcodes a 30m node-pool create timeout
+          # (terraform/compute.tf), but a slow GPU pool can take ~35m; Terraform
+          # then fails the create even though GKE finishes and reports the pool
+          # RUNNING moments later (observed on run 30965268896, #2065). On a
+          # nightly run that false failure is recoverable (Destroy still runs),
+          # but on daytime-up / skip_delete runs it strands a healthy cluster and
+          # its whole VPC network group, leaking the GPU node and NETWORKS quota.
+          # `terraform apply` is idempotent: a second attempt refreshes state,
+          # waits out the still-completing (or already-healthy) pool, and
+          # converges. Bounded to 2 attempts so a genuinely-stuck provision still
+          # fails fast and surfaces. The durable fix is an upstream node-pool
+          # timeout bump 30m->60m (mirroring the AKS actuator's
+          # mchmarny/cluster#31) — tracked in #2065.
+          brought_up=false
+          for attempt in 1 2; do
+            echo "Bringup attempt ${attempt}..."
+            if /usr/bin/docker run \
+              -e CONFIG_CONTENT="$(base64 < "$CLUSTER_CONFIG")" \
+              -e AUTO_APPROVE=true \
+              -e KEY_CONTENT="$(base64 < ${{ steps.auth.outputs.credentials_file_path }})" \
+              ${{ env.GKE_ACTUATOR_IMAGE }} apply; then
+              brought_up=true
+              break
+            fi
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Bringup attempt ${attempt} failed; retrying in 60s (a transient node-pool state often self-heals, and apply is idempotent)..."
+              sleep 60
+            fi
+          done
+          # Fail the step if every attempt failed: `docker run` in an `if` does
+          # not trip `set -e`, so without this guard a real bringup failure would
+          # exit 0 and the run would proceed against a cluster that never came up.
+          if [ "$brought_up" != true ]; then
+            echo "::error::Bringup failed after 2 attempts"
+            exit 1
+          fi
 
       # Connect
       - name: Install GKE auth plugin


### PR DESCRIPTION
## Summary

Wrap the GCP UAT **Bringup Infra** step in a bounded 2-attempt retry so a transient node-pool provisioning timeout no longer fails the run (and strands a healthy cluster).

## Motivation / Context

The GKE actuator (`ghcr.io/mchmarny/cluster/gke`) hardcodes a **30-minute `create` timeout** on `google_container_node_pool` (`terraform/compute.tf`). A slow GPU pool can take **~35 min**: Terraform times out and fails the `apply` even though GKE finishes and reports the pool `RUNNING` moments later. On run [30965268896](https://github.com/NVIDIA/aicr/actions/runs/30965268896) the `cpu-worker` pool did exactly this — and because it was a held/manual run, teardown was skipped and the healthy cluster + its full VPC network group (1 cluster VPC + 8 `gpu-nic` VPCs + router + NAT + firewall + subnets) leaked, contributing to the `NETWORKS` quota (50) exhaustion that blocked later runs.

`terraform apply` is idempotent, so a second attempt refreshes state, waits out the still-completing (or already-healthy) pool, and converges. Bounded to 2 attempts so a genuinely-stuck provision still fails fast and surfaces (and, on nightly, teardown still runs).

Fixes: N/A (mitigates)
Related: #2065 (upstream node-pool timeout bump 30m→60m — the durable fix)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT GCP workflow (`.github/workflows/uat-gcp.yaml`)

## Implementation Notes

- Mirrors the existing `Destroy Cluster` retry pattern (`docker run` inside an `if`, which does not trip `set -e`, plus an explicit post-loop guard so a real failure still `exit 1`s).
- Scoped to GCP, where the 30m timeout and the evidence are. AKS already carries 60m worker-pool timeouts (mchmarny/cluster#31); EKS parity can follow if the same symptom appears there.
- This reduces the orphan *rate* for one mode; the general backstop (a scheduled janitor that reaps orphaned `aicr-<run_id>` groups with no live workflow run) is tracked separately.

## Testing

```bash
yamllint .github/workflows/uat-gcp.yaml    # clean
actionlint .github/workflows/uat-gcp.yaml  # no new findings (3 pre-existing info-level SC2016 in an unrelated step)
```

## Risk Assessment

- [x] **Low** — Adds a bounded retry around an idempotent apply; worst case is one extra apply attempt (~within the 280m job budget). Easy to revert.

**Rollout notes:** N/A — CI-only.

## Checklist

- [x] Linter passes (`make lint` — yamllint/actionlint clean on the edited step)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
