### PR TITLE
feat(ci): add UAT orphan janitor (dry-run-first, all clouds)

### DIFF
--- a/.github/scripts/uat-janitor.sh
+++ b/.github/scripts/uat-janitor.sh
@@ -1,0 +1,569 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# UAT orphan janitor — the backstop for the in-run teardown (uat-{gcp,aws,azure}
+# .yaml "Destroy Cluster"). A UAT run can leave its cluster + full resource group
+# (GPU node, VPC network group, router/NAT, resource group, TF state) behind when
+# teardown never runs: a runner hard-killed mid-cancel, a daytime-up held cluster
+# whose evening daytime-down never fired, a manual skip_delete run abandoned, or a
+# Bringup "failure" that stranded a healthy cluster. Those orphans accumulate until
+# they exhaust a cloud quota (in Aug 2026 the GCP NETWORKS quota, 50, hit 48/50).
+#
+# This reaps them. For every cloud resource whose name carries the UAT deployment
+# id (aicr-uat-<run_id> nightly and aicr-uat-day-<reservation-or-slug>-<run_id>
+# daytime — see the ALLOWLIST below for both forms), it
+# asks GitHub whether the OWNING run <run_id> is still active — and only reaps once
+# the run is finished and old enough. It reaps via the SAME actuator `destroy` the
+# in-run teardown uses, so Terraform handles resource ordering (router/NAT before
+# VPC, the GCP default-route quirk, the Azure resource group) correctly.
+#
+# Safety model (this deletes cloud infrastructure — read before editing):
+#   * ALLOWLIST — a candidate must match one of the two deployment-id schemas,
+#     anchored end to end:
+#       ^aicr-uat-[0-9]+$                 nightly, all clouds
+#       ^aicr-uat-day-[a-z0-9-]+-[0-9]+$  daytime, all clouds. The middle segment
+#                                         is deliberately permissive so it matches
+#                                         BOTH the ADR-017 name now used on main —
+#                                         aicr-uat-day-<slug>-<slot>-<run_id>
+#                                         (for example gh1-0) — AND the legacy
+#                                         aicr-uat-day-<reservation>-<run_id>
+#                                         form (for example gcp-h100) during the
+#                                         transition. Tighten to the slug/slot
+#                                         shape once no legacy-held clusters remain.
+#                                         Still anchored: the aicr-uat-day- prefix
+#                                         and a trailing numeric run_id are required.
+#     (GCP nightly stays aicr-uat-<run_id> too: the GKE actuator now bounds the
+#     derived node-SA account_id — mchmarny/cluster#36, image >= v0.5.17.)
+#     A prefix test would admit aicr-uat-unrelated-7, which no workflow produces;
+#     the anchors reject it. Persistent infra (aicr-testgrid-*, anything else)
+#     matches neither schema and is never in scope. Per-cloud discovery is
+#     deliberately coarser — it only nominates CANDIDATES; classify() is the
+#     authoritative gate, and run_id_of/is_daytime remain defense in depth.
+#   * RUN-ID REQUIRED — a name with no trailing numeric run_id is skipped. We
+#     never guess.
+#   * NOT-ACTIVE — the owning run must be `completed` (or purged/404). This is an
+#     allowlist: queued / in_progress / waiting / pending / requested are skipped
+#     because the cluster is live, and ANY other status — including one GitHub
+#     adds after this was written — is skipped as indeterminate.
+#   * FAIL CLOSED — any GitHub API error that is not a definitive run-level 404
+#     skips the candidate this cycle. We never delete on ambiguous liveness.
+#     "Definitive" is narrow on purpose: the runs endpoint must first be proven
+#     reachable (else a repo-level 404 would mark every candidate an orphan), the
+#     error must be an `HTTP 404` and not merely text containing "404", and a
+#     200 whose body lacks `status`/`updated_at` is ambiguous, not a green light.
+#     An unparsable `updated_at` skips rather than reading as infinitely old.
+#   * AGE FLOOR — keyed off the RUN's updated_at (uniform across clouds), not the
+#     cloud resource's create time. Nightly/ad-hoc: NIGHTLY_MIN_AGE_HOURS (default
+#     24h). Well above the 280-min job cap, so a still-finishing run's just-created
+#     cluster is never touched — and, deliberately, long enough that a nightly
+#     `skip_delete` run (a supported debugging hold, uat-{aws,azure,gcp}.yaml) can
+#     survive a full working day before the janitor reclaims it. There is NO API
+#     signal that distinguishes a skip_delete hold from a genuine orphan, so the
+#     floor is the only lever: a real mid-cancel orphan therefore also persists up
+#     to ~a day, which is acceptable — quota pressure builds over days, and the
+#     hourly janitor reaps within the hour once the floor clears. (Lower it only if
+#     a cloud's quota headroom demands faster reclamation.) Daytime:
+#     DAYTIME_MIN_AGE_HOURS (default 24h). daytime-up is on-demand (workflow_dispatch), so its run is
+#     already `completed` while the cluster is legitimately HELD for the working
+#     day; the sole daytime schedule is the evening daytime-down (uat-daytime.yaml,
+#     cron '0 2 * * *' UTC), which reaps the held cluster each night. A legitimate
+#     hold therefore always lasts < 24h (up just after one 02:00 down, torn down at
+#     the next), so a daytime cluster older than 24h has provably survived an
+#     evening daytime-down = an orphan the nightly teardown missed. (Do NOT lower
+#     this to the nightly floor: a completed daytime-up run does not mean the
+#     cluster should be gone.)
+#   * DRY_RUN — defaults to true. It reports every decision and never deletes until
+#     a caller sets DRY_RUN=false (the workflow's `enforce` dispatch input). Only
+#     the exact strings `true`/`false` are accepted; anything else aborts before
+#     discovery rather than being resolved toward enforce. In dry-run the summary
+#     counts "would-reap", never "reaped" — a report must not claim a destroy
+#     that did not happen.
+#
+# Usage:   DRY_RUN=true ./uat-janitor.sh <gcp|aws|azure>
+# Requires: gh (GH_TOKEN in env, actions:read), jq, yq, docker, and the cloud CLI
+#           + credentials for <cloud> already configured by the caller.
+
+set -euo pipefail
+
+CLOUD="${1:?usage: uat-janitor.sh <gcp|aws|azure>}"
+DRY_RUN="${DRY_RUN:-true}"
+REPO="${GITHUB_REPOSITORY:-NVIDIA/aicr}"
+# AWS/Azure discovery only. GCP matches a second shape too (see ALLOWLIST above),
+# so it spells its patterns out inline rather than using this.
+NAME_PREFIX="aicr-uat-"
+NIGHTLY_MIN_AGE_HOURS="${NIGHTLY_MIN_AGE_HOURS:-24}"
+DAYTIME_MIN_AGE_HOURS="${DAYTIME_MIN_AGE_HOURS:-24}"
+
+# Directory of this script, so sibling helpers (uat-aws-cleanup-lb.sh) resolve
+# regardless of the caller's CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Probed once by main(). A path-level 404 (repo renamed, GITHUB_REPOSITORY wrong,
+# token missing actions:read) is indistinguishable from a purged-run 404 when
+# looking at a single candidate — and would classify the ENTIRE fleet as orphaned.
+# So a 404 is only ever read as "run purged" once the runs endpoint itself is
+# proven reachable. Default `no` keeps a sourced/never-probed caller fail-closed.
+REPO_REACHABLE="${REPO_REACHABLE:-no}"
+
+log() { echo "[janitor:${CLOUD}] $*"; }
+
+# --- pure decision helpers -------------------------------------------------
+
+# Trailing all-digit segment (the run id). Fails (non-zero) if the last
+# hyphen-delimited segment is not purely numeric — we then skip the candidate.
+run_id_of() {
+  local last="${1##*-}"
+  case "$last" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  printf '%s' "$last"
+}
+
+is_daytime() { case "$1" in aicr-uat-day-*) return 0 ;; *) return 1 ;; esac; }
+
+# DRY_RUN gates every destroy, and only the exact string `true` holds it back.
+# Anything else would select the enforce path, so a typo (DRY_RUN=flase) or a
+# shell-truthy value (1, yes, TRUE) must be rejected outright rather than read as
+# permission to delete. Only `true`/`false` are accepted.
+valid_dry_run() { case "$1" in true | false) return 0 ;; *) return 1 ;; esac; }
+
+# The age floors gate every destroy on the run's age. A non-integer floor (e.g.
+# "24h") makes `[ "$age" -lt "$min" ]` error under an `if` — read as false, i.e.
+# REAP — and a negative floor clears for every age. The shipped workflow never
+# sets these, but the script accepts them as configuration, so validate them up
+# front like DRY_RUN. `*[!0-9]*` rejects empty, non-numeric, and negative alike;
+# the length cap rejects a value big enough to overflow bash arithmetic (past
+# ~2^63 the same `-lt` test errors with status 2 and fails open to REAP). Five
+# digits (<=99999h ~= 11y) is far more than any real floor and well under overflow.
+valid_age_floor() {
+  case "$1" in '' | *[!0-9]*) return 1 ;; esac
+  [ "${#1}" -le 5 ]
+}
+
+# Whole hours between an ISO-8601 timestamp and now (GNU date; runner is ubuntu).
+# Returns non-zero on an unparsable timestamp rather than substituting an epoch:
+# a 0 would read as an infinitely-old deployment and clear every age floor.
+age_hours_since() {
+  local t
+  t="$(date -u -d "$1" +%s 2>/dev/null)" || return 1
+  [ -n "$t" ] || return 1
+  echo $(( ( $(date -u +%s) - t ) / 3600 ))
+}
+
+# Is a UAT lifecycle run currently in flight? A daytime cluster's NAME carries the
+# daytime-UP run id, so classify()'s run-status gate cannot see an evening
+# daytime-DOWN tearing down the SAME reservation (a different run). The teardown
+# always executes as a uat-run.yaml run — whether the evening scheduler dispatched
+# it (uat-daytime.yaml's drive job dispatches uat-run.yaml as its own top-level
+# run) or an operator ran `gh workflow run uat-run.yaml -f lifecycle=daytime-down`
+# directly — so THAT is the workflow we watch, not the scheduler wrapper (whose
+# watcher can time out before the child). Coarse but safe: ANY in-flight uat-run
+# run defers ALL daytime reaps this cycle (the janitor is hourly, so the cost is a
+# one-cycle delay).
+#
+# This is a liveness PROBE, not a mutex: it collapses the common race (a
+# scheduled/dispatched down already running) to near zero, but a residual TOCTOU
+# window remains — a down that STARTS in the ~1h between this check and the reap.
+# The 24h floor and DRY_RUN-default backstop that window; a shared cross-workflow
+# lease (#2132) is the tracked follow-up for a hard "never races" guarantee.
+#
+# Fails CLOSED: any API error, or a 200 whose body is not a well-formed run list
+# (`{"message":...}`, `{"workflow_runs":null}`), reads as "active" (defer) rather
+# than idle. Uses `gh` raw + external `jq` (like classify()) so the harness drives it.
+LIFECYCLE_WORKFLOW="uat-run.yaml"
+uat_lifecycle_active() {
+  local json count
+  # Filter to in_progress SERVER-SIDE (?status=in_progress) rather than reading the
+  # newest N mixed-status runs and filtering here — that removes any dependence on
+  # dispatch volume fitting in one page. in_progress is the state of a run actually
+  # executing a teardown; a run still queued / about to start is the documented
+  # TOCTOU residual, backstopped by the 24h floor + DRY_RUN default. per_page=100
+  # is far above the number of concurrently-executing uat-run runs (the lease
+  # serializes per reservation), so the count is effectively unbounded for our need.
+  json="$(gh api "repos/${REPO}/actions/workflows/${LIFECYCLE_WORKFLOW}/runs?status=in_progress&per_page=100" 2>/dev/null)" || return 0
+  # Fail CLOSED on a malformed 200: require an actual array, else emit a non-numeric
+  # marker the case below reads as "active" (defer). `.workflow_runs | length` on a
+  # missing/null field would otherwise be 0 = idle.
+  count="$(jq -r 'if (.workflow_runs | type) == "array" then (.workflow_runs | length) else "malformed" end' <<<"$json" 2>/dev/null)" || return 0
+  case "$count" in '' | *[!0-9]*) return 0 ;; esac
+  [ "$count" -gt 0 ]
+}
+
+# Echo "REAP" or "SKIP:<reason>" for a deployment id. Consults the GitHub run for
+# both liveness and age so the decision is identical across clouds.
+classify() {
+  local id="$1" run_id json status upd age min
+  # Exactly the two supported deployment-id schemas (see the ALLOWLIST bullet in
+  # the header) — fully anchored, so merely starting with `aicr-` is not enough and
+  # a shape we do not generate (aicr-uat-unrelated-7, aicr-testgrid-vpc) can never
+  # reach the actuator. discover_* is deliberately coarser; THIS is the gate.
+  if [[ ! "$id" =~ ^aicr-uat-[0-9]+$ ]] &&
+     [[ ! "$id" =~ ^aicr-uat-day-[a-z0-9-]+-[0-9]+$ ]]; then
+    echo "SKIP:not-allowlisted"; return
+  fi
+  run_id="$(run_id_of "$id")" || { echo "SKIP:no-run-id"; return; }
+
+  local errf; errf="$(mktemp)"
+  if json="$(gh api "repos/${REPO}/actions/runs/${run_id}" 2>"$errf")"; then
+    rm -f "$errf"
+    status="$(jq -r '.status // empty' <<<"$json")"
+    upd="$(jq -r '.updated_at // empty' <<<"$json")"
+    if [ -z "$status" ] || [ -z "$upd" ]; then
+      echo "SKIP:incomplete-run-json(run ${run_id})"; return   # fail closed
+    fi
+  elif [ "$REPO_REACHABLE" = yes ] && grep -q 'HTTP 404' "$errf"; then
+    rm -f "$errf"
+    # Run purged from history (GitHub retains ~months) => long dead => orphan.
+    status="completed"; upd=""
+  else
+    rm -f "$errf"
+    echo "SKIP:gh-api-error(run ${run_id})"; return   # fail closed
+  fi
+
+  # Allowlist, not denylist: ONLY a confirmed `completed` run may be reaped. The
+  # active statuses are named separately because they are a routine skip an
+  # operator should not have to think about; anything else is a status GitHub did
+  # not have when this was written, and fails closed rather than falling through.
+  case "$status" in
+    completed) ;;
+    queued | in_progress | waiting | pending | requested)
+      echo "SKIP:run-active(${status},run ${run_id})"; return ;;
+    *)
+      echo "SKIP:run-status-unsupported(${status},run ${run_id})"; return ;;
+  esac
+
+  if [ -n "$upd" ]; then
+    age="$(age_hours_since "$upd")" || { echo "SKIP:bad-updated-at(${upd})"; return; }
+  else
+    age=999999   # confirmed run-level 404: purged from history, past every floor
+  fi
+  if is_daytime "$id"; then min="$DAYTIME_MIN_AGE_HOURS"; else min="$NIGHTLY_MIN_AGE_HOURS"; fi
+  if [ "$age" -lt "$min" ]; then
+    echo "SKIP:too-young(${age}h < ${min}h)"; return
+  fi
+  # Daytime last-mile race guard (see the concurrency note in uat-janitor.yaml):
+  # only daytime needs it — a nightly cluster's owning run IS the one the gate
+  # above already checked, but a daytime name points at the daytime-UP run, not
+  # the daytime-DOWN run (a uat-run.yaml run) that tears it down. Defer if any
+  # uat-run lifecycle run is in flight. Reduces, does not eliminate, the race
+  # (residual TOCTOU per uat_lifecycle_active); fails closed.
+  if is_daytime "$id" && uat_lifecycle_active; then
+    echo "SKIP:lifecycle-active(run ${run_id})"; return
+  fi
+  echo "REAP"
+}
+
+# --- reaping (actuator destroy) --------------------------------------------
+
+# The Azure reap stages a copy of the runner's az credentials for the actuator
+# container. This is module-level (not a `local`) so main() can arm an EXIT trap
+# for it BEFORE any credential is written, which a `trap ... RETURN` inside reap
+# cannot do safely: a RETURN trap set in a function is not cleared when that
+# function returns, so it fires again on the caller's return with the variable
+# out of scope — under `set -e` that aborts the whole janitor mid-sweep.
+AZ_MOUNT=""
+cleanup_az_mount() {
+  [ -n "$AZ_MOUNT" ] || return 0
+  rm -rf "$AZ_MOUNT"
+  AZ_MOUNT=""
+}
+
+# Break a stale Terraform state lock before destroying. Orphans from a run
+# cancelled mid-bringup carry an orphaned lock that would fail every destroy
+# attempt (see uat-*.yaml teardown). Best-effort; a genuinely-absent lock is the
+# common case. AWS has no state lock (S3 backend without dynamodb/use_lockfile).
+break_state_lock() {
+  local id="$1" loc
+  case "$CLOUD" in
+    gcp)
+      loc="$(yq -r '.deployment.location' "$JANITOR_CONFIG")"
+      gcloud storage rm \
+        "gs://cluster-state-${GCP_PROJECT_ID}/deployments/${loc}/${id}/default.tflock" \
+        2>/dev/null && log "cleared stale GCS state lock for ${id}" || true
+      ;;
+    azure)
+      loc="$(yq -r '.deployment.location' "$JANITOR_CONFIG")"
+      local rg="cluster-state-rg" sa key blob="deployments/${loc}/${id}/terraform.tfstate"
+      sa="$(az storage account list -g "$rg" --subscription "$AZURE_SUBSCRIPTION_ID" \
+        --query "[?starts_with(name, 'clst')].name | [0]" -o tsv 2>/dev/null || true)"
+      if [ -n "${sa:-}" ]; then
+        key="$(az storage account keys list -g "$rg" -n "$sa" \
+          --subscription "$AZURE_SUBSCRIPTION_ID" --query '[0].value' -o tsv 2>/dev/null || true)"
+        # Hand the account key to `az` through AZURE_STORAGE_KEY, not --account-key,
+        # so the full-access tfstate key never appears in argv (world-readable via
+        # /proc/<pid>/cmdline). Mirrors the proven pattern in uat-azure.yaml teardown.
+        AZURE_STORAGE_ACCOUNT="$sa" AZURE_STORAGE_KEY="$key" \
+          az storage blob lease break --account-name "$sa" \
+          --container-name tfstate --blob-name "$blob" >/dev/null 2>&1 \
+          && log "broke stale state-blob lease for ${id}" || true
+      fi
+      ;;
+  esac
+}
+
+# One EKS actuator destroy pass for the staged config <cfg>. Factored out so the
+# AWS reap can run it, sweep leaked LB resources, and run it again.
+aws_actuator_destroy() {
+  docker run --rm \
+    -e CONFIG_CONTENT="$(base64 <"$1" | tr -d '\n')" \
+    -e AUTO_APPROVE=true \
+    -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+    -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+    -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}" \
+    "$JANITOR_ACTUATOR_IMAGE" apply
+}
+
+# Destroy one orphaned deployment via the actuator (destroy == apply w/ destroy=true).
+# Returns the actuator's exit status so the caller counts only destroys that
+# actually happened — the rollout asks operators to trust these logs before
+# enabling enforce, so a reported reap must be a real one.
+reap() {
+  local id="$1" cfg rc=0
+  # `reap` is invoked as `if reap "$id"`, which disables errexit for this whole
+  # body — a failure while staging the destroy config does NOT abort here. So
+  # check each step explicitly and bail BEFORE docker: an unmodified or
+  # half-written config still carries the committed placeholder deployment.id and
+  # destroy=false, which in ENFORCE mode would make the actuator APPLY
+  # (provision/update) a cluster while this logged a reap. Fail closed instead.
+  if ! cfg="$(mktemp --suffix=.yaml)"; then
+    echo "::warning::janitor could not create temp config for ${id}"
+    return 1
+  fi
+  if ! yq '.' "$JANITOR_CONFIG" >"$cfg" ||
+     ! DEPLOY_ID="$id" yq -i '.deployment.id = strenv(DEPLOY_ID) | .deployment.destroy = true' "$cfg"; then
+    echo "::warning::janitor could not stage destroy config for ${id} (destroy NOT attempted)"
+    rm -f "$cfg"
+    return 1
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log "DRY-RUN would reap: ${id}"
+    rm -f "$cfg"; return 0
+  fi
+
+  log "reaping: ${id}"
+  break_state_lock "$id"
+  case "$CLOUD" in
+    gcp)
+      docker run --rm \
+        -e CONFIG_CONTENT="$(base64 <"$cfg" | tr -d '\n')" \
+        -e AUTO_APPROVE=true \
+        -e KEY_CONTENT="$(base64 <"$GOOGLE_GHA_CREDS_PATH" | tr -d '\n')" \
+        "$JANITOR_ACTUATOR_IMAGE" apply || rc=$?
+      ;;
+    aws)
+      # A LoadBalancer Service (AWS inference UAT deploys agentgateway) leaves a
+      # classic ELB + k8s-elb-* SG OUTSIDE Terraform state; `destroy` then fails
+      # at DeleteVpc with DependencyViolation and the VPC leaks — the exact orphan
+      # class this janitor exists to reap, failing identically every cycle without
+      # this. Mirror uat-aws.yaml teardown: delete the LB Services gracefully while
+      # the cluster still answers (best-effort — no-op once the cluster is gone),
+      # destroy, and if that fails, sweep the leaked ELB/SG and retry once so a
+      # VPC-only remnant still tears down. Both helper modes are scoped to this
+      # deployment id's ownership tag and always exit 0.
+      "$SCRIPT_DIR/uat-aws-cleanup-lb.sh" graceful "$id" || true
+      aws_actuator_destroy "$cfg" || rc=$?
+      if [ "$rc" -ne 0 ]; then
+        log "aws destroy failed for ${id} (rc=${rc}); sweeping leaked LB resources and retrying once"
+        "$SCRIPT_DIR/uat-aws-cleanup-lb.sh" sweep "$id" || true
+        rc=0
+        aws_actuator_destroy "$cfg" || rc=$?
+      fi
+      ;;
+    azure)
+      # The actuator container runs as uid `builder` (not the runner's uid) and
+      # writes to its az config dir on startup, so it needs a writable copy —
+      # `chmod -R a+rwX` on a throwaway mirrors the proven Bringup/Destroy steps
+      # in uat-azure.yaml. Do not tighten the mode without confirming the image's
+      # uid, or every Azure reap fails. mktemp -d is 0700, so the copy is private
+      # until the chmod, and the runner is ephemeral and single-tenant.
+      #
+      # Cleanup is already armed: AZ_MOUNT is module-level and main() installs an
+      # EXIT trap for it before any reap runs, so the credentials cannot survive
+      # even a `set -e` abort between mktemp and the copy. The inline call below
+      # removes them at the earliest possible moment rather than at exit.
+      AZ_MOUNT="$(mktemp -d)"
+      if cp -a "$HOME/.azure/." "$AZ_MOUNT/" && chmod -R a+rwX "$AZ_MOUNT"; then
+        docker run --rm \
+          -e CONFIG_CONTENT="$(base64 <"$cfg" | tr -d '\n')" \
+          -e AUTO_APPROVE=true \
+          -v "$AZ_MOUNT:/home/builder/.azure" \
+          "$JANITOR_ACTUATOR_IMAGE" apply || rc=$?
+      else
+        rc=1
+        echo "::warning::janitor could not stage az config for ${id}"
+      fi
+      cleanup_az_mount
+      ;;
+  esac
+  rm -f "$cfg"
+
+  if [ "$rc" -eq 0 ]; then
+    log "reaped: ${id}"
+  else
+    echo "::warning::janitor reap failed for ${id} (rc=${rc}; will retry next run)"
+  fi
+  return "$rc"
+}
+
+# --- per-cloud discovery ---------------------------------------------------
+# Each emits candidate deployment ids (one per line, matching the header's
+# ALLOWLIST), deduped by the caller. Discovery is intentionally broad (clusters
+# AND their networks /
+# resource groups) so a cluster that was already deleted but left its network
+# group / resource group behind is still caught.
+
+# All GCP deployment ids (nightly aicr-uat-<run_id> and daytime aicr-uat-day-*)
+# share the aicr-uat- prefix, same as AWS/Azure.
+# This is a coarse CANDIDATE filter; classify() is the authoritative, schema-anchored
+# gate.
+# Run one cloud list command and echo its stdout. A NON-ZERO exit (missing CLI,
+# expired creds, a per-API authorization gap the auth step did not catch, a
+# throttle) is surfaced as a ::warning:: rather than swallowed — otherwise a
+# failed listing looks identical to an empty fleet and the run reports "nothing
+# to reap" while orphans persist. Discovery stays best-effort (the run continues
+# and reaps whatever DID list), but the failure is now visible in the log.
+run_discovery() {
+  local label="$1"; shift
+  local out errf rc
+  errf="$(mktemp)"
+  out="$("$@" 2>"$errf")" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "::warning::${CLOUD} discovery '${label}' failed (rc=${rc}); its orphans are NOT reconciled this run: $(tr '\n' ' ' <"$errf")" >&2
+  fi
+  rm -f "$errf"
+  printf '%s' "$out"
+}
+
+discover_gcp() {
+  run_discovery "GKE clusters" gcloud container clusters list \
+    --project "$GCP_PROJECT_ID" --format="value(name)" | grep -E "^${NAME_PREFIX}" || true
+  # A deployment's VPC is named <id>-vpc; recover <id> for clusters already gone.
+  # The ^ anchor means a foreign name merely ending in -vpc cannot be captured.
+  run_discovery "GCP networks" gcloud compute networks list \
+    --project "$GCP_PROJECT_ID" --format="value(name)" | sed -nE "s/^(${NAME_PREFIX}.*)-vpc$/\1/p" || true
+}
+
+discover_aws() {
+  run_discovery "EKS clusters" aws eks list-clusters \
+    --region "$AWS_REGION" --query 'clusters[]' --output text | tr '\t' '\n' | grep -E "^${NAME_PREFIX}" || true
+  # The EKS actuator tags the VPC Name=<id>-vpc (network.tf); recover <id> for a
+  # cluster already deleted but whose VPC group still leaks (mirrors the GCP -vpc
+  # and Azure -rg recovery so AWS is not the one path that misses network-only
+  # orphans). --output text tab-joins Name-tag values within a VPC.
+  run_discovery "EC2 VPCs" aws ec2 describe-vpcs --region "$AWS_REGION" \
+    --query "Vpcs[].Tags[?Key=='Name'].Value | [] | [?starts_with(@, '${NAME_PREFIX}')]" --output text \
+    | tr '\t' '\n' | sed -nE "s/^(${NAME_PREFIX}.*)-vpc$/\1/p" || true
+}
+
+discover_azure() {
+  run_discovery "AKS clusters" az aks list \
+    --subscription "$AZURE_SUBSCRIPTION_ID" --query '[].name' -o tsv | grep -E "^${NAME_PREFIX}" || true
+  # The actuator's resource group is <id>-rg; recover <id> for clusters already gone.
+  run_discovery "Azure resource groups" az group list \
+    --subscription "$AZURE_SUBSCRIPTION_ID" --query '[].name' -o tsv | sed -nE "s/^(${NAME_PREFIX}.*)-rg$/\1/p" || true
+}
+
+# --- main ------------------------------------------------------------------
+
+main() {
+  : "${JANITOR_CONFIG:?committed cluster-config path for this cloud}"
+  : "${JANITOR_ACTUATOR_IMAGE:?actuator image for this cloud}"
+
+  # Arm credential cleanup before anything can stage credentials. Installed here
+  # rather than at module scope so that sourcing this file (the unit harness)
+  # does not clobber the caller's own EXIT trap.
+  trap cleanup_az_mount EXIT
+
+  # Reject an unknown cloud up front with the usage message rather than letting a
+  # typo reach `discover_<x>` and die with a cryptic `command not found`. Fails
+  # closed — it can only narrow scope, never widen deletion.
+  case "$CLOUD" in
+    gcp | aws | azure) ;;
+    *) log "FATAL: unknown cloud '${CLOUD}' (want gcp|aws|azure)"; return 2 ;;
+  esac
+
+  # Refuse to run at all on a malformed DRY_RUN, before any discovery: an
+  # unrecognized value must never be resolved in the enforce direction.
+  if ! valid_dry_run "$DRY_RUN"; then
+    log "FATAL: DRY_RUN must be exactly 'true' or 'false', got '${DRY_RUN}'"
+    return 2
+  fi
+
+  # Same fail-closed treatment for the age floors: a non-integer or negative
+  # override would otherwise silently widen the reap window (see valid_age_floor).
+  local floor
+  for floor in NIGHTLY_MIN_AGE_HOURS DAYTIME_MIN_AGE_HOURS; do
+    if ! valid_age_floor "${!floor}"; then
+      log "FATAL: ${floor} must be a non-negative integer, got '${!floor}'"
+      return 2
+    fi
+  done
+  log "mode: $([ "$DRY_RUN" = true ] && echo DRY-RUN || echo ENFORCE) | nightly>=${NIGHTLY_MIN_AGE_HOURS}h daytime>=${DAYTIME_MIN_AGE_HOURS}h"
+
+  # Prove the runs endpoint resolves before any 404 may be read as "run purged".
+  # classify() consults this; without it a repo-level 404 orphans the whole fleet.
+  if gh api "repos/${REPO}/actions/runs?per_page=1" >/dev/null 2>&1; then
+    REPO_REACHABLE=yes
+  else
+    REPO_REACHABLE=no
+    log "WARNING: repos/${REPO}/actions/runs unreachable — every 404 stays ambiguous"
+  fi
+
+  local candidates
+  candidates="$(discover_"$CLOUD" | sort -u)"
+  [ -n "$candidates" ] || log "no allowlisted deployments found"
+
+  local reaped=0 failed=0 skipped=0 id verdict
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    verdict="$(classify "$id")"
+    if [ "$verdict" = "REAP" ]; then
+      log "REAP  ${id}"
+      if reap "$id"; then reaped=$((reaped + 1)); else failed=$((failed + 1)); fi
+    else
+      log "skip  ${id} -> ${verdict#SKIP:}"
+      skipped=$((skipped + 1))
+    fi
+  done <<<"$candidates"
+
+  # In dry-run nothing was destroyed, so the count is of candidates that WOULD
+  # be — never label it "reaped". Operators read these logs to decide whether to
+  # trust enforce; a report claiming destroys that never happened poisons that.
+  local mode verb
+  if [ "$DRY_RUN" = true ]; then mode=dry-run; verb=would-reap; else mode=enforce; verb=reaped; fi
+  log "summary: ${reaped} ${verb}, ${failed} failed, ${skipped} skipped (${mode})"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "### UAT janitor — ${CLOUD} (${mode})"
+      echo
+      echo "| ${verb} | failed | skipped |"
+      echo "| ---: | ---: | ---: |"
+      echo "| ${reaped} | ${failed} | ${skipped} |"
+    } >>"$GITHUB_STEP_SUMMARY"
+  fi
+
+  # A destroy that keeps failing (stale lock, permissions gap) is exactly the
+  # silent drift this workflow exists to catch, so fail the job rather than
+  # leaving it buried in a ::warning:: that nobody reads until a quota blows.
+  [ "$failed" -eq 0 ]
+}
+
+# Run main only when executed directly; sourcing exposes the pure helpers
+# (run_id_of, is_daytime, age_hours_since, classify) without provisioning
+# anything. tools/uat-janitor_test.sh drives them via `make test`.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main
+fi

