### PR TITLE
fix(ci): tear down daytime-up UAT cluster on failed/cancelled run

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -897,14 +897,25 @@ jobs:
       # Teardown gating (#1275, DC2): tear down for the nightly lifecycle
       # (unless skip_delete) and for daytime-down (the explicit evening
       # teardown of the held cluster — daytime-down provisions nothing, so it
-      # does not gate on steps.infra). NEVER for daytime-up, which holds the
-      # cluster for handoff. skip_delete is a nightly-only debugging escape and
-      # is ignored for daytime-down.
+      # does not gate on steps.infra). skip_delete is a nightly-only debugging
+      # escape and is ignored for daytime-down.
+      #
+      # daytime-up (provision + deploy + HOLD) holds the cluster for handoff ONLY
+      # on a clean run: if any stage failed or the run was cancelled
+      # (failure() || cancelled()), there is no usable cluster to hand off, so we
+      # tear it down rather than leak its GPU node / capacity reservation + VPC.
+      # Gated on steps.infra.outcome != 'skipped' so a cancel before Bringup —
+      # which provisioned nothing — still no-ops. The Destroy step targets this
+      # run's own DEPLOYMENT_ID (aicr-uat-day-<reservation>-<run_id>), which it
+      # sets itself, so it tears down exactly the cluster this up-run created
+      # (the daytime-down runtime name resolution is gated on daytime-down and
+      # does not run here).
       - name: Refresh AWS credentials for teardown
         if: >-
           always() && (
             (inputs.lifecycle == 'daytime-down' && env.DAYTIME_FOUND == 'true') ||
-            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped') ||
+            (inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')
           )
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
         with:
@@ -926,7 +937,8 @@ jobs:
         if: >-
           always() && (
             (inputs.lifecycle == 'daytime-down' && env.DAYTIME_FOUND == 'true') ||
-            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped') ||
+            (inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')
           )
         # Bounded so a hung API server (or many LB Services) can never starve the
         # always()-run Destroy Cluster of the job-timeout budget it needs — a
@@ -966,7 +978,8 @@ jobs:
         if: >-
           always() && (
             (inputs.lifecycle == 'daytime-down' && env.DAYTIME_FOUND == 'true') ||
-            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped') ||
+            (inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')
           )
         shell: bash
         run: |

--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -929,14 +929,23 @@ jobs:
       # Teardown gating (#1275, DC2): tear down for the nightly lifecycle
       # (unless skip_delete) and for daytime-down (the explicit evening
       # teardown of the held cluster — daytime-down provisions nothing, so it
-      # does not gate on steps.infra). NEVER for daytime-up, which holds the
-      # cluster for handoff. skip_delete is a nightly-only debugging escape
-      # and is ignored for daytime-down.
+      # does not gate on steps.infra). skip_delete is a nightly-only debugging
+      # escape and is ignored for daytime-down.
+      #
+      # daytime-up (provision + deploy + HOLD) holds the cluster for handoff ONLY
+      # on a clean run: if any stage failed or the run was cancelled
+      # (failure() || cancelled()), there is no usable cluster to hand off, so we
+      # tear it down rather than leak its GPU node + resource group. Gated on
+      # steps.infra.outcome != 'skipped' so a cancel before Bringup — which
+      # provisioned nothing — still no-ops. The Destroy step targets this run's
+      # own DEPLOYMENT_ID (aicr-uat-day-<reservation>-<run_id>), which it sets
+      # itself, so it tears down exactly the cluster this up-run created.
       - name: Re-authenticate to Azure for teardown
         if: >-
           always() && (
             (inputs.lifecycle == 'daytime-down' && env.DAYTIME_FOUND == 'true') ||
-            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped') ||
+            (inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')
           )
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
         with:
@@ -958,7 +967,8 @@ jobs:
         if: >-
           always() && (
             (inputs.lifecycle == 'daytime-down' && env.DAYTIME_FOUND == 'true') ||
-            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped') ||
+            (inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')
           )
         shell: bash
         run: |

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -744,15 +744,25 @@ jobs:
       # Teardown gating (#1275, DC2): tear down for the nightly lifecycle
       # (unless skip_delete) and for daytime-down (the explicit evening
       # teardown of the held cluster — daytime-down provisions nothing, so it
-      # does not gate on steps.infra). NEVER for daytime-up, which holds the
-      # cluster for handoff. skip_delete is a nightly-only debugging escape and
-      # is ignored for daytime-down.
+      # does not gate on steps.infra). skip_delete is a nightly-only debugging
+      # escape and is ignored for daytime-down.
+      #
+      # daytime-up (provision + deploy + HOLD) holds the cluster for handoff ONLY
+      # on a clean run: if any stage failed or the run was cancelled
+      # (failure() || cancelled()), there is no usable cluster to hand off, so we
+      # tear it down rather than leak its GPU node + full VPC network group (the
+      # orphan class behind the NETWORKS-quota exhaustion). Gated on
+      # steps.infra.outcome != 'skipped' so a cancel before Bringup — which
+      # provisioned nothing — still no-ops. The Destroy step targets this run's
+      # own DEPLOYMENT_ID (aicr-uat-day-<reservation>-<run_id>), which it sets
+      # itself, so it tears down exactly the cluster this up-run created.
       - name: Re-authenticate to GCP for teardown
         id: auth_teardown
         if: >-
           always() && (
             (inputs.lifecycle == 'daytime-down' && env.DAYTIME_FOUND == 'true') ||
-            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped') ||
+            (inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')
           )
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
@@ -765,7 +775,8 @@ jobs:
         if: >-
           always() && (
             (inputs.lifecycle == 'daytime-down' && env.DAYTIME_FOUND == 'true') ||
-            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped')
+            (inputs.lifecycle == 'nightly' && inputs.skip_delete != true && steps.infra.outcome != 'skipped') ||
+            (inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')
           )
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Make `daytime-up` UAT runs tear down their cluster when the run **failed or was cancelled**, instead of unconditionally holding it. A clean `daytime-up` still holds for handoff.

## Motivation / Context

`daytime-up` (provision + deploy + HOLD) deliberately skips teardown so a human can use the cluster during the day. But that skip is **unconditional**: a `daytime-up` run that fails at Bringup/deploy — or is cancelled — leaves a broken, unusable cluster held indefinitely, leaking its GPU node and full VPC network group (1 cluster VPC + 8 `gpu-nic` VPCs + Cloud Router + NAT + firewall + subnets). This is one of the sources of the `NETWORKS` quota (50) exhaustion that recently blocked all GCP UAT runs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT workflows (`.github/workflows/uat-{gcp,azure,aws}.yaml`)

## Implementation Notes

- Adds a `daytime-up` branch — `(inputs.lifecycle == 'daytime-up' && (failure() || cancelled()) && steps.infra.outcome != 'skipped')` — to every teardown-gating step: **Re-authenticate for teardown**, **Destroy Cluster**, and (AWS) **Delete LoadBalancer Services (pre-teardown)**, across all three clouds.
- **Holds on success:** on a clean `daytime-up` all three branches are false, so teardown is skipped and the cluster is held — unchanged behavior.
- **No-ops a pre-provision cancel:** `steps.infra.outcome != 'skipped'` means a cancel before Bringup (nothing created) does nothing.
- **Targets the right cluster:** each Destroy step sets `.deployment.id` from this run's own `DEPLOYMENT_ID` (`aicr-uat-day-<reservation>-<run_id>`); the daytime-*down* runtime name-resolution is gated on `daytime-down` and does not run here.
- **Composes with #2049:** a `daytime-up` cancelled mid-Bringup now triggers Destroy, which relies on that PR's orphaned-lock break to actually succeed.

## Testing

```bash
yamllint  .github/workflows/uat-{gcp,azure,aws}.yaml   # clean
actionlint .github/workflows/uat-{gcp,azure,aws}.yaml  # no expression errors; only pre-existing info-level SC2016 in unrelated steps
```

## Risk Assessment

- [x] **Low** — Only broadens teardown to a case that currently leaks; clean-run hold behavior is unchanged. Easy to revert.

**Rollout notes:** N/A — CI-only.

## Checklist

- [x] Linter passes (`make lint` — yamllint/actionlint clean on the edited steps)
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
