### PR TITLE
ci(supply-chain): daily re-verification of the latest release

### DIFF
--- a/.github/workflows/release-reverify.yaml
+++ b/.github/workflows/release-reverify.yaml
@@ -158,6 +158,14 @@ env:
   SIGSTORE_PROBE_URLS: >-
     https://tuf-repo-cdn.sigstore.dev/1.root.json
     https://fulcio.sigstore.dev/api/v2/trustBundle
+  # The binaries whose linux/amd64 SPDX SBOM every post-floor release must
+  # publish, each with a sibling .sigstore.json bundle. The expected set is
+  # derived from the TAG, never from the release's own inventory: deriving it
+  # from the artifact under test would make only a zero-SBOM release a finding,
+  # so deleting one of the two would leave the loop verifying the survivor and
+  # reporting clean. Authoritative list: expected_release_asset_names() in
+  # .github/scripts/release-images.sh -- keep this linux/amd64 subset in sync.
+  EXPECTED_SBOM_BINARIES: "aicr aicrd"
   # Workspace for downloads and captured verification logs, kept out of ./_rel
   # (which belongs to the install-aicr-release action).
   WORK_DIR: ./_reverify
@@ -258,10 +266,17 @@ jobs:
           RELEASE_ASSETS: ${{ steps.release.outputs.assets_file }}
           INSTALL_OUTCOME: ${{ steps.install.outcome }}
         run: |
-          # Deliberately not `set -e`: this step must run every check, aggregate
-          # the findings, and exit with the classified status. Each check owns
-          # its own failure handling.
+          # This step must run EVERY check, aggregate the findings, and exit with
+          # the classified status, so errexit has to be off. It is not off by
+          # default: with no `shell:` key GitHub invokes this block as
+          # `bash -e {0}`, and `set -uo pipefail` does not clear an inherited
+          # -e. Turn it off explicitly, as rekor-monitor.yaml does. Without
+          # this, any unguarded top-level failure aborts the step before
+          # `finish` runs, and a `tamper` already recorded earlier in the same
+          # run never reaches GITHUB_OUTPUT: the gates then read the empty
+          # classification as operational and the finding never pages.
           set -uo pipefail
+          set +e
 
           mkdir -p "${WORK_DIR}"
           classification=clean
@@ -434,17 +449,18 @@ jobs:
           elif ! command -v cosign > /dev/null 2>&1; then
             operational "cosign was never installed; treating as infrastructure"
           else
-            # Re-run the verification the action already performed, this time
-            # capturing its output so guard #2 has something to read. The action
-            # retried three times; this is the classification pass, and a pass
-            # here means the action's failure was transient -- its own log stays
-            # authoritative for WHICH of its sub-checks (checksum, extract,
-            # cosign) failed.
-            # Guarded: the step runs without `set -e`, so an unguarded failure
-            # here would fall through to cosign, which then fails on a missing
-            # bundle with a message no infra_shaped pattern matches, producing a
-            # security page for what is only a full disk or a permissions fault
-            # on WORK_DIR. Every sibling branch demotes, and so must this one.
+            # Re-run BOTH of the action's sub-checks, capturing their output so
+            # the demotion tests have something to read. Nothing here parses the
+            # action's own log, so reproducing its checks is the only way to know
+            # WHICH one failed; presuming "cosign" would misread a checksum
+            # mismatch (see the checksum re-check below). The action retried
+            # three times, so a pass here means its failure was transient.
+            # Guarded: errexit is off in this step (see `set +e` above), so an
+            # unguarded failure here would fall through to cosign, which then
+            # fails on a missing bundle with a message no infra_shaped pattern
+            # matches, producing a security page for what is only a full disk or
+            # a permissions fault on WORK_DIR. Every sibling branch demotes, and
+            # so must this one.
             if ! tar -xzf "${REL_DIR}/${archive}" -C "${WORK_DIR}" \
                 aicr aicr-attestation.sigstore.json 2>/dev/null; then
               operational "the archive listed but could not be extracted; treating as infrastructure"
@@ -454,7 +470,30 @@ jobs:
                 --certificate-oidc-issuer https://token.actions.githubusercontent.com \
                 --certificate-identity-regexp "${identity_re}" \
                 "${WORK_DIR}/aicr" > "${WORK_DIR}/binary-verify.log" 2>&1; then
-              operational "binary provenance verified on re-run after the install action failed; treating as a transient failure"
+              # Provenance passing does NOT clear the checksums manifest: the
+              # attestation binds the BINARY, while aicr_checksums.txt covers the
+              # ARCHIVE. The action fails at its own `sha256sum -c` before it
+              # ever reaches cosign, so without this re-check a manifest that
+              # stopped matching an otherwise-valid archive would report
+              # "transient" every single day, while every consumer following the
+              # documented checksum flow fails every single time.
+              #
+              # Ordered after cosign deliberately: a truncated or corrupt
+              # download also fails a checksum, but such an archive would have
+              # failed to list, or produced a binary the attestation rejects,
+              # further up this chain. Reaching here means the bytes are intact,
+              # so a mismatch is the published manifest disagreeing with the
+              # published archive.
+              if [ ! -r "${REL_DIR}/aicr_checksums.txt" ]; then
+                operational "the checksums manifest is not on disk to re-check; treating as infrastructure"
+              elif (cd "${REL_DIR}" && grep " ${archive}\$" aicr_checksums.txt | sha256sum -c -) \
+                  > "${WORK_DIR}/checksum-verify.log" 2>&1; then
+                operational "binary provenance and checksum verified on re-run after the install action failed; treating as a transient failure"
+              else
+                status=$?
+                cat "${WORK_DIR}/checksum-verify.log" >&2 || true
+                classify_failure "checksum verification of ${archive} for ${TAG}" "${WORK_DIR}/checksum-verify.log" "${status}"
+              fi
             else
               # $? is the elif condition's status and MUST be captured before any
               # other command runs, so timeout's 124 (or a 137 SIGKILL) survives
@@ -500,14 +539,23 @@ jobs:
           elif [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then
             echo "release ${TAG} is at or before the SBOM signing floor ${SBOM_SIGNING_FLOOR}; SBOM bundles not expected"
           else
-            sboms="$(grep -E '_linux_amd64\.sbom\.json$' "${RELEASE_ASSETS}" || true)"
-            if [ -z "${sboms}" ]; then
-              security "release ${TAG} publishes no linux/amd64 SBOM assets"
+            # Derived from the tag, so a mandatory SBOM that was never uploaded
+            # is a finding rather than an entry that simply is not iterated.
+            read -r -a sbom_binaries <<< "${EXPECTED_SBOM_BINARIES}"
+            expected_sboms=""
+            for binary in "${sbom_binaries[@]}"; do
+              expected_sboms+="${binary}_${version}_linux_amd64.sbom.json"$'\n'
+            done
+            expected_sboms="${expected_sboms%$'\n'}"
+            if [ -z "${expected_sboms}" ]; then
+              operational "EXPECTED_SBOM_BINARIES is empty; no SBOM subjects to check"
             fi
             while IFS= read -r sbom; do
               [ -n "${sbom}" ] || continue
               bundle="${sbom}.sigstore.json"
-              if ! have_asset "${bundle}"; then
+              if ! have_asset "${sbom}"; then
+                security "release ${TAG} does not publish the mandatory SBOM ${sbom}"
+              elif ! have_asset "${bundle}"; then
                 security "release ${TAG} ships ${sbom} with no attestation bundle (${bundle})"
               elif ! command -v cosign > /dev/null 2>&1; then
                 operational "cosign is unavailable; cannot verify ${sbom}"
@@ -530,7 +578,7 @@ jobs:
                 cat "${WORK_DIR}/${sbom}.verify.log" >&2 || true
                 classify_failure "SBOM attestation verification for ${sbom}" "${WORK_DIR}/${sbom}.verify.log" "${status}"
               fi
-            done <<< "${sboms}"
+            done <<< "${expected_sboms}"
           fi
 
           finish

--- a/.github/workflows/release-reverify.yaml
+++ b/.github/workflows/release-reverify.yaml
@@ -1,0 +1,525 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Daily re-verification of the latest published release's Sigstore artifacts
+# (NVIDIA/aicr#1461, part of the supply-chain epic #1149).
+#
+# WHAT THIS COVERS THAT rekor-monitor.yaml DOES NOT. The Rekor monitor proves the
+# transparency LOG is sound (append-only, no unexplained entries under the release
+# identity). It says nothing about whether a given release actually SHIPPED the
+# artifacts that chain to that log. A signing-side upload that silently failed or
+# was skipped -- goreleaser's post-hook exiting 0 without writing a bundle, an
+# asset that never made it onto the GitHub Release -- leaves a published release
+# whose provenance cannot be reconstructed by a consumer, and nothing in the log
+# is wrong. This workflow is the consumer's-eye check: every day it resolves the
+# latest release and runs the SHIPPED verification commands against it, exactly as
+# documented in docs/integrator/supply-chain-verification.md.
+#
+# WHAT IT VERIFIES (all release assets of the latest non-draft, non-prerelease
+# GitHub Release):
+#   - aicr_<version>_linux_amd64.tar.gz against aicr_checksums.txt, then the
+#     binary's SLSA provenance bundle (aicr-attestation.sigstore.json, shipped
+#     inside the archive) with `cosign verify-blob-attestation` pinned to
+#     on-tag.yaml@refs/tags/<exact tag>. This is delegated wholesale to the
+#     .github/actions/install-aicr-release composite, which already does the
+#     download, checksum, extract, exact-tag identity pinning, 3-attempt retry
+#     and fail-closed-on-missing-attestation.
+#   - recipe-catalog.sigstore.json (a loose release asset, deliberately NOT
+#     covered by aicr_checksums.txt) via `aicr recipe verify-catalog`, run with
+#     the released binary the step above just verified. This is the only check
+#     that proves the SHIPPED binary's embedded registry.yaml +
+#     validators/catalog.yaml still digest to what the release signed.
+#   - every aicr*/aicrd* linux/amd64 SPDX SBOM asset and its sibling
+#     <asset>.sigstore.json attestation bundle, again with
+#     `cosign verify-blob-attestation`. Gated behind SBOM_SIGNING_FLOOR: releases
+#     at or before that tag predate SBOM signing (NVIDIA/aicr#1957) and
+#     legitimately ship unsigned SBOMs; every release after it MUST ship a bundle
+#     per SBOM, and a missing one is a finding.
+#
+# WHAT IT DELIBERATELY DOES NOT VERIFY:
+#   - `aicr verify` (bundle attestation). A deployment bundle is produced on
+#     demand by a user (`aicr bundle --attest`); no bundle is a release asset, so
+#     there is nothing released to re-verify. Generating one here would test the
+#     signing path, not the retrievability of a published artifact.
+#   - The container images' OCI referrer attestations (SBOM / OpenVEX / SLSA
+#     provenance, NVIDIA/aicr#1982). Those live in ghcr.io's referrer store, a
+#     different system with a different retention and GC model from GitHub
+#     Releases, and re-verifying all seven images x three predicate kinds would
+#     add ~21 registry round-trips per run -- multiplying this job's operational
+#     noise against the one signal it exists to keep crisp. The images are
+#     already pulled and scanned weekly by vuln-scan-images.yaml. A sibling
+#     registry-side re-verification (which would need `gh attestation verify
+#     --bundle-from-oci` so it reads the REGISTRY copy rather than GitHub's
+#     attestations API) is tracked separately; see docs/contributor/maintaining.md.
+#   - Rekor entry liveness by log index. `cosign verify-blob-attestation` verifies
+#     a self-contained bundle: the inclusion proof and RFC3161 timestamp travel
+#     inside it and are checked against the live Sigstore TUF trust root, so a
+#     pass proves the bundle is retrievable and cryptographically sound, not that
+#     Rekor would still serve that entry by index. Re-fetching by index is a
+#     documented residual, also in maintaining.md.
+#
+# CLASSIFICATION (same vocabulary and exit codes as rekor-monitor.yaml, so the
+# two workflows triage identically):
+#   - clean      -> exit 0
+#   - tamper     -> exit 1, security: a released artifact is MISSING, or it fails
+#                   verification against a Sigstore that answered. Opens a
+#                   security tracking issue mentioning the maintainers.
+#   - operational-> exit 3, infrastructure: Sigstore/GitHub-API/network trouble.
+#                   Pages no one. The job goes red; only three consecutive failed
+#                   scheduled runs open a calm `area/ci` degraded issue.
+#
+# WHY AN INFRA FAILURE CANNOT MASQUERADE AS A MISSING ENTRY. `tamper` is asserted
+# on POSITIVE evidence only, never as a fallback:
+#   1. "Missing" means the asset name is absent from the release's own asset
+#      inventory (a GitHub API read that either succeeded or aborted the step), or
+#      the attestation is absent from an archive we successfully downloaded and
+#      checksummed. Neither can be produced by a network failure -- a failed read
+#      aborts before any comparison.
+#   2. A failed cryptographic verification is promoted to `tamper` only when BOTH
+#      independent guards agree: Sigstore's TUF CDN answered a live probe, AND the
+#      captured failure output carries no transport/outage signature. Either guard
+#      alone demotes to `operational`. The guards are demote-only, so the failure
+#      mode is a real finding reported as operational (still a red job, still a
+#      degraded issue after three days, and it re-fires tomorrow) -- never the
+#      reverse.
+#   3. Any failure BEFORE the classifying step runs (checkout, release
+#      resolution, load-versions) leaves the classification output empty, which
+#      the issue gates treat as operational by construction.
+#
+# TRIAGE:
+#   - Security issue (tamper): confirm by hand with the commands in
+#     docs/integrator/supply-chain-verification.md against the named tag. A
+#     genuinely missing asset means the release must be re-cut or the asset
+#     re-uploaded and re-signed; a verification failure on a present asset means
+#     the artifact does not match what the release signed -- treat as tampering
+#     and begin incident response.
+#   - Degraded issue (operational, 3+ consecutive days): Sigstore or the GitHub
+#     API has been unreachable. No action unless it persists past an upstream
+#     incident window.
+
+name: Release Re-Verification
+
+on:
+  schedule:
+    - cron: "41 13 * * *"  # daily, offset away from the release and UAT crons
+  # Also manual: GitHub disables scheduled workflows after 60 days of repository
+  # inactivity, and a dispatch re-arms the schedule as well as allowing an
+  # on-demand run after a release.
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: release-reverify
+  cancel-in-progress: false
+
+env:
+  ALERT_TITLE: "Release re-verification: a released artifact is missing or does not verify"
+  DEGRADED_TITLE: "Release re-verification: degraded"
+  # Maintainers group notified on an alert (GitHub team; issues cannot be
+  # assigned to a team, so it is @-mentioned in the issue body instead).
+  MAINTAINERS_TEAM: "@nvidia/aicr-maintainer"
+  # Releases at or before this tag predate signed SBOM assets (NVIDIA/aicr#1957)
+  # and ship SPDX documents with no sibling .sigstore.json. From the next release
+  # onward a missing bundle is a finding. Raise this ONLY to correct history.
+  SBOM_SIGNING_FLOOR: v0.18.0
+  # Liveness probe for the Sigstore trust root every verification depends on.
+  # This is the outer guard that keeps an outage from reading as a finding.
+  SIGSTORE_PROBE_URL: https://tuf-repo-cdn.sigstore.dev/1.root.json
+  # Workspace for downloads and captured verification logs, kept out of ./_rel
+  # (which belongs to the install-aicr-release action).
+  WORK_DIR: ./_reverify
+  # Where install-aicr-release leaves its download and its installed binary.
+  REL_DIR: ./_rel
+  AICR_BIN: ./aicr
+
+jobs:
+  reverify:
+    name: Re-verify the latest release's Sigstore artifacts
+    runs-on: ubuntu-latest
+    # Bounds the worst case: a release download, one cosign verification per
+    # artifact (each internally retried), and the issue bookkeeping. Every
+    # network call is individually bounded by `timeout --foreground`, so this is
+    # a backstop, not the primary bound.
+    timeout-minutes: 30
+    permissions:
+      contents: read  # checkout, plus `gh release download` for the assets
+      actions: read   # read this workflow's run history for the failure streak
+      issues: write   # open/close the alert and degraded issues
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve the latest release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # /releases/latest excludes drafts and prereleases, so this is the
+          # release a `curl .../releases/latest` consumer would actually install
+          # -- the same resolution documented in supply-chain-verification.md.
+          # gh-api-retry.sh publishes release.json only on success and removes it
+          # on total failure, so a GitHub API outage aborts this step (and, with
+          # no classification emitted, is treated as operational downstream)
+          # rather than falling through to an empty asset inventory that would
+          # read as "every asset is missing".
+          .github/scripts/gh-api-retry.sh release.json "repos/${GITHUB_REPOSITORY}/releases/latest"
+          tag="$(jq -r '.tag_name // empty' release.json)"
+          # Validate before the tag reaches a regexp or a filename. Same shape
+          # install-aicr-release enforces on its input.
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.]*)?$ ]]; then
+            echo "::error::/releases/latest returned '${tag}', which is not a release tag like v1.2.3." >&2
+            exit 1
+          fi
+          jq -r '.assets[].name' release.json > release-assets.txt
+          {
+            echo "tag=${tag}"
+            echo "assets_file=${PWD}/release-assets.txt"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved latest release ${tag} with $(wc -l < release-assets.txt) assets."
+          {
+            echo "### Release re-verification"
+            echo
+            echo "Target: [\`${tag}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${tag})"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      # The authoritative binary check. Reused rather than reimplemented: this
+      # action already downloads the archive and checksums, verifies the tarball
+      # against the published checksum, extracts the SLSA provenance bundle,
+      # fails closed when the bundle is absent, and runs
+      # `cosign verify-blob-attestation` pinned to on-tag.yaml at the EXACT tag
+      # with a 3-attempt retry. continue-on-error hands its outcome to the
+      # classifying step below instead of ending the job with an unclassified
+      # red, which would page nobody but also file nothing.
+      - name: Verify the released aicr binary provenance
+        id: install
+        continue-on-error: true
+        uses: ./.github/actions/install-aicr-release
+        with:
+          aicr-version: ${{ steps.release.outputs.tag }}
+          cosign_version: ${{ steps.versions.outputs.cosign }}
+
+      - name: Re-verify release artifacts and classify
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_ASSETS: ${{ steps.release.outputs.assets_file }}
+          INSTALL_OUTCOME: ${{ steps.install.outcome }}
+        run: |
+          # Deliberately not `set -e`: this step must run every check, aggregate
+          # the findings, and exit with the classified status. Each check owns
+          # its own failure handling.
+          set -uo pipefail
+
+          mkdir -p "${WORK_DIR}"
+          classification=clean
+
+          # security() records POSITIVE evidence that a released artifact is
+          # missing or does not verify. It is the only path to a page, and it is
+          # never reachable from a failed network call.
+          security() {
+            echo "::error::$1" >&2
+            classification=tamper
+          }
+
+          # operational() records infrastructure trouble. It never overwrites a
+          # security finding: a real finding that coincides with an outage still
+          # pages.
+          operational() {
+            echo "::warning::$1" >&2
+            [ "${classification}" = "tamper" ] || classification=operational
+          }
+
+          # sigstore_reachable is guard #1. Every verification here depends on
+          # the Sigstore TUF trust root; if the CDN does not answer, a failed
+          # verification says nothing about the artifact.
+          sigstore_reachable() {
+            local attempt
+            for attempt in 1 2 3; do
+              if timeout --foreground 30s curl -fsS -o /dev/null "${SIGSTORE_PROBE_URL}"; then
+                return 0
+              fi
+              [ "${attempt}" -eq 3 ] || sleep $((attempt * 5))
+            done
+            return 1
+          }
+
+          # infra_shaped is guard #2: does the captured failure output carry a
+          # transport or upstream-outage signature? Demote-only by construction
+          # -- a match can turn a would-be finding into operational, never the
+          # reverse -- so a broad pattern set is the safe direction.
+          infra_shaped() {
+            local patterns
+            patterns='timed? ?out|deadline exceeded|connection (refused|reset)|no such host'
+            patterns="${patterns}|i/o timeout|dial tcp|network is unreachable|tls handshake"
+            patterns="${patterns}|unexpected eof|temporary failure|too many requests|rate limit"
+            patterns="${patterns}|status (429|5[0-9][0-9])|service unavailable|bad gateway"
+            patterns="${patterns}|gateway time-?out|trusted root|tuf|error fetching"
+            patterns="${patterns}|could not (fetch|download|reach)|failed to (fetch|download)"
+            grep -qiE "${patterns}" "$1"
+          }
+
+          # classify_failure turns a failed cryptographic verification into a
+          # classification. tamper requires BOTH guards to agree; anything else
+          # is operational.
+          classify_failure() {
+            if ! sigstore_reachable; then
+              operational "$1 failed while Sigstore was unreachable; treating as infrastructure, not a finding"
+              return
+            fi
+            if infra_shaped "$2"; then
+              operational "$1 failed with a transport/outage signature in its output; treating as infrastructure, not a finding"
+              return
+            fi
+            security "$1 failed against a reachable Sigstore: the released artifact does not verify"
+          }
+
+          have_asset() { grep -Fxq "$1" "${RELEASE_ASSETS}"; }
+
+          version="${TAG#v}"
+          archive="aicr_${version}_linux_amd64.tar.gz"
+
+          # Pin provenance to the release workflow AND the exact tag, matching
+          # install-aicr-release: a bundle attested for one release must not
+          # satisfy another. Escape the tag's dots so they match literally.
+          identity_tag="${TAG//./\\.}"
+          identity_re="^https://github.com/${REPO}/.github/workflows/on-tag\\.yaml@refs/tags/${identity_tag}$"
+
+          # (1) Inventory. Absence from the release's own asset list is the
+          # cleanest possible "the upload silently failed" signal, and it is
+          # decided from an API read that already succeeded.
+          for required in "${archive}" "aicr_checksums.txt" "recipe-catalog.sigstore.json"; do
+            if have_asset "${required}"; then
+              echo "asset present: ${required}"
+            else
+              security "release ${TAG} does not publish ${required}; a consumer cannot verify this release"
+            fi
+          done
+
+          # (2) Binary provenance. install-aicr-release is authoritative; this
+          # only classifies its outcome.
+          if [ "${INSTALL_OUTCOME}" = "success" ]; then
+            echo "binary provenance verified for ${TAG}"
+          elif [ ! -f "${REL_DIR}/${archive}" ]; then
+            operational "the released archive never downloaded; treating as infrastructure"
+          elif ! tar -tzf "${REL_DIR}/${archive}" > "${WORK_DIR}/archive-members.txt" 2>/dev/null; then
+            # Listed into a file rather than piped into `grep -q`: under
+            # `pipefail`, grep's early exit can SIGPIPE tar and turn a PRESENT
+            # attestation into a non-zero pipeline, i.e. a false finding.
+            # A tarball that will not list at all is a truncated or corrupt
+            # download, not a publishing failure.
+            operational "the downloaded archive could not be listed; treating as infrastructure"
+          elif ! grep -qx 'aicr-attestation.sigstore.json' "${WORK_DIR}/archive-members.txt"; then
+            security "release ${TAG} ships no binary attestation (aicr-attestation.sigstore.json) inside ${archive}"
+          elif ! command -v cosign > /dev/null 2>&1; then
+            operational "cosign was never installed; treating as infrastructure"
+          else
+            # Re-run the verification the action already performed, this time
+            # capturing its output so guard #2 has something to read. The action
+            # retried three times; this is the classification pass, and a pass
+            # here means the action's failure was transient -- its own log stays
+            # authoritative for WHICH of its sub-checks (checksum, extract,
+            # cosign) failed.
+            tar -xzf "${REL_DIR}/${archive}" -C "${WORK_DIR}" aicr aicr-attestation.sigstore.json
+            if timeout --foreground 300s cosign verify-blob-attestation \
+                --bundle "${WORK_DIR}/aicr-attestation.sigstore.json" \
+                --type https://slsa.dev/provenance/v1 \
+                --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+                --certificate-identity-regexp "${identity_re}" \
+                "${WORK_DIR}/aicr" > "${WORK_DIR}/binary-verify.log" 2>&1; then
+              operational "binary provenance verified on re-run after the install action failed; treating as a transient failure"
+            else
+              cat "${WORK_DIR}/binary-verify.log" >&2
+              classify_failure "binary provenance verification for ${TAG}" "${WORK_DIR}/binary-verify.log"
+            fi
+          fi
+
+          # (3) Signed recipe catalog. The loose asset is the path
+          # cli-reference.md tells users to curl, so that is the copy verified
+          # here; the archive ships an identical bundle.
+          if have_asset "recipe-catalog.sigstore.json"; then
+            if ! timeout --foreground 120s gh release download "${TAG}" --repo "${REPO}" \
+                --pattern 'recipe-catalog.sigstore.json' --dir "${WORK_DIR}" --clobber; then
+              operational "downloading recipe-catalog.sigstore.json failed; treating as infrastructure"
+            elif [ ! -x "${AICR_BIN}" ]; then
+              operational "no verified aicr binary is available to verify the recipe catalog"
+            elif timeout --foreground 300s "${AICR_BIN}" recipe verify-catalog \
+                "${WORK_DIR}/recipe-catalog.sigstore.json" > "${WORK_DIR}/catalog-verify.log" 2>&1; then
+              cat "${WORK_DIR}/catalog-verify.log"
+            else
+              cat "${WORK_DIR}/catalog-verify.log" >&2
+              classify_failure "recipe catalog verification for ${TAG}" "${WORK_DIR}/catalog-verify.log"
+            fi
+          fi
+
+          # (4) Signed SBOM assets, for releases after the signing floor only.
+          # sort -V puts the floor first when TAG is newer; equal tags are
+          # excluded explicitly so the floor release itself stays exempt.
+          newest="$(printf '%s\n%s\n' "${SBOM_SIGNING_FLOOR}" "${TAG}" | sort -V | tail -n1)"
+          if [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then
+            echo "release ${TAG} is at or before the SBOM signing floor ${SBOM_SIGNING_FLOOR}; SBOM bundles not expected"
+          else
+            sboms="$(grep -E '_linux_amd64\.sbom\.json$' "${RELEASE_ASSETS}" || true)"
+            if [ -z "${sboms}" ]; then
+              security "release ${TAG} publishes no linux/amd64 SBOM assets"
+            fi
+            while IFS= read -r sbom; do
+              [ -n "${sbom}" ] || continue
+              bundle="${sbom}.sigstore.json"
+              if ! have_asset "${bundle}"; then
+                security "release ${TAG} ships ${sbom} with no attestation bundle (${bundle})"
+              elif ! command -v cosign > /dev/null 2>&1; then
+                operational "cosign is unavailable; cannot verify ${sbom}"
+              elif ! timeout --foreground 120s gh release download "${TAG}" --repo "${REPO}" \
+                  --pattern "${sbom}" --pattern "${bundle}" --dir "${WORK_DIR}" --clobber; then
+                operational "downloading ${sbom} and its bundle failed; treating as infrastructure"
+              elif timeout --foreground 300s cosign verify-blob-attestation \
+                  --bundle "${WORK_DIR}/${bundle}" \
+                  --type https://slsa.dev/provenance/v1 \
+                  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+                  --certificate-identity-regexp "${identity_re}" \
+                  "${WORK_DIR}/${sbom}" > "${WORK_DIR}/${sbom}.verify.log" 2>&1; then
+                echo "SBOM attestation verified: ${sbom}"
+              else
+                cat "${WORK_DIR}/${sbom}.verify.log" >&2
+                classify_failure "SBOM attestation verification for ${sbom}" "${WORK_DIR}/${sbom}.verify.log"
+              fi
+            done <<< "${sboms}"
+          fi
+
+          {
+            echo ""
+            echo "Classification: \`${classification}\`"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          # Machine-readable line for the log, mirroring tools/rekor-monitor.
+          echo "CLASSIFICATION=${classification}"
+          echo "classification=${classification}" >> "${GITHUB_OUTPUT}"
+          case "${classification}" in
+            clean) exit 0 ;;
+            tamper) exit 1 ;;
+            *) exit 3 ;;
+          esac
+
+      - name: Open security alert issue
+        if: ${{ failure() && steps.verify.outputs.classification == 'tamper' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Exact-title match: GitHub title search is phrase-based, so filter the
+          # results rather than trusting the search to be exact.
+          existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
+            --search "in:title \"${ALERT_TITLE}\"" --json title,url \
+            | jq -r --arg t "${ALERT_TITLE}" '[.[] | select(.title == $t)] | .[0].url // empty')"
+          if [ -n "${existing}" ]; then
+            echo "Alert issue already open: ${existing}"
+            exit 0
+          fi
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "${MAINTAINERS_TEAM}: daily re-verification of release \`${TAG}\` found a released artifact that is **missing or does not verify** ([run ${GITHUB_RUN_ID}](${run_url}))."
+            echo
+            echo "This is **not** a transparency-log problem (that is \`rekor-monitor.yaml\`). It means a consumer following"
+            echo "\`docs/integrator/supply-chain-verification.md\` against \`${TAG}\` today would be unable to verify what we published."
+            echo
+            echo "The run log names the exact artifact. Confirm by hand against \`${TAG}\`, then:"
+            echo "- **asset absent** — a signing/upload step silently skipped. Re-upload and re-sign the asset, or re-cut the release."
+            echo "- **asset present but fails verification** — the published bytes do not match what the release signed. Treat as tampering and begin incident response."
+            echo
+            echo "Sigstore reachability and the failure output were both checked before this was raised, so an outage alone cannot have produced it."
+            echo
+            echo "This issue auto-closes on the next clean run."
+          } > alert-body.md
+          url="$(gh issue create --repo "${GITHUB_REPOSITORY}" \
+            --title "${ALERT_TITLE}" \
+            --label "area/security,theme/supply-chain" \
+            --body-file alert-body.md)"
+          echo "Opened alert issue: ${url}"
+
+      - name: Open degraded issue if a non-security failure is persistent
+        # Inverse of the security allowlist: every failure that is NOT a
+        # confirmed finding is operational. This deliberately also covers an
+        # EMPTY classification, i.e. a step BEFORE the classifier failed
+        # (checkout, release resolution, load-versions) so nothing was ever
+        # classified. Those are exactly the GitHub-API/network outages the
+        # degraded path exists for. The two gates are mutually exclusive and
+        # together partition every failure() case.
+        if: ${{ failure() && steps.verify.outputs.classification != 'tamper' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Persistence via run history rather than a state file: escalate only
+          # when this run plus the two prior SCHEDULED runs all failed. The API
+          # returns completed runs most-recent-first and excludes this in-progress
+          # run, so index("success") is the count of consecutive leading
+          # failures; `// length` handles an all-failures window. This is a true
+          # streak, not a failure count: [fail,success,fail] yields 1.
+          streak="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/release-reverify.yaml/runs?event=schedule&status=completed&per_page=3" \
+            | jq -r '[.workflow_runs[].conclusion] | (index("success") // length)')"
+          if [ "${streak}" -lt 2 ]; then
+            echo "Operational failure but not yet persistent (prior consecutive failures: ${streak}); staying quiet."
+            exit 0
+          fi
+          existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
+            --search "in:title \"${DEGRADED_TITLE}\"" --json title,url \
+            | jq -r --arg t "${DEGRADED_TITLE}" '[.[] | select(.title == $t)] | .[0].url // empty')"
+          if [ -n "${existing}" ]; then
+            echo "Degraded issue already open: ${existing}"
+            exit 0
+          fi
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "Daily release re-verification has been **unable to complete** for 3+ consecutive scheduled runs (latest: [run ${GITHUB_RUN_ID}](${run_url}))."
+            echo
+            echo "This is an **operational** problem (Sigstore/TUF reachability, the GitHub API, or the release download), **not** a finding:"
+            echo "no released artifact was shown to be missing or unverifiable. No maintainer action is required unless it persists;"
+            echo "the check resumes automatically when upstream recovers."
+            echo
+            echo "This issue auto-closes on the next clean run."
+          } > degraded-body.md
+          gh issue create --repo "${GITHUB_REPOSITORY}" \
+            --title "${DEGRADED_TITLE}" \
+            --label "area/ci" \
+            --body-file degraded-body.md
+
+      - name: Close open issues on success
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for title in "${ALERT_TITLE}" "${DEGRADED_TITLE}"; do
+            gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
+              --search "in:title \"${title}\"" --json number,title \
+              | jq -r --arg t "${title}" '.[] | select(.title == $t) | .number' \
+              | while read -r n; do
+                  [ -n "$n" ] || continue
+                  # Tolerate a per-issue close failure (transient API error, rate
+                  # limit, already-closed race): it must not abort the loop or
+                  # flip a clean run to failed.
+                  gh issue close "$n" --repo "${GITHUB_REPOSITORY}" \
+                    --comment "Release re-verification completed cleanly on run ${GITHUB_RUN_ID}; auto-closing." \
+                    || echo "::warning::failed to close issue #${n}"
+                done
+          done