--- a/.github/workflows/uat-janitor.yaml
+++ b/.github/workflows/uat-janitor.yaml
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: UAT Janitor
+
+# Backstop teardown for orphaned UAT clusters + resource groups across all three
+# clouds. The in-run "Destroy Cluster" step (uat-{gcp,aws,azure}.yaml) is the
+# first line; it cannot cover every case (a runner hard-killed mid-cancel, a
+# daytime held cluster whose evening daytime-down never fired, an abandoned
+# skip_delete run). This reaps whatever the in-run teardown missed, reconciling
+# each aicr-uat-<run_id> deployment against its owning GitHub run. See
+# .github/scripts/uat-janitor.sh for the full safety model.
+#
+# ROLLOUT: dry-run-first. The scheduled run always reports only (DRY_RUN=true) —
+# it never deletes. To actually reap, dispatch this workflow with enforce=true
+# (a deliberate human action). Once the scheduled dry-run logs have been trusted
+# over a few cycles, flip the schedule to enforce by changing the DRY_RUN env
+# expression below to default false for the schedule event.
+#
+# PREREQUISITE (verify before enforce): each cloud's OIDC/WIF trust must permit
+# this workflow. The federated identities are subject-pinned to NVIDIA/aicr refs
+# (main + test/uat). Every job is additionally gated on
+# github.ref == 'refs/heads/main', so a workflow_dispatch that selects another
+# branch (the GCP/Azure trusts also admit test/uat) cannot run that branch's copy
+# of the janitor with delete authority — scheduled + dispatch runs only ever
+# execute main's version. A ref-scoped trust already covers this; if any trust is
+# workflow-file-scoped, add uat-janitor.yaml. The first scheduled dry-run surfaces
+# any auth gap harmlessly.
+
+on:
+  schedule:
+    - cron: '17 * * * *' # hourly, offset from top-of-hour job contention
+  workflow_dispatch:
+    inputs:
+      cloud:
+        description: 'Which cloud(s) to reconcile.'
+        type: choice
+        options: [all, gcp, aws, azure]
+        default: all
+      enforce:
+        description: 'Actually delete orphans (default: dry-run report only).'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Never let two janitor runs reconcile the same cloud state concurrently; let an
+# in-flight reap finish rather than cancelling it mid-destroy.
+#
+# Deliberately NOT the per-reservation `uat-<reservation>` group that uat-run.yaml
+# leases. That would be a cross-workflow mutex, and the exclusion it buys is
+# already provided by the design:
+#   * Janitor candidates are RUN-SCOPED unique deployment ids. A live lifecycle
+#     run reports `queued`/`in_progress` on the GitHub API, so classify() skips
+#     it outright — its cluster is never a candidate in the first place.
+#   * A lifecycle run touches only its OWN run-scoped name and Terraform state
+#     prefix, so it shares no resource with whatever older orphan the janitor is
+#     targeting. There is no collision to serialize.
+#   * Actuator destroys are idempotent, and GCP/Azure additionally serialize on
+#     the Terraform state lock.
+#   * Daytime last-mile: a daytime name encodes the daytime-UP run id, so the
+#     run-status liveness gate cannot see an active daytime-DOWN teardown of the
+#     same cluster (a different run). The teardown always executes as a
+#     uat-run.yaml run — the evening scheduler dispatches uat-run.yaml as its own
+#     top-level run, and a direct `gh workflow run uat-run.yaml -f
+#     lifecycle=daytime-down` is a uat-run.yaml run too — so classify() calls
+#     uat_lifecycle_active() and, if ANY uat-run run is in flight, defers
+#     (SKIP:lifecycle-active) to the next hourly cycle. This is a liveness PROBE,
+#     not a mutex: it collapses the common race (a down already running) to near
+#     zero but leaves a residual TOCTOU window — a down that STARTS in the ~1h
+#     between the check and the reap. The daytime>=24h floor and the DRY_RUN
+#     default backstop that window (break_state_lock is best-effort and idempotent;
+#     an AWS destroy has no lock but the actuator destroy is itself idempotent).
+# For a hard "never races" guarantee a shared cross-workflow lease would be
+# required; that is the tracked follow-up (#2132) to revisit before scheduled
+# enforcement is enabled. With DRY_RUN defaulting true, the liveness probe, and the
+# age floors, the residual window does not justify that coupling for this backstop
+# today.
+concurrency:
+  group: uat-janitor
+  cancel-in-progress: false
+
+env:
+  # Scheduled runs are always dry-run; only an explicit enforce=true dispatch
+  # deletes. inputs.enforce is null for the schedule event, so this is 'true' there.
+  DRY_RUN: ${{ inputs.enforce == true && 'false' || 'true' }}
+
+jobs:
+  gcp:
+    if: >-
+      github.repository == 'nvidia/aicr' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'schedule' || inputs.cloud == 'all' || inputs.cloud == 'gcp')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    env:
+      GCP_PROJECT_ID: "eidosx"
+      JANITOR_CONFIG: "tests/uat/gcp/cluster-config.yaml"
+      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:v0.5.17@sha256:8bfffd412d98276ee1000a6c083514e6b28928416cc37602ec637ed3a2167c99"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Authenticate to GCP
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: "projects/116689922666/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider"
+          service_account: "github-actions@eidosx.iam.gserviceaccount.com"
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+      - name: Reconcile GCP orphans
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GOOGLE_GHA_CREDS_PATH: ${{ steps.auth.outputs.credentials_file_path }}
+        run: ./.github/scripts/uat-janitor.sh gcp
+
+  aws:
+    if: >-
+      github.repository == 'nvidia/aicr' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'schedule' || inputs.cloud == 'all' || inputs.cloud == 'aws')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    env:
+      AWS_REGION: "us-east-1"
+      JANITOR_CONFIG: "tests/uat/aws/cluster-config.yaml"
+      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:8bc33d14e6e5659d242aa2cdbcd69fca389cfcdb9e94f7a7a1b82fd33176befa"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: "arn:aws:iam::615299774277:role/github-actions-role-aicr"
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: GitHubActions-UAT-Janitor
+      - name: Reconcile AWS orphans
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/scripts/uat-janitor.sh aws
+
+  # GB200 lives in a SEPARATE AWS account — the cross-account Capacity Block in
+  # tenancy 897722687756 (tests/uat/aws/cluster-config-gb200.yaml), not the
+  # standard 615299774277 the `aws` job above covers — so it needs its own role
+  # assumption + config, or aws-gb200 orphans are never discovered or reaped.
+  # PREREQUISITE: infra/uat-aws-account applied in 897722687756 (GitHub OIDC
+  # provider + github-actions-role-aicr whose trust permits this workflow's ref).
+  # Until then the auth step fails harmlessly and the first dry-run surfaces the gap.
+  aws-gb200:
+    if: >-
+      github.repository == 'nvidia/aicr' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'schedule' || inputs.cloud == 'all' || inputs.cloud == 'aws')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    env:
+      AWS_REGION: "us-east-1"
+      JANITOR_CONFIG: "tests/uat/aws/cluster-config-gb200.yaml"
+      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:8bc33d14e6e5659d242aa2cdbcd69fca389cfcdb9e94f7a7a1b82fd33176befa"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Authenticate to AWS (GB200 account)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: "arn:aws:iam::897722687756:role/github-actions-role-aicr"
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: GitHubActions-UAT-Janitor
+      - name: Reconcile GB200 orphans
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/scripts/uat-janitor.sh aws
+
+  azure:
+    if: >-
+      github.repository == 'nvidia/aicr' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'schedule' || inputs.cloud == 'all' || inputs.cloud == 'azure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    env:
+      AZURE_SUBSCRIPTION_ID: "e88faa01-b4fd-49d3-b934-0ad9f9fca307"
+      JANITOR_CONFIG: "tests/uat/azure/cluster-config.yaml"
+      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/aks@sha256:70f049e45cd0025e0d2172503f9d0569baeabff27080919e2fa04f3339b9f9ee"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Authenticate to Azure
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: "047f0427-5dcf-4e7c-97c3-9c71d92c5abb"
+          tenant-id: "43083d15-7273-40c1-b7db-39efd9ccc17a"
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+      - name: Reconcile Azure orphans
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/scripts/uat-janitor.sh azure

