### PR TITLE
fix(evidence): bound on-disk bundle reads with FileReadTimeout ctx

### DIFF
--- a/pkg/evidence/attestation/publish.go
+++ b/pkg/evidence/attestation/publish.go
@@ -93,7 +93,7 @@ func Publish(ctx context.Context, opts PublishOptions) error {
 		return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid push reference", err)
 	}
 
-	bundle, outDir, err := loadOnDiskBundle(opts.BundleDir)
+	bundle, outDir, err := loadOnDiskBundle(ctx, opts.BundleDir)
 	if err != nil {
 		return err
 	}
@@ -143,15 +143,15 @@ func Publish(ctx context.Context, opts PublishOptions) error {
 // unsigned in-toto Statement. The predicate is trusted as-is — Publish
 // signs the pre-built bundle bytes verbatim; integrity auditing is the
 // job of `aicr evidence verify`.
-func loadOnDiskBundle(dir string) (*Bundle, string, error) {
+func loadOnDiskBundle(ctx context.Context, dir string) (*Bundle, string, error) {
 	if dir == "" {
 		return nil, "", errors.New(errors.ErrCodeInvalidRequest, "bundle directory is required")
 	}
-	summaryDir, outDir, err := resolveSummaryDir(dir)
+	summaryDir, outDir, err := resolveSummaryDir(ctx, dir)
 	if err != nil {
 		return nil, "", err
 	}
-	pred, stmt, err := readBundlePredicate(summaryDir)
+	pred, stmt, err := readBundlePredicate(ctx, summaryDir)
 	if err != nil {
 		return nil, "", err
 	}
@@ -159,7 +159,7 @@ func loadOnDiskBundle(dir string) (*Bundle, string, error) {
 		return nil, "", errors.New(errors.ErrCodeInvalidRequest,
 			"bundle statement predicate is missing recipe.{name,digest}")
 	}
-	profile, advertiser, descriptorIdentity, err := readBundleRecipeProfile(summaryDir)
+	profile, advertiser, descriptorIdentity, err := readBundleRecipeProfile(ctx, summaryDir)
 	if err != nil {
 		return nil, "", err
 	}
@@ -184,6 +184,40 @@ func loadOnDiskBundle(dir string) (*Bundle, string, error) {
 	return bundle, outDir, nil
 }
 
+// withFileReadTimeout runs fn — a blocking local-filesystem syscall (os.Open /
+// io.ReadAll / os.Stat) — under a FileReadTimeout-bounded derivative of ctx,
+// returning fn's own error, or an ErrCodeTimeout error if the bound elapses
+// first. It exists because a bare os.Open/os.Stat against a hung NFS/FUSE mount
+// blocks in the syscall indefinitely: no downstream sign/push timeout can
+// unblock it, so the read itself must be time-bounded to surface a dead mount
+// as a timeout rather than an indefinite hang.
+//
+// fn runs in a goroutine so the caller unblocks the instant ctx expires. The
+// accepted tradeoff: on timeout the parked goroutine stays blocked in the
+// syscall until the kernel returns or the process exits — fine for a
+// short-lived CLI leaf command (evidence publish/sign), which is the only
+// caller of these bundle readers.
+func withFileReadTimeout(ctx context.Context, what string, fn func() error) error {
+	ctx, cancel := context.WithTimeout(ctx, defaults.FileReadTimeout)
+	defer cancel()
+	// Fail closed and deterministically if the caller's context is already
+	// canceled/expired, before launching the goroutine — otherwise a fast
+	// syscall could win the select race against an already-done context.
+	if err := ctx.Err(); err != nil {
+		return errors.WrapWithContext(errors.ErrCodeTimeout, "timed out reading "+what, err,
+			map[string]interface{}{"timeout": defaults.FileReadTimeout.String()})
+	}
+	done := make(chan error, 1) // buffered so the goroutine never leaks on timeout
+	go func() { done <- fn() }()
+	select {
+	case <-ctx.Done():
+		return errors.WrapWithContext(errors.ErrCodeTimeout, "timed out reading "+what, ctx.Err(),
+			map[string]interface{}{"timeout": defaults.FileReadTimeout.String()})
+	case err := <-done:
+		return err
+	}
+}
+
 // readBundleRecipeProfile decodes the summary bundle's recipe.yaml and
 // returns the canonical name=value selection it carries, its declared
 // advertiser, and the recipe-scoped policy-descriptor identity recomputed
@@ -194,17 +228,25 @@ func loadOnDiskBundle(dir string) (*Bundle, string, error) {
 // carries only the (suffixed) recipe name. The read is size-bounded like
 // readBundlePredicate: the publish target may be an attacker-influenced
 // bundle root where os.ReadFile would allocate the whole file before any
-// size check.
-func readBundleRecipeProfile(summaryDir string) (profile, advertiser, descriptorIdentity string, err error) {
+// size check. It is also time-bounded via withFileReadTimeout so the read
+// cannot hang indefinitely on a dead NFS/FUSE mount.
+func readBundleRecipeProfile(ctx context.Context, summaryDir string) (profile, advertiser, descriptorIdentity string, err error) {
 	path := filepath.Join(summaryDir, RecipeFilename)
-	f, err := os.Open(path) //nolint:gosec // bundle-local path resolved by resolveSummaryDir
-	if err != nil {
-		return "", "", "", errors.Wrap(errors.ErrCodeNotFound, "failed to read bundle recipe.yaml", err)
-	}
-	defer func() { _ = f.Close() }()
-	body, err := io.ReadAll(io.LimitReader(f, defaults.MaxRecipePOSTBytes+1))
-	if err != nil {
-		return "", "", "", errors.Wrap(errors.ErrCodeInternal, "failed to read bundle recipe.yaml", err)
+	var body []byte
+	if rerr := withFileReadTimeout(ctx, "bundle recipe.yaml", func() error {
+		f, oErr := os.Open(path) //nolint:gosec // bundle-local path resolved by resolveSummaryDir
+		if oErr != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "failed to read bundle recipe.yaml", oErr)
+		}
+		defer func() { _ = f.Close() }()
+		b, rErr := io.ReadAll(io.LimitReader(f, defaults.MaxRecipePOSTBytes+1))
+		if rErr != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to read bundle recipe.yaml", rErr)
+		}
+		body = b
+		return nil
+	}); rerr != nil {
+		return "", "", "", rerr
 	}
 	if int64(len(body)) > defaults.MaxRecipePOSTBytes {
 		return "", "", "", errors.New(errors.ErrCodeInvalidRequest,
@@ -226,13 +268,21 @@ func readBundleRecipeProfile(summaryDir string) (profile, advertiser, descriptor
 // pointer lands in its parent so the on-disk layout matches the one-shot
 // `validate --emit-attestation --push` output (pointer.yaml beside
 // summary-bundle/).
-func resolveSummaryDir(dir string) (summaryDir, outDir string, err error) {
+func resolveSummaryDir(ctx context.Context, dir string) (summaryDir, outDir string, err error) {
 	clean := filepath.Clean(dir)
-	if HasBundleMarkers(clean) {
+	ok, err := HasBundleMarkers(ctx, clean)
+	if err != nil {
+		return "", "", err
+	}
+	if ok {
 		return clean, filepath.Dir(clean), nil
 	}
 	candidate := filepath.Join(clean, SummaryBundleDirName)
-	if HasBundleMarkers(candidate) {
+	ok, err = HasBundleMarkers(ctx, candidate)
+	if err != nil {
+		return "", "", err
+	}
+	if ok {
 		return candidate, clean, nil
 	}
 	return "", "", errors.New(errors.ErrCodeInvalidRequest,
@@ -246,33 +296,65 @@ func resolveSummaryDir(dir string) (summaryDir, outDir string, err error) {
 // other artifacts, but this pair only co-occurs in a summary bundle. It is
 // the single source of truth for "is this directory a summary bundle?",
 // shared by the publish path here and the verifier's materialization.
-func HasBundleMarkers(dir string) bool {
+//
+// The two os.Stat calls are time-bounded via withFileReadTimeout so a dead
+// NFS/FUSE mount surfaces as a timeout error instead of an indefinite hang.
+// The (bool, error) shape keeps a genuine "not a bundle" answer distinct from
+// a ctx timeout: only the timeout wrapper yields (false, err), which stops a
+// hung mount from masquerading as "not a bundle" and failing open. Every stat
+// error itself — absent, is-a-dir, and equally permission/EIO/ESTALE — reads
+// as "not a marker" (false, nil); this preserves the pre-change fail-soft
+// behavior. Surfacing non-ENOENT stat faults distinctly (so a soft-mount I/O
+// error is not diagnosed as a bad bundle) is a deliberate follow-up, not done
+// here — see #2083 for the remaining unbounded/undiagnosed reads.
+func HasBundleMarkers(ctx context.Context, dir string) (bool, error) {
 	for _, f := range []string{RecipeFilename, ManifestFilename} {
-		info, statErr := os.Stat(filepath.Join(dir, f))
-		if statErr != nil || info.IsDir() {
-			return false
+		path := filepath.Join(dir, f)
+		var present bool
+		// Label with the full path (not just f) so a timeout names which
+		// candidate directory stalled — the probe sites try more than one.
+		if err := withFileReadTimeout(ctx, "bundle marker "+path, func() error {
+			info, statErr := os.Stat(path)
+			// Any stat error (absent, permission, is-a-dir) means "not a
+			// marker"; only the timeout wrapper injects a non-nil error.
+			present = statErr == nil && !info.IsDir()
+			return nil
+		}); err != nil {
+			return false, err
+		}
+		if !present {
+			return false, nil
 		}
 	}
-	return true
+	return true, nil
 }
 
 // readBundlePredicate reads the bundle's unsigned in-toto Statement and
 // returns the predicate body plus the raw statement bytes. Mirrors the
 // verifier's loadUnsignedPredicate: the predicate is trusted as-is.
-func readBundlePredicate(summaryDir string) (*Predicate, []byte, error) {
+func readBundlePredicate(ctx context.Context, summaryDir string) (*Predicate, []byte, error) {
 	path := filepath.Join(summaryDir, StatementFilename)
-	// Bound the read: a publish target may be an attacker-influenced bundle
-	// root (extracted archive, symlinked path) where os.ReadFile would
-	// allocate the whole file before any size check. Mirrors the verifier's
-	// readBoundedFile against the same defaults cap.
-	f, err := os.Open(path) //nolint:gosec // bundle-local path resolved by resolveSummaryDir
-	if err != nil {
-		return nil, nil, errors.Wrap(errors.ErrCodeNotFound, "failed to read in-toto Statement", err)
-	}
-	defer func() { _ = f.Close() }()
-	body, err := io.ReadAll(io.LimitReader(f, defaults.MaxAttestationFileBytes+1))
-	if err != nil {
-		return nil, nil, errors.Wrap(errors.ErrCodeInternal, "failed to read in-toto Statement", err)
+	// Bound the read two ways: by size — a publish target may be an
+	// attacker-influenced bundle root (extracted archive, symlinked path)
+	// where os.ReadFile would allocate the whole file before any size check
+	// (mirrors the verifier's readBoundedFile against the same defaults cap)
+	// — and by time, via withFileReadTimeout, so a dead NFS/FUSE mount
+	// surfaces as a timeout instead of hanging indefinitely.
+	var body []byte
+	if rerr := withFileReadTimeout(ctx, "in-toto Statement", func() error {
+		f, oErr := os.Open(path) //nolint:gosec // bundle-local path resolved by resolveSummaryDir
+		if oErr != nil {
+			return errors.Wrap(errors.ErrCodeNotFound, "failed to read in-toto Statement", oErr)
+		}
+		defer func() { _ = f.Close() }()
+		b, rErr := io.ReadAll(io.LimitReader(f, defaults.MaxAttestationFileBytes+1))
+		if rErr != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to read in-toto Statement", rErr)
+		}
+		body = b
+		return nil
+	}); rerr != nil {
+		return nil, nil, rerr
 	}
 	if int64(len(body)) > defaults.MaxAttestationFileBytes {
 		return nil, nil, errors.New(errors.ErrCodeInvalidRequest,

--- a/pkg/evidence/attestation/publish_test.go
+++ b/pkg/evidence/attestation/publish_test.go
@@ -65,6 +65,140 @@ func wantInvalidRequest(t *testing.T, err error) {
 	}
 }
 
+func wantTimeout(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+		t.Errorf("expected ErrCodeTimeout, got %v", err)
+	}
+}
+
+// TestBundleReaders_CanceledContextSurfacesTimeout proves each on-disk reader
+// path is bounded by the caller's context: against a real, valid bundle (so an
+// unbounded read would succeed instantly), an already-canceled context makes
+// every reader fail closed with ErrCodeTimeout rather than block on a
+// potentially hung mount. This is the load-bearing guarantee of issue #2054 —
+// a dead NFS/FUSE mount surfaces as a timeout, not an indefinite hang.
+func TestBundleReaders_CanceledContextSurfacesTimeout(t *testing.T) {
+	dir := emitUnsignedBundle(t)
+	summaryDir := filepath.Join(dir, SummaryBundleDirName)
+
+	tests := []struct {
+		name string
+		run  func(ctx context.Context) error
+	}{
+		{"readBundlePredicate", func(ctx context.Context) error {
+			_, _, err := readBundlePredicate(ctx, summaryDir)
+			return err
+		}},
+		{"readBundleRecipeProfile", func(ctx context.Context) error {
+			_, _, _, err := readBundleRecipeProfile(ctx, summaryDir)
+			return err
+		}},
+		{"HasBundleMarkers", func(ctx context.Context) error {
+			_, err := HasBundleMarkers(ctx, summaryDir)
+			return err
+		}},
+		{"resolveSummaryDir", func(ctx context.Context) error {
+			_, _, err := resolveSummaryDir(ctx, dir)
+			return err
+		}},
+		{"loadOnDiskBundle", func(ctx context.Context) error {
+			_, _, err := loadOnDiskBundle(ctx, dir)
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			wantTimeout(t, tt.run(ctx))
+		})
+	}
+}
+
+// TestWithFileReadTimeout_InFlightTimeout exercises the goroutine+select arm of
+// withFileReadTimeout — the part that actually delivers hang-immunity. The
+// canceled-context tests above return at the ctx.Err() pre-check and never
+// reach the select, so this covers the case a wedged mount hits: fn is already
+// running (blocked in the syscall) when the caller context is canceled. It uses
+// a started/release/finished handshake so the cancellation is observed
+// in-flight, asserts ErrCodeTimeout, then unblocks fn and joins it — proving
+// the parked worker returns rather than leaking.
+func TestWithFileReadTimeout_InFlightTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- withFileReadTimeout(ctx, "blocked read", func() error {
+			close(started)
+			<-release // stand in for a syscall wedged on a hung mount
+			close(finished)
+			return nil
+		})
+	}()
+
+	<-started // fn is now running inside the goroutine+select path
+	cancel()  // cancel the caller context while fn is still blocked
+	wantTimeout(t, <-errCh)
+
+	close(release) // release the parked worker...
+	<-finished     // ...and confirm it returns (no leaked goroutine)
+}
+
+func TestHasBundleMarkers(t *testing.T) {
+	valid := filepath.Join(emitUnsignedBundle(t), SummaryBundleDirName)
+
+	tests := []struct {
+		name    string
+		dir     string
+		want    bool
+		wantErr bool
+	}{
+		{"valid summary bundle", valid, true, false},
+		{"empty dir is not a bundle", t.TempDir(), false, false},
+		{"missing dir is not a bundle", filepath.Join(t.TempDir(), "nope"), false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HasBundleMarkers(context.Background(), tt.dir)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("HasBundleMarkers error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("HasBundleMarkers = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasBundleMarkers_DirectoryMarkerIsNotABundle guards the IsDir() branch:
+// a directory named recipe.yaml must not be mistaken for the marker file, and
+// the non-timeout path must still report (false, nil), not an error.
+func TestHasBundleMarkers_DirectoryMarkerIsNotABundle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, RecipeFilename), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ManifestFilename), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := HasBundleMarkers(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("HasBundleMarkers returned unexpected error: %v", err)
+	}
+	if got {
+		t.Errorf("HasBundleMarkers = true, want false (recipe.yaml is a directory)")
+	}
+}
+
 func TestPublish_RequiresPush(t *testing.T) {
 	err := Publish(context.Background(), PublishOptions{BundleDir: t.TempDir()})
 	wantInvalidRequest(t, err)
@@ -92,7 +226,7 @@ func TestPublish_MissingBundleDir(t *testing.T) {
 func TestLoadOnDiskBundle_ParentDir(t *testing.T) {
 	dir := emitUnsignedBundle(t)
 
-	bundle, outDir, err := loadOnDiskBundle(dir)
+	bundle, outDir, err := loadOnDiskBundle(context.Background(), dir)
 	if err != nil {
 		t.Fatalf("loadOnDiskBundle: %v", err)
 	}
@@ -118,7 +252,7 @@ func TestLoadOnDiskBundle_SummaryDirItself(t *testing.T) {
 	dir := emitUnsignedBundle(t)
 	summaryDir := filepath.Join(dir, SummaryBundleDirName)
 
-	bundle, outDir, err := loadOnDiskBundle(summaryDir)
+	bundle, outDir, err := loadOnDiskBundle(context.Background(), summaryDir)
 	if err != nil {
 		t.Fatalf("loadOnDiskBundle: %v", err)
 	}
@@ -133,17 +267,17 @@ func TestLoadOnDiskBundle_SummaryDirItself(t *testing.T) {
 }
 
 func TestLoadOnDiskBundle_EmptyArg(t *testing.T) {
-	_, _, err := loadOnDiskBundle("")
+	_, _, err := loadOnDiskBundle(context.Background(), "")
 	wantInvalidRequest(t, err)
 }
 
 func TestResolveSummaryDir_NotABundle(t *testing.T) {
-	_, _, err := resolveSummaryDir(t.TempDir())
+	_, _, err := resolveSummaryDir(context.Background(), t.TempDir())
 	wantInvalidRequest(t, err)
 }
 
 func TestReadBundlePredicate_MissingStatement(t *testing.T) {
-	_, _, err := readBundlePredicate(t.TempDir())
+	_, _, err := readBundlePredicate(context.Background(), t.TempDir())
 	if err == nil {
 		t.Fatalf("expected error for missing statement")
 	}
@@ -157,7 +291,7 @@ func TestReadBundlePredicate_InvalidJSON(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, StatementFilename), []byte("not json"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := readBundlePredicate(dir)
+	_, _, err := readBundlePredicate(context.Background(), dir)
 	wantInvalidRequest(t, err)
 }
 
@@ -167,7 +301,7 @@ func TestReadBundlePredicate_WrongPredicateType(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, StatementFilename), body, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := readBundlePredicate(dir)
+	_, _, err := readBundlePredicate(context.Background(), dir)
 	wantInvalidRequest(t, err)
 }
 
@@ -188,7 +322,7 @@ func TestLoadOnDiskBundle_MissingRecipeIdentity(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(summaryDir, StatementFilename), body, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := loadOnDiskBundle(dir)
+	_, _, err := loadOnDiskBundle(context.Background(), dir)
 	wantInvalidRequest(t, err)
 }
 
@@ -227,7 +361,7 @@ componentRefs:
 	if err := os.WriteFile(filepath.Join(summaryDir, StatementFilename), body, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := loadOnDiskBundle(dir)
+	_, _, err := loadOnDiskBundle(context.Background(), dir)
 	wantInvalidRequest(t, err)
 	if !strings.Contains(err.Error(), "no profile block") {
 		t.Fatalf("error = %v, want profile/predicate incoherence rejection", err)
@@ -273,7 +407,7 @@ func TestLoadOnDiskBundle_ProfiledEmitRoundTrip(t *testing.T) {
 		t.Fatalf("Emit: %v", err)
 	}
 
-	bundle, _, err := loadOnDiskBundle(dir)
+	bundle, _, err := loadOnDiskBundle(context.Background(), dir)
 	if err != nil {
 		t.Fatalf("loadOnDiskBundle rejected a coherent profiled bundle: %v", err)
 	}
@@ -343,7 +477,7 @@ componentRefs:
 	if err := os.WriteFile(filepath.Join(summaryDir, StatementFilename), body, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := loadOnDiskBundle(dir)
+	_, _, err := loadOnDiskBundle(context.Background(), dir)
 	wantInvalidRequest(t, err)
 	if !strings.Contains(err.Error(), "historical-only") {
 		t.Fatalf("error = %v, want stale descriptor-identity rejection", err)

--- a/pkg/evidence/attestation/sign.go
+++ b/pkg/evidence/attestation/sign.go
@@ -90,7 +90,7 @@ func SignExisting(ctx context.Context, opts SignExistingOptions) error {
 			"artifact descriptor (digest, mediaType, size) is required to sign an existing bundle")
 	}
 
-	bundle, _, err := loadOnDiskBundle(opts.BundleDir)
+	bundle, _, err := loadOnDiskBundle(ctx, opts.BundleDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/evidence/attestation/sign_test.go
+++ b/pkg/evidence/attestation/sign_test.go
@@ -138,6 +138,29 @@ func TestSignExisting_RejectsIncompleteDescriptor(t *testing.T) {
 	}
 }
 
+// TestSignExisting_CanceledContextSurfacesTimeout proves SignExisting threads
+// the caller's context into the on-disk bundle read: with a valid signable
+// pointer and a real bundle on disk (so the read would otherwise succeed), an
+// already-canceled context fails closed with ErrCodeTimeout instead of blocking
+// on a potentially hung mount (issue #2054).
+func TestSignExisting_CanceledContextSurfacesTimeout(t *testing.T) {
+	dir := emitUnsignedBundle(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := SignExisting(ctx, SignExistingOptions{
+		Pointer:     signableSignPointer(),
+		PointerPath: filepath.Join(t.TempDir(), "pointer.yaml"),
+		BundleDir:   dir,
+		Artifact:    MainArtifactDescriptor{Digest: "sha256:abc", MediaType: "application/json", Size: 1},
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+		t.Errorf("expected ErrCodeTimeout, got %v", err)
+	}
+}
+
 func TestPointerSignerFromSignature(t *testing.T) {
 	if PointerSignerFromSignature(nil) != nil {
 		t.Errorf("nil signature should yield nil signer")

--- a/pkg/evidence/verifier/fetch.go
+++ b/pkg/evidence/verifier/fetch.go
@@ -98,7 +98,7 @@ func MaterializeBundle(
 	}
 	switch form {
 	case InputFormDir:
-		return materializeDir(opts.Input)
+		return materializeDir(ctx, opts.Input)
 	case InputFormPointer:
 		return materializeFromPointer(ctx, pointer, opts)
 	case InputFormOCI:
@@ -114,12 +114,22 @@ func MaterializeBundle(
 // materializeDir accepts either the summary-bundle root or a parent
 // containing it. Bundles are recognized by recipe.yaml + manifest.json
 // at the candidate root.
-func materializeDir(input string) (*MaterializedBundle, error) {
-	if attestation.HasBundleMarkers(input) {
+func materializeDir(ctx context.Context, input string) (*MaterializedBundle, error) {
+	ok, err := attestation.HasBundleMarkers(ctx, input)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			"failed to probe bundle markers at "+input)
+	}
+	if ok {
 		return &MaterializedBundle{BundleDir: filepath.Clean(input)}, nil
 	}
 	candidate := filepath.Join(input, attestation.SummaryBundleDirName)
-	if attestation.HasBundleMarkers(candidate) {
+	ok, err = attestation.HasBundleMarkers(ctx, candidate)
+	if err != nil {
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			"failed to probe bundle markers at "+candidate)
+	}
+	if ok {
 		return &MaterializedBundle{BundleDir: filepath.Clean(candidate)}, nil
 	}
 	return nil, errors.New(errors.ErrCodeInvalidRequest,
@@ -242,7 +252,7 @@ func materializeOCIRefRequireDigest(ctx context.Context, ref string, opts Verify
 		return nil, errors.Wrap(errors.ErrCodeUnavailable, "OCI pull failed", copyErr)
 	}
 
-	resolved, dErr := resolveBundleDir(tmp)
+	resolved, dErr := resolveBundleDir(ctx, tmp)
 	if dErr != nil {
 		cleanup()
 		return nil, dErr
@@ -392,12 +402,22 @@ func fetchAndWriteReferrerLayer(ctx context.Context, repo referrerFetcher, refer
 
 // resolveBundleDir picks the bundle root from a temp dir holding the
 // pulled or extracted layer contents.
-func resolveBundleDir(dir string) (string, error) {
-	if attestation.HasBundleMarkers(dir) {
+func resolveBundleDir(ctx context.Context, dir string) (string, error) {
+	ok, err := attestation.HasBundleMarkers(ctx, dir)
+	if err != nil {
+		return "", errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			"failed to probe bundle markers at "+dir)
+	}
+	if ok {
 		return dir, nil
 	}
 	candidate := filepath.Join(dir, attestation.SummaryBundleDirName)
-	if attestation.HasBundleMarkers(candidate) {
+	ok, err = attestation.HasBundleMarkers(ctx, candidate)
+	if err != nil {
+		return "", errors.PropagateOrWrap(err, errors.ErrCodeInternal,
+			"failed to probe bundle markers at "+candidate)
+	}
+	if ok {
 		return candidate, nil
 	}
 	return "", errors.New(errors.ErrCodeInvalidRequest,

--- a/pkg/evidence/verifier/fetch_test.go
+++ b/pkg/evidence/verifier/fetch_test.go
@@ -16,8 +16,11 @@ package verifier
 
 import (
 	"context"
+	stderrors "errors"
 	"strings"
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 func TestMaterializeBundle_DirAcceptsParentOrSummary(t *testing.T) {
@@ -43,6 +46,79 @@ func TestMaterializeBundle_DirRejectsNonBundle(t *testing.T) {
 		VerifyOptions{Input: t.TempDir()}, InputFormDir, nil)
 	if err == nil {
 		t.Errorf("expected error for empty directory")
+	}
+}
+
+// TestBundleMarkerProbe_CanceledCtxPropagatesTimeout verifies that a
+// canceled caller context surfaces as an ErrCodeTimeout error through the
+// bundle-marker probe rather than being flattened into a benign "not a
+// bundle" (ErrCodeInvalidRequest) answer: at these probe sites a hung NFS/FUSE
+// mount fails closed, not open. Both marker-probing sites are exercised:
+// materializeDir (directory input) and resolveBundleDir (pulled-artifact
+// input), which share attestation.HasBundleMarkers underneath.
+//
+// Scope: this bounds the marker probe only. It is not an end-to-end guarantee
+// for `aicr evidence verify` — DetectInputForm stats the input dir before the
+// probe, and several post-materialize reads are still unbounded; both are
+// tracked in #2083. The test calls the probes directly, so it must not be
+// read as proving the whole verify path is hang-immune.
+func TestBundleMarkerProbe_CanceledCtxPropagatesTimeout(t *testing.T) {
+	// A real bundle so a live context would succeed — proving the failure
+	// comes from cancellation, not a missing bundle.
+	bundleDir := buildTestBundle(t)
+
+	tests := []struct {
+		name string
+		call func(ctx context.Context) error
+	}{
+		{
+			name: "materializeDir",
+			call: func(ctx context.Context) error {
+				_, err := materializeDir(ctx, bundleDir)
+				return err
+			},
+		},
+		{
+			name: "resolveBundleDir",
+			call: func(ctx context.Context) error {
+				_, err := resolveBundleDir(ctx, bundleDir)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := tt.call(ctx)
+			if err == nil {
+				t.Fatalf("%s: expected error on canceled ctx, got nil", tt.name)
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
+				t.Errorf("%s: got %v, want ErrCodeTimeout (must not flatten to \"not a bundle\")", tt.name, err)
+			}
+			if stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("%s: canceled ctx was misreported as ErrCodeInvalidRequest (fail-open): %v", tt.name, err)
+			}
+		})
+	}
+}
+
+// TestBundleMarkerProbe_LiveCtxSucceeds is the positive control: with an
+// uncanceled context the same probes accept a real bundle, confirming the
+// timeout paths above are cancellation-driven, not always-erroring.
+func TestBundleMarkerProbe_LiveCtxSucceeds(t *testing.T) {
+	bundleDir := buildTestBundle(t)
+
+	mat, err := materializeDir(context.Background(), bundleDir)
+	if err != nil {
+		t.Fatalf("materializeDir(live ctx): %v", err)
+	}
+	mat.Cleanup()
+
+	if _, err := resolveBundleDir(context.Background(), bundleDir); err != nil {
+		t.Fatalf("resolveBundleDir(live ctx): %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Bounds `aicr evidence publish`/`sign` on-disk summary-bundle reads with the caller context plus `defaults.FileReadTimeout`, so a hung NFS/FUSE mount surfaces as `ErrCodeTimeout` instead of hanging the command forever.

## Motivation / Context

The evidence publish/sign path read the on-disk summary bundle with unbounded blocking syscalls. On a wedged network/FUSE mount those reads block indefinitely, and the caller's context deadline had no effect — the command simply hung with no error. This bounds every on-disk summary-bundle read so the operation fails closed with a timeout error.

Fixes: #2054
Related: #2083 (follow-up: bound the residual reads on these paths)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: Evidence attestation + verifier (`pkg/evidence/attestation`, `pkg/evidence/verifier`)

## Implementation Notes

- **Bound the real read, not a preflight probe.** We wrap each blocking read (marker detection and the statement/recipe file reads in `publish`, `sign`, and the verifier `fetch` path) with the caller context and `defaults.FileReadTimeout`, rather than adding a `stat` preflight. A `stat` can succeed while the subsequent `read` wedges on the same hung mount, so only bounding the actual read is correct.
- **Goroutine + `select` mechanism.** Each blocking read runs in a goroutine whose result is delivered on a buffered channel consumed via `select` against `ctx.Done()`. When the context deadline fires first, the call returns `ErrCodeTimeout`. The tradeoff is one short-lived goroutine per read that may outlive the timeout on a truly stuck mount; it is detached and harmless (no shared mutable state, result discarded), and this is the standard pattern for making an otherwise-uninterruptible syscall respect a context deadline. Both human reviewers confirmed this is fine for a short-lived CLI leaf command.
- **Signature change:** `HasBundleMarkers(dir string) bool` becomes `HasBundleMarkers(ctx context.Context, dir string) (bool, error)` so marker detection is itself bounded and reports a **timeout** (not a bad-input answer) when the mount is wedged. All six call sites were updated to thread the context and check `err` before `ok`. Non-timeout stat errors still read as "not a marker" (fail-soft, unchanged from before this PR).

## Testing

```bash
# Commands run (prefer `make qualify` for non-trivial changes)
make qualify
golangci-lint run -c .golangci.yaml ./pkg/evidence/attestation/... ./pkg/evidence/verifier/...
go test -race ./pkg/evidence/attestation/... ./pkg/evidence/verifier/...
```

`make qualify` passes; lint clean on both touched packages. Table-driven timeout tests in `publish_test.go`, `sign_test.go`, and `fetch_test.go` cover the canceled-context path, plus a dedicated `TestWithFileReadTimeout_InFlightTimeout` that exercises the goroutine+`select` arm deterministically (fn blocks past an in-flight cancel via a started/release/finished handshake, then is joined so no worker leaks). Coverage is healthy on all touched functions.

## Known Limitations (tracked in #2083)

This PR bounds the on-disk **summary-bundle** reads, which is the scope of #2054. Cross-review surfaced adjacent reads on the same code paths that remain unbounded or mis-diagnosed and are deferred to #2083 to keep this change minimal:

- `verify`'s `DetectInputForm` stats the input dir *before* the bounded probe, and several post-materialize verifier reads are still unbounded.
- The OCI push-staging walk (`pkg/oci`) is only ctx-checked between entries, so `publish` can still hang one step later on a fully dead mount.
- `verify`'s `classifyFailure` has no transient branch, so a timeout currently classifies identically to a genuine "invalid attestation".
- Non-`ENOENT` stat errors (EIO/ESTALE) read as "not a marker" rather than surfacing the storage fault distinctly.

The doc comments and this description are scoped to what is actually bounded here; the follow-up will close the residual end-to-end.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No user-facing surface change. `HasBundleMarkers` is an internal helper; its signature change is contained to `pkg/evidence` and all call sites are updated in this PR. Backwards compatible for CLI users — the only behavioral change is that a previously-hanging summary-bundle read now returns a timeout error.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