--- a/.github/workflows/release-reverify.yaml
+++ b/.github/workflows/release-reverify.yaml
@@ -74,7 +74,8 @@
 #   - clean      -> exit 0
 #   - tamper     -> exit 1, security: a released artifact is MISSING, or it fails
 #                   verification against a Sigstore that answered. Opens a
-#                   security tracking issue mentioning the maintainers.
+#                   TAG-SCOPED security tracking issue mentioning the maintainers
+#                   AND posts a Slack alert, exactly as rekor-monitor does.
 #   - operational-> exit 3, infrastructure: Sigstore/GitHub-API/network trouble.
 #                   Pages no one. The job goes red; only three consecutive failed
 #                   scheduled runs open a calm `area/ci` degraded issue.
@@ -85,17 +86,27 @@
 #      inventory (a GitHub API read that either succeeded or aborted the step), or
 #      the attestation is absent from an archive we successfully downloaded and
 #      checksummed. Neither can be produced by a network failure -- a failed read
-#      aborts before any comparison.
-#   2. A failed cryptographic verification is promoted to `tamper` only when BOTH
-#      independent guards agree: Sigstore's TUF CDN answered a live probe, AND the
-#      captured failure output carries no transport/outage signature. Either guard
-#      alone demotes to `operational`. The guards are demote-only, so the failure
-#      mode is a real finding reported as operational (still a red job, still a
-#      degraded issue after three days, and it re-fires tomorrow) -- never the
-#      reverse.
+#      aborts before any comparison, and an inventory file that is unreadable at
+#      all demotes and stops rather than reporting every asset as missing.
+#   2. A failed cryptographic verification is promoted to `tamper` only when
+#      EVERY demotion test declines it:
+#        - the command was not killed (exit 124 from `timeout`, or 137 from a
+#          SIGKILL/OOM);
+#        - it produced a non-empty, readable log (`grep` declines to match an
+#          empty file and exits 2 on an unreadable one, either of which would
+#          otherwise sail through the pattern guard);
+#        - every Sigstore liveness probe answered;
+#        - the captured output carries no transport/outage signature.
+#      Any one of them demotes to `operational`. All are demote-only, so the
+#      failure mode is a real finding reported as operational (still a red job,
+#      still a degraded issue after three days, and it re-fires tomorrow) --
+#      never the reverse.
 #   3. Any failure BEFORE the classifying step runs (checkout, release
 #      resolution, load-versions) leaves the classification output empty, which
 #      the issue gates treat as operational by construction.
+#   4. Every unguarded command whose failure could fall THROUGH into a branch
+#      that reaches `security` has been guarded, because the demotion tests
+#      above cannot save a path that never reaches them.
 #
 # TRIAGE:
 #   - Security issue (tamper): confirm by hand with the commands in
@@ -103,7 +114,10 @@
 #     genuinely missing asset means the release must be re-cut or the asset
 #     re-uploaded and re-signed; a verification failure on a present asset means
 #     the artifact does not match what the release signed -- treat as tampering
-#     and begin incident response.
+#     and begin incident response. The issue title carries the tag, and a clean
+#     run only closes the alert for the tag it actually verified: once a newer
+#     release ships, the older tag is never re-checked, so its issue must be
+#     closed by hand after remediation.
 #   - Degraded issue (operational, 3+ consecutive days): Sigstore or the GitHub
 #     API has been unreachable. No action unless it persists past an upstream
 #     incident window.
@@ -134,9 +148,16 @@ env:
   # and ship SPDX documents with no sibling .sigstore.json. From the next release
   # onward a missing bundle is a finding. Raise this ONLY to correct history.
   SBOM_SIGNING_FLOOR: v0.18.0
-  # Liveness probe for the Sigstore trust root every verification depends on.
-  # This is the outer guard that keeps an outage from reading as a finding.
-  SIGSTORE_PROBE_URL: https://tuf-repo-cdn.sigstore.dev/1.root.json
+  # Liveness probes for the Sigstore services every verification depends on,
+  # space separated. This is the outer guard that keeps an outage from reading as
+  # a finding, and ALL of them must answer: probing only the TUF CDN would stay
+  # green through a Fulcio outage. Fulcio has a stable hostname; Rekor v2 shard
+  # hostnames rotate (log2025-1 -> log2026-1 -> ...), so a fixed shard URL is
+  # deliberately NOT probed. A probe that broke permanently would silently
+  # disable paging, so each failure is logged by name (see sigstore_reachable).
+  SIGSTORE_PROBE_URLS: >-
+    https://tuf-repo-cdn.sigstore.dev/1.root.json
+    https://fulcio.sigstore.dev/api/v2/trustBundle
   # Workspace for downloads and captured verification logs, kept out of ./_rel
   # (which belongs to the install-aicr-release action).
   WORK_DIR: ./_reverify
@@ -148,11 +169,23 @@ jobs:
   reverify:
     name: Re-verify the latest release's Sigstore artifacts
     runs-on: ubuntu-latest
-    # Bounds the worst case: a release download, one cosign verification per
-    # artifact (each internally retried), and the issue bookkeeping. Every
-    # network call is individually bounded by `timeout --foreground`, so this is
-    # a backstop, not the primary bound.
-    timeout-minutes: 30
+    # Sized from the stacked per-call bounds, because a job that hits
+    # timeout-minutes is CANCELLED, and a cancelled job skips every
+    # `if: failure()` step: it would go red with no degraded issue and still
+    # count against the streak. Worst case, all sequential:
+    #   binary cosign re-run          120s
+    #   catalog download              120s
+    #   catalog verify                120s
+    #   4 SBOMs x (120s dl + 120s)    960s   (aicr + aicrd today, sized for 4)
+    #   6 x classify_failure probes   840s   (2 URLs x 2 attempts x 20s + 5s backoff)
+    #   subtotal                     2160s = 36m
+    #   install-aicr-release          ~10m   (its gh/cosign calls are unbounded;
+    #                                         3 cosign attempts + 15s backoff)
+    #   checkout + load-versions       ~2m
+    #   issue/Slack bookkeeping        ~3m
+    #   total                         ~51m
+    # 60 leaves headroom without letting a wedged run occupy a runner for hours.
+    timeout-minutes: 60
     permissions:
       contents: read  # checkout, plus `gh release download` for the assets
       actions: read   # read this workflow's run history for the failure streak
@@ -249,25 +282,66 @@ jobs:
             [ "${classification}" = "tamper" ] || classification=operational
           }
 
+          # finish() publishes the verdict and exits with the classified status.
+          # Defined up front so an early abort (an unreadable asset inventory)
+          # still emits an explicit classification instead of relying on the
+          # gates' treat-empty-as-operational fallback.
+          finish() {
+            {
+              echo ""
+              echo "Classification: \`${classification}\`"
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+            # Machine-readable line for the log, mirroring tools/rekor-monitor.
+            echo "CLASSIFICATION=${classification}"
+            echo "classification=${classification}" >> "${GITHUB_OUTPUT}"
+            case "${classification}" in
+              clean) exit 0 ;;
+              tamper) exit 1 ;;
+              *) exit 3 ;;
+            esac
+          }
+
           # sigstore_reachable is guard #1. Every verification here depends on
-          # the Sigstore TUF trust root; if the CDN does not answer, a failed
-          # verification says nothing about the artifact.
+          # Sigstore, so if any probed endpoint does not answer, a failed
+          # verification says nothing about the artifact. ALL probes must answer:
+          # a Fulcio-only outage has to demote too, which a TUF-only probe would
+          # miss. Demote-only, so the cost of a probe that breaks permanently is
+          # silently disabled paging; each failure is therefore named in the log,
+          # and a persistently red job still opens the degraded issue.
           sigstore_reachable() {
-            local attempt
-            for attempt in 1 2 3; do
-              if timeout --foreground 30s curl -fsS -o /dev/null "${SIGSTORE_PROBE_URL}"; then
-                return 0
+            local url attempt reached
+            local -a urls
+            read -r -a urls <<< "${SIGSTORE_PROBE_URLS}"
+            for url in "${urls[@]}"; do
+              reached=0
+              for attempt in 1 2; do
+                if timeout --foreground 20s curl -fsS -o /dev/null "${url}"; then
+                  reached=1
+                  break
+                fi
+                [ "${attempt}" -eq 2 ] || sleep 5
+              done
+              if [ "${reached}" -ne 1 ]; then
+                echo "Sigstore liveness probe failed for ${url}" >&2
+                return 1
               fi
-              [ "${attempt}" -eq 3 ] || sleep $((attempt * 5))
             done
-            return 1
+            return 0
           }
 
           # infra_shaped is guard #2: does the captured failure output carry a
           # transport or upstream-outage signature? Demote-only by construction
           # -- a match can turn a would-be finding into operational, never the
           # reverse -- so a broad pattern set is the safe direction.
+          #
+          # A log we cannot READ is not evidence of anything. grep exits 2 on a
+          # missing or unreadable file, which is indistinguishable from "no
+          # pattern matched" and would otherwise pass this guard straight through
+          # to security. That is reachable: if the `> <log>` redirect itself fails
+          # (a full disk, an unwritable WORK_DIR) the command never runs and no
+          # readable log is produced.
           infra_shaped() {
+            [ -r "$1" ] || return 0
             local patterns
             patterns='timed? ?out|deadline exceeded|connection (refused|reset)|no such host'
             patterns="${patterns}|i/o timeout|dial tcp|network is unreachable|tls handshake"
@@ -279,21 +353,48 @@ jobs:
           }
 
           # classify_failure turns a failed cryptographic verification into a
-          # classification. tamper requires BOTH guards to agree; anything else
-          # is operational.
+          # classification. Every demotion test below must decline before tamper
+          # is asserted; anything else is operational. Arguments: description,
+          # captured log, exit status of the failed command.
           classify_failure() {
+            local what="$1" log="$2" status="${3:-0}"
+            # A `timeout --foreground` kill (124) or a SIGKILL (137, typically
+            # the OOM killer) is infrastructure by definition, and both usually
+            # leave nothing useful behind to pattern match.
+            if [ "${status}" -eq 124 ] || [ "${status}" -eq 137 ]; then
+              operational "${what} was killed (exit ${status}: timeout or OOM); treating as infrastructure, not a finding"
+              return
+            fi
+            # An EMPTY log is not evidence either. grep declines to match an
+            # empty file, so without this the run would pass guard #2 and reach
+            # security on, for example, a killed or OOMed cosign that wrote
+            # nothing to stderr.
+            if [ ! -s "${log}" ]; then
+              operational "${what} failed without producing any output; treating as infrastructure, not a finding"
+              return
+            fi
             if ! sigstore_reachable; then
-              operational "$1 failed while Sigstore was unreachable; treating as infrastructure, not a finding"
+              operational "${what} failed while Sigstore was unreachable; treating as infrastructure, not a finding"
               return
             fi
-            if infra_shaped "$2"; then
-              operational "$1 failed with a transport/outage signature in its output; treating as infrastructure, not a finding"
+            if infra_shaped "${log}"; then
+              operational "${what} failed with a transport/outage signature in its output; treating as infrastructure, not a finding"
               return
             fi
-            security "$1 failed against a reachable Sigstore: the released artifact does not verify"
+            security "${what} failed against a reachable Sigstore: the released artifact does not verify"
           }
 
           have_asset() { grep -Fxq "$1" "${RELEASE_ASSETS}"; }