--- a/.github/workflows/uat-run.yaml
+++ b/.github/workflows/uat-run.yaml
@@ -77,7 +77,7 @@ on:
         type: string
         default: '0'
       skip_delete:
-        description: 'Skip cluster teardown (manual debugging only; ignored for daytime lifecycles).'
+        description: 'Skip cluster teardown (manual debugging only; ignored for daytime lifecycles). A retained cluster becomes eligible for janitor reclamation ~24h after the run finishes.'
         type: boolean
         default: false
       skip_tests:

--- a/docs/contributor/uat.md
+++ b/docs/contributor/uat.md
@@ -146,6 +146,12 @@ You never *have* to tear a cluster down by hand — the evening safety-net cron 
 
 The teardown is not the only safety net. If a `daytime-down` is skipped or fails and the daytime cluster is still up when the nightly batch opens, DC2's [pre-batch guard](#pre-batch-guard) **blocks** the batch (fail-closed) rather than racing the held deployment. Recover by tearing the daytime cluster down — `gh workflow run uat-daytime.yaml -f action=down`, or a single `uat-run.yaml … -f lifecycle=daytime-down` for one reservation — then re-run the batch.
 
+### The orphan janitor (backstop teardown)
+
+`uat-janitor.yaml` (hourly, all three clouds) is the last-resort backstop for whatever the in-run teardown misses — a runner hard-killed mid-cancel, a daytime hold whose evening `daytime-down` never fired, an abandoned `skip_delete` run, or a Bringup false-failure that stranded a healthy cluster. It reconciles every `aicr-uat-<run_id>` / `aicr-uat-day-<reservation>-<run_id>` deployment against its owning GitHub run and reaps only the ones whose run is finished and past an age floor, via the same actuator `destroy` the in-run teardown uses. It is **dry-run by default**: scheduled runs only report; an actual reap requires a deliberate `workflow_dispatch` with `enforce=true`. See `.github/scripts/uat-janitor.sh` for the full safety model.
+
+**Retention limit for `skip_delete`.** A cluster kept alive with `skip_delete=true` (manual debugging) **becomes eligible for enforced reclamation ~24h after its run finishes** — there is no API signal that distinguishes an intentional hold from a genuine orphan, so the age floor is the only lever. (While the janitor stays dry-run-first, eligibility only becomes a *reclaim* on an `enforce=true` dispatch — or automatically once scheduled enforcement is turned on.) Treat a `skip_delete` cluster as a one-working-day loan; if you need it longer, re-provision.
+
 ### Reaching the daytime cluster
 
 Access is **out-of-band by design**: nothing here routes a kubeconfig or endpoint URL through the CI path, the evidence bundle, or the dashboard. Access is gated by **cloud IAM** on the daytime cluster — so an authorized operator mints their own kubeconfig directly and no credential ever transits CI. Because the daytime cluster is now ephemerally named, first **discover** it by its `(slug, slot)`-scoped prefix (with the legacy `aicr-uat-day-<reservation>-` prefix as a fallback during the ADR-017 migration window, matching the dual-prefix scan the workflows carry), then bind to the discovered name:

--- a/tools/uat-janitor_test.sh
+++ b/tools/uat-janitor_test.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit harness for .github/scripts/uat-janitor.sh decision logic.
+# Run directly: bash tools/uat-janitor_test.sh
+# Wired into CI via `make test` (test-shell target).
+#
+# Hermetic: sources the janitor (its `main` guard means sourcing provisions
+# nothing) and stubs `gh` on PATH, so no cloud CLI, credential, or network call
+# is involved and no resource is ever touched. The assertions guard the
+# safety-critical logic that decides whether a cloud deployment gets DESTROYED:
+# the allowlist, the run-id requirement, the not-active liveness gate, the
+# fail-closed handling of ambiguous GitHub API answers, and the age floors.
+# Every ambiguous input must produce SKIP, never REAP.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JANITOR="${REPO_ROOT}/.github/scripts/uat-janitor.sh"
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+
+# --- Stub `gh` on PATH --------------------------------------------------------
+# GH_STUB drives the response for `gh api repos/*/actions/runs/<id>`:
+#   ok:<status>:<updated_at>  200 with that run JSON
+#   nofield                   200 whose body lacks status/updated_at
+#   404                       run-level Not Found (the exact `HTTP 404` token)
+#   404plain                  failure whose text merely CONTAINS 404, no HTTP 404
+#   500                       any other API failure
+# `gh api <url> [--jq ...]`. Branch on the URL so the two distinct calls
+# classify() can make are stubbed independently: the single-run status lookup
+# (keyed by GH_STUB) and the uat-daytime liveness list (keyed by DAYTIME_STUB).
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+url="${2:-}"
+case "${url}" in
+  *"/actions/workflows/"*"/runs"*)
+    # uat_lifecycle_active() queries ?status=in_progress, so the list is already
+    # filtered server-side. LIFECYCLE_STUB=active => one in-progress run; error =>
+    # API failure; malformed/nullruns => 200 with a body that is not a well-formed
+    # run list (all three must fail SAFE => "active"); default idle => empty array.
+    # classify()'s reap assertions never set it, so they see idle.
+    case "${LIFECYCLE_STUB:-idle}" in
+      active)    printf '{"workflow_runs":[{"status":"in_progress"}]}\n' ;;
+      error)     echo "gh: Internal Server Error (HTTP 500)" >&2; exit 1 ;;
+      malformed) printf '{"message":"partial response"}\n' ;;
+      nullruns)  printf '{"workflow_runs":null}\n' ;;
+      *)         printf '{"workflow_runs":[]}\n' ;;
+    esac
+    ;;
+  *)
+    case "${GH_STUB:-500}" in
+      ok:*)
+        rest="${GH_STUB#ok:}"
+        printf '{"status":"%s","updated_at":"%s"}\n' "${rest%%:*}" "${rest#*:}"
+        ;;
+      nofield) printf '{"id":1}\n' ;;
+      404) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+      404plain) echo "gh: gateway error code 404 upstream" >&2; exit 1 ;;
+      *)   echo "gh: Internal Server Error (HTTP 500)" >&2; exit 1 ;;
+    esac
+    ;;
+esac
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+# The janitor uses GNU `date -u -d`; on a BSD-date host (macOS dev box) forward
+# to gdate so the age assertions run everywhere CI does.
+if ! date -u -d "2026-01-01T00:00:00Z" +%s >/dev/null 2>&1; then
+    if command -v gdate >/dev/null 2>&1; then
+        printf '#!/usr/bin/env bash\nexec gdate "$@"\n' >"${STUB_DIR}/date"
+        chmod +x "${STUB_DIR}/date"
+    else
+        echo "SKIP: no GNU date (install coreutils for gdate)" >&2
+        exit 0
+    fi
+fi
+PATH="${STUB_DIR}:${PATH}"
+
+# GH_STUB is read by the `gh` stub (a subprocess), REPO_REACHABLE by classify()
+# from the sourced janitor — export both so later plain assignments carry over
+# and shellcheck can see they are consumed.
+export GH_STUB=500 REPO_REACHABLE=no
+# Neutralize any host/CI export of the age floors so the SOURCED defaults are what
+# we exercise (hermetic) AND the shipped default is actually asserted below — a
+# regression flipping it would flip the assertion. Boundary cases set an explicit
+# floor locally (a plain assignment; classify() reads the global at call time).
+unset NIGHTLY_MIN_AGE_HOURS DAYTIME_MIN_AGE_HOURS
+# Keyed independently of GH_STUB by the URL-aware `gh` stub above; idle so the
+# daytime classify() reap assertions below (which don't set it) see no active run.
+export LIFECYCLE_STUB=idle
+
+# Source the janitor: the `main` guard keeps this inert. `gcp` only sets $CLOUD
+# for log lines; no discovery or reaping is reachable from the pure helpers.
+# shellcheck source=/dev/null
+source "${JANITOR}" gcp
+set +e   # the janitor's `set -e` would abort the harness on a failed assertion
+
+ago() { date -u -d "-${1} hours" +%Y-%m-%dT%H:%M:%SZ; }
+
+FAILED=0
+check() { # check <label> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        FAILED=1
+    fi
+}
+
+echo "shipped age-floor defaults:"
+# Asserted from the sourced defaults (floors were unset above), so a regression in
+# the shipped skip_delete retention policy is caught here, not silently pinned.
+check "nightly default is 24h" "24" "${NIGHTLY_MIN_AGE_HOURS}"
+check "daytime default is 24h" "24" "${DAYTIME_MIN_AGE_HOURS}"
+
+echo "run_id_of:"
+check "extracts trailing run id" "12345" "$(run_id_of aicr-uat-12345)"
+check "extracts from daytime name" "999" "$(run_id_of aicr-uat-day-gh1-0-999)"
+run_id_of aicr-uat-nightly >/dev/null 2>&1
+check "rejects non-numeric tail" "1" "$?"
+run_id_of aicr-uat >/dev/null 2>&1
+check "rejects name with no id" "1" "$?"
+
+echo "is_daytime:"
+is_daytime aicr-uat-day-gh1-0-1; check "daytime name" "0" "$?"
+is_daytime aicr-uat-1;           check "nightly name" "1" "$?"
+
+echo "valid_dry_run:"
+for v in true false; do
+    valid_dry_run "$v"; check "accepts ${v}" "0" "$?"
+done
+# Anything else must be rejected outright: DRY_RUN is the last gate before the
+# actuator, and only the exact string `true` holds it back, so a typo or a
+# shell-truthy value must abort rather than resolve toward enforce.
+for v in flase TRUE True 1 yes on "" " " "true "; do
+    valid_dry_run "$v"; check "rejects '${v}'" "1" "$?"
+done
+
+echo "valid_age_floor:"
+for v in 0 6 24 99999; do
+    valid_age_floor "$v"; check "accepts '${v}'" "0" "$?"
+done
+# Empty, non-numeric, and negative are the obvious rejects; the last two guard the
+# overflow class: >5 digits (and the 20-digit value that makes bash's `-lt` error
+# with status 2) must be rejected up front, not read as REAP for a young run.
+for v in "" " " -1 24h 1.5 100000 99999999999999999999; do
+    valid_age_floor "$v"; check "rejects '${v}'" "1" "$?"
+done
+
+echo "age_hours_since:"
+check "computes whole hours" "8" "$(age_hours_since "$(ago 8)")"
+age_hours_since "not-a-timestamp" >/dev/null 2>&1
+check "fails closed on garbage" "1" "$?"
+age_hours_since "null" >/dev/null 2>&1
+check "fails closed on literal null" "1" "$?"
+
+echo "classify (allowlist + run id):"
+GH_STUB="ok:completed:$(ago 99)"
+# The allowlist is the outermost guard on a job that DESTROYS clusters, so both
+# directions are asserted. Two schemas are accepted, anchored end to end:
+#   aicr-uat-<run_id>                    nightly, all clouds
+#   aicr-uat-day-<mid>-<run_id>          daytime, all clouds. <mid> is permissive
+#                                        so it matches BOTH the current ADR-017
+#                                        <slug>-<slot> form (gh1-0) AND the legacy
+#                                        hyphenated <reservation> form (gcp-h100)
+#                                        during the migration window.
+# (GCP nightly is aicr-uat-<run_id> like the others — the GKE actuator now bounds
+# the node-SA account_id, so the earlier aicr-<run_id> short form was dropped.)
+check "accepts nightly"                  "REAP" "$(classify aicr-uat-31021150393)"
+check "accepts daytime (reservation)"    "REAP" "$(classify aicr-uat-day-gcp-h100-31021150393)"
+check "accepts daytime (adr-017 slug)"   "REAP" "$(classify aicr-uat-day-gh1-0-31021150393)"
+check "accepts daytime multi-digit slot" "REAP" "$(classify aicr-uat-day-gh1-12-31021150393)"
+# Still anchored: the aicr-uat-day- prefix and a trailing numeric run_id are
+# required, so these are rejected — empty middle, no run id, wrong/absent prefix,
+# or a non-numeric nightly tail. Persistent infra (aicr-testgrid-*) and the
+# dropped GCP short form (aicr-<run_id>) match neither schema.
+for n in aicr-uat-unrelated-7 aicr-uat- aicr-testgrid-vpc aicr-uat-day--7 \
+         aicr-testgrid aicr-testgrid-7 aicr-prod-7 aicr- aicr \
+         some-aicr-uat-123 aicr-uat-123-vpc aicr-uat-day-h100- \
+         aicr-31021150393 ; do
+    check "rejects '${n}'" "SKIP:not-allowlisted" "$(classify "$n")"
+done
+check "rejects missing run id" "SKIP:not-allowlisted" "$(classify aicr-uat-manual)"
+
+echo "classify (liveness gate):"
+for st in queued in_progress waiting pending requested; do
+    GH_STUB="ok:${st}:$(ago 99)"
+    check "skips active run (${st})" "SKIP:run-active(${st},run 7)" "$(classify aicr-uat-7)"
+done
+# Only `completed` may be reaped: a status GitHub adds later must fail closed,
+# not fall through the case as "not active" and get destroyed on age alone.
+for st in some_new_status neutral timed_out; do
+    GH_STUB="ok:${st}:$(ago 99)"
+    check "skips unsupported status (${st})" "SKIP:run-status-unsupported(${st},run 7)" "$(classify aicr-uat-7)"
+done
+
+echo "classify (fail closed on ambiguity):"
+GH_STUB=500
+check "skips on API error" "SKIP:gh-api-error(run 7)" "$(classify aicr-uat-7)"
+GH_STUB=nofield
+check "skips on incomplete run JSON" "SKIP:incomplete-run-json(run 7)" "$(classify aicr-uat-7)"
+GH_STUB="ok:completed:not-a-timestamp"
+check "skips on unparsable updated_at" "SKIP:bad-updated-at(not-a-timestamp)" "$(classify aicr-uat-7)"
+
+echo "classify (404 requires a reachable repo):"
+GH_STUB=404
+REPO_REACHABLE=no
+check "skips 404 when repo unproven" "SKIP:gh-api-error(run 7)" "$(classify aicr-uat-7)"
+REPO_REACHABLE=yes
+check "reaps 404 when repo proven" "REAP" "$(classify aicr-uat-7)"
+# Narrowness guard: only the exact `HTTP 404` token counts as a definitive
+# run-level 404. An error that merely CONTAINS "404" must stay a fail-closed skip
+# EVEN with the repo proven reachable, so a future loosening of classify()'s grep
+# (e.g. to a bare "404") can't silently widen the purged-run reap path.
+GH_STUB=404plain
+check "skips bare-404 text even when repo proven" "SKIP:gh-api-error(run 7)" "$(classify aicr-uat-7)"
+
+echo "classify (age floors):"
+REPO_REACHABLE=yes
+# Boundary cases use an explicit nightly floor (6h) via a plain assignment —
+# classify() reads the global at call time — so the arithmetic is exercised at a
+# known threshold independent of the shipped 24h default asserted above.
+NIGHTLY_MIN_AGE_HOURS=6
+GH_STUB="ok:completed:$(ago 2)"
+check "nightly under floor" "SKIP:too-young(2h < 6h)" "$(classify aicr-uat-7)"
+GH_STUB="ok:completed:$(ago 8)"
+check "nightly over floor" "REAP" "$(classify aicr-uat-7)"
+GH_STUB="ok:completed:$(ago 8)"
+check "daytime under floor" "SKIP:too-young(8h < 24h)" "$(classify aicr-uat-day-gcp-h100-7)"
+GH_STUB="ok:completed:$(ago 30)"
+check "daytime over floor" "REAP" "$(classify aicr-uat-day-gcp-h100-7)"
+
+echo "uat_lifecycle_active (fail-safe liveness):"
+# Only the uat-run.yaml workflow list drives this, so GH_STUB is irrelevant here.
+# The three fail-safe cases (error/malformed/nullruns) must all read as "active".
+LIFECYCLE_STUB=active;    uat_lifecycle_active; check "active when a lifecycle run is in flight" "0" "$?"
+LIFECYCLE_STUB=idle;      uat_lifecycle_active; check "idle when none in flight"                 "1" "$?"
+LIFECYCLE_STUB=error;     uat_lifecycle_active; check "fails safe (active) on api error"         "0" "$?"
+LIFECYCLE_STUB=malformed; uat_lifecycle_active; check "fails safe (active) on missing field"     "0" "$?"
+LIFECYCLE_STUB=nullruns;  uat_lifecycle_active; check "fails safe (active) on null workflow_runs" "0" "$?"
+
+echo "classify (lifecycle liveness):"
+# A daytime deployment old enough to reap must still DEFER while an evening
+# daytime-DOWN (a uat-run.yaml run) is tearing down the same reservation — its live
+# run id differs from the daytime-UP id in the name, so this is the only gate that
+# can see it. Nightly is unaffected: its owning run IS what the run-status gate
+# already checked.
+REPO_REACHABLE=yes
+GH_STUB="ok:completed:$(ago 30)"
+LIFECYCLE_STUB=active
+check "defers daytime reap while a lifecycle run is active" "SKIP:lifecycle-active(run 7)" "$(classify aicr-uat-day-gcp-h100-7)"
+check "nightly ignores lifecycle liveness"                  "REAP"                          "$(classify aicr-uat-7)"
+LIFECYCLE_STUB=idle
+check "reaps daytime when no lifecycle run active"          "REAP"                          "$(classify aicr-uat-day-gcp-h100-7)"
+
+if [[ "${FAILED}" -eq 0 ]]; then
+    echo "PASS: uat-janitor decision logic"
+else
+    echo "FAIL: uat-janitor decision logic"
+fi
+exit "${FAILED}"


