### PR TITLE
ci(uat): re-pin GKE actuator to v0.5.17

### DIFF
--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -117,10 +117,10 @@ jobs:
       # DC2 selects the AICRConfig by intent; both intents drive the same
       # cluster-config (GPU pool from the reservation, system/CPU pools dynamic).
       TEST_CONFIG: ${{ inputs.test_config_dir }}/h100-${{ inputs.intent }}-config.yaml
-      # v0.5.16. Keep the release tag for update visibility and the digest for
+      # v0.5.17. Keep the release tag for update visibility and the digest for
       # execution identity. Review the upstream release and verify its signature
       # before rotating both values; never use a tag-only actuator reference.
-      GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:v0.5.16@sha256:f586ffa14dccb867c81fb8a12484f6e31d3adad93242292b7c9cc00c93af2367"
+      GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:v0.5.17@sha256:8bfffd412d98276ee1000a6c083514e6b28928416cc37602ec637ed3a2167c99"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
       # Pin validator-image resolution for MAIN cells to this run's freshly


### PR DESCRIPTION
## Summary

Re-pin the UAT GKE cluster actuator image from `v0.5.16` to `v0.5.17` in `.github/workflows/uat-gcp.yaml`, updating both the release tag and the immutable SHA-256 digest (plus the explanatory comment above the pin).

## Motivation / Context

Routine rotation of the upstream `mchmarny/cluster` GKE actuator used by the UAT-GCP lane. Keeps the tag current for update visibility while retaining a digest-pinned, immutable reference for execution identity (never a tag-only reference).

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI — UAT-GCP workflow (`.github/workflows/uat-gcp.yaml`)

## Implementation Notes

Single pin site, one-line change plus its comment:

```diff
-      # v0.5.16. Keep the release tag for update visibility and the digest for
+      # v0.5.17. Keep the release tag for update visibility and the digest for
         # execution identity. Review the upstream release and verify its signature
         # before rotating both values; never use a tag-only actuator reference.
-      GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:v0.5.16@sha256:f586ffa14dccb867c81fb8a12484f6e31d3adad93242292b7c9cc00c93af2367"
+      GKE_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/gke:v0.5.17@sha256:8bfffd412d98276ee1000a6c083514e6b28928416cc37602ec637ed3a2167c99"
```

The AKS actuator pin and all other content are untouched.

**Digest provenance:** `v0.5.17` → `sha256:8bfffd412d98276ee1000a6c083514e6b28928416cc37602ec637ed3a2167c99`, resolved via `crane digest ghcr.io/mchmarny/cluster/gke:v0.5.17`.

**Upstream release / signature verification (please review before merge):**
- There is **no GitHub Release object** for tag `v0.5.17` in `mchmarny/cluster` — only the image tag / git tag exists. There is no human-authored release notes page to review.
- The image **does carry a valid keyless Sigstore (cosign) signature**, which verifies:
  - `cosign verify --certificate-identity-regexp '.*' --certificate-oidc-issuer-regexp '.*' ghcr.io/mchmarny/cluster/gke:v0.5.17` → all checks pass (cosign claims validated, existence in the transparency log verified, code-signing cert verified against the trusted Fulcio CA).
  - Signer identity (Fulcio SAN): `https://github.com/mchmarny/cluster/.github/workflows/on-tag.yaml@refs/tags/v0.5.17-gke`
  - OIDC issuer: `https://token.actions.githubusercontent.com` (GitHub Actions, github-hosted runner)
  - Attestation type: `https://slsa.dev/provenance/v1`
- Interpretation: the image was built and signed by the upstream repo's tag-release GitHub Actions workflow for the `v0.5.17-gke` tag — consistent with prior pins. The **only** gap versus an ideal rotation is the absence of a published GitHub Release object; a maintainer should confirm that is acceptable (it matches how earlier `mchmarny/cluster` actuator tags have been shipped).

## Testing

```bash
# Actuator-pin format gate (immutable SHA-256 reference enforcement)
go test ./tests/uat/ -run 'TestUATActuatorInvocationsArePinnedApplyCommands|TestUATWorkflowsContainNoMutableActuatorReferences|TestGKECredentialApplyStepsUsePinnedImageAndExpectedAuth' -v
# → PASS (GCP/AWS/Azure subtests all green)

yamllint .github/workflows/uat-gcp.yaml   # → clean

unset GITLAB_TOKEN && make qualify        # → "Codebase qualification completed"
```

- `tests/uat/workflow_security_test.go` actuator-pin gate: **PASS**.
- `yamllint` on the changed workflow: **clean**.
- `make qualify` (test + lint + e2e + scan + repo checks): **passed** end to end. (Vulnerability scan reported only pre-existing Low/Unknown advisories in transitive deps — `GO-2025-3547` k8s.io/kubernetes, `GO-2026-5932` golang.org/x/crypto — unrelated to this change; scan completed successfully.)

## Risk Assessment

- [x] **Low** — Isolated CI-only change (single digest-pinned env value), signature-verified upstream image, trivially revertible by restoring the prior tag+digest.

**Rollout notes:** Takes effect on the next UAT-GCP run. Backwards compatible; revert = restore the `v0.5.16` tag+digest. N/A for product/runtime behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — via `make qualify`
- [x] Linter passes (`make lint`) — via `make qualify`; `yamllint` clean on the changed file
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (no new functionality; existing pin-format gate covers this)
- [ ] I updated docs if user-facing behavior changed — N/A (no user-facing behavior change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

<!-- Suggested labels: theme/supply-chain, area/ci -->