+
+          # (0) The asset inventory is the evidence base for every "missing"
+          # finding below. grep exits 2 on an unreadable file, which neither
+          # have_asset nor the SBOM enumeration can tell from "not present", so
+          # an unreadable inventory would report every required asset as missing
+          # and page. Demote and stop instead.
+          if [ ! -r "${RELEASE_ASSETS}" ]; then
+            operational "the release asset inventory (${RELEASE_ASSETS}) is missing or unreadable; treating as infrastructure"
+            finish
+          fi
 
           version="${TAG#v}"
           archive="aicr_${version}_linux_amd64.tar.gz"
@@ -302,7 +403,7 @@ jobs:
           # install-aicr-release: a bundle attested for one release must not
           # satisfy another. Escape the tag's dots so they match literally.
           identity_tag="${TAG//./\\.}"
-          identity_re="^https://github.com/${REPO}/.github/workflows/on-tag\\.yaml@refs/tags/${identity_tag}$"
+          identity_re="^https://github\\.com/${REPO}/\\.github/workflows/on-tag\\.yaml@refs/tags/${identity_tag}$"
 
           # (1) Inventory. Absence from the release's own asset list is the
           # cleanest possible "the upload silently failed" signal, and it is
@@ -339,8 +440,15 @@ jobs:
             # here means the action's failure was transient -- its own log stays
             # authoritative for WHICH of its sub-checks (checksum, extract,
             # cosign) failed.
-            tar -xzf "${REL_DIR}/${archive}" -C "${WORK_DIR}" aicr aicr-attestation.sigstore.json
-            if timeout --foreground 300s cosign verify-blob-attestation \
+            # Guarded: the step runs without `set -e`, so an unguarded failure
+            # here would fall through to cosign, which then fails on a missing
+            # bundle with a message no infra_shaped pattern matches, producing a
+            # security page for what is only a full disk or a permissions fault
+            # on WORK_DIR. Every sibling branch demotes, and so must this one.
+            if ! tar -xzf "${REL_DIR}/${archive}" -C "${WORK_DIR}" \
+                aicr aicr-attestation.sigstore.json 2>/dev/null; then
+              operational "the archive listed but could not be extracted; treating as infrastructure"
+            elif timeout --foreground 120s cosign verify-blob-attestation \
                 --bundle "${WORK_DIR}/aicr-attestation.sigstore.json" \
                 --type https://slsa.dev/provenance/v1 \
                 --certificate-oidc-issuer https://token.actions.githubusercontent.com \
@@ -348,8 +456,12 @@ jobs:
                 "${WORK_DIR}/aicr" > "${WORK_DIR}/binary-verify.log" 2>&1; then
               operational "binary provenance verified on re-run after the install action failed; treating as a transient failure"
             else
-              cat "${WORK_DIR}/binary-verify.log" >&2
-              classify_failure "binary provenance verification for ${TAG}" "${WORK_DIR}/binary-verify.log"
+              # $? is the elif condition's status and MUST be captured before any
+              # other command runs, so timeout's 124 (or a 137 SIGKILL) survives
+              # to classify_failure.
+              status=$?
+              cat "${WORK_DIR}/binary-verify.log" >&2 || true
+              classify_failure "binary provenance verification for ${TAG}" "${WORK_DIR}/binary-verify.log" "${status}"
             fi
           fi
 
@@ -362,20 +474,30 @@ jobs:
               operational "downloading recipe-catalog.sigstore.json failed; treating as infrastructure"
             elif [ ! -x "${AICR_BIN}" ]; then
               operational "no verified aicr binary is available to verify the recipe catalog"
-            elif timeout --foreground 300s "${AICR_BIN}" recipe verify-catalog \
+            elif timeout --foreground 120s "${AICR_BIN}" recipe verify-catalog \
                 "${WORK_DIR}/recipe-catalog.sigstore.json" > "${WORK_DIR}/catalog-verify.log" 2>&1; then
               cat "${WORK_DIR}/catalog-verify.log"
             else
-              cat "${WORK_DIR}/catalog-verify.log" >&2
-              classify_failure "recipe catalog verification for ${TAG}" "${WORK_DIR}/catalog-verify.log"
+              status=$?
+              cat "${WORK_DIR}/catalog-verify.log" >&2 || true
+              classify_failure "recipe catalog verification for ${TAG}" "${WORK_DIR}/catalog-verify.log" "${status}"
             fi
           fi
 
           # (4) Signed SBOM assets, for releases after the signing floor only.
           # sort -V puts the floor first when TAG is newer; equal tags are
           # excluded explicitly so the floor release itself stays exempt.
-          newest="$(printf '%s\n%s\n' "${SBOM_SIGNING_FLOOR}" "${TAG}" | sort -V | tail -n1)"
-          if [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then
+          #
+          # Guarded: an unavailable or failing `sort -V` leaves newest empty, and
+          # the ordering test below would then read as "at or before the floor"
+          # and skip every SBOM check while logging that it did so on purpose.
+          # That direction is fail-OPEN (silent under-verification), the opposite
+          # of a false page but still wrong, so it is demoted explicitly.
+          newest=""
+          if ! newest="$(printf '%s\n%s\n' "${SBOM_SIGNING_FLOOR}" "${TAG}" | sort -V | tail -n1)" \
+              || [ -z "${newest}" ]; then
+            operational "could not order ${TAG} against the SBOM signing floor ${SBOM_SIGNING_FLOOR}; treating as infrastructure"
+          elif [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then
             echo "release ${TAG} is at or before the SBOM signing floor ${SBOM_SIGNING_FLOOR}; SBOM bundles not expected"
           else
             sboms="$(grep -E '_linux_amd64\.sbom\.json$' "${RELEASE_ASSETS}" || true)"
@@ -396,7 +518,7 @@ jobs:
               elif ! timeout --foreground 120s gh release download "${TAG}" --repo "${REPO}" \
                   --pattern "${sbom}" --pattern "${bundle}" --dir "${WORK_DIR}" --clobber < /dev/null; then
                 operational "downloading ${sbom} and its bundle failed; treating as infrastructure"
-              elif timeout --foreground 300s cosign verify-blob-attestation \
+              elif timeout --foreground 120s cosign verify-blob-attestation \
                   --bundle "${WORK_DIR}/${bundle}" \
                   --type https://slsa.dev/provenance/v1 \
                   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
@@ -404,39 +526,42 @@ jobs:
                   "${WORK_DIR}/${sbom}" < /dev/null > "${WORK_DIR}/${sbom}.verify.log" 2>&1; then
                 echo "SBOM attestation verified: ${sbom}"
               else
-                cat "${WORK_DIR}/${sbom}.verify.log" >&2
-                classify_failure "SBOM attestation verification for ${sbom}" "${WORK_DIR}/${sbom}.verify.log"
+                status=$?
+                cat "${WORK_DIR}/${sbom}.verify.log" >&2 || true
+                classify_failure "SBOM attestation verification for ${sbom}" "${WORK_DIR}/${sbom}.verify.log" "${status}"
               fi
             done <<< "${sboms}"
           fi
 
-          {
-            echo ""
-            echo "Classification: \`${classification}\`"
-          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-          # Machine-readable line for the log, mirroring tools/rekor-monitor.
-          echo "CLASSIFICATION=${classification}"
-          echo "classification=${classification}" >> "${GITHUB_OUTPUT}"
-          case "${classification}" in
-            clean) exit 0 ;;
-            tamper) exit 1 ;;
-            *) exit 3 ;;
-          esac
+          finish
 
       - name: Open security alert issue
+        id: alert_issue
         if: ${{ failure() && steps.verify.outputs.classification == 'tamper' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
-          # Exact-title match: GitHub title search is phrase-based, so filter the
-          # results rather than trusting the search to be exact.
-          existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
-            --search "in:title \"${ALERT_TITLE}\"" --json title,url \
-            | jq -r --arg t "${ALERT_TITLE}" '[.[] | select(.title == $t)] | .[0].url // empty')"
+          # TAG-SCOPED title. The job only ever verifies /releases/latest, so an
+          # unresolved finding for vX must NOT be closed by a later clean run on
+          # vX+1: once vX stops being latest it is never re-checked, and closing
+          # it would silently resolve a live supply-chain finding. This is the
+          # deliberate difference from rekor-monitor, whose alert tracks the
+          # release-agnostic log and so genuinely clears on any clean run.
+          title="${ALERT_TITLE} [${TAG}]"
+          # De-duplicate off a LISTING read, not the search API: search indexing
+          # lags, so a title search can miss an issue this workflow opened
+          # minutes ago and open a duplicate. Bounded retry via the shared helper
+          # because a transient 5xx here would otherwise drop the one
+          # notification this workflow exists to deliver.
+          .github/scripts/gh-api-retry.sh issues.json --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues?state=open&per_page=100"
+          existing="$(jq -rs --arg t "${title}" \
+            '[.[][] | select(.pull_request == null) | select(.title == $t)] | .[0].html_url // empty' issues.json)"
           if [ -n "${existing}" ]; then
             echo "Alert issue already open: ${existing}"
+            echo "url=${existing}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
@@ -447,18 +572,72 @@ jobs:
             echo "\`docs/integrator/supply-chain-verification.md\` against \`${TAG}\` today would be unable to verify what we published."
             echo
             echo "The run log names the exact artifact. Confirm by hand against \`${TAG}\`, then:"
-            echo "- **asset absent** — a signing/upload step silently skipped. Re-upload and re-sign the asset, or re-cut the release."
-            echo "- **asset present but fails verification** — the published bytes do not match what the release signed. Treat as tampering and begin incident response."
+            echo "- **asset absent**: a signing or upload step silently skipped. Re-upload and re-sign the asset, or re-cut the release."
+            echo "- **asset present but fails verification**: the published bytes do not match what the release signed. Treat as tampering and begin incident response."
             echo
             echo "Sigstore reachability and the failure output were both checked before this was raised, so an outage alone cannot have produced it."
             echo
-            echo "This issue auto-closes on the next clean run."
+            echo "**Closing:** this issue auto-closes only while \`${TAG}\` is still the latest release and a later run re-verifies it cleanly."
+            echo "The workflow checks only the latest release, so once a newer release ships, \`${TAG}\` is no longer re-checked and this must be closed by hand after remediation."
           } > alert-body.md
-          url="$(gh issue create --repo "${GITHUB_REPOSITORY}" \
-            --title "${ALERT_TITLE}" \
-            --label "area/security,theme/supply-chain" \
-            --body-file alert-body.md)"
+          # A renamed or deleted label must not cost us the notification: retry
+          # the labelled create, then fall back to an unlabelled one rather than
+          # aborting the step.
+          url=""
+          for attempt in 1 2 3; do
+            if url="$(gh issue create --repo "${GITHUB_REPOSITORY}" \
+                --title "${title}" \
+                --label "area/security,theme/supply-chain" \
+                --body-file alert-body.md < /dev/null)"; then
+              break
+            fi
+            url=""
+            echo "::warning::gh issue create failed (attempt ${attempt}/3)"
+            [ "${attempt}" -eq 3 ] || sleep $((attempt * 5))
+          done
+          if [ -z "${url}" ]; then
+            if url="$(gh issue create --repo "${GITHUB_REPOSITORY}" \
+                --title "${title}" --body-file alert-body.md < /dev/null)"; then
+              echo "::warning::opened the alert issue without labels; check that area/security and theme/supply-chain still exist"
+            else
+              echo "::error::could not open an alert issue for ${TAG}; Slack is the only remaining channel for this finding" >&2
+              exit 0
+            fi
+          fi
           echo "Opened alert issue: ${url}"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+
+      # Mirrors rekor-monitor.yaml's "Post Slack alert on security finding": same
+      # SLACK_SERVICE secret, same gate shape (security classification only,
+      # never degraded), same message structure. Bounded with `timeout
+      # --foreground` per repo convention. Compounds with the retry above: the
+      # GitHub issue is no longer the only channel for an incident-grade finding.
+      - name: Post Slack alert on security finding
+        if: ${{ failure() && steps.verify.outputs.classification == 'tamper' }}
+        env:
+          # Slack incoming-webhook path suffix; same secret the release and
+          # rekor-monitor workflows use. Unset in forks, so this no-ops there.
+          SLACK_SERVICE: ${{ secrets.SLACK_SERVICE }}
+          ISSUE_URL: ${{ steps.alert_issue.outputs.url }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_SERVICE:-}" ]; then
+            echo "::warning::SLACK_SERVICE not set; skipping Slack notification"
+            exit 0
+          fi
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # To ping a Slack usergroup, prepend "<!subteam^GROUP_ID> " below.
+          text=":rotating_light: *Release re-verification: tamper signal on ${TAG}*: a released artifact is missing or does not verify."
+          text="${text} <${run_url}|View run>"
+          if [ -n "${ISSUE_URL:-}" ]; then
+            text="${text} · <${ISSUE_URL}|tracking issue>"
+          fi
+          jq -n --arg t "${text}" '{text: $t}' > slack-payload.json
+          timeout --foreground 30s curl -sSf -X POST -H 'Content-type: application/json' \
+            --data @slack-payload.json \
+            "https://hooks.slack.com/services/${SLACK_SERVICE}"
+          echo "Posted Slack alert."
 
       - name: Open degraded issue if a non-security failure is persistent
         # Inverse of the security allowlist: every failure that is NOT a
@@ -476,11 +655,24 @@ jobs:
           # Persistence via run history rather than a state file: escalate only
           # when this run plus the two prior SCHEDULED runs all failed. The API
           # returns completed runs most-recent-first and excludes this in-progress
-          # run, so index("success") is the count of consecutive leading
-          # failures; `// length` handles an all-failures window. This is a true
-          # streak, not a failure count: [fail,success,fail] yields 1.
-          streak="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/release-reverify.yaml/runs?event=schedule&status=completed&per_page=3" \
-            | jq -r '[.workflow_runs[].conclusion] | (index("success") // length)')"
+          # run, so the leading run of "failure" conclusions is the streak;
+          # `// length` handles an all-failures window. This is a true streak,
+          # not a failure count: [fail,success,fail] yields 1.
+          #
+          # Only "failure" counts. A `cancelled`, `skipped`, `timed_out` or
+          # `startup_failure` run says nothing about upstream health, and
+          # counting it would open the calm degraded issue before three genuine
+          # operational failures.
+          #
+          # A failed API read leaves the streak at 0 and stays quiet: the read
+          # failing is itself part of the outage being reported, and aborting the
+          # step here would only add a second red without a tracking issue.
+          runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/release-reverify.yaml/runs?event=schedule&status=completed&per_page=3" 2>/dev/null || true)"
+          streak=0
+          if [ -n "${runs_json}" ]; then
+            streak="$(printf '%s' "${runs_json}" \
+              | jq -r '[.workflow_runs[].conclusion] | map(. == "failure") | (index(false) // length)' 2>/dev/null || echo 0)"
+          fi
           if [ "${streak}" -lt 2 ]; then
             echo "Operational failure but not yet persistent (prior consecutive failures: ${streak}); staying quiet."
             exit 0
@@ -511,19 +703,30 @@ jobs:
         if: ${{ success() }}
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
-          for title in "${ALERT_TITLE}" "${DEGRADED_TITLE}"; do
-            gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
-              --search "in:title \"${title}\"" --json number,title \
-              | jq -r --arg t "${title}" '.[] | select(.title == $t) | .number' \
-              | while read -r n; do
-                  [ -n "$n" ] || continue
-                  # Tolerate a per-issue close failure (transient API error, rate
-                  # limit, already-closed race): it must not abort the loop or
-                  # flip a clean run to failed.
-                  gh issue close "$n" --repo "${GITHUB_REPOSITORY}" \
-                    --comment "Release re-verification completed cleanly on run ${GITHUB_RUN_ID}; auto-closing." \
-                    || echo "::warning::failed to close issue #${n}"
-                done
+          # The alert is TAG-SCOPED: a clean run may only close the alert for the
+          # tag it actually verified, never an older tag it did not look at. The
+          # degraded issue tracks the checker's own health rather than a release,
+          # so any clean run legitimately clears it.
+          for title in "${ALERT_TITLE} [${TAG}]" "${DEGRADED_TITLE}"; do
+            # A transient list failure must not flip a clean verification red
+            # (which would also inflate the next run's failure streak); fall back
+            # to an empty list and try again tomorrow.
+            listed="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
+              --search "in:title \"${title}\"" --json number,title < /dev/null 2>/dev/null || echo '[]')"
+            # Exact-title filter: GitHub title search is phrase-based, so never
+            # close an issue whose title merely contains the search text.
+            numbers="$(printf '%s' "${listed}" \
+              | jq -r --arg t "${title}" '.[] | select(.title == $t) | .number' 2>/dev/null || true)"
+            while read -r n; do
+              [ -n "$n" ] || continue
+              # Tolerate a per-issue close failure (transient API error, rate
+              # limit, already-closed race): it must not abort the loop or flip a
+              # clean run to failed.
+              gh issue close "$n" --repo "${GITHUB_REPOSITORY}" \
+                --comment "Release re-verification of ${TAG} completed cleanly on run ${GITHUB_RUN_ID}; auto-closing." \
+                < /dev/null || echo "::warning::failed to close issue #${n}"
+            done <<< "${numbers}"
           done

--- a/.github/workflows/release-reverify.yaml
+++ b/.github/workflows/release-reverify.yaml
@@ -389,15 +389,19 @@ jobs:
                 security "release ${TAG} ships ${sbom} with no attestation bundle (${bundle})"
               elif ! command -v cosign > /dev/null 2>&1; then
                 operational "cosign is unavailable; cannot verify ${sbom}"
+              # Both commands read stdin from the loop's here-string unless it is
+              # redirected. A child that consumes stdin would eat the remaining
+              # SBOM names, silently skipping them with no finding, which is the
+              # exact failure mode this job exists to catch.
               elif ! timeout --foreground 120s gh release download "${TAG}" --repo "${REPO}" \
-                  --pattern "${sbom}" --pattern "${bundle}" --dir "${WORK_DIR}" --clobber; then
+                  --pattern "${sbom}" --pattern "${bundle}" --dir "${WORK_DIR}" --clobber < /dev/null; then
                 operational "downloading ${sbom} and its bundle failed; treating as infrastructure"
               elif timeout --foreground 300s cosign verify-blob-attestation \
                   --bundle "${WORK_DIR}/${bundle}" \
                   --type https://slsa.dev/provenance/v1 \
                   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
                   --certificate-identity-regexp "${identity_re}" \