### PR DESCRIPTION
## Summary

Adds an hourly, all-cloud backstop that finds orphaned UAT deployments and reaps them through the existing cloud actuator. Scheduled runs are report-only; deletion requires an explicit `workflow_dispatch` with `enforce=true` on `main`.

## Motivation / Context

The in-run `Destroy Cluster` step cannot cover teardown misses caused by hard-cancelled runners, failed daytime teardown, abandoned `skip_delete` runs, or false-negative bringup failures. Those misses can leave clusters, networks, resource groups, and Terraform state behind until cloud quotas are exhausted.

This janitor complements the in-run teardown and the focused lifecycle fixes. It is the final reconciliation backstop, not a replacement for teardown at the end of each UAT run.

Fixes: N/A
Related: #2049, #2066, #2067, #2081, #2132

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT workflows and shell tooling

## Implementation Notes

**Reconciliation.** The hourly workflow discovers UAT clusters and cluster-gone network/resource-group remnants in GCP, both AWS accounts (including GB200), and Azure. Candidate discovery is deliberately broad, but deletion eligibility is controlled by an anchored allowlist for the nightly and daytime deployment-name schemas. The daytime expression accepts both the active ADR-017 slug/slot names and legacy reservation names during the migration window.

**Safety gates.** A candidate must contain a numeric run ID, have a completed or definitively purged owning run, and be at least 24 hours old. Unknown run statuses, malformed API responses, non-404 API errors, invalid timestamps, bad configuration values, and discovery failures all fail closed. A daytime candidate is additionally deferred while a UAT lifecycle run is active; the residual check-to-reap TOCTOU window is tracked in #2132 for resolution before scheduled enforcement.