-                  "${WORK_DIR}/${sbom}" > "${WORK_DIR}/${sbom}.verify.log" 2>&1; then
+                  "${WORK_DIR}/${sbom}" < /dev/null > "${WORK_DIR}/${sbom}.verify.log" 2>&1; then
                 echo "SBOM attestation verified: ${sbom}"
               else
                 cat "${WORK_DIR}/${sbom}.verify.log" >&2

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -278,6 +278,12 @@ failed or was skipped, which leaves a published release whose provenance cannot
 be reconstructed while nothing in the log is wrong
 ([#1461](https://github.com/NVIDIA/aicr/issues/1461)).
 
+It also declares `workflow_dispatch`, which matters operationally: GitHub
+disables scheduled workflows after 60 days of repository inactivity, so a manual
+dispatch is how a maintainer re-arms the schedule. It is also the way to get an
+on-demand run right after cutting a release, rather than waiting for the next
+day's cron to be the first thing that looks at the new artifacts.
+
 Each run resolves the latest non-draft, non-prerelease release (never a hardcoded
 tag; the resolved tag is written to the job summary) and runs the **shipped**
 verification commands against it, exactly as
@@ -289,17 +295,27 @@ documents them:
   `cosign verify-blob-attestation` pinned to `on-tag.yaml@refs/tags/<exact tag>`.
   This is delegated wholesale to the `install-aicr-release` composite that UAT
   release cells already use, so there is one hardened implementation of the
-  binary check, not two;
+  binary check, not two. When that composite fails, the classifier re-runs
+  **both** of its sub-checks (the checksum and the provenance) rather than
+  presuming which one broke: the attestation binds the *binary* while
+  `aicr_checksums.txt` covers the *archive*, so a manifest that stopped matching
+  an otherwise-valid archive would otherwise report "transient" every day while
+  every consumer following the documented checksum flow fails every time;
 - `recipe-catalog.sigstore.json` (a loose asset, deliberately outside
   `aicr_checksums.txt`) via `aicr recipe verify-catalog`, run with the released
   binary just verified — the only check that proves the *shipped* binary's
   embedded `registry.yaml` and `validators/catalog.yaml` still digest to what the
   release signed;
-- every `linux/amd64` SPDX SBOM asset and its sibling `.sigstore.json` bundle.
-  Gated on `SBOM_SIGNING_FLOOR` (`v0.18.0`): releases at or before it predate
-  SBOM signing ([#1957](https://github.com/NVIDIA/aicr/issues/1957)) and
-  legitimately ship unsigned SBOMs, while every later release must ship a bundle
-  per SBOM.
+- the `linux/amd64` SPDX SBOM every release must publish for each binary in
+  `EXPECTED_SBOM_BINARIES`, and each one's sibling `.sigstore.json` bundle. The
+  expected set is derived from the **tag**, mirroring
+  `expected_release_asset_names()` in `.github/scripts/release-images.sh`, never
+  from the release's own inventory: derived from the release, only a zero-SBOM
+  release would be a finding, and deleting one of the two would leave the check
+  verifying the survivor and reporting clean. Gated on `SBOM_SIGNING_FLOOR`
+  (`v0.18.0`): releases at or before it predate SBOM signing
+  ([#1957](https://github.com/NVIDIA/aicr/issues/1957)) and legitimately ship
+  unsigned SBOMs, while every later release must ship a bundle per SBOM.
 
 Classification reuses the monitor's vocabulary and exit codes so both workflows
 triage identically: `clean` (0), `tamper` (1, security), `operational` (3). A
@@ -370,10 +386,19 @@ Two things are deliberately out of scope, both tracked as follow-ups:
   proves the bundle is retrievable and cryptographically sound, not that Rekor
   would still serve that entry by index.
 
-Triage is in the workflow file's header comment. In short: a security issue names
-the exact artifact — an absent asset means re-upload and re-sign (or re-cut the
-release), while an asset that is present but fails verification means the
-published bytes do not match what the release signed, and is an incident.
+Triage is in the workflow file's header comment. In short, a security issue names
+the exact artifact:
+
+- **Absent asset**: a signing or upload step silently skipped. Re-upload and
+  re-sign the asset, or re-cut the release.
+- **Present asset that fails verification**: read the **verifier's reported
+  failure reason** before concluding anything. `cosign verify-blob-attestation`
+  fails on a certificate-identity or predicate-type mismatch just as it does on a
+  digest mismatch, so an asset re-signed under a different workflow identity, with
+  its bytes fully intact, produces the same red as tampering. A digest mismatch
+  means the published bytes are not what the release signed and is an incident;
+  an identity or predicate mismatch is a signing-path problem, and the remediation
+  is different.
 
 ## Reviewing Recipe Contributions
 

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -268,6 +268,82 @@ monitoring-coverage gap, not a verification gap. A follow-up may add a one-time
 new-shard backfill; until then, treat a rotation log line as a prompt to
 spot-check releases made around the rotation boundary.
 
+### Daily release re-verification
+
+`Release Re-Verification` (`.github/workflows/release-reverify.yaml`) runs daily
+and answers the question the Rekor monitor cannot: did the release we published
+actually **ship** the artifacts a consumer needs to verify it? The monitor proves
+the log is sound; it says nothing about a signing-side upload that silently
+failed or was skipped, which leaves a published release whose provenance cannot
+be reconstructed while nothing in the log is wrong
+([#1461](https://github.com/NVIDIA/aicr/issues/1461)).
+
+Each run resolves the latest non-draft, non-prerelease release (never a hardcoded
+tag; the resolved tag is written to the job summary) and runs the **shipped**
+verification commands against it, exactly as
+[`supply-chain-verification.md`](../integrator/supply-chain-verification.md)
+documents them:
+
+- the `linux/amd64` archive against `aicr_checksums.txt`, then its
+  `aicr-attestation.sigstore.json` SLSA provenance bundle via
+  `cosign verify-blob-attestation` pinned to `on-tag.yaml@refs/tags/<exact tag>`.
+  This is delegated wholesale to the `install-aicr-release` composite that UAT
+  release cells already use, so there is one hardened implementation of the
+  binary check, not two;
+- `recipe-catalog.sigstore.json` (a loose asset, deliberately outside
+  `aicr_checksums.txt`) via `aicr recipe verify-catalog`, run with the released
+  binary just verified — the only check that proves the *shipped* binary's
+  embedded `registry.yaml` and `validators/catalog.yaml` still digest to what the
+  release signed;
+- every `linux/amd64` SPDX SBOM asset and its sibling `.sigstore.json` bundle.
+  Gated on `SBOM_SIGNING_FLOOR` (`v0.18.0`): releases at or before it predate
+  SBOM signing ([#1957](https://github.com/NVIDIA/aicr/issues/1957)) and
+  legitimately ship unsigned SBOMs, while every later release must ship a bundle
+  per SBOM.
+
+Classification reuses the monitor's vocabulary and exit codes so both workflows
+triage identically: `clean` (0), `tamper` (1, security), `operational` (3). It
+opens the same two issue kinds with the same de-duplication and the same
+three-consecutive-failures rule before a calm `area/ci` degraded issue, and a
+later clean run closes both.
+
+**`tamper` is asserted only on positive evidence**, never as a fallback, so an
+outage cannot masquerade as a missing entry. "Missing" means an asset name is
+absent from the release's own asset inventory, or an attestation is absent from
+an archive that already downloaded and checksummed — neither is reachable from a
+failed network call, because a failed read aborts the step before any comparison.
+A failed *cryptographic* check is promoted to `tamper` only when two independent
+guards agree: Sigstore's TUF CDN answered a live probe, **and** the captured
+failure output carries no transport/outage signature. Either guard alone demotes
+to `operational`. The guards are demote-only, so the worst case is a real finding
+reported as operational — still a red job, still a degraded issue after three
+days, and it re-fires the next day — never the reverse. Any failure *before* the
+classifier runs leaves the classification empty, which the gates treat as
+operational by construction.
+
+Two things are deliberately out of scope, both tracked as follow-ups:
+
+- **Container-image OCI referrer attestations** (SBOM / OpenVEX / SLSA
+  provenance, [#1982](https://github.com/NVIDIA/aicr/issues/1982)). Those live in
+  ghcr.io's referrer store — a different system with a different retention and GC
+  model from GitHub Releases — and re-verifying seven images times three
+  predicate kinds would add roughly twenty registry round-trips per run,
+  multiplying operational noise against the one signal this job exists to keep
+  crisp. The images are already pulled and scanned weekly by
+  `vuln-scan-images.yaml`. A registry-side sibling check must use
+  `gh attestation verify --bundle-from-oci`, otherwise it reads GitHub's
+  attestations API and proves nothing about the registry copy's retrievability.
+- **Rekor entry liveness by log index.** `cosign verify-blob-attestation`
+  verifies a self-contained bundle: the inclusion proof and RFC3161 timestamp
+  travel inside it and are checked against the live Sigstore trust root. A pass
+  proves the bundle is retrievable and cryptographically sound, not that Rekor
+  would still serve that entry by index.
+
+Triage is in the workflow file's header comment. In short: a security issue names
+the exact artifact — an absent asset means re-upload and re-sign (or re-cut the
+release), while an asset that is present but fails verification means the
+published bytes do not match what the release signed, and is an incident.
+
 ## Reviewing Recipe Contributions
 
 A recipe PR touches `recipes/overlays/`, `recipes/mixins/`,

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -302,24 +302,55 @@ documents them:
   per SBOM.
 
 Classification reuses the monitor's vocabulary and exit codes so both workflows
-triage identically: `clean` (0), `tamper` (1, security), `operational` (3). It
-opens the same two issue kinds with the same de-duplication and the same
-three-consecutive-failures rule before a calm `area/ci` degraded issue, and a
-later clean run closes both.
+triage identically: `clean` (0), `tamper` (1, security), `operational` (3). A
+`tamper` finding opens a security issue **and** posts a Slack alert through the
+same `SLACK_SERVICE` webhook rekor-monitor uses, so an incident-grade finding
+does not depend on one channel. Operational failures page no one, and only three
+consecutive failed scheduled runs open a calm `area/ci` degraded issue. Only a
+`failure` conclusion counts toward that streak: a canceled or timed-out run says
+nothing about upstream health.
+
+**The alert is tag-scoped, and that is a deliberate divergence from
+rekor-monitor.** The issue title carries the resolved tag, and a clean run only
+closes the alert for the tag it actually verified. The job checks the latest
+release, so a clean run on `vX+1` proves nothing about `vX`; closing `vX`'s issue
+would silently resolve a live finding on a release that is never re-checked
+again. The degraded issue has no such scoping, because it tracks the checker's
+own health rather than a release, so any clean run clears it. rekor-monitor's
+alert is release-agnostic (it tracks the log), which is why a clean run genuinely
+clears it there.
 
 **`tamper` is asserted only on positive evidence**, never as a fallback, so an
 outage cannot masquerade as a missing entry. "Missing" means an asset name is
 absent from the release's own asset inventory, or an attestation is absent from
-an archive that already downloaded and checksummed — neither is reachable from a
-failed network call, because a failed read aborts the step before any comparison.
-A failed *cryptographic* check is promoted to `tamper` only when two independent
-guards agree: Sigstore's TUF CDN answered a live probe, **and** the captured
-failure output carries no transport/outage signature. Either guard alone demotes
-to `operational`. The guards are demote-only, so the worst case is a real finding
-reported as operational — still a red job, still a degraded issue after three
-days, and it re-fires the next day — never the reverse. Any failure *before* the
-classifier runs leaves the classification empty, which the gates treat as
-operational by construction.
+an archive that already downloaded and checksummed. Neither is reachable from a
+failed network call: a failed read aborts the step before any comparison, and an
+inventory file that cannot be read at all demotes and stops rather than reporting
+every asset as missing. A failed *cryptographic* check is promoted to `tamper`
+only when every demotion test declines it:
+
+- the command was not killed (`timeout` exit 124, or 137 from a SIGKILL or the
+  OOM killer);
+- it produced a non-empty, readable log: `grep` declines to match an empty file
+  and exits 2 on an unreadable one, either of which would otherwise sail straight
+  through the pattern guard;
+- every Sigstore liveness probe answered. Both the TUF CDN and Fulcio are
+  probed and **all** must respond, so a Fulcio-only outage demotes too. Rekor v2
+  shard hostnames rotate, so no fixed shard is probed;
+- the captured output carries no transport or outage signature.
+
+All of these are demote-only, so the worst case is a real finding reported as
+operational: still a red job, still a degraded issue after three days, and it
+re-fires the next day. Never the reverse. The cost of that bias is that a probe
+URL which broke permanently would silently disable paging, so each probe failure
+is logged by name. Any failure *before* the classifier runs leaves the
+classification empty, which the gates treat as operational by construction.
+
+One fault in the step fails in the **opposite** direction and is guarded
+separately: if `sort -V` cannot order the tag against the SBOM signing floor, an
+unguarded comparison would read as "at or before the floor" and skip every SBOM
+check while logging that it did so on purpose. That is silent under-verification
+rather than a false page, and it is demoted explicitly.
 
 Two things are deliberately out of scope, both tracked as follow-ups:
 

--- a/tests/releasepolicy/release_reverify_test.go
+++ b/tests/releasepolicy/release_reverify_test.go
@@ -16,6 +16,7 @@ package releasepolicy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -68,8 +69,14 @@ func TestReleaseReverifyWorkflowShape(t *testing.T) {
 		"actions":  "read",
 		"issues":   "write",
 	})
-	if _, ok := job["timeout-minutes"]; !ok {
-		t.Error("the re-verification job must have an explicit timeout")
+	// The per-call `timeout --foreground` bounds stack, and a job that hits
+	// timeout-minutes is CANCELED by GitHub, which skips every `if: failure()`
+	// step: red
+	// with no degraded issue. The budget is sized in a comment on the field; this
+	// pins the floor so a casual reduction has to revisit that arithmetic.
+	budget, isInt := job["timeout-minutes"].(int)
+	if !isInt || budget < 45 {
+		t.Errorf("timeout-minutes = %v, want an explicit budget of at least 45 to cover the stacked per-call bounds", job["timeout-minutes"])
 	}
 
 	env := mapValue(t, doc, "env")
@@ -121,13 +128,20 @@ func TestReleaseReverifyWorkflowShape(t *testing.T) {
 	}
 	verifyScript := stringValue(t, steps[verify].(map[string]any), "run")
 	for _, required := range []string{
-		"CLASSIFICATION=${classification}", // same machine-readable line as tools/rekor-monitor
-		"classification=${classification}", // and the step output the gates branch on
-		"timeout --foreground",             // every network call is bounded
-		"recipe verify-catalog",            // the shipped catalog verification command
-		"cosign verify-blob-attestation",   // the shipped blob attestation command
-		"sigstore_reachable",               // guard #1
-		"infra_shaped",                     // guard #2
+		"CLASSIFICATION=${classification}",   // same machine-readable line as tools/rekor-monitor
+		"classification=${classification}",   // and the step output the gates branch on
+		"timeout --foreground",               // every network call is bounded
+		"recipe verify-catalog",              // the shipped catalog verification command
+		"cosign verify-blob-attestation",     // the shipped blob attestation command
+		"sigstore_reachable",                 // liveness guard
+		"infra_shaped",                       // pattern guard
+		`[ -r "$1" ] || return 0`,            // an unreadable log is not evidence
+		`if [ ! -s "${log}" ]; then`,         // nor is an empty one
+		`-eq 124 ]`,                          // a timeout kill is infrastructure
+		`-eq 137 ]`,                          // so is a SIGKILL or OOM
+		`if [ ! -r "${RELEASE_ASSETS}" ];`,   // grep exits 2 on an unreadable inventory
+		`^https://github\\.com/`,             // fully escaped identity regexp
+		`/\\.github/workflows/on-tag\\.yaml`, // including the /.github/ segment
 	} {
 		if !strings.Contains(verifyScript, required) {
 			t.Errorf("classifier missing %q", required)
@@ -157,16 +171,55 @@ func TestReleaseReverifyWorkflowShape(t *testing.T) {
 	if !strings.Contains(degradedGate, "steps.verify.outputs.classification != 'tamper'") {
 		t.Errorf("operational gate = %q, want the exact inverse of the security gate", degradedGate)
 	}
-	alertText := marshalYAML(t, steps[alert])
-	if !strings.Contains(alertText, "select(.title == $t)") {
+	alertScript := stringValue(t, steps[alert].(map[string]any), "run")
+	if !strings.Contains(alertScript, "select(.title == $t)") {
 		t.Error("the security issue must de-duplicate on an exact title match")
 	}
+	// Tag-scoped: the job only verifies the latest release, so an alert must name
+	// the tag it was raised for or a later clean run on a different tag would
+	// close it (see TestReleaseReverifyAlertCloseIsTagScoped).
+	if !strings.Contains(alertScript, `title="${ALERT_TITLE} [${TAG}]"`) {
+		t.Error("the alert title must carry the resolved tag")
+	}
+	// A transient 5xx or a renamed label must not cost the one notification this
+	// workflow exists to deliver.
+	if !strings.Contains(alertScript, "gh-api-retry.sh") {
+		t.Error("the alert de-duplication read must use the shared bounded-retry helper")
+	}
+	if !strings.Contains(alertScript, `--title "${title}" --body-file alert-body.md`) {
+		t.Error("the alert must fall back to an unlabelled issue rather than abort on a missing label")
+	}
+
+	slack := stepIndex(steps, "Post Slack alert on security finding")
+	if slack < 0 {
+		t.Fatal("a tamper finding must page Slack, as rekor-monitor does")
+	}
+	slackStep := steps[slack].(map[string]any)
+	if got := fmt.Sprint(slackStep["if"]); !strings.Contains(got, "classification == 'tamper'") {
+		t.Errorf("Slack gate = %q, want the security classification only, never degraded", got)
+	}
+	if got := fmt.Sprint(mapValue(t, slackStep, "env")["SLACK_SERVICE"]); got != "${{ secrets.SLACK_SERVICE }}" {
+		t.Errorf("Slack secret wiring = %q, want the same SLACK_SERVICE rekor-monitor uses", got)
+	}
+
 	degradedText := marshalYAML(t, steps[degraded])
-	if !strings.Contains(degradedText, `index("success") // length`) {
-		t.Error("the degraded issue must escalate on a consecutive-failure streak, not a failure count")
+	// Only a "failure" conclusion counts. A run that was canceled, skipped or
+	// timed out says nothing about upstream health and would inflate the streak.
+	if !strings.Contains(degradedText, `map(. == "failure") | (index(false) // length)`) {
+		t.Error("the streak must count only consecutive failure conclusions")
 	}
 	if !strings.Contains(degradedText, "workflows/release-reverify.yaml/runs") {
 		t.Error("the streak query must read this workflow's own run history")
+	}
+
+	closeScript := stringValue(t, steps[closer].(map[string]any), "run")
+	if !strings.Contains(closeScript, `"${ALERT_TITLE} [${TAG}]"`) {
+		t.Error("the close loop must scope the alert to the tag this run verified")
+	}
+	// A list blip must not flip a clean verification red, which would also
+	// inflate the next run's streak.
+	if !strings.Contains(closeScript, `|| echo '[]'`) {
+		t.Error("the close-on-success listing must tolerate a transient list failure")
 	}
 
 	// Repo convention: no ${{ }} interpolation inside run: blocks. Every value a
@@ -388,6 +441,127 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			code: 3,
 		},
 		{
+			// The fault mchmarny found: a full disk or a permissions fault on
+			// WORK_DIR breaks the extract. Before the guard, control fell
+			// through to cosign, which failed on a bundle that was never
+			// written -- and "no such file or directory" matches no
+			// infra_shaped pattern, so both guards passed it through to a
+			// security page. Every sibling branch in this chain demotes.
+			name: "a failed extract is operational, never a security finding",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				tarExtractFails:   true,
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			// A `timeout --foreground` kill exits 124. The message the fake still
+			// writes is deliberately NOT infra-shaped, so only the exit-status
+			// demotion can catch this.
+			name: "a cosign killed by its timeout is operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          124,
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			// A SIGKILL (OOM killer) surfaces as 137.
+			name: "a cosign killed by the OOM killer is operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          137,
+				cosignSilent:      true,
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			// An empty log is not evidence: grep declines to match it, so the
+			// pattern guard alone would pass this straight through to security.
+			name: "a failure that produced no output is operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          1,
+				cosignSilent:      true,
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			// The `> <log>` redirect fails against a pre-existing unreadable
+			// file, so the classifier is handed a non-empty log it cannot read.
+			// grep exits 2 there, which is indistinguishable from "no match".
+			name: "a log the classifier cannot read is operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "success",
+				seedUnreadableLog: "catalog-verify.log",
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			// grep exits 2 on an unreadable inventory, which have_asset cannot
+			// tell from "not present", so every required asset would read as
+			// missing and page.
+			name: "an unreadable asset inventory is operational, not every asset missing",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				missingAssetsFile: true,
+				installOutcome:    "success",
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			// A Fulcio-only outage must demote too: probing the TUF CDN alone
+			// would stay green through it.
+			name: "a Fulcio-only outage demotes a failed verification",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          1,
+				cosignMessage:     "Error: no matching signatures found for the given identity",
+				sigstoreReachable: true,
+				sigstoreFailURL:   "fulcio",
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			// Failing to order the tag against the floor must not silently skip
+			// every SBOM check.
+			name: "an undecidable SBOM floor ordering is operational",
+			opts: reverifyOptions{
+				tag:               "v0.19.0",
+				assets:            assetsFor("0.19.0"),
+				installOutcome:    "success",
+				sortFails:         true,
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
 			name: "a corrupt archive download is operational, not a missing attestation",
 			opts: reverifyOptions{
 				tag:               reverifySBOMFloor,
@@ -436,6 +610,13 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			if !strings.Contains(output, "CLASSIFICATION="+tc.want) {
 				t.Errorf("classifier did not print the machine-readable CLASSIFICATION line\n%s", output)
 			}
+			// security() is the only emitter of ::error:: in the step, so a run
+			// that is not a finding must carry none. This pins "NOT tamper"
+			// directly rather than inferring it from the classification, and it
+			// holds for every non-finding row, not just the one being added.
+			if tc.want != "tamper" && strings.Contains(output, "::error::") {
+				t.Errorf("a %s run emitted a security annotation; an infrastructure fault must never page\n%s", tc.want, output)
+			}
 		})
 	}
 }
@@ -468,8 +649,79 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 			},
 		},
 		{
+			// Restores the pre-fix, unguarded extract. The step runs without
+			// `set -e`, so the failure falls through to cosign and reaches
+			// security -- the guards are demote-only and cannot save a path
+			// that never reaches them.
+			name: "restoring the unguarded tar extract",
+			from: `  if ! tar -xzf "${REL_DIR}/${archive}" -C "${WORK_DIR}" \
+      aicr aicr-attestation.sigstore.json 2>/dev/null; then
+    operational "the archive listed but could not be extracted; treating as infrastructure"
+  elif timeout --foreground 120s cosign verify-blob-attestation \`,
+			to: `  tar -xzf "${REL_DIR}/${archive}" -C "${WORK_DIR}" \
+      aicr aicr-attestation.sigstore.json 2>/dev/null
+  if timeout --foreground 120s cosign verify-blob-attestation \`,
+			opts: reverifyOptions{
+				installOutcome: "failure",
+				// The extract fails; Sigstore is up and the resulting cosign
+				// message is not infra-shaped, so the intact script must still
+				// say operational.
+				tarExtractFails:   true,
+				sigstoreReachable: true,
+			},
+		},
+		{
+			// Exit 124 is a `timeout --foreground` kill and 137 a SIGKILL/OOM.
+			// The fake still writes a non-infra-shaped message, so nothing else
+			// in the chain can demote this.
+			name: "removing the killed-command demotion",
+			from: `  if [ "${status}" -eq 124 ] || [ "${status}" -eq 137 ]; then`,
+			to:   "  if false; then",
+			opts: reverifyOptions{
+				installOutcome:    "failure",
+				cosignRC:          124,
+				sigstoreReachable: true,
+			},
+		},
+		{
+			// grep declines to match an empty file, so the pattern guard reads
+			// "no infrastructure signature" and reaches security.
+			name: "removing the empty-log demotion",
+			from: `  if [ ! -s "${log}" ]; then`,
+			to:   "  if false; then",
+			opts: reverifyOptions{
+				installOutcome:    "failure",
+				cosignRC:          1,
+				cosignSilent:      true,
+				sigstoreReachable: true,
+			},
+		},
+		{
+			// grep exits 2 on an unreadable file, indistinguishable from rc 1.
+			name: "removing the unreadable-log demotion",
+			from: `  [ -r "$1" ] || return 0`,
+			to:   `  [ -r "$1" ] || true`,
+			opts: reverifyOptions{
+				installOutcome:    "success",
+				seedUnreadableLog: "catalog-verify.log",
+				sigstoreReachable: true,
+			},
+		},
+		{
+			// Same rc-2 conflation one level up: an unreadable inventory makes
+			// have_asset report every required asset as missing.
+			name: "removing the asset-inventory readability guard",
+			from: `if [ ! -r "${RELEASE_ASSETS}" ]; then`,
+			to:   "if false; then",
+			opts: reverifyOptions{
+				missingAssetsFile: true,
+				installOutcome:    "success",
+				sigstoreReachable: true,
+			},
+		},
+		{
 			name: "removing the infrastructure-signature guard",
-			from: `if infra_shaped "$2"; then`,
+			from: `  if infra_shaped "${log}"; then`,
 			to:   "if false; then",
 			opts: reverifyOptions{
 				installOutcome: "failure",
@@ -485,10 +737,12 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := tc.opts
 			opts.tag = reverifySBOMFloor
-			opts.assets = []string{
-				"aicr_0.18.0_linux_amd64.tar.gz",
-				"aicr_checksums.txt",
-				"recipe-catalog.sigstore.json",
+			if !opts.missingAssetsFile {
+				opts.assets = []string{
+					"aicr_0.18.0_linux_amd64.tar.gz",
+					"aicr_checksums.txt",
+					"recipe-catalog.sigstore.json",
+				}
 			}
 
 			intact, _, output := runReverifyClassifier(t, script, opts)
@@ -624,6 +878,254 @@ func verifiedSBOMs(output string) []string {
 	return verified
 }
 
+// TestReleaseReverifySBOMFloorOrderingIsGuarded covers the one fault in this
+// step that fails OPEN rather than paging. If `sort -V` is unavailable or dies,
+// the floor comparison is undecidable; unguarded, the ordering test then reads
+// as "at or before the floor" and skips every SBOM check while logging that it
+// did so deliberately. A release that is genuinely missing an SBOM bundle would
+// come back clean.
+func TestReleaseReverifySBOMFloorOrderingIsGuarded(t *testing.T) {
+	script := reverifyClassifierScript(t)
+
+	const from = `newest=""
+if ! newest="$(printf '%s\n%s\n' "${SBOM_SIGNING_FLOOR}" "${TAG}" | sort -V | tail -n1)" \
+    || [ -z "${newest}" ]; then
+  operational "could not order ${TAG} against the SBOM signing floor ${SBOM_SIGNING_FLOOR}; treating as infrastructure"
+elif [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then`
+	const to = `newest="$(printf '%s\n%s\n' "${SBOM_SIGNING_FLOOR}" "${TAG}" | sort -V | tail -n1)"
+if [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then`
+	if !strings.Contains(script, from) {
+		t.Fatal("the SBOM floor ordering guard is no longer in the classifier")
+	}
+	mutated := strings.Replace(script, from, to, 1)
+
+	// A release above the floor that ships an SBOM with no attestation bundle:
+	// a finding the SBOM block is supposed to catch.
+	opts := reverifyOptions{
+		tag: "v0.19.0",
+		assets: []string{
+			"aicr_0.19.0_linux_amd64.tar.gz",
+			"aicr_checksums.txt",
+			"recipe-catalog.sigstore.json",
+			"aicr_0.19.0_linux_amd64.sbom.json",
+		},
+		installOutcome:    "success",
+		sigstoreReachable: true,
+	}
+
+	// Baseline: with a working sort the block runs and finds it.
+	if class, code, output := runReverifyClassifier(t, script, opts); class != "tamper" || code != 1 {
+		t.Fatalf("baseline classification = %q (exit %d), want tamper (exit 1)\n%s", class, code, output)
+	}
+
+	// Undecidable ordering: demote, do not silently skip.
+	opts.sortFails = true
+	class, code, output := runReverifyClassifier(t, script, opts)
+	if class != "operational" || code != 3 {
+		t.Fatalf("with an undecidable ordering, classification = %q (exit %d), want operational (exit 3)\n%s", class, code, output)
+	}
+
+	// Unguarded, the same fault reports a clean release and never mentions the
+	// missing bundle. That is the fail-open direction this guard exists for.
+	brokenClass, brokenCode, brokenOutput := runReverifyClassifier(t, mutated, opts)
+	if brokenClass == "operational" {
+		t.Fatalf("the unguarded ordering still demoted; the guard is not load-bearing and this test proves nothing\n%s", brokenOutput)
+	}
+	if brokenClass != "clean" || brokenCode != 0 {
+		t.Errorf("unguarded ordering = %q (exit %d), want clean (exit 0): the skip is expected to be SILENT", brokenClass, brokenCode)
+	}
+	if !strings.Contains(brokenOutput, "at or before the SBOM signing floor") {
+		t.Errorf("unguarded ordering did not take the misleading floor branch\n%s", brokenOutput)
+	}
+	if strings.Contains(brokenOutput, "with no attestation bundle") {
+		t.Errorf("unguarded ordering unexpectedly still reported the missing bundle\n%s", brokenOutput)
+	}
+}
+
+// TestReleaseReverifyAlertCloseIsTagScoped covers the close-on-success step. The
+// job only ever verifies /releases/latest, so a clean run on vX+1 proves nothing
+// about vX and must not close vX's alert: once vX stops being latest it is never
+// re-checked, and closing its issue would silently resolve a live finding. This
+// is the deliberate divergence from rekor-monitor, whose alert tracks the
+// release-agnostic log and so genuinely clears on any clean run.
+func TestReleaseReverifyAlertCloseIsTagScoped(t *testing.T) {
+	doc := loadYAML(t, reverifyWorkflow)
+	env := mapValue(t, doc, "env")
+	alertTitle := fmt.Sprint(env["ALERT_TITLE"])
+	degradedTitle := fmt.Sprint(env["DEGRADED_TITLE"])
+
+	steps := sliceValue(t, mapValue(t, mapValue(t, doc, "jobs"), "reverify"), "steps")
+	index := stepIndex(steps, "Close open issues on success")
+	if index < 0 {
+		t.Fatal("re-verification must auto-close its issues on a clean run")
+	}
+	script := stringValue(t, steps[index].(map[string]any), "run")
+
+	scoped := func(tag string) string { return alertTitle + " [" + tag + "]" }
+
+	tests := []struct {
+		name   string
+		tag    string
+		issues []closableIssue
+		want   []string
+	}{
+		{
+			name: "a clean run on a newer release leaves the older tag's alert open",
+			tag:  "v0.19.0",
+			issues: []closableIssue{
+				{Number: 11, Title: scoped("v0.18.0")},
+				{Number: 12, Title: degradedTitle},
+			},
+			// Only the degraded issue, which tracks the checker rather than a
+			// release, closes.
+			want: []string{"12"},
+		},
+		{
+			name: "a clean run closes the alert for the tag it verified",
+			tag:  "v0.19.0",
+			issues: []closableIssue{
+				{Number: 21, Title: scoped("v0.19.0")},
+				{Number: 22, Title: degradedTitle},
+			},
+			want: []string{"21", "22"},
+		},
+		{
+			name: "a title that merely contains the alert text is not closed",
+			tag:  "v0.19.0",
+			issues: []closableIssue{
+				{Number: 31, Title: scoped("v0.19.0") + " (follow-up)"},
+			},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			closed, output, err := runReverifyCloseStep(t, script, tc.tag, tc.issues)
+			if err != nil {
+				t.Fatalf("close step failed: %v\n%s", err, output)
+			}
+			if !slices.Equal(closed, tc.want) {
+				t.Errorf("closed %v, want %v\n%s", closed, tc.want, output)
+			}
+		})
+	}
+
+	t.Run("an unscoped close reopens the bug", func(t *testing.T) {
+		// The pre-fix shape: one global alert title, closed by any clean run.
+		// Staged with the unscoped title on both sides, which is what the
+		// workflow used to create.
+		const from = `for title in "${ALERT_TITLE} [${TAG}]" "${DEGRADED_TITLE}"; do`
+		if !strings.Contains(script, from) {
+			t.Fatal("the close loop no longer scopes the alert title by tag")
+		}
+		mutated := strings.Replace(script, from, `for title in "${ALERT_TITLE}" "${DEGRADED_TITLE}"; do`, 1)
+		issues := []closableIssue{{Number: 41, Title: alertTitle}}
+
+		closed, output, err := runReverifyCloseStep(t, script, "v0.19.0", issues)
+		if err != nil {
+			t.Fatalf("close step failed: %v\n%s", err, output)
+		}
+		if len(closed) != 0 {
+			t.Fatalf("the tag-scoped close matched an unscoped title: closed %v", closed)
+		}
+
+		brokenClosed, brokenOutput, err := runReverifyCloseStep(t, mutated, "v0.19.0", issues)
+		if err != nil {
+			t.Fatalf("mutated close step failed: %v\n%s", err, brokenOutput)
+		}
+		if !slices.Equal(brokenClosed, []string{"41"}) {
+			t.Fatalf("without tag scoping the close did not reach the unscoped alert (closed %v); the scoping is not load-bearing", brokenClosed)
+		}
+	})
+}
+
+// closableIssue is one open issue the fake `gh issue list` returns.
+type closableIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+}
+
+// runReverifyCloseStep executes the extracted close-on-success step against a
+// fake gh, returning the issue numbers it closed in order.
+func runReverifyCloseStep(t *testing.T, script, tag string, issues []closableIssue) ([]string, string, error) {
+	t.Helper()
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.Mkdir(bin, 0o700); err != nil {
+		t.Fatalf("create fake bin: %v", err)
+	}
+	writeExecutable(t, filepath.Join(bin, "gh"), reverifyFakeGHIssues)
+
+	// The fake answers every `issue list` with the whole fixture, mirroring
+	// GitHub's phrase-based title search over-matching. The step's own exact
+	// title filter is what has to do the work.
+	listing, err := json.Marshal(issues)
+	if err != nil {
+		t.Fatalf("marshal issue fixture: %v", err)
+	}
+	listFile := filepath.Join(root, "issues.json")
+	if err := os.WriteFile(listFile, listing, 0o600); err != nil {
+		t.Fatalf("write issue fixture: %v", err)
+	}
+	closedFile := filepath.Join(root, "closed.txt")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "bash", "-c", script)
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"GH_TOKEN=fake",
+		"GITHUB_REPOSITORY=NVIDIA/aicr",
+		"GITHUB_RUN_ID=1234",
+		"TAG="+tag,
+		"ALERT_TITLE="+reverifyWorkflowEnv(t, "ALERT_TITLE"),
+		"DEGRADED_TITLE="+reverifyWorkflowEnv(t, "DEGRADED_TITLE"),
+		"FAKE_ISSUE_LIST="+listFile,
+		"FAKE_CLOSED_LOG="+closedFile,
+	)
+	combined, runErr := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("close step exceeded the test deadline: %v\n%s", ctx.Err(), combined)
+	}
+	var closed []string
+	if data, readErr := os.ReadFile(closedFile); readErr == nil {
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line != "" {
+				closed = append(closed, line)
+			}
+		}
+	} else if !os.IsNotExist(readErr) {
+		t.Fatalf("read closed log: %v", readErr)
+	}
+	return closed, string(combined), runErr
+}
+
+// reverifyWorkflowEnv reads one workflow-level env value, so the tests bind to
+// the shipped titles rather than a copy of them.
+func reverifyWorkflowEnv(t *testing.T, key string) string {
+	t.Helper()
+	return fmt.Sprint(mapValue(t, loadYAML(t, reverifyWorkflow), "env")[key])
+}
+
+// reverifyFakeGHIssues answers `gh issue list` from a fixture and records every
+// `gh issue close` so the test can assert on exactly which issues were touched.
+const reverifyFakeGHIssues = `#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}:${2:-}" in
+  issue:list)
+    cat "${FAKE_ISSUE_LIST}"
+    ;;
+  issue:close)
+    printf '%s\n' "${3}" >> "${FAKE_CLOSED_LOG}"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 64
+    ;;
+esac
+`
+
 // reverifyOptions describes one simulated release and the behavior of the
 // binaries the classifier shells out to.
 type reverifyOptions struct {
@@ -637,6 +1139,19 @@ type reverifyOptions struct {
 	omitAttestation bool
 	// corruptArchive stages bytes that are not a tarball (a truncated download).
 	corruptArchive bool
+	// tarExtractFails makes the fake tar list the archive fine but fail the
+	// extract, modeling a full disk or a permissions fault on WORK_DIR.
+	tarExtractFails bool
+	// missingAssetsFile points RELEASE_ASSETS at a path that does not exist, so
+	// every `grep` against it exits 2 rather than 1.
+	missingAssetsFile bool
+	// seedUnreadableLog pre-creates the named log under WORK_DIR with content and
+	// mode 0000, so the step's `> <log>` redirect fails and the classifier is
+	// handed a non-empty log it cannot read.
+	seedUnreadableLog string
+	// sortFails makes the fake sort exit non-zero, breaking the SBOM floor
+	// ordering.
+	sortFails bool
 
 	cosignRC          int
 	cosignMessage     string
@@ -652,6 +1167,13 @@ type reverifyOptions struct {
 	// names off the loop's here-string.
 	drainGHStdin     bool
 	drainCosignStdin bool
+
+	// cosignSilent makes the fake fail without writing anything, so the captured
+	// log is empty (a killed or OOMed process).
+	cosignSilent bool
+	// sigstoreFailURL fails only the probe whose URL contains this substring,
+	// modeling a Fulcio-only or TUF-only outage.
+	sigstoreFailURL string
 }
 
 // reverifyClassifierScript extracts the classifying step's shell from the
@@ -687,18 +1209,38 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 	writeExecutable(t, filepath.Join(bin, "timeout"), passthroughTimeout)
 	writeExecutable(t, filepath.Join(bin, "sleep"), reverifyFakeSleep)
 	writeExecutable(t, filepath.Join(bin, "curl"), reverifyFakeCurl)
+	writeExecutable(t, filepath.Join(bin, "tar"), reverifyFakeTar)
+	writeExecutable(t, filepath.Join(bin, "sort"), reverifyFakeSort)
 	writeExecutable(t, filepath.Join(bin, "cosign"), reverifyFakeCosign)
 	writeExecutable(t, filepath.Join(bin, "gh"), reverifyFakeGH)
 	aicrBin := filepath.Join(bin, "aicr")
 	writeExecutable(t, aicrBin, reverifyFakeAicr)
 
 	assetsFile := filepath.Join(root, "release-assets.txt")
+	if opts.missingAssetsFile {
+		assetsFile = filepath.Join(root, "no-such-inventory.txt")
+	}
 	contents := ""
 	if len(opts.assets) > 0 {
 		contents = strings.Join(opts.assets, "\n") + "\n"
 	}
-	if err := os.WriteFile(assetsFile, []byte(contents), 0o600); err != nil {
-		t.Fatalf("write asset inventory: %v", err)
+	if !opts.missingAssetsFile {
+		if err := os.WriteFile(assetsFile, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write asset inventory: %v", err)
+		}
+	}
+	if opts.seedUnreadableLog != "" {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses file permissions; the unreadable-log path cannot be staged")
+		}
+		seeded := filepath.Join(workDir, opts.seedUnreadableLog)
+		if err := os.WriteFile(seeded, []byte("stale output from a previous run\n"), 0o600); err != nil {
+			t.Fatalf("seed unreadable log: %v", err)
+		}
+		if err := os.Chmod(seeded, 0o000); err != nil {
+			t.Fatalf("chmod unreadable log: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(seeded, 0o600) })
 	}
 
 	archiveName := "aicr_" + strings.TrimPrefix(opts.tag, "v") + "_linux_amd64.tar.gz"
@@ -729,7 +1271,7 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 		"WORK_DIR="+workDir,
 		"AICR_BIN="+aicrBin,
 		"SBOM_SIGNING_FLOOR="+reverifySBOMFloor,
-		"SIGSTORE_PROBE_URL=https://tuf-repo-cdn.example.invalid/1.root.json",
+		"SIGSTORE_PROBE_URLS=https://tuf.example.invalid/1.root.json https://fulcio.example.invalid/api/v2/trustBundle",
 		"GITHUB_OUTPUT="+outputs,
 		"GITHUB_STEP_SUMMARY="+summary,
 		"GH_TOKEN=fake",
@@ -741,6 +1283,12 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 		fmt.Sprintf("FAKE_GH_RC=%d", opts.ghRC),
 		fmt.Sprintf("FAKE_GH_DRAIN_STDIN=%t", opts.drainGHStdin),
 		fmt.Sprintf("FAKE_COSIGN_DRAIN_STDIN=%t", opts.drainCosignStdin),
+		"FAKE_TAR_REAL="+systemBinary(t, "tar"),
+		"FAKE_SORT_REAL="+systemBinary(t, "sort"),
+		fmt.Sprintf("FAKE_TAR_EXTRACT_FAILS=%t", opts.tarExtractFails),
+		fmt.Sprintf("FAKE_COSIGN_SILENT=%t", opts.cosignSilent),
+		"FAKE_SIGSTORE_FAIL_URL="+opts.sigstoreFailURL,
+		fmt.Sprintf("FAKE_SORT_FAILS=%t", opts.sortFails),
 	)
 	combined, err := command.CombinedOutput()
 	if ctx.Err() != nil {
@@ -800,10 +1348,16 @@ exit 0
 // TUF CDN, reproducing curl's exit 7 when the host does not answer.
 const reverifyFakeCurl = `#!/usr/bin/env bash
 set -euo pipefail
+url="${*: -1}"
+# Fail one probe only, so a Fulcio-only (or TUF-only) outage can be modeled.
+if [[ -n "${FAKE_SIGSTORE_FAIL_URL:-}" && "${url}" == *"${FAKE_SIGSTORE_FAIL_URL}"* ]]; then
+  echo "curl: (7) Failed to connect to ${url}" >&2
+  exit 7
+fi
 if [[ "${FAKE_SIGSTORE_REACHABLE:-true}" == "true" ]]; then
   exit 0
 fi
-echo "curl: (7) Failed to connect to tuf-repo-cdn.sigstore.dev port 443" >&2
+echo "curl: (7) Failed to connect to ${url}" >&2
 exit 7
 `
 
@@ -818,11 +1372,27 @@ set -euo pipefail
 if [[ "${FAKE_COSIGN_DRAIN_STDIN:-false}" == "true" ]]; then
   cat > /dev/null
 fi
+# Real cosign opens the bundle before it verifies anything. Modeling that is
+# what makes a failed extract observable: the pre-fix, unguarded tar extract
+# fell through to here with no bundle on disk.
+bundle=""
+previous=""
+for argument in "$@"; do
+  if [[ "${previous}" == "--bundle" ]]; then bundle="${argument}"; fi
+  previous="${argument}"
+done
+if [[ -n "${bundle}" && ! -f "${bundle}" ]]; then
+  echo "Error: opening bundle: open ${bundle}: no such file or directory" >&2
+  exit 1
+fi
 if [[ "${FAKE_COSIGN_RC:-0}" == "0" ]]; then
   echo "Verified OK"
   exit 0
 fi
-printf '%s\n' "${FAKE_COSIGN_MESSAGE:-Error: verification failed}" >&2
+# A killed or OOMed process writes nothing; the captured log is then empty.
+if [[ "${FAKE_COSIGN_SILENT:-false}" != "true" ]]; then
+  printf '%s\n' "${FAKE_COSIGN_MESSAGE:-Error: verification failed}" >&2
+fi
 exit "${FAKE_COSIGN_RC}"
 `
 
@@ -835,6 +1405,43 @@ if [[ "${FAKE_AICR_RC:-0}" == "0" ]]; then
 fi
 printf '%s\n' "${FAKE_AICR_MESSAGE:-Error: catalog verification failed}" >&2
 exit "${FAKE_AICR_RC}"
+`
+
+// systemBinary resolves a real binary once, so a fake can delegate everything it
+// is not deliberately failing. The archive fixtures are built with the same tar
+// from the test process, which never sees the fake.
+func systemBinary(t *testing.T, name string) string {
+	t.Helper()
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Fatalf("locate %s: %v", name, err)
+	}
+	return path
+}
+
+// reverifyFakeTar delegates to the real tar except that, when
+// FAKE_TAR_EXTRACT_FAILS is set, `-x` fails while `-t` still succeeds. That
+// asymmetry is the only way to reach the extract branch: the listing has to
+// succeed first, or the classifier stops one branch earlier.
+const reverifyFakeTar = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == -x* && "${FAKE_TAR_EXTRACT_FAILS:-false}" == "true" ]]; then
+  echo "tar: aicr: Cannot open: No space left on device" >&2
+  exit 2
+fi
+exec "${FAKE_TAR_REAL}" "$@"
+`
+
+// reverifyFakeSort delegates to the real sort unless FAKE_SORT_FAILS is set, in
+// which case it models a coreutils without -V (or a sort that dies), which is
+// what leaves the SBOM floor ordering undecidable.
+const reverifyFakeSort = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FAKE_SORT_FAILS:-false}" == "true" ]]; then
+  echo "sort: unrecognized option '--version-sort'" >&2
+  exit 2
+fi
+exec "${FAKE_SORT_REAL}" "$@"
 `
 
 // reverifyFakeGH materializes every --pattern into --dir, or fails the

--- a/tests/releasepolicy/release_reverify_test.go
+++ b/tests/releasepolicy/release_reverify_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -508,6 +509,121 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 	}
 }
 
+// TestReleaseReverifySBOMLoopIsolatesChildStdin is the regression test for the
+// SBOM loop's `< /dev/null` redirects.
+//
+// The loop reads its subject list from a here-string, so every child it spawns
+// inherits that same stdin. A child that consumed stdin would swallow the
+// remaining SBOM names and end the loop early — and because the skipped
+// subjects are never examined, the run would report `clean` with no finding and
+// no warning. That is precisely the "silently verifies nothing" outcome this
+// whole workflow exists to catch, so it is the one bug class the job must never
+// have. Neither `gh` nor `cosign` reads stdin today; the redirects make the loop
+// independent of that, and this test keeps them.
+//
+// Three subjects, not two: with two, an early-terminating loop and a loop that
+// merely dropped the last entry are indistinguishable. Three makes the skipped
+// set unambiguous, and the assertions name the exact subjects rather than
+// counting them.
+func TestReleaseReverifySBOMLoopIsolatesChildStdin(t *testing.T) {
+	script := reverifyClassifierScript(t)
+
+	// Pin the redirect count so a change in form (a different redirection, or a
+	// third stdin-reading child added to the loop) has to revisit this test
+	// rather than silently neutering it.
+	const redirect = " < /dev/null"
+	if got := strings.Count(script, redirect); got != 2 {
+		t.Fatalf("classifier has %d %q redirects, want 2 (gh release download and cosign inside the SBOM loop)", got, redirect)
+	}
+	mutated := strings.ReplaceAll(script, redirect, "")
+
+	// A release above the SBOM signing floor, so the loop actually runs.
+	const version = "0.19.0"
+	// aicr and aicrd are the two binaries GoReleaser builds today; the third is
+	// a stand-in for any future binary, since the loop is generic over whatever
+	// SBOM assets the release publishes.
+	subjects := []string{
+		"aicr_" + version + "_linux_amd64.sbom.json",
+		"aicrd_" + version + "_linux_amd64.sbom.json",
+		"aicr-gate_" + version + "_linux_amd64.sbom.json",
+	}
+	assets := make([]string, 0, 3+2*len(subjects))
+	assets = append(assets,
+		"aicr_"+version+"_linux_amd64.tar.gz",
+		"aicr_checksums.txt",
+		"recipe-catalog.sigstore.json",
+	)
+	for _, subject := range subjects {
+		assets = append(assets, subject, subject+".sigstore.json")
+	}
+
+	tests := []struct {
+		name             string
+		drainGHStdin     bool
+		drainCosignStdin bool
+	}{
+		{name: "a stdin-consuming gh release download", drainGHStdin: true},
+		{name: "a stdin-consuming cosign verify-blob-attestation", drainCosignStdin: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := reverifyOptions{
+				tag:               "v" + version,
+				assets:            assets,
+				installOutcome:    "success",
+				sigstoreReachable: true,
+				drainGHStdin:      tc.drainGHStdin,
+				drainCosignStdin:  tc.drainCosignStdin,
+			}
+
+			class, code, output := runReverifyClassifier(t, script, opts)
+			if class != "clean" || code != 0 {
+				t.Fatalf("intact classifier = %q (exit %d), want clean (exit 0)\n%s", class, code, output)
+			}
+			if got := verifiedSBOMs(output); !slices.Equal(got, subjects) {
+				t.Fatalf("intact classifier verified %v, want every subject %v\n%s", got, subjects, output)
+			}
+
+			// Strip the redirects and the stdin-consuming child eats the rest of
+			// the loop's input.
+			brokenClass, brokenCode, brokenOutput := runReverifyClassifier(t, mutated, opts)
+			broken := verifiedSBOMs(brokenOutput)
+			if slices.Equal(broken, subjects) {
+				t.Fatalf("without the stdin redirects the loop still verified every subject; the redirects are not load-bearing and this test proves nothing\n%s", brokenOutput)
+			}
+			if !slices.Equal(broken, subjects[:1]) {
+				t.Errorf("without the stdin redirects the loop verified %v, want only the first subject %v", broken, subjects[:1])
+			}
+			// The damning part: the skipped subjects produce no finding and no
+			// warning, so the run still reports a clean verification.
+			if brokenClass != "clean" || brokenCode != 0 {
+				t.Errorf("mutated classifier = %q (exit %d); the skip is expected to be SILENT (clean/0), which is why it needs a test",
+					brokenClass, brokenCode)
+			}
+			for _, skipped := range subjects[1:] {
+				if strings.Contains(brokenOutput, "SBOM attestation verified: "+skipped) {
+					t.Errorf("%s was expected to be silently skipped by the mutated loop", skipped)
+				}
+			}
+		})
+	}
+}
+
+// verifiedSBOMs extracts, in order, the SBOM subjects the classifier reported as
+// verified. The loop emits exactly one such line per subject it processes, so
+// the returned set is the set it actually examined.
+func verifiedSBOMs(output string) []string {
+	const marker = "SBOM attestation verified: "
+	var verified []string
+	for _, line := range strings.Split(output, "\n") {
+		if subject, found := strings.CutPrefix(strings.TrimSpace(line), marker); found {
+			verified = append(verified, subject)
+		}
+	}
+	return verified
+}
+
 // reverifyOptions describes one simulated release and the behavior of the
 // binaries the classifier shells out to.
 type reverifyOptions struct {
@@ -528,6 +644,14 @@ type reverifyOptions struct {
 	aicrMessage       string
 	ghRC              int
 	sigstoreReachable bool
+
+	// drainGHStdin / drainCosignStdin make the fake drain its standard input,
+	// modeling a child that reads stdin. Neither real binary does today, which
+	// is exactly why the SBOM loop's `< /dev/null` redirects need a regression
+	// test: a future version that did would silently eat the remaining SBOM
+	// names off the loop's here-string.
+	drainGHStdin     bool
+	drainCosignStdin bool
 }
 
 // reverifyClassifierScript extracts the classifying step's shell from the
@@ -615,6 +739,8 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 		fmt.Sprintf("FAKE_AICR_RC=%d", opts.aicrRC),
 		"FAKE_AICR_MESSAGE="+opts.aicrMessage,
 		fmt.Sprintf("FAKE_GH_RC=%d", opts.ghRC),
+		fmt.Sprintf("FAKE_GH_DRAIN_STDIN=%t", opts.drainGHStdin),
+		fmt.Sprintf("FAKE_COSIGN_DRAIN_STDIN=%t", opts.drainCosignStdin),
 	)
 	combined, err := command.CombinedOutput()
 	if ctx.Err() != nil {
@@ -686,6 +812,12 @@ exit 7
 // cosign-shaped output to read.
 const reverifyFakeCosign = `#!/usr/bin/env bash
 set -euo pipefail
+# Model a child that reads stdin. Real cosign does not, but the SBOM loop must
+# not depend on that: without its ` + "`< /dev/null`" + ` redirect this drain would consume
+# the loop's remaining here-string and silently skip every later SBOM.
+if [[ "${FAKE_COSIGN_DRAIN_STDIN:-false}" == "true" ]]; then
+  cat > /dev/null
+fi
 if [[ "${FAKE_COSIGN_RC:-0}" == "0" ]]; then
   echo "Verified OK"
   exit 0
@@ -709,6 +841,10 @@ exit "${FAKE_AICR_RC}"
 // whole download when FAKE_GH_RC is set (a GitHub API / transport failure).
 const reverifyFakeGH = `#!/usr/bin/env bash
 set -euo pipefail
+# Same stdin-consuming child model as the cosign fake above.
+if [[ "${FAKE_GH_DRAIN_STDIN:-false}" == "true" ]]; then
+  cat > /dev/null
+fi
 if [[ "${FAKE_GH_RC:-0}" != "0" ]]; then
   echo "gh: HTTP 503 (https://api.github.com)" >&2
   exit "${FAKE_GH_RC}"

--- a/tests/releasepolicy/release_reverify_test.go
+++ b/tests/releasepolicy/release_reverify_test.go
@@ -16,6 +16,8 @@ package releasepolicy
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -133,6 +135,7 @@ func TestReleaseReverifyWorkflowShape(t *testing.T) {
 		"timeout --foreground",               // every network call is bounded
 		"recipe verify-catalog",              // the shipped catalog verification command
 		"cosign verify-blob-attestation",     // the shipped blob attestation command
+		"set -uo pipefail\nset +e",           // errexit is INHERITED from `bash -e {0}`
 		"sigstore_reachable",                 // liveness guard
 		"infra_shaped",                       // pattern guard
 		`[ -r "$1" ] || return 0`,            // an unreadable log is not evidence
@@ -247,7 +250,15 @@ func TestReleaseReverifyWorkflowShape(t *testing.T) {
 func TestReleaseReverifyClassification(t *testing.T) {
 	script := reverifyClassifierScript(t)
 
+	// Every fixture derives from the floor constant. Hardcoding a version here
+	// would desynchronize the moment the floor is raised, and unevenly: clean and
+	// operational cases would fail loudly on a now-missing archive, while
+	// security cases would keep PASSING on that spurious missing-archive finding
+	// (tamper is sticky) rather than on the condition they were written for.
+	atFloor := reverifySBOMFloor
+	atFloorVersion := strings.TrimPrefix(atFloor, "v")
 	aboveFloor := "v0.19.0"
+	aboveFloorVersion := strings.TrimPrefix(aboveFloor, "v")
 	assetsFor := func(version string, extra ...string) []string {
 		base := make([]string, 0, 3+len(extra))
 		base = append(base,
@@ -257,11 +268,25 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		)
 		return append(base, extra...)
 	}
+	// The linux/amd64 SBOM subjects every post-floor release must publish, read
+	// from the workflow so the fixtures cannot drift from what it mandates.
+	sbomSubjects := func(version string) []string {
+		binaries := strings.Fields(reverifyWorkflowEnv(t, "EXPECTED_SBOM_BINARIES"))
+		names := make([]string, 0, len(binaries))
+		for _, binary := range binaries {
+			names = append(names, binary+"_"+version+"_linux_amd64.sbom.json")
+		}
+		return names
+	}
+	unsignedSBOMAssets := func(version string) []string {
+		return assetsFor(version, sbomSubjects(version)...)
+	}
 	signedSBOMAssets := func(version string) []string {
-		return assetsFor(version,
-			"aicr_"+version+"_linux_amd64.sbom.json",
-			"aicr_"+version+"_linux_amd64.sbom.json.sigstore.json",
-		)
+		assets := assetsFor(version)
+		for _, subject := range sbomSubjects(version) {
+			assets = append(assets, subject, subject+".sigstore.json")
+		}
+		return assets
 	}
 
 	tests := []struct {
@@ -271,10 +296,15 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		code int
 	}{
 		{
-			name: "a complete release verifies clean",
+			// The real at-floor release ships unsigned aicr and aicrd linux/amd64
+			// SBOMs with no .sigstore.json siblings, which is precisely the shape
+			// the floor exempts. Without those assets this case would prove the
+			// version gate fires but not that the exemption works on a release
+			// that actually ships unsigned SBOMs.
+			name: "a release at the floor with unsigned SBOMs verifies clean",
 			opts: reverifyOptions{
-				tag:            reverifySBOMFloor,
-				assets:         assetsFor(strings.TrimPrefix(reverifySBOMFloor, "v")),
+				tag:            atFloor,
+				assets:         unsignedSBOMAssets(atFloorVersion),
 				installOutcome: "success",
 			},
 			want: "clean",
@@ -295,9 +325,9 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a missing catalog signature is a security finding",
 			opts: reverifyOptions{
-				tag: reverifySBOMFloor,
+				tag: atFloor,
 				assets: []string{
-					"aicr_0.18.0_linux_amd64.tar.gz",
+					"aicr_" + atFloorVersion + "_linux_amd64.tar.gz",
 					"aicr_checksums.txt",
 				},
 				installOutcome: "success",
@@ -308,7 +338,7 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a missing binary archive is a security finding",
 			opts: reverifyOptions{
-				tag:            reverifySBOMFloor,
+				tag:            atFloor,
 				assets:         []string{"aicr_checksums.txt", "recipe-catalog.sigstore.json"},
 				installOutcome: "failure",
 				noArchiveFile:  true,
@@ -319,10 +349,27 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "an archive shipped without its attestation bundle is a security finding",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				omitAttestation:   true,
+				sigstoreReachable: true,
+			},
+			want: "tamper",
+			code: 1,
+		},
+		{
+			// The expected set is derived from the tag, so deleting one of the
+			// two mandatory SBOMs is a finding. Derived from the RELEASE's own
+			// inventory it would not be: the loop would verify the survivor and
+			// report clean.
+			name: "a mandatory SBOM missing from the release is a security finding",
+			opts: reverifyOptions{
+				tag: aboveFloor,
+				assets: append(assetsFor(aboveFloorVersion),
+					"aicr_"+aboveFloorVersion+"_linux_amd64.sbom.json",
+					"aicr_"+aboveFloorVersion+"_linux_amd64.sbom.json.sigstore.json"),
+				installOutcome:    "success",
 				sigstoreReachable: true,
 			},
 			want: "tamper",
@@ -342,7 +389,7 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			name: "a release above the floor with no SBOM assets at all is a security finding",
 			opts: reverifyOptions{
 				tag:            aboveFloor,
-				assets:         assetsFor("0.19.0"),
+				assets:         assetsFor(aboveFloorVersion),
 				installOutcome: "success",
 			},
 			want: "tamper",
@@ -351,8 +398,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a signature that fails against a reachable Sigstore is a security finding",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          1,
 				cosignMessage:     "Error: no matching signatures found for the given identity",
@@ -364,8 +411,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a catalog digest mismatch is a security finding",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "success",
 				aicrRC:            1,
 				aicrMessage:       "Error: recomputed catalog digest does not match the signed subject",
@@ -379,8 +426,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "an unreachable Sigstore demotes a failed verification to operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          1,
 				cosignMessage:     "Error: no matching signatures found for the given identity",
@@ -392,8 +439,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a Rekor outage in the failure output demotes to operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          1,
 				cosignMessage:     "Error: uploading to rekor: POST https://rekor.sigstore.dev: status 503 service unavailable",
@@ -405,8 +452,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a TUF trusted-root fetch failure demotes to operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          1,
 				cosignMessage:     "Error: initializing trusted root: could not fetch metadata",
@@ -418,8 +465,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a network timeout during catalog verification is operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "success",
 				aicrRC:            1,
 				aicrMessage:       "Error: verifying catalog: dial tcp 34.1.2.3:443: i/o timeout",
@@ -431,8 +478,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a failed release-asset download is operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "success",
 				ghRC:              1,
 				sigstoreReachable: true,
@@ -449,8 +496,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// security page. Every sibling branch in this chain demotes.
 			name: "a failed extract is operational, never a security finding",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				tarExtractFails:   true,
 				sigstoreReachable: true,
@@ -464,8 +511,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// demotion can catch this.
 			name: "a cosign killed by its timeout is operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          124,
 				sigstoreReachable: true,
@@ -477,8 +524,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// A SIGKILL (OOM killer) surfaces as 137.
 			name: "a cosign killed by the OOM killer is operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          137,
 				cosignSilent:      true,
@@ -492,8 +539,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// pattern guard alone would pass this straight through to security.
 			name: "a failure that produced no output is operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          1,
 				cosignSilent:      true,
@@ -508,8 +555,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// grep exits 2 there, which is indistinguishable from "no match".
 			name: "a log the classifier cannot read is operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "success",
 				seedUnreadableLog: "catalog-verify.log",
 				sigstoreReachable: true,
@@ -523,7 +570,7 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// missing and page.
 			name: "an unreadable asset inventory is operational, not every asset missing",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
+				tag:               atFloor,
 				missingAssetsFile: true,
 				installOutcome:    "success",
 				sigstoreReachable: true,
@@ -536,8 +583,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// would stay green through it.
 			name: "a Fulcio-only outage demotes a failed verification",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				cosignRC:          1,
 				cosignMessage:     "Error: no matching signatures found for the given identity",
@@ -552,8 +599,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 			// every SBOM check.
 			name: "an undecidable SBOM floor ordering is operational",
 			opts: reverifyOptions{
-				tag:               "v0.19.0",
-				assets:            assetsFor("0.19.0"),
+				tag:               aboveFloor,
+				assets:            assetsFor(aboveFloorVersion),
 				installOutcome:    "success",
 				sortFails:         true,
 				sigstoreReachable: true,
@@ -564,8 +611,8 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a corrupt archive download is operational, not a missing attestation",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            assetsFor(atFloorVersion),
 				installOutcome:    "failure",
 				corruptArchive:    true,
 				sigstoreReachable: true,
@@ -576,20 +623,38 @@ func TestReleaseReverifyClassification(t *testing.T) {
 		{
 			name: "a transient install failure that re-verifies is operational",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
-				assets:            assetsFor("0.18.0"),
+				tag:               atFloor,
+				assets:            unsignedSBOMAssets(atFloorVersion),
 				installOutcome:    "failure",
+				checksumsManifest: "match",
 				sigstoreReachable: true,
 			},
 			want: "operational",
 			code: 3,
+		},
+		{
+			// The attestation binds the BINARY, so cosign passes while the
+			// published manifest no longer describes the published archive. The
+			// install action fails at its own sha256sum long before cosign, so
+			// without the checksum re-check this reports "transient" forever
+			// while every consumer following the documented checksum flow fails.
+			name: "a checksums manifest that stopped matching is a security finding",
+			opts: reverifyOptions{
+				tag:               atFloor,
+				assets:            unsignedSBOMAssets(atFloorVersion),
+				installOutcome:    "failure",
+				checksumsManifest: "mismatch",
+				sigstoreReachable: true,
+			},
+			want: "tamper",
+			code: 1,
 		},
 
 		// --- precedence: a real finding is never masked by a concurrent outage ---
 		{
 			name: "a missing asset still pages when the network is also down",
 			opts: reverifyOptions{
-				tag:               reverifySBOMFloor,
+				tag:               atFloor,
 				assets:            []string{"aicr_0.18.0_linux_amd64.tar.gz", "aicr_checksums.txt"},
 				installOutcome:    "failure",
 				noArchiveFile:     true,
@@ -635,6 +700,10 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 		from string
 		to   string
 		opts reverifyOptions
+		// wantIntactTamper inverts the assertion for a guard whose REMOVAL hides
+		// a finding rather than manufacturing one: intact must be tamper and the
+		// mutation must demote it to operational.
+		wantIntactTamper bool
 	}{
 		{
 			name: "removing the Sigstore reachability guard",
@@ -720,6 +789,29 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 			},
 		},
 		{
+			// The pre-fix shape: a passing cosign was taken as proof the install
+			// action's failure was transient. It is not: the attestation binds
+			// the binary, the manifest covers the archive.
+			name: "presuming a passing cosign clears the checksums manifest",
+			from: `    if [ ! -r "${REL_DIR}/aicr_checksums.txt" ]; then
+      operational "the checksums manifest is not on disk to re-check; treating as infrastructure"
+    elif (cd "${REL_DIR}" && grep " ${archive}\$" aicr_checksums.txt | sha256sum -c -) \
+        > "${WORK_DIR}/checksum-verify.log" 2>&1; then
+      operational "binary provenance and checksum verified on re-run after the install action failed; treating as a transient failure"
+    else
+      status=$?
+      cat "${WORK_DIR}/checksum-verify.log" >&2 || true
+      classify_failure "checksum verification of ${archive} for ${TAG}" "${WORK_DIR}/checksum-verify.log" "${status}"
+    fi`,
+			to: `    operational "binary provenance verified on re-run after the install action failed; treating as a transient failure"`,
+			opts: reverifyOptions{
+				installOutcome:    "failure",
+				checksumsManifest: "mismatch",
+				sigstoreReachable: true,
+			},
+			wantIntactTamper: true,
+		},
+		{
 			name: "removing the infrastructure-signature guard",
 			from: `  if infra_shaped "${log}"; then`,
 			to:   "if false; then",
@@ -738,16 +830,25 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 			opts := tc.opts
 			opts.tag = reverifySBOMFloor
 			if !opts.missingAssetsFile {
+				version := strings.TrimPrefix(reverifySBOMFloor, "v")
 				opts.assets = []string{
-					"aicr_0.18.0_linux_amd64.tar.gz",
+					"aicr_" + version + "_linux_amd64.tar.gz",
 					"aicr_checksums.txt",
 					"recipe-catalog.sigstore.json",
 				}
+				for _, binary := range strings.Fields(reverifyWorkflowEnv(t, "EXPECTED_SBOM_BINARIES")) {
+					opts.assets = append(opts.assets, binary+"_"+version+"_linux_amd64.sbom.json")
+				}
+			}
+
+			wantIntact, wantBroken := "operational", "tamper"
+			if tc.wantIntactTamper {
+				wantIntact, wantBroken = "tamper", "operational"
 			}
 
 			intact, _, output := runReverifyClassifier(t, script, opts)
-			if intact != "operational" {
-				t.Fatalf("intact classifier = %q, want operational for an infrastructure failure\n%s", intact, output)
+			if intact != wantIntact {
+				t.Fatalf("intact classifier = %q, want %s\n%s", intact, wantIntact, output)
 			}
 
 			if !strings.Contains(script, tc.from) {
@@ -755,9 +856,9 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 			}
 			mutated := strings.Replace(script, tc.from, tc.to, 1)
 			broken, _, brokenOutput := runReverifyClassifier(t, mutated, opts)
-			if broken != "tamper" {
-				t.Fatalf("classifier without %s = %q, want tamper — the guard is not load-bearing and this test proves nothing\n%s",
-					tc.name, broken, brokenOutput)
+			if broken != wantBroken {
+				t.Fatalf("classifier without %s = %q, want %s: the guard is not load-bearing and this test proves nothing\n%s",
+					tc.name, broken, wantBroken, brokenOutput)
 			}
 		})
 	}
@@ -793,13 +894,16 @@ func TestReleaseReverifySBOMLoopIsolatesChildStdin(t *testing.T) {
 
 	// A release above the SBOM signing floor, so the loop actually runs.
 	const version = "0.19.0"
-	// aicr and aicrd are the two binaries GoReleaser builds today; the third is
-	// a stand-in for any future binary, since the loop is generic over whatever
-	// SBOM assets the release publishes.
-	subjects := []string{
-		"aicr_" + version + "_linux_amd64.sbom.json",
-		"aicrd_" + version + "_linux_amd64.sbom.json",
-		"aicr-gate_" + version + "_linux_amd64.sbom.json",
+	// aicr and aicrd are the two binaries GoReleaser builds today; the third is a
+	// stand-in for any future binary, injected through the same env var the
+	// workflow derives its expected set from. Three subjects, not two: with two,
+	// an early-terminating loop and a loop that merely dropped the last entry are
+	// indistinguishable.
+	const binaries = "aicr aicrd aicr-gate"
+	names := strings.Fields(binaries)
+	subjects := make([]string, 0, len(names))
+	for _, binary := range names {
+		subjects = append(subjects, binary+"_"+version+"_linux_amd64.sbom.json")
 	}
 	assets := make([]string, 0, 3+2*len(subjects))
 	assets = append(assets,
@@ -823,12 +927,13 @@ func TestReleaseReverifySBOMLoopIsolatesChildStdin(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := reverifyOptions{
-				tag:               "v" + version,
-				assets:            assets,
-				installOutcome:    "success",
-				sigstoreReachable: true,
-				drainGHStdin:      tc.drainGHStdin,
-				drainCosignStdin:  tc.drainCosignStdin,
+				tag:                  "v" + version,
+				assets:               assets,
+				installOutcome:       "success",
+				sigstoreReachable:    true,
+				drainGHStdin:         tc.drainGHStdin,
+				drainCosignStdin:     tc.drainCosignStdin,
+				expectedSBOMBinaries: binaries,
 			}
 
 			class, code, output := runReverifyClassifier(t, script, opts)
@@ -939,6 +1044,85 @@ if [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then`
 	}
 	if strings.Contains(brokenOutput, "with no attestation bundle") {
 		t.Errorf("unguarded ordering unexpectedly still reported the missing bundle\n%s", brokenOutput)
+	}
+}
+
+// TestReleaseReverifyMandatorySBOMSetIsDerivedFromTheTag pins the one thing that
+// makes the SBOM check able to find a missing artifact at all.
+//
+// Derived from the RELEASE's own inventory, the loop only iterates what the
+// release already published, so the only detectable fault is a release with zero
+// SBOMs: delete one of the two mandatory subjects and the loop verifies the
+// survivor and reports clean. Deriving the expected set from the TAG, as
+// expected_release_asset_names() in .github/scripts/release-images.sh does, is
+// what turns a silently-missing mandatory artifact into a finding. This is the
+// same derive-from-the-artifact-under-test flaw that shipped the allowlist bug
+// in NVIDIA/aicr#1982.
+func TestReleaseReverifyMandatorySBOMSetIsDerivedFromTheTag(t *testing.T) {
+	script := reverifyClassifierScript(t)
+
+	derivation := "  read -r -a sbom_binaries <<< \"${EXPECTED_SBOM_BINARIES}\"\n" +
+		"  expected_sboms=\"\"\n" +
+		"  for binary in \"${sbom_binaries[@]}\"; do\n" +
+		"    expected_sboms+=\"${binary}_${version}_linux_amd64.sbom.json\"$'\\n'\n" +
+		"  done\n" +
+		"  expected_sboms=\"${expected_sboms%$'\\n'}\""
+	presence := "    if ! have_asset \"${sbom}\"; then\n" +
+		"      security \"release ${TAG} does not publish the mandatory SBOM ${sbom}\"\n" +
+		"    elif ! have_asset \"${bundle}\"; then"
+	for _, target := range []string{derivation, presence} {
+		if !strings.Contains(script, target) {
+			t.Fatalf("mutation target is no longer in the classifier:\n%s", target)
+		}
+	}
+	// Revert to the pre-fix shape: enumerate whatever the release shipped, and
+	// check only that each of those has a bundle.
+	inventoryDerived := "  expected_sboms=\"$(grep -E '_linux_amd64\\.sbom\\.json$' \"${RELEASE_ASSETS}\" || true)\""
+	mutated := strings.Replace(script, derivation, inventoryDerived, 1)
+	mutated = strings.Replace(mutated, presence, "    if ! have_asset \"${bundle}\"; then", 1)
+
+	const version = "0.19.0"
+	binaries := strings.Fields(reverifyWorkflowEnv(t, "EXPECTED_SBOM_BINARIES"))
+	if len(binaries) < 2 {
+		t.Fatalf("EXPECTED_SBOM_BINARIES = %v, want at least two mandatory subjects", binaries)
+	}
+	// A release that dropped the last mandatory subject and its bundle, but
+	// published every other one correctly.
+	dropped := binaries[len(binaries)-1] + "_" + version + "_linux_amd64.sbom.json"
+	assets := make([]string, 0, 3+2*(len(binaries)-1))
+	assets = append(assets,
+		"aicr_"+version+"_linux_amd64.tar.gz",
+		"aicr_checksums.txt",
+		"recipe-catalog.sigstore.json",
+	)
+	for _, binary := range binaries[:len(binaries)-1] {
+		subject := binary + "_" + version + "_linux_amd64.sbom.json"
+		assets = append(assets, subject, subject+".sigstore.json")
+	}
+	opts := reverifyOptions{
+		tag:               "v" + version,
+		assets:            assets,
+		installOutcome:    "success",
+		sigstoreReachable: true,
+	}
+
+	class, code, output := runReverifyClassifier(t, script, opts)
+	if class != "tamper" || code != 1 {
+		t.Fatalf("classification = %q (exit %d), want tamper (exit 1) for a missing mandatory SBOM\n%s", class, code, output)
+	}
+	if !strings.Contains(output, dropped) {
+		t.Errorf("the finding did not name the missing subject %q\n%s", dropped, output)
+	}
+
+	brokenClass, brokenCode, brokenOutput := runReverifyClassifier(t, mutated, opts)
+	if brokenClass == "tamper" {
+		t.Fatalf("the inventory-derived form still found it; the tag derivation is not load-bearing\n%s", brokenOutput)
+	}
+	if brokenClass != "clean" || brokenCode != 0 {
+		t.Errorf("inventory-derived form = %q (exit %d), want clean (exit 0): the miss is expected to be SILENT", brokenClass, brokenCode)
+	}
+	if strings.Contains(brokenOutput, dropped) {
+		t.Errorf("the inventory-derived form unexpectedly mentioned %q\n%s", dropped, brokenOutput)
 	}
 }
 
@@ -1071,7 +1255,7 @@ func runReverifyCloseStep(t *testing.T, script, tag string, issues []closableIss
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	command := exec.CommandContext(ctx, "bash", "-c", script)
+	command := exec.CommandContext(ctx, "bash", reverifyStepShell(t, root, script)...)
 	command.Dir = root
 	command.Env = append(os.Environ(),
 		"PATH="+bin+":"+os.Getenv("PATH"),
@@ -1152,6 +1336,10 @@ type reverifyOptions struct {
 	// sortFails makes the fake sort exit non-zero, breaking the SBOM floor
 	// ordering.
 	sortFails bool
+	// checksumsManifest stages aicr_checksums.txt next to the downloaded archive:
+	// "match" for the archive's real digest, "mismatch" for a manifest that no
+	// longer describes it. Empty stages none.
+	checksumsManifest string
 
 	cosignRC          int
 	cosignMessage     string
@@ -1174,6 +1362,39 @@ type reverifyOptions struct {
 	// sigstoreFailURL fails only the probe whose URL contains this substring,
 	// modeling a Fulcio-only or TUF-only outage.
 	sigstoreFailURL string
+	// expectedSBOMBinaries overrides EXPECTED_SBOM_BINARIES. Empty means the
+	// shipped workflow value, so cases bind to what production actually
+	// mandates unless they need a different subject count.
+	expectedSBOMBinaries string
+}
+
+// expectedSBOMBinaries resolves the SBOM subjects a case runs against, defaulting
+// to the shipped workflow value so a case exercises what production mandates.
+func expectedSBOMBinaries(t *testing.T, opts reverifyOptions) string {
+	t.Helper()
+	if opts.expectedSBOMBinaries != "" {
+		return opts.expectedSBOMBinaries
+	}
+	return reverifyWorkflowEnv(t, "EXPECTED_SBOM_BINARIES")
+}
+
+// reverifyStepShell stages an extracted `run:` block and returns the bash
+// arguments GitHub itself would use to invoke it.
+//
+// A step with no `shell:` key runs as `bash -e {0}` on the Actions runner: a
+// FILE, under errexit. Running it any other way (a plain `bash -c` with no -e,
+// which is what these tests used to do) tests semantics production does not
+// have, so an unguarded command added to the step would pass here and abort the
+// job in production. The classifier turns errexit off itself with an explicit
+// `set +e`; this harness is what proves the step does so rather than assuming
+// it. Keep in lockstep with GitHub's documented default shell.
+func reverifyStepShell(t *testing.T, dir, script string) []string {
+	t.Helper()
+	path := filepath.Join(dir, "step.sh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("stage extracted step: %v", err)
+	}
+	return []string{"-e", path}
 }
 
 // reverifyClassifierScript extracts the classifying step's shell from the
@@ -1211,6 +1432,7 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 	writeExecutable(t, filepath.Join(bin, "curl"), reverifyFakeCurl)
 	writeExecutable(t, filepath.Join(bin, "tar"), reverifyFakeTar)
 	writeExecutable(t, filepath.Join(bin, "sort"), reverifyFakeSort)
+	writeExecutable(t, filepath.Join(bin, "sha256sum"), reverifyFakeSha256Sum)
 	writeExecutable(t, filepath.Join(bin, "cosign"), reverifyFakeCosign)
 	writeExecutable(t, filepath.Join(bin, "gh"), reverifyFakeGH)
 	aicrBin := filepath.Join(bin, "aicr")
@@ -1254,12 +1476,16 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 		stageReleaseArchive(t, relDir, archiveName, !opts.omitAttestation)
 	}
 
+	if opts.checksumsManifest != "" {
+		stageChecksumsManifest(t, relDir, archiveName, opts.checksumsManifest)
+	}
+
 	outputs := filepath.Join(root, "outputs")
 	summary := filepath.Join(root, "summary.md")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	command := exec.CommandContext(ctx, "bash", "-c", script)
+	command := exec.CommandContext(ctx, "bash", reverifyStepShell(t, root, script)...)
 	command.Dir = root
 	command.Env = append(os.Environ(),
 		"PATH="+bin+":"+os.Getenv("PATH"),
@@ -1271,6 +1497,7 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 		"WORK_DIR="+workDir,
 		"AICR_BIN="+aicrBin,
 		"SBOM_SIGNING_FLOOR="+reverifySBOMFloor,
+		"EXPECTED_SBOM_BINARIES="+expectedSBOMBinaries(t, opts),
 		"SIGSTORE_PROBE_URLS=https://tuf.example.invalid/1.root.json https://fulcio.example.invalid/api/v2/trustBundle",
 		"GITHUB_OUTPUT="+outputs,
 		"GITHUB_STEP_SUMMARY="+summary,
@@ -1314,6 +1541,25 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 		t.Fatalf("read step outputs: %v", readErr)
 	}
 	return published, code, string(combined)
+}
+
+// stageChecksumsManifest writes the aicr_checksums.txt the install action leaves
+// beside the archive, either describing it correctly or not.
+func stageChecksumsManifest(t *testing.T, dir, archive, mode string) {
+	t.Helper()
+	digest := strings.Repeat("0", 64)
+	if mode == "match" {
+		data, err := os.ReadFile(filepath.Join(dir, archive))
+		if err != nil {
+			t.Fatalf("read archive for its digest: %v", err)
+		}
+		sum := sha256.Sum256(data)
+		digest = hex.EncodeToString(sum[:])
+	}
+	line := fmt.Sprintf("%s  %s\n", digest, archive)
+	if err := os.WriteFile(filepath.Join(dir, "aicr_checksums.txt"), []byte(line), 0o600); err != nil {
+		t.Fatalf("stage checksums manifest: %v", err)
+	}
 }
 
 // stageReleaseArchive builds a real gzipped tarball shaped like a released aicr
@@ -1442,6 +1688,46 @@ if [[ "${FAKE_SORT_FAILS:-false}" == "true" ]]; then
   exit 2
 fi
 exec "${FAKE_SORT_REAL}" "$@"
+`
+
+// reverifyFakeSha256Sum implements the `-c -` subset the step uses. GNU
+// coreutils ships sha256sum on the runner, but macOS provides only
+// `shasum -a 256`, so the fake keeps the harness host-independent rather than
+// letting a missing binary read as a checksum failure.
+const reverifyFakeSha256Sum = `#!/usr/bin/env bash
+set -uo pipefail
+if [[ "${1:-}" != "-c" ]]; then
+  echo "fake sha256sum only implements -c" >&2
+  exit 64
+fi
+digest_of() {
+  if command -v shasum > /dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    openssl dgst -sha256 "$1" | awk '{print $NF}'
+  fi
+}
+lines=0
+status=0
+while read -r expected name; do
+  [[ -n "${expected}" ]] || continue
+  lines=$((lines + 1))
+  actual="$(digest_of "${name}")"
+  if [[ "${actual}" == "${expected}" ]]; then
+    echo "${name}: OK"
+  else
+    echo "${name}: FAILED"
+    status=1
+  fi
+done
+if [[ "${lines}" -eq 0 ]]; then
+  echo "sha256sum: no properly formatted checksum lines found" >&2
+  exit 1
+fi
+if [[ "${status}" -ne 0 ]]; then
+  echo "sha256sum: WARNING: 1 computed checksum did NOT match" >&2
+fi
+exit "${status}"
 `
 
 // reverifyFakeGH materializes every --pattern into --dir, or fails the

--- a/tests/releasepolicy/release_reverify_test.go
+++ b/tests/releasepolicy/release_reverify_test.go
@@ -1,0 +1,730 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package releasepolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const reverifyWorkflow = ".github/workflows/release-reverify.yaml"
+
+// reverifySBOMFloor mirrors the workflow's SBOM_SIGNING_FLOOR env value and is
+// asserted against it, so raising the floor has to move this constant and with
+// it the below/above-floor cases below.
+const reverifySBOMFloor = "v0.18.0"
+
+// TestReleaseReverifyWorkflowShape locks the structural contract of the daily
+// re-verification workflow: how it is triggered, what it is allowed to do, that
+// it reuses the hardened install-aicr-release composite rather than
+// reimplementing binary verification, and that its two notification gates
+// partition every failure with the security side as a strict allowlist.
+func TestReleaseReverifyWorkflowShape(t *testing.T) {
+	doc := loadYAML(t, reverifyWorkflow)
+
+	triggers := mapValue(t, doc, "on")
+	schedule := sliceValue(t, triggers, "schedule")
+	if len(schedule) != 1 {
+		t.Fatalf("re-verification must run on exactly one cron, got %d", len(schedule))
+	}
+	cron := fmt.Sprint(schedule[0].(map[string]any)["cron"])
+	if fields := strings.Fields(cron); len(fields) != 5 || fields[2] != "*" || fields[4] != "*" {
+		t.Errorf("cron %q must be a daily schedule", cron)
+	}
+	// GitHub disables scheduled workflows after 60 days of repository
+	// inactivity; workflow_dispatch is how a maintainer re-arms it.
+	if _, ok := triggers["workflow_dispatch"]; !ok {
+		t.Error("re-verification must be dispatchable so the schedule can be re-armed on demand")
+	}
+
+	if permissions, ok := doc["permissions"].(map[string]any); !ok || len(permissions) != 0 {
+		t.Errorf("workflow permissions = %v, want an empty fail-closed default", doc["permissions"])
+	}
+	assertConcurrency(t, doc, "release-reverify")
+
+	job := mapValue(t, mapValue(t, doc, "jobs"), "reverify")
+	assertPermissions(t, job, map[string]string{
+		"contents": "read",
+		"actions":  "read",
+		"issues":   "write",
+	})
+	if _, ok := job["timeout-minutes"]; !ok {
+		t.Error("the re-verification job must have an explicit timeout")
+	}
+
+	env := mapValue(t, doc, "env")
+	if got := fmt.Sprint(env["SBOM_SIGNING_FLOOR"]); got != reverifySBOMFloor {
+		t.Fatalf("SBOM_SIGNING_FLOOR = %q, want %q", got, reverifySBOMFloor)
+	}
+
+	steps := sliceValue(t, job, "steps")
+
+	resolve := stepIndex(steps, "Resolve the latest release")
+	if resolve < 0 {
+		t.Fatal("re-verification must resolve the latest release rather than hardcode a tag")
+	}
+	resolveScript := stringValue(t, steps[resolve].(map[string]any), "run")
+	for _, required := range []string{
+		"gh-api-retry.sh",            // the shared bounded-retry helper, not a bare gh api
+		"releases/latest",            // resolved, never hardcoded
+		"GITHUB_STEP_SUMMARY",        // the resolved tag is visible in the job output
+		"tag=${tag}",                 // and exported for the verification steps
+		"^v[0-9]+\\.[0-9]+\\.[0-9]+", // validated before it reaches a regexp
+	} {
+		if !strings.Contains(resolveScript, required) {
+			t.Errorf("release resolution missing %q", required)
+		}
+	}
+
+	install := stepIndex(steps, "Verify the released aicr binary provenance")
+	if install < 0 {
+		t.Fatal("re-verification must verify the released binary's provenance")
+	}
+	installStep := steps[install].(map[string]any)
+	if got := fmt.Sprint(installStep["uses"]); got != "./.github/actions/install-aicr-release" {
+		t.Errorf("binary verification uses %q, want the hardened install-aicr-release composite", got)
+	}
+	if enabled, ok := installStep["continue-on-error"].(bool); !ok || !enabled {
+		t.Error("the install step must hand its outcome to the classifier instead of ending the job unclassified")
+	}
+	with := mapValue(t, installStep, "with")
+	if got := fmt.Sprint(with["aicr-version"]); got != "${{ steps.release.outputs.tag }}" {
+		t.Errorf("install aicr-version = %q, want the resolved tag", got)
+	}
+	if got := fmt.Sprint(with["cosign_version"]); got != "${{ steps.versions.outputs.cosign }}" {
+		t.Errorf("install cosign_version = %q, want the pinned .settings.yaml version", got)
+	}
+
+	verify := stepIndex(steps, "Re-verify release artifacts and classify")
+	if verify < 0 {
+		t.Fatal("re-verification must classify its outcome")
+	}
+	verifyScript := stringValue(t, steps[verify].(map[string]any), "run")
+	for _, required := range []string{
+		"CLASSIFICATION=${classification}", // same machine-readable line as tools/rekor-monitor
+		"classification=${classification}", // and the step output the gates branch on
+		"timeout --foreground",             // every network call is bounded
+		"recipe verify-catalog",            // the shipped catalog verification command
+		"cosign verify-blob-attestation",   // the shipped blob attestation command
+		"sigstore_reachable",               // guard #1
+		"infra_shaped",                     // guard #2
+	} {
+		if !strings.Contains(verifyScript, required) {
+			t.Errorf("classifier missing %q", required)
+		}
+	}
+	// Exit codes mirror tools/rekor-monitor: 0 clean, 1 security, 3 operational.
+	for _, mapping := range []string{"clean) exit 0", "tamper) exit 1", "*) exit 3"} {
+		if !strings.Contains(verifyScript, mapping) {
+			t.Errorf("classifier missing the rekor-monitor exit mapping %q", mapping)
+		}
+	}
+
+	alert := stepIndex(steps, "Open security alert issue")
+	degraded := stepIndex(steps, "Open degraded issue if a non-security failure is persistent")
+	closer := stepIndex(steps, "Close open issues on success")
+	if alert < 0 || degraded < 0 || closer < 0 {
+		t.Fatal("re-verification must open, de-duplicate, and auto-close both issue kinds")
+	}
+	alertGate := fmt.Sprint(steps[alert].(map[string]any)["if"])
+	degradedGate := fmt.Sprint(steps[degraded].(map[string]any)["if"])
+	// The security gate is a strict allowlist on one value and the operational
+	// gate is its exact inverse, so an EMPTY classification (a step before the
+	// classifier failed) can only ever land on the operational side.
+	if !strings.Contains(alertGate, "steps.verify.outputs.classification == 'tamper'") {
+		t.Errorf("security gate = %q, want an allowlist on the tamper classification", alertGate)
+	}
+	if !strings.Contains(degradedGate, "steps.verify.outputs.classification != 'tamper'") {
+		t.Errorf("operational gate = %q, want the exact inverse of the security gate", degradedGate)
+	}
+	alertText := marshalYAML(t, steps[alert])
+	if !strings.Contains(alertText, "select(.title == $t)") {
+		t.Error("the security issue must de-duplicate on an exact title match")
+	}
+	degradedText := marshalYAML(t, steps[degraded])
+	if !strings.Contains(degradedText, `index("success") // length`) {
+		t.Error("the degraded issue must escalate on a consecutive-failure streak, not a failure count")
+	}
+	if !strings.Contains(degradedText, "workflows/release-reverify.yaml/runs") {
+		t.Error("the streak query must read this workflow's own run history")
+	}
+
+	// Repo convention: no ${{ }} interpolation inside run: blocks. Every value a
+	// script consumes arrives through env, so a tag or title can never be
+	// spliced into shell source.
+	for _, raw := range steps {
+		step := raw.(map[string]any)
+		script, ok := step["run"].(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(script, "${{") {
+			t.Errorf("step %v interpolates an expression inside run:; use env indirection", step["name"])
+		}
+	}
+}
+
+// TestReleaseReverifyClassification is the behavioral half: it extracts the
+// classifier and runs it under bash against fake gh/cosign/curl/aicr binaries.
+//
+// The property under test is asymmetric and is the whole point of the workflow.
+// A *missing* artifact must be a security finding; Sigstore, GitHub-API and
+// network trouble must be operational and must never look like a missing entry.
+// Every case here is one side of that line.
+func TestReleaseReverifyClassification(t *testing.T) {
+	script := reverifyClassifierScript(t)
+
+	aboveFloor := "v0.19.0"
+	assetsFor := func(version string, extra ...string) []string {
+		base := make([]string, 0, 3+len(extra))
+		base = append(base,
+			"aicr_"+version+"_linux_amd64.tar.gz",
+			"aicr_checksums.txt",
+			"recipe-catalog.sigstore.json",
+		)
+		return append(base, extra...)
+	}
+	signedSBOMAssets := func(version string) []string {
+		return assetsFor(version,
+			"aicr_"+version+"_linux_amd64.sbom.json",
+			"aicr_"+version+"_linux_amd64.sbom.json.sigstore.json",
+		)
+	}
+
+	tests := []struct {
+		name string
+		opts reverifyOptions
+		want string
+		code int
+	}{
+		{
+			name: "a complete release verifies clean",
+			opts: reverifyOptions{
+				tag:            reverifySBOMFloor,
+				assets:         assetsFor(strings.TrimPrefix(reverifySBOMFloor, "v")),
+				installOutcome: "success",
+			},
+			want: "clean",
+			code: 0,
+		},
+		{
+			name: "a release above the floor with signed SBOMs verifies clean",
+			opts: reverifyOptions{
+				tag:            aboveFloor,
+				assets:         signedSBOMAssets(strings.TrimPrefix(aboveFloor, "v")),
+				installOutcome: "success",
+			},
+			want: "clean",
+			code: 0,
+		},
+
+		// --- security: positive evidence that a published artifact is absent ---
+		{
+			name: "a missing catalog signature is a security finding",
+			opts: reverifyOptions{
+				tag: reverifySBOMFloor,
+				assets: []string{
+					"aicr_0.18.0_linux_amd64.tar.gz",
+					"aicr_checksums.txt",
+				},
+				installOutcome: "success",
+			},
+			want: "tamper",
+			code: 1,
+		},
+		{
+			name: "a missing binary archive is a security finding",
+			opts: reverifyOptions{
+				tag:            reverifySBOMFloor,
+				assets:         []string{"aicr_checksums.txt", "recipe-catalog.sigstore.json"},
+				installOutcome: "failure",
+				noArchiveFile:  true,
+			},
+			want: "tamper",
+			code: 1,
+		},
+		{
+			name: "an archive shipped without its attestation bundle is a security finding",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				omitAttestation:   true,
+				sigstoreReachable: true,
+			},
+			want: "tamper",
+			code: 1,
+		},
+		{
+			name: "an SBOM published without its attestation bundle is a security finding",
+			opts: reverifyOptions{
+				tag:            aboveFloor,
+				assets:         assetsFor("0.19.0", "aicr_0.19.0_linux_amd64.sbom.json"),
+				installOutcome: "success",
+			},
+			want: "tamper",
+			code: 1,
+		},
+		{
+			name: "a release above the floor with no SBOM assets at all is a security finding",
+			opts: reverifyOptions{
+				tag:            aboveFloor,
+				assets:         assetsFor("0.19.0"),
+				installOutcome: "success",
+			},
+			want: "tamper",
+			code: 1,
+		},
+		{
+			name: "a signature that fails against a reachable Sigstore is a security finding",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          1,
+				cosignMessage:     "Error: no matching signatures found for the given identity",
+				sigstoreReachable: true,
+			},
+			want: "tamper",
+			code: 1,
+		},
+		{
+			name: "a catalog digest mismatch is a security finding",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "success",
+				aicrRC:            1,
+				aicrMessage:       "Error: recomputed catalog digest does not match the signed subject",
+				sigstoreReachable: true,
+			},
+			want: "tamper",
+			code: 1,
+		},
+
+		// --- operational: infrastructure must never look like a missing entry ---
+		{
+			name: "an unreachable Sigstore demotes a failed verification to operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          1,
+				cosignMessage:     "Error: no matching signatures found for the given identity",
+				sigstoreReachable: false,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			name: "a Rekor outage in the failure output demotes to operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          1,
+				cosignMessage:     "Error: uploading to rekor: POST https://rekor.sigstore.dev: status 503 service unavailable",
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			name: "a TUF trusted-root fetch failure demotes to operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				cosignRC:          1,
+				cosignMessage:     "Error: initializing trusted root: could not fetch metadata",
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			name: "a network timeout during catalog verification is operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "success",
+				aicrRC:            1,
+				aicrMessage:       "Error: verifying catalog: dial tcp 34.1.2.3:443: i/o timeout",
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			name: "a failed release-asset download is operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "success",
+				ghRC:              1,
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			name: "a corrupt archive download is operational, not a missing attestation",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				corruptArchive:    true,
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+		{
+			name: "a transient install failure that re-verifies is operational",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            assetsFor("0.18.0"),
+				installOutcome:    "failure",
+				sigstoreReachable: true,
+			},
+			want: "operational",
+			code: 3,
+		},
+
+		// --- precedence: a real finding is never masked by a concurrent outage ---
+		{
+			name: "a missing asset still pages when the network is also down",
+			opts: reverifyOptions{
+				tag:               reverifySBOMFloor,
+				assets:            []string{"aicr_0.18.0_linux_amd64.tar.gz", "aicr_checksums.txt"},
+				installOutcome:    "failure",
+				noArchiveFile:     true,
+				ghRC:              1,
+				sigstoreReachable: false,
+			},
+			want: "tamper",
+			code: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, code, output := runReverifyClassifier(t, script, tc.opts)
+			if got != tc.want || code != tc.code {
+				t.Fatalf("classification = %q (exit %d), want %q (exit %d)\n%s", got, code, tc.want, tc.code, output)
+			}
+			if !strings.Contains(output, "CLASSIFICATION="+tc.want) {
+				t.Errorf("classifier did not print the machine-readable CLASSIFICATION line\n%s", output)
+			}
+		})
+	}
+}
+
+// TestReleaseReverifyGuardsAreLoadBearing proves the classification logic is
+// what produces the operational verdicts above, rather than the fakes happening
+// to agree with the expectations. Each mutation removes exactly one guard from
+// the extracted script and asserts that an infrastructure failure then
+// misclassifies as a security finding — which is the failure mode this workflow
+// exists to prevent, so the tests must not pass without the guards.
+func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
+	script := reverifyClassifierScript(t)
+
+	tests := []struct {
+		name string
+		from string
+		to   string
+		opts reverifyOptions
+	}{
+		{
+			name: "removing the Sigstore reachability guard",
+			from: "if ! sigstore_reachable; then",
+			to:   "if false; then",
+			opts: reverifyOptions{
+				installOutcome: "failure",
+				cosignRC:       1,
+				cosignMessage:  "Error: no matching signatures found for the given identity",
+				// Sigstore is DOWN, so the intact script must say operational.
+				sigstoreReachable: false,
+			},
+		},
+		{
+			name: "removing the infrastructure-signature guard",
+			from: `if infra_shaped "$2"; then`,
+			to:   "if false; then",
+			opts: reverifyOptions{
+				installOutcome: "failure",
+				cosignRC:       1,
+				// A textbook upstream outage, so the intact script must say operational.
+				cosignMessage:     "Error: fetching bundle: status 503 service unavailable",
+				sigstoreReachable: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.opts
+			opts.tag = reverifySBOMFloor
+			opts.assets = []string{
+				"aicr_0.18.0_linux_amd64.tar.gz",
+				"aicr_checksums.txt",
+				"recipe-catalog.sigstore.json",
+			}
+
+			intact, _, output := runReverifyClassifier(t, script, opts)
+			if intact != "operational" {
+				t.Fatalf("intact classifier = %q, want operational for an infrastructure failure\n%s", intact, output)
+			}
+
+			if !strings.Contains(script, tc.from) {
+				t.Fatalf("mutation target %q is no longer in the classifier", tc.from)
+			}
+			mutated := strings.Replace(script, tc.from, tc.to, 1)
+			broken, _, brokenOutput := runReverifyClassifier(t, mutated, opts)
+			if broken != "tamper" {
+				t.Fatalf("classifier without %s = %q, want tamper — the guard is not load-bearing and this test proves nothing\n%s",
+					tc.name, broken, brokenOutput)
+			}
+		})
+	}
+}
+
+// reverifyOptions describes one simulated release and the behavior of the
+// binaries the classifier shells out to.
+type reverifyOptions struct {
+	tag    string
+	assets []string
+	// installOutcome is what the install-aicr-release composite reported.
+	installOutcome string
+	// noArchiveFile omits the downloaded archive entirely (a failed download).
+	noArchiveFile bool
+	// omitAttestation ships an archive with no aicr-attestation.sigstore.json.
+	omitAttestation bool
+	// corruptArchive stages bytes that are not a tarball (a truncated download).
+	corruptArchive bool
+
+	cosignRC          int
+	cosignMessage     string
+	aicrRC            int
+	aicrMessage       string
+	ghRC              int
+	sigstoreReachable bool
+}
+
+// reverifyClassifierScript extracts the classifying step's shell from the
+// workflow so the test executes the shipped source, not a copy of it.
+func reverifyClassifierScript(t *testing.T) string {
+	t.Helper()
+	doc := loadYAML(t, reverifyWorkflow)
+	job := mapValue(t, mapValue(t, doc, "jobs"), "reverify")
+	steps := sliceValue(t, job, "steps")
+	index := stepIndex(steps, "Re-verify release artifacts and classify")
+	if index < 0 {
+		t.Fatal("re-verification must have a classifying step")
+	}
+	return stringValue(t, steps[index].(map[string]any), "run")
+}
+
+// runReverifyClassifier stages a fake release plus fake gh/cosign/curl/aicr
+// binaries, runs the extracted classifier, and returns the classification it
+// published, its exit status, and the combined output.
+func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (string, int, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	relDir := filepath.Join(root, "_rel")
+	workDir := filepath.Join(root, "_reverify")
+	for _, dir := range []string{bin, relDir, workDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+
+	writeExecutable(t, filepath.Join(bin, "timeout"), passthroughTimeout)
+	writeExecutable(t, filepath.Join(bin, "sleep"), reverifyFakeSleep)
+	writeExecutable(t, filepath.Join(bin, "curl"), reverifyFakeCurl)
+	writeExecutable(t, filepath.Join(bin, "cosign"), reverifyFakeCosign)
+	writeExecutable(t, filepath.Join(bin, "gh"), reverifyFakeGH)
+	aicrBin := filepath.Join(bin, "aicr")
+	writeExecutable(t, aicrBin, reverifyFakeAicr)
+
+	assetsFile := filepath.Join(root, "release-assets.txt")
+	contents := ""
+	if len(opts.assets) > 0 {
+		contents = strings.Join(opts.assets, "\n") + "\n"
+	}
+	if err := os.WriteFile(assetsFile, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write asset inventory: %v", err)
+	}
+
+	archiveName := "aicr_" + strings.TrimPrefix(opts.tag, "v") + "_linux_amd64.tar.gz"
+	switch {
+	case opts.noArchiveFile:
+	case opts.corruptArchive:
+		if err := os.WriteFile(filepath.Join(relDir, archiveName), []byte("not a tarball"), 0o600); err != nil {
+			t.Fatalf("stage corrupt archive: %v", err)
+		}
+	default:
+		stageReleaseArchive(t, relDir, archiveName, !opts.omitAttestation)
+	}
+
+	outputs := filepath.Join(root, "outputs")
+	summary := filepath.Join(root, "summary.md")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "bash", "-c", script)
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"REPO=NVIDIA/aicr",
+		"TAG="+opts.tag,
+		"RELEASE_ASSETS="+assetsFile,
+		"INSTALL_OUTCOME="+opts.installOutcome,
+		"REL_DIR="+relDir,
+		"WORK_DIR="+workDir,
+		"AICR_BIN="+aicrBin,
+		"SBOM_SIGNING_FLOOR="+reverifySBOMFloor,
+		"SIGSTORE_PROBE_URL=https://tuf-repo-cdn.example.invalid/1.root.json",
+		"GITHUB_OUTPUT="+outputs,
+		"GITHUB_STEP_SUMMARY="+summary,
+		"GH_TOKEN=fake",
+		fmt.Sprintf("FAKE_SIGSTORE_REACHABLE=%t", opts.sigstoreReachable),
+		fmt.Sprintf("FAKE_COSIGN_RC=%d", opts.cosignRC),
+		"FAKE_COSIGN_MESSAGE="+opts.cosignMessage,
+		fmt.Sprintf("FAKE_AICR_RC=%d", opts.aicrRC),
+		"FAKE_AICR_MESSAGE="+opts.aicrMessage,
+		fmt.Sprintf("FAKE_GH_RC=%d", opts.ghRC),
+	)
+	combined, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("classifier exceeded the test deadline: %v\n%s", ctx.Err(), combined)
+	}
+	code := 0
+	if err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("run classifier: %v\n%s", err, combined)
+		}
+		code = exit.ExitCode()
+	}
+
+	published := ""
+	if data, readErr := os.ReadFile(outputs); readErr == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if rest, found := strings.CutPrefix(line, "classification="); found {
+				published = rest
+			}
+		}
+	} else if !os.IsNotExist(readErr) {
+		t.Fatalf("read step outputs: %v", readErr)
+	}
+	return published, code, string(combined)
+}
+
+// stageReleaseArchive builds a real gzipped tarball shaped like a released aicr
+// archive, so the classifier's `tar -tzf` presence check runs against real tar
+// output rather than a stub.
+func stageReleaseArchive(t *testing.T, dir, name string, withAttestation bool) {
+	t.Helper()
+	staging := t.TempDir()
+	members := []string{"aicr"}
+	if err := os.WriteFile(filepath.Join(staging, "aicr"), []byte("#!/bin/true\n"), 0o700); err != nil {
+		t.Fatalf("stage binary: %v", err)
+	}
+	if withAttestation {
+		members = append(members, "aicr-attestation.sigstore.json")
+		if err := os.WriteFile(filepath.Join(staging, "aicr-attestation.sigstore.json"), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("stage attestation: %v", err)
+		}
+	}
+	arguments := append([]string{"-czf", filepath.Join(dir, name), "-C", staging}, members...)
+	if output, err := exec.Command("tar", arguments...).CombinedOutput(); err != nil {
+		t.Fatalf("build release archive: %v\n%s", err, output)
+	}
+}
+
+// reverifyFakeSleep keeps the reachability retry loop's backoff off the test clock. The
+// bounds themselves are asserted against the step's source text.
+const reverifyFakeSleep = `#!/usr/bin/env bash
+exit 0
+`
+
+// reverifyFakeCurl stands in for the curl liveness probe against Sigstore's
+// TUF CDN, reproducing curl's exit 7 when the host does not answer.
+const reverifyFakeCurl = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FAKE_SIGSTORE_REACHABLE:-true}" == "true" ]]; then
+  exit 0
+fi
+echo "curl: (7) Failed to connect to tuf-repo-cdn.sigstore.dev port 443" >&2
+exit 7
+`
+
+// reverifyFakeCosign answers verify-blob-attestation from FAKE_COSIGN_RC, emitting the
+// caller-supplied failure text so the infrastructure-signature guard has real
+// cosign-shaped output to read.
+const reverifyFakeCosign = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FAKE_COSIGN_RC:-0}" == "0" ]]; then
+  echo "Verified OK"
+  exit 0
+fi
+printf '%s\n' "${FAKE_COSIGN_MESSAGE:-Error: verification failed}" >&2
+exit "${FAKE_COSIGN_RC}"
+`
+
+// reverifyFakeAicr answers `aicr recipe verify-catalog` from FAKE_AICR_RC.
+const reverifyFakeAicr = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FAKE_AICR_RC:-0}" == "0" ]]; then
+  echo "catalog verified"
+  exit 0
+fi
+printf '%s\n' "${FAKE_AICR_MESSAGE:-Error: catalog verification failed}" >&2
+exit "${FAKE_AICR_RC}"
+`
+
+// reverifyFakeGH materializes every --pattern into --dir, or fails the
+// whole download when FAKE_GH_RC is set (a GitHub API / transport failure).
+const reverifyFakeGH = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FAKE_GH_RC:-0}" != "0" ]]; then
+  echo "gh: HTTP 503 (https://api.github.com)" >&2
+  exit "${FAKE_GH_RC}"
+fi
+dir="."
+patterns=()
+previous=""
+for argument in "$@"; do
+  case "${previous}" in
+    --dir) dir="${argument}" ;;
+    --pattern) patterns+=("${argument}") ;;
+  esac
+  previous="${argument}"
+done
+mkdir -p "${dir}"
+for pattern in "${patterns[@]}"; do
+  printf 'fake release asset: %s\n' "${pattern}" > "${dir}/${pattern}"
+done
+`