**Destruction.** Reaping uses the same pinned actuator images and `destroy` path as in-run teardown. It breaks stale state locks first, preserves cloud-specific resource ordering, performs the AWS load-balancer cleanup required before VPC deletion, reports per-candidate results, and fails the job if any enforced reap fails.

**Dry-run-first rollout.** The schedule always sets `DRY_RUN=true`. Only an explicit `enforce=true` dispatch on `refs/heads/main` can delete resources, and invalid `DRY_RUN`, age-floor, or cloud values abort before discovery.

## Testing

```bash
bash tools/uat-janitor_test.sh
# PASS: 77/77 decision-logic assertions

shellcheck -x .github/scripts/uat-janitor.sh tools/uat-janitor_test.sh
yamllint -c .yamllint.yaml .github/workflows/uat-janitor.yaml .github/workflows/uat-run.yaml
actionlint -color -shellcheck= .github/workflows/uat-janitor.yaml .github/workflows/uat-run.yaml
git diff --check origin/main...HEAD
# All passed on the rebased head
```

Full `make qualify` was not repeated locally because this change is limited to workflows, shell tooling, and documentation. The scoped executable tests and linters above cover the changed surfaces. The final rebased head also passed the complete GitHub Merge Gate, including Test, Lint, CLI E2E, E2E, Security Scan, CodeQL analysis, actionlint, and malware scanning.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Keep scheduled runs in dry-run mode while reviewing decisions and confirming OIDC/WIF access in every cloud account, including the separate AWS GB200 account. Enforced deletion remains a deliberate manual dispatch. Revisit the cross-workflow lease in #2132 before enabling scheduled enforcement.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