--- a/tests/releasepolicy/release_workflow_test.go
+++ b/tests/releasepolicy/release_workflow_test.go
@@ -1167,6 +1167,7 @@ func TestReleaseRunnableJobsHaveTimeouts(t *testing.T) {
 		".github/workflows/attest-images.yaml",
 		".github/workflows/build-attested.yaml",
 		".github/workflows/packaging.yaml",
+		".github/workflows/release-reverify.yaml",
 	} {
 		doc := loadYAML(t, path)
 		for name, raw := range mapValue(t, doc, "jobs") {


### PR DESCRIPTION
## Summary

Adds a daily scheduled workflow that re-runs AICR's shipped verification commands against the latest release, so an artifact that shipped without a live, retrievable Rekor entry is detected rather than discovered by a user.

## Motivation / Context

A signing-side upload can silently fail or be skipped, leaving a released artifact whose attestation cannot be verified. That is distinct from transparency-log soundness and is not covered by `rekor-monitor`, which watches the log rather than our published assets.

Fixes: #1461
Related: #1149, #1460, #1897

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: CI (`.github/workflows/`, `tests/releasepolicy`)

## Implementation Notes

**Almost entirely assembly, per the issue's "near-zero new code".** `.github/actions/install-aicr-release` already downloads the release archive, checks it against `aicr_checksums.txt`, extracts `aicr-attestation.sigstore.json`, and runs `cosign verify-blob-attestation` pinned to `on-tag.yaml@refs/tags/<exact tag>` with retries, failing closed when the bundle is missing. It is reused directly and leaves a verified `./aicr` that the catalog check then uses. Release resolution reuses `.github/scripts/gh-api-retry.sh`, the cosign pin comes from `load-versions`, and the issue-filing, de-duplication, streak and auto-close steps are taken from `rekor-monitor.yaml`. The only genuinely new logic is the classifier.

**What is verified:** the binary provenance bundle; `recipe-catalog.sigstore.json` via `aicr recipe verify-catalog`, run with the binary just verified and against the loose release asset (the copy `cli-reference.md` tells users to curl); and each `*_linux_amd64.sbom.json` against its `.sigstore.json` sibling.

**What is deliberately not verified**, with the reason recorded in the workflow header and in `maintaining.md`:
- Bundle attestations. No bundle is a release asset; bundles are produced on demand by `aicr bundle --attest`, so there is nothing released to check and no step was fabricated.
- `aicrd`. Confirmed not archived (`archives.ids: [aicr]`), so no `aicrd` tarball or attestation is a release asset. Its SBOM is, and is covered.
- Image OCI referrers from #1982. Different retention and GC model from GitHub Releases, and 7 images times 3 predicate kinds is roughly 21 registry round-trips per run, which would dilute the one signal this job keeps crisp. Images are already pulled weekly by `vuln-scan-images.yaml`. Recorded as a follow-up, with the requirement that any registry-side check must use `gh attestation verify --bundle-from-oci`, since the default form reads GitHub's attestations API and proves nothing about the registry copy.

**Infra noise must not page.** This is the central design constraint, and it reuses `rekor-monitor`'s vocabulary rather than inventing a parallel one: `clean`/0, `tamper`/1 (security), `operational`/3. The security gate is a strict allowlist (`== 'tamper'`) and the degraded gate its exact inverse, so an empty classification (any failure before the classifier runs) lands on the operational side by construction. `tamper` is asserted only on positive evidence: an artifact absent from the release's own asset inventory (an API read that either succeeded or aborted the step), or a cryptographic failure that survives two independent guards, a live TUF reachability probe and a transport-signature check on the captured failure text. Both guards are demote-only, so the worst case is a real finding reported as operational, which is still a red job that escalates after three consecutive failures and re-fires the next day. Never the reverse.

**One latent false-page found and fixed while building this:** the attestation presence check was `tar -tzf … | grep -q`, which under `pipefail` can SIGPIPE `tar` and turn a *present* attestation into a non-zero pipeline. It now lists to a file and greps the file, and an unlistable tarball classifies as `operational` rather than as a finding.

**SBOM signature checks are gated on a `v0.18.0` floor.** SBOM signing landed in #1957, after that release, and the current latest ships SBOMs with no signatures. Requiring them unconditionally would false-page today; from the next release a missing bundle is a finding. Both sides of the floor are covered by tests.

## Testing

```bash
go test ./tests/releasepolicy/...
make lint
actionlint -shellcheck=
```

22 subtests across `TestReleaseReverifyWorkflowShape`, `TestReleaseReverifyClassification`, and `TestReleaseReverifyGuardsAreLoadBearing`, executing the step's real `run:` under bash with fakes for `gh`, `cosign`, `curl`, `aicr` and `sleep`, and a real `tar -czf` archive. Coverage includes a clean pass, each missing-artifact case, Sigstore and Rekor outages, a TUF failure, a network timeout, and the case where a genuine finding coincides with an outage (which must still page).

`TestReleaseReverifyGuardsAreLoadBearing` mutates the extracted script in memory (each guard to `if false`) and asserts the intact script classifies `operational` while the mutated one classifies `tamper`, so the suite cannot pass if a guard silently stops being load-bearing.

Test delta: `tests/releasepolicy` fails the same 13 tests as unmodified `main` (`comm` of the two failure sets is empty in both directions), all from the missing GNU `timeout` on macOS. With a passthrough `timeout` shim the full package passes. `golangci-lint` reports 0 issues; `actionlint -shellcheck=` is clean.

**Also run against live services, not only fakes.** `workflow_dispatch` cannot be triggered before merge (GitHub requires the workflow file on the default branch), so both `run:` blocks were extracted verbatim and executed locally against the real GitHub API, the real `v0.18.0` release, live Rekor and live Sigstore:

- **Resolve step:** resolved `v0.18.0`, 13 assets, correct step summary.
- **Happy path:** asset-presence checks passed, `binary provenance verified for v0.18.0`, `catalog verified` with identity `on-tag.yaml@refs/tags/v0.18.0`, SBOM checks correctly skipped at the floor. `CLASSIFICATION=clean`, exit 0.
- **Missing artifact:** with `recipe-catalog.sigstore.json` removed from the inventory, `::error::release v0.18.0 does not publish recipe-catalog.sigstore.json`, `CLASSIFICATION=tamper`, exit 1.
- **Infrastructure failure:** with Sigstore unreachable and the download failing, `::warning::the released archive never downloaded; treating as infrastructure`, `CLASSIFICATION=operational`, exit 3.

The last two are the properties this job lives or dies on: a genuinely missing artifact pages, an outage does not. Both are now confirmed against real tooling rather than inferred from fake-based tests.

Separately, the live run confirms the `SBOM_SIGNING_FLOOR` is load-bearing rather than defensive: `v0.18.0` publishes six SPDX documents and zero `.sigstore.json` siblings, so without the floor this job would have paged on its first scheduled run.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Additive, observe-only. It reads releases and verifies published artifacts; it publishes nothing and changes no release path. Worst case on a bug is a spurious issue, and the classification design biases toward under-reporting rather than false-paging. The verification logic and both classification outcomes have been run against live GitHub, Rekor and Sigstore (see Testing). What remains unexercised is only the Actions plumbing around them: the composite-action invocation, the `steps.*.outcome` wiring, and the issue create/close/streak steps (same code as `rekor-monitor`, asserted structurally here), plus the three-consecutive-failure escalation, which needs three real runs. Running `gh workflow run release-reverify.yaml` immediately after merge exercises the first three.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

