### PR TITLE
feat(supply-chain): publish aiperf-bench third-party source as OCI referrer

### DIFF
--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -67,6 +67,9 @@ outputs:
   cosign:
     description: 'Cosign version (must be >= v3.1.0 so DSSE attestations are logged to Rekor v2 as hashedrekord/PAE, not the legacy dsse entry type)'
     value: ${{ steps.versions.outputs.cosign }}
+  oras:
+    description: 'ORAS version (attaches the aiperf-bench source archive as an OCI 1.1 referrer; cosign cannot attach arbitrary artifacts)'
+    value: ${{ steps.versions.outputs.oras }}
   yamllint:
     description: 'yamllint version'
     value: ${{ steps.versions.outputs.yamllint }}
@@ -175,6 +178,7 @@ runs:
         # Security tools
         echo "grype=$(yq eval '.security_tools.grype' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "cosign=$(yq eval '.security_tools.cosign' .settings.yaml)" >> $GITHUB_OUTPUT
+        echo "oras=$(yq eval '.security_tools.oras' .settings.yaml)" >> $GITHUB_OUTPUT
 
         # Testing tools
         echo "kubectl=$(yq eval '.testing_tools.kubectl' .settings.yaml)" >> $GITHUB_OUTPUT

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -811,6 +811,173 @@ jobs:
   # =============================================================================
   # Notify: Post release announcement to Slack
   # =============================================================================
+  # Source: attach the aiperf-bench third-party source as an OCI 1.1 referrer
+  # =============================================================================
+  #
+  # NVIDIA's container policy requires the source of every third-party
+  # open-source component added on top of an approved base image to be
+  # retrievable by whoever pulls that image, regardless of license. This is a
+  # separate obligation from attribution (THIRD_PARTY_NOTICES.md) and is not
+  # satisfied by it.
+  #
+  # Only aiperf-bench needs this. The six Go images vendor their dependencies,
+  # so the GitHub release source archive for this tag already carries the
+  # complete source of every module compiled into them.
+  #
+  # A referrer rather than a layer in the image: the sdists are ~250 MB, which
+  # would otherwise be paid on every benchmark pod pull forever for data nothing
+  # reads at runtime. OSRB confirmed the referrers API is acceptable provided
+  # retrieval is documented (docs/integrator/supply-chain-verification.md).
+  #
+  # Runs against the resolved candidate digest, not a tag: a referrer binds to
+  # one digest, so attaching to a moving tag would leave later builds
+  # unreferenced.
+  #
+  # Deliberately NOT part of release-check, and deliberately after publish.
+  # Attaching depends on PyPI serving 129 sdists, which is an uncontrolled
+  # third party on the critical path of a release. Gating on it converts a PyPI
+  # blip, or a yanked package version, into a failed release and a release-day
+  # fire drill. Nothing is lost by attaching afterwards: a referrer binds to the
+  # image digest, and promotion does not change the digest, so the artifact
+  # lands on exactly the same subject either way. A failure here is re-runnable
+  # as a single job rather than requiring the tag to be recut.
+  #
+  # Gated on resolve-candidates and publish succeeding: there is no image to
+  # attach to otherwise. The job itself fails loudly if the attach, the
+  # signature, or the discoverability check does not succeed.
+  attach-source:
+    name: Attach Third-Party Source
+    runs-on: ubuntu-latest
+    needs: [detect, resolve-candidates, publish]
+    if: needs.resolve-candidates.result == 'success' && needs.publish.result == 'success'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      # packages: write to push the referrer to ghcr.io alongside the image.
+      packages: write
+      # id-token: write for keyless cosign signing of the referrer. oras attach
+      # produces an unsigned artifact, and anyone with push access could attach a
+      # second one carrying the same artifactType; signing lets a consumer tell
+      # ours apart rather than trusting whatever the type filter returns.
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Authenticate to registry
+        uses: ./.github/actions/ghcr-login
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d  # v2.0.1
+        with:
+          version: ${{ steps.versions.outputs.oras }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          cosign-release: ${{ steps.versions.outputs.cosign }}
+
+      - name: Build and attach source archive
+        id: attach
+        env:
+          DIGEST_MAP: ${{ needs.resolve-candidates.outputs.digest_map }}
+        run: |
+          set -euo pipefail
+          digest="$(jq -er '."aiperf-bench"' <<<"${DIGEST_MAP}")"
+          image="ghcr.io/nvidia/aicr-validators/aiperf-bench@${digest}"
+          # Skip if a source referrer is already attached to this digest.
+          # `oras attach` stamps org.opencontainers.image.created into the
+          # manifest, so re-running would push a NEW manifest digest and leave
+          # two referrers of the same artifactType on one image. A consumer
+          # selecting by type could then not tell which is ours -- reintroducing,
+          # on the deliberately re-runnable path, exactly the ambiguity the
+          # signature exists to remove.
+          # Reuse an existing referrer rather than attaching a second one:
+          # `oras attach` stamps org.opencontainers.image.created, so a re-run
+          # would push a new manifest digest and leave two referrers of the same
+          # artifactType on one image, which a consumer could not disambiguate.
+          #
+          # Crucially this does NOT skip signing. If a previous run attached and
+          # then failed before signing, the digest carries an unsigned referrer;
+          # skipping here would make every re-run skip the signature too and
+          # fail verification forever, contradicting this job's re-runnable
+          # recovery. Reusing the digest lets a re-run finish the interrupted
+          # attach-then-sign sequence instead of wedging on it.
+          existing="$(oras discover --format json "${image}" \
+            | jq -r '[.referrers[]? | select(.artifactType
+                     == "application/vnd.nvidia.aicr.source.v1+tar")
+                     | .digest] | first // ""')"
+          if [[ -n "${existing}" ]]; then
+            echo "Source referrer already attached (${existing}); reusing it and re-signing."
+            echo "referrer=${existing}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Attaching third-party source to ${image}"
+          # The tool prints the referrer manifest digest on stdout; everything
+          # else goes to stderr.
+          referrer="$(python3 tools/generate-aiperf-source --attach "${image}")"
+          if [[ ! "${referrer}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::did not receive a referrer digest from the attach step"
+            exit 1
+          fi
+          echo "referrer=${referrer}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign the source referrer
+        env:
+          REFERRER: ${{ steps.attach.outputs.referrer }}
+        # Signed for the same reason every other referrer AICR publishes is:
+        # the artifact is otherwise unauthenticated, and a consumer selecting by
+        # artifactType alone cannot distinguish ours from one an attacker with
+        # push access attached beside it (CWE-345). Signing the referrer's own
+        # digest is what makes the documented retrieval verifiable.
+        run: |
+          set -euo pipefail
+          cosign sign --yes \
+            "ghcr.io/nvidia/aicr-validators/aiperf-bench@${REFERRER}"
+
+      - name: Verify the referrer is retrievable
+        env:
+          DIGEST_MAP: ${{ needs.resolve-candidates.outputs.digest_map }}
+        # Attaching is not the same as being findable. ghcr.io has no referrers
+        # API and serves these through the spec's tag fallback, so confirm a
+        # client can actually discover the artifact before the release proceeds.
+        run: |
+          set -euo pipefail
+          digest="$(jq -er '."aiperf-bench"' <<<"${DIGEST_MAP}")"
+          image="ghcr.io/nvidia/aicr-validators/aiperf-bench@${digest}"
+          found="$(oras discover --format json "${image}" \
+            | jq -r '[.referrers[]? | select(.artifactType
+                     == "application/vnd.nvidia.aicr.source.v1+tar")] | length')"
+          # Exactly one, not at least one. Two referrers of the same type leave
+          # a consumer unable to tell which is authoritative, and `>= 1` would
+          # hide that rather than catch it.
+          if [[ "${found}" -ne 1 ]]; then
+            echo "::error::expected exactly 1 source referrer on ${image}, found ${found}"
+            exit 1
+          fi
+
+          # Discoverable is not the same as verifiable. Confirm the signature we
+          # just created actually resolves, so a silently-failed sign cannot ship
+          # an artifact the documented retrieval will then reject.
+          referrer="$(oras discover --format json "${image}" \
+            | jq -r '.referrers[] | select(.artifactType
+                     == "application/vnd.nvidia.aicr.source.v1+tar") | .digest')"
+          cosign verify \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity \
+              "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/on-tag.yaml@${GITHUB_REF}" \
+            "ghcr.io/nvidia/aicr-validators/aiperf-bench@${referrer}" >/dev/null
+
+          echo "Source referrer discoverable and signature verified on ${image}"
+
+  # =============================================================================
 
   notify:
     name: Slack Notification
@@ -846,7 +1013,23 @@ jobs:
   summary:
     name: Release Summary
     runs-on: ubuntu-latest
-    needs: [detect, tests, build-ko, build-docker, build-gate, docker-manifest, resolve-candidates, image-vuln-scan, attest, release-check, promote-images, publish, publish-homebrew, deploy, notify]
+    needs:
+      - detect
+      - tests
+      - build-ko
+      - build-docker
+      - build-gate
+      - docker-manifest
+      - resolve-candidates
+      - image-vuln-scan
+      - attest
+      - attach-source
+      - release-check
+      - promote-images
+      - publish
+      - publish-homebrew
+      - deploy
+      - notify
     if: always()
     timeout-minutes: 5
     permissions:
@@ -868,6 +1051,11 @@ jobs:
           HOMEBREW: ${{ needs.publish-homebrew.result }}
           DEPLOY: ${{ needs.deploy.result }}
           NOTIFY: ${{ needs.notify.result }}
+          # Non-gating by design (see the attach-source job), so a failure here
+          # does not red the release. It still reds its own job, but the summary
+          # is where the release outcome is read as a whole, and a missing row
+          # would leave "did the source publish?" unanswered there.
+          ATTACH_SOURCE: ${{ needs.attach-source.result }}
           TAG: ${{ github.ref_name }}
           COMMIT: ${{ github.sha }}
           IS_PRERELEASE: ${{ needs.detect.outputs.is_prerelease }}
@@ -892,6 +1080,7 @@ jobs:
             echo "| Release Check | ${RELEASE_CHECK} |"
             echo "| Image Promotion | ${PROMOTE} |"
             echo "| Publish | ${PUBLISH} |"
+            echo "| Third-Party Source | ${ATTACH_SOURCE} |"
             echo "| Homebrew | ${HOMEBREW} |"
             echo "| Deploy | ${DEPLOY} |"
             echo "| Slack Notification | ${NOTIFY} |"

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -46,6 +46,15 @@ security_tools:
   cosign: 'v3.1.2'
   # renovate: datasource=github-releases depName=anchore/syft depType=security_tools
   syft: 'v1.50.0'
+  # renovate: datasource=github-releases depName=oras-project/oras depType=security_tools
+  # Attaches the aiperf-bench third-party source archive as an OCI 1.1 referrer
+  # (tools/generate-aiperf-source). Cosign cannot attach arbitrary artifacts, so
+  # this is a separate dependency from the signing/attestation path.
+  #
+  # Stored WITHOUT the leading 'v', unlike cosign/syft/grype above:
+  # oras-project/setup-oras looks the version up against bare release keys and
+  # throws on 'v1.3.0'. tools/setup-tools re-adds the prefix for the download URL.
+  oras: '1.3.0'
 
 # E2E Testing Tools
 testing_tools:

--- a/docs/integrator/supply-chain-verification.md
+++ b/docs/integrator/supply-chain-verification.md
@@ -13,8 +13,9 @@ top-level [`SECURITY.md`](../../SECURITY.md).
 
 Verification uses [Cosign](https://docs.sigstore.dev/cosign/system_config/installation/),
 the [GitHub CLI](https://cli.github.com/) (`gh`), `crane` (recommended; `docker inspect` resolves a digest only after a local pull),
-`jq`, and — for in-cluster enforcement — `kubectl`. Binary and bundle
-verification (`aicr verify`) need only the `aicr` binary.
+`jq`, [ORAS](https://oras.land/docs/installation) (only for retrieving the
+third-party source archive), and — for in-cluster enforcement — `kubectl`.
+Binary and bundle verification (`aicr verify`) need only the `aicr` binary.
 
 **Cosign version.** AICR release signatures (the binary attestation and the
 signed recipe catalog) are recorded in **Rekor v2** as of the v2 cutover (see the
@@ -57,15 +58,19 @@ docker login ghcr.io
 
 ## Unified Metadata Retrieval
 
-Every piece of release metadata AICR publishes for a container image is a
-signed in-toto attestation attached to that image as an OCI referrer. There is
-one retrieval command per metadata kind, and each kind has a fixed subject:
+Release metadata AICR publishes for a container image is attached to that image
+as an OCI referrer. The first three kinds below are signed in-toto attestations.
+The source archive is a plain OCI artifact rather than an attestation, but it is
+Sigstore-signed like the rest, so it is verified with `cosign verify` instead of
+`cosign verify-attestation`. There is one retrieval command per kind, and each
+has a fixed subject:
 
 | Metadata | Predicate type | Subject | Retrieved with |
 |----------|----------------|---------|----------------|
 | SLSA build provenance | `https://slsa.dev/provenance/v1` | multi-platform index digest | `gh attestation verify` |
 | SPDX SBOM | `https://spdx.dev/Document` | per-platform manifest digest | `cosign verify-attestation --type spdxjson` |
 | OpenVEX | `https://openvex.dev/ns` | multi-platform index digest | `cosign verify-attestation --type openvex` |
+| Third-party source (`aiperf-bench` only) | `application/vnd.nvidia.aicr.source.v1+tar` | multi-platform index digest | `oras pull` — see [Third-Party Source Code](#third-party-source-code) |
 
 The subjects differ because the claims differ. Provenance describes the build
 that produced the whole release image, and the VEX document is a single,
@@ -153,6 +158,87 @@ Cosign, so the floor does not apply to it. GHCR does not implement the OCI 1.1
 specification's referrers *tag* schema (a `sha256-{hex}` tag holding an index of
 referrers). Cosign and ORAS do this transparently, which is why the commands
 above are the documented path rather than a raw referrers API call.
+
+## Third-Party Source Code
+
+Source for every third-party open-source component AICR adds on top of its base
+images is published, regardless of license. Where it lives depends on how the
+component reaches the image.
+
+| Image | Third-party components | Where the source is |
+|-------|------------------------|---------------------|
+| `aicr`, `aicrd`, `aicr-gate`, `aicr-validators/{conformance,deployment,performance}` | Go modules compiled into the binary | The GitHub release source archive for the matching tag. Builds run with `-mod=vendor`, so `vendor/` in that archive is exactly the source that ships. |
+| `aicr-validators/aiperf-bench` | Python packages installed from wheels | An OCI referrer on the image, retrieved with the commands below. |
+| all | base image contents | Provided by NVIDIA with `nvcr.io/nvidia/distroless/*` under that image's own approval. |
+
+License texts for all of the above are in `THIRD_PARTY_NOTICES.md`, published as
+an asset on each release. That file discharges attribution; this section covers
+source availability, which is a separate obligation.
+
+### Retrieving the aiperf-bench source
+
+The archive is attached as an OCI referrer, so it is **not** fetched by
+`docker pull` and will not appear in the image's layers. Retrieve it explicitly:
+
+```bash
+IMAGE="ghcr.io/nvidia/aicr-validators/aiperf-bench:v0.19.0"
+
+# 1. Resolve the image to its digest and list what is attached to it.
+DIGEST=$(crane digest "${IMAGE}")
+oras discover --format tree "${IMAGE%:*}@${DIGEST}"
+
+# 2. Select the source referrer. Fail loudly on anything but exactly one:
+#    artifactType is not a unique key, and anyone with push access to the
+#    repository can attach another referrer carrying the same type. Taking the
+#    first match would silently pick theirs.
+mapfile -t MATCHES < <(oras discover --format json "${IMAGE%:*}@${DIGEST}" \
+  | jq -r '.referrers[]
+           | select(.artifactType == "application/vnd.nvidia.aicr.source.v1+tar")
+           | .digest')
+if [ "${#MATCHES[@]}" -ne 1 ]; then
+  echo "expected exactly 1 source referrer, found ${#MATCHES[@]}" >&2
+  exit 1
+fi
+SOURCE="${MATCHES[0]}"
+
+# 3. Verify the signature before trusting the bytes. Pin the exact signing
+#    workflow and tag; a regexp over the repository would accept a signature
+#    from any workflow in it.
+cosign verify \
+  --certificate-oidc-issuer "${AICR_ISSUER}" \
+  --certificate-identity \
+    "https://github.com/NVIDIA/aicr/.github/workflows/on-tag.yaml@refs/tags/${TAG}" \
+  "${IMAGE%:*}@${SOURCE}"
+
+# 4. Pull the verified archive.
+oras pull -o ./aiperf-source "${IMAGE%:*}@${SOURCE}"
+
+# 5. The archive holds one sdist per installed package, plus a README.
+tar tzf ./aiperf-source/aiperf-bench-python-source.tar.gz | head
+```
+
+The archive contains the source distribution of every Python package installed
+into the image **that publishes one upstream**, at the exact version installed.
+One package is intentionally absent: `aiperf` itself publishes no source
+distribution to PyPI. It is an
+NVIDIA package and its source is at [ai-dynamo/aiperf](https://github.com/ai-dynamo/aiperf); the
+archive's `README.txt` records this too.
+
+Only `aiperf-bench` carries this referrer. The other six images need none: their
+dependencies are vendored, so the release source archive already contains them.
+
+**Scope of the correspondence.** The archive is resolved from the same
+`requirements.txt` the image installs, so both derive from one input. Two gaps
+remain and are tracked rather than claimed away:
+
+* `pip` and `wheel` are provided by `python -m venv` rather than declared in
+  `requirements.txt`, so they ship in the image without source in this archive.
+* The image build layer-caches its dependency resolution, so a cached build can
+  carry an older closure than a freshly resolved archive (tracked in
+  [#2086](https://github.com/NVIDIA/aicr/issues/2086)).
+
+A referrer binds to one image digest, so resolve the tag to a digest first as
+shown above rather than assuming a tag keeps the same attachment across builds.
 
 ### Using the published VEX document
 

--- a/tests/notices/aiperf_source_test.go
+++ b/tests/notices/aiperf_source_test.go
@@ -1,0 +1,332 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notices
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const sourceTool = "tools/generate-aiperf-source"
+
+// runPy loads the tool as a module and runs the supplied assertions against it.
+// The tool is a script, not an importable package, so tests exec it with
+// __name__ guarded and then call its functions directly. This executes the real
+// code rather than asserting on its source text: a substring check passes even
+// when the logic it names has become unreachable.
+func runPy(t *testing.T, body string) (string, error) {
+	t.Helper()
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	preamble := `
+import pathlib, types, urllib.error, sys
+_p = "` + repositoryPath(t, sourceTool) + `"
+src = pathlib.Path(_p).read_text()
+mod = types.ModuleType("t"); mod.__dict__["__file__"] = _p
+exec(compile(src.replace("sys.exit(main())", "pass"), "t", "exec"), mod.__dict__)
+mod.BACKOFF_BASE_SECONDS = 0.001
+`
+	ctx, cancel := context.WithTimeout(context.Background(), scriptTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "python3", "-c", preamble+body)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("python helper exceeded deadline: %v\n%s", ctx.Err(), out)
+	}
+	return string(out), err
+}
+
+// TestAiperfSourceResolvesFromRequirements pins the coupling that makes the
+// published archive correspond to the shipped image: the closure is resolved
+// from the same requirements.txt the Dockerfile installs, not from a committed
+// snapshot that ages out of step with what a later build resolves.
+//
+// The pip resolution is stubbed. A real one costs ~90s and needs PyPI, and the
+// behavior under test is that the tool asks pip about requirements.txt and
+// parses what comes back — not that PyPI is reachable.
+func TestAiperfSourceResolvesFromRequirements(t *testing.T) {
+	out, err := runPy(t, `
+import json, pathlib, types
+
+captured = {}
+
+class FakeResult:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+
+def fake_run(cmd, **kwargs):
+    captured["cmd"] = cmd
+    # pip writes the resolution to the --report path; emit a minimal one.
+    report = pathlib.Path(cmd[cmd.index("--report") + 1])
+    report.write_text(json.dumps({"install": [
+        {"metadata": {"name": "aiperf", "version": "0.11.0"}},
+        {"metadata": {"name": "certifi", "version": "2026.7.22"}},
+    ]}))
+    return FakeResult()
+
+mod.subprocess.run = fake_run
+pkgs = mod.read_closure()
+
+assert pkgs == [("aiperf", "0.11.0"), ("certifi", "2026.7.22")], pkgs
+
+cmd = captured["cmd"]
+# The requirements file the image installs must be the resolution input.
+assert "--requirement" in cmd, cmd
+req = cmd[cmd.index("--requirement") + 1]
+assert req.endswith("validators/performance/requirements.txt"), req
+# Resolution only; a real install here would be a different (and slow) thing.
+assert "--dry-run" in cmd, cmd
+print("resolved from:", req.split("/")[-1])
+`)
+	if err != nil {
+		t.Fatalf("read_closure failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "resolved from: requirements.txt") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+// TestAiperfSourceFailsClosedOnMissingSdist drives build_archive with a stubbed
+// index so the fail-closed path actually runs. A package with no obtainable
+// source must abort the build; only an allowlisted one may be absent.
+func TestAiperfSourceFailsClosedOnMissingSdist(t *testing.T) {
+	t.Run("unlisted package aborts", func(t *testing.T) {
+		out, err := runPy(t, `
+import tempfile, pathlib
+mod.read_closure = lambda: [("ghost", "1.0.0")]
+mod.sdist_for = lambda name, version: None      # no source anywhere
+try:
+    mod.build_archive(pathlib.Path(tempfile.mkdtemp()))
+    print("NO-ABORT")
+except SystemExit as e:
+    print("ABORTED:", str(e).splitlines()[0])
+`)
+		if err != nil {
+			t.Fatalf("helper failed: %v\n%s", err, out)
+		}
+		if strings.Contains(out, "NO-ABORT") {
+			t.Error("a package with no obtainable source did not abort the build")
+		}
+		if !strings.Contains(out, "no source distribution published for") {
+			t.Errorf("expected the fail-closed error, got: %s", out)
+		}
+		if !strings.Contains(out, "ghost") {
+			t.Errorf("the error does not name the offending package: %s", out)
+		}
+	})
+
+	t.Run("allowlisted package is permitted", func(t *testing.T) {
+		out, err := runPy(t, `
+import tempfile, pathlib
+# aiperf is the allowlisted no-sdist entry; everything else resolves.
+mod.read_closure = lambda: [("aiperf", "0.11.0")]
+mod.sdist_for = lambda name, version: None
+archive, count, missing = mod.build_archive(pathlib.Path(tempfile.mkdtemp()))
+assert missing == ["aiperf"], f"unexpected missing set: {missing}"
+assert archive.exists(), "archive was not written"
+print("OK count=", count, "missing=", missing)
+`)
+		if err != nil {
+			t.Fatalf("an allowlisted package must not abort: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "missing= ['aiperf']") {
+			t.Errorf("unexpected output: %s", out)
+		}
+	})
+}
+
+// TestAiperfSourceRejectsChecksumMismatch executes the integrity check. A
+// download whose bytes do not match the sha256 PyPI publishes must abort rather
+// than land in the archive, otherwise the "source" we publish is unverifiable
+// against what the author released.
+func TestAiperfSourceRejectsChecksumMismatch(t *testing.T) {
+	out, err := runPy(t, `
+import tempfile, pathlib, io
+mod.read_closure = lambda: [("pkg", "1.0.0")]
+# Declare a digest that the served bytes cannot match.
+mod.sdist_for = lambda n, v: ("pkg-1.0.0.tar.gz", "https://example.invalid/pkg", "00"*32)
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+mod.urllib.request.urlopen = lambda *a, **k: FakeResponse(b"tampered bytes")
+
+try:
+    mod.build_archive(pathlib.Path(tempfile.mkdtemp()))
+    print("NO-ABORT")
+except SystemExit as e:
+    print("ABORTED:", str(e).splitlines()[0])
+`)
+	if err != nil {
+		t.Fatalf("helper failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "NO-ABORT") {
+		t.Error("a checksum mismatch did not abort the build")
+	}
+	if !strings.Contains(out, "failed integrity check") {
+		t.Errorf("expected an integrity-check failure, got: %s", out)
+	}
+}
+
+// TestAiperfSourceSdistSelectionIsOrderIndependent pins determinism of the
+// archive: if PyPI returns more than one sdist, response order must not decide
+// which source ships, or identical inputs would produce different archives.
+func TestAiperfSourceSdistSelectionIsOrderIndependent(t *testing.T) {
+	out, err := runPy(t, `
+import json, io
+entries = [
+    {"packagetype": "sdist", "filename": "pkg-1.0.0.zip",
+     "url": "u2", "digests": {"sha256": "b"*64}},
+    {"packagetype": "sdist", "filename": "pkg-1.0.0.tar.gz",
+     "url": "u1", "digests": {"sha256": "a"*64}},
+]
+
+def serve(order):
+    payload = json.dumps({"urls": order}).encode()
+    class R(io.BytesIO):
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    mod.urllib.request.urlopen = lambda *a, **k: R(payload)
+    return mod.sdist_for("pkg", "1.0.0")
+
+forward = serve(entries)
+reverse = serve(list(reversed(entries)))
+assert forward == reverse, f"order changed the selection: {forward} vs {reverse}"
+print("stable:", forward[0])
+`)
+	if err != nil {
+		t.Fatalf("helper failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "stable:") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+// TestAiperfSourceDoesNotLeakMaintainerContacts keeps third-party contact
+// details out of the README that ships inside a public artifact. aiperf's PyPI
+// metadata carries a maintainer distribution list; republishing it here would
+// route external mail at another team without serving the obligation.
+func TestAiperfSourceDoesNotLeakMaintainerContacts(t *testing.T) {
+	body, err := os.ReadFile(repositoryPath(t, sourceTool))
+	if err != nil {
+		t.Fatalf("read %s: %v", sourceTool, err)
+	}
+	if strings.Contains(string(body), "@nvidia.com") {
+		t.Error("an @nvidia.com address is embedded in the tool; it would ship " +
+			"in the archive README published to customers")
+	}
+}
+
+// TestAiperfSourceAttachUsesRelativePath pins a fix that only reproduces
+// against a real registry: `oras attach` rejects absolute file paths, because
+// the file argument becomes the layer's org.opencontainers.image.title and an
+// absolute path would publish the builder's local directory layout. The tool
+// must pass a bare filename with cwd set, not re-enable the path by suppressing
+// the check.
+func TestAiperfSourceAttachUsesRelativePath(t *testing.T) {
+	body, err := os.ReadFile(repositoryPath(t, sourceTool))
+	if err != nil {
+		t.Fatalf("read %s: %v", sourceTool, err)
+	}
+	text := string(body)
+
+	// Match the flag only as a quoted argument. The script mentions it in a
+	// comment explaining why it is not used, and a bare substring check would
+	// fail on that explanation.
+	if strings.Contains(text, `"--disable-path-validation"`) {
+		t.Error("path validation is disabled; the archive's absolute local path " +
+			"would be published as the layer title")
+	}
+	if !strings.Contains(text, "archive.name") || !strings.Contains(text, "cwd=archive.parent") {
+		t.Error("oras attach must receive a bare filename with cwd set to the " +
+			"archive directory; an absolute path is rejected by oras")
+	}
+}
+
+// TestAiperfSourceRetriesTransientFailuresOnly exercises the retry policy the
+// release job depends on. 130 metadata lookups plus 129 downloads against PyPI
+// make transient failures likely, but a 404 is a definitive answer and must not
+// be retried, because it is what feeds the fail-closed reporting.
+func TestAiperfSourceRetriesTransientFailuresOnly(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	tool := repositoryPath(t, sourceTool)
+	script := `
+import pathlib, types, urllib.error
+src = pathlib.Path("` + tool + `").read_text()
+mod = types.ModuleType("t"); mod.__dict__["__file__"] = "` + tool + `"
+exec(compile(src.replace("sys.exit(main())", "pass"), "t", "exec"), mod.__dict__)
+mod.BACKOFF_BASE_SECONDS = 0.001
+
+def flaky(fails, exc):
+    n = {"c": 0}
+    def op():
+        n["c"] += 1
+        if n["c"] <= fails:
+            raise exc
+        return "ok"
+    return op, n
+
+# name, failures raised, exception, expected attempts, expected exception type
+CASES = [
+    ("transient 503 recovers",
+     2, urllib.error.HTTPError("u", 503, "busy", {}, None), 3, None),
+    ("404 is definitive and not retried",
+     99, urllib.error.HTTPError("u", 404, "gone", {}, None), 1, urllib.error.HTTPError),
+    ("persistent transport error gives up at MAX_ATTEMPTS",
+     99, urllib.error.URLError("down"), mod.MAX_ATTEMPTS, urllib.error.URLError),
+]
+
+failures = []
+for name, fails, exc, want_attempts, want_raise in CASES:
+    op, n = flaky(fails, exc)
+    try:
+        result = mod.with_retry(op, "x")
+        if want_raise is not None:
+            failures.append(f"{name}: expected {want_raise.__name__}, got {result!r}")
+    except Exception as err:
+        if want_raise is None or not isinstance(err, want_raise):
+            failures.append(f"{name}: unexpected {type(err).__name__}: {err}")
+    if n["c"] != want_attempts:
+        failures.append(f"{name}: attempts = {n['c']}, want {want_attempts}")
+
+if failures:
+    raise SystemExit("\n".join(failures))
+print("ok")
+`
+	ctx, cancel := context.WithTimeout(context.Background(), scriptTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "python3", "-c", script)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("retry policy check exceeded deadline: %v\n%s", ctx.Err(), out)
+	}
+	if err != nil {
+		t.Fatalf("retry policy check failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "ok") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}

--- a/tools/check-tools
+++ b/tools/check-tools
@@ -100,6 +100,9 @@ get_tool_metadata() {
         syft)
             echo "syft:::syft version 2>/dev/null | grep -E '^Version:' | awk '{print \$2}':::major_minor"
             ;;
+        oras)
+            echo "oras:::oras version 2>/dev/null | grep -E '^Version:' | awk '{print \$2}':::major_minor"
+            ;;
         # Testing tools
         kubectl)
             echo "kubectl:::kubectl version --client -o json 2>/dev/null | grep gitVersion | grep -oE 'v[0-9]+\.[0-9]+' || echo installed:::major"

--- a/tools/generate-aiperf-source
+++ b/tools/generate-aiperf-source
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Publish the third-party Python source for the aiperf-bench image.
+
+Builds a tarball of the source distributions for every Python package installed
+into `aicr-validators/aiperf-bench`, and optionally attaches it to the published
+image as an OCI 1.1 referrer.
+
+Usage::
+
+    tools/generate-aiperf-source
+    tools/generate-aiperf-source --attach ghcr.io/nvidia/aicr-validators/aiperf-bench@sha256:...
+
+Why only this image
+-------------------
+NVIDIA's container policy requires the source of every third-party open-source
+component added on top of an approved base image to be retrievable by whoever
+pulls the image, regardless of license. Attribution (THIRD_PARTY_NOTICES.md) is
+a separate obligation and does not satisfy this one.
+
+The six Go images already satisfy it: their dependencies are vendored, so the
+GitHub release source archive for the matching tag contains the complete source
+of every module compiled in. Only aiperf-bench installs from wheels (built
+distributions), leaving nothing that holds its source.
+
+Why a referrer rather than baking it into the image
+---------------------------------------------------
+The sdists are ~250 MB. Embedding them would be paid on every benchmark pod
+pull, forever, for data nothing reads at runtime. A referrer leaves the runtime
+image untouched, binds the source to the exact image digest so correspondence
+cannot drift, and changes no other part of the release pipeline. OSRB confirmed
+the referrers API is acceptable provided retrieval is documented, which
+docs/integrator/supply-chain-verification.md covers.
+
+A referrer binds to one digest, so this runs per published build.
+
+Why the closure is read from the committed notices fragment
+-----------------------------------------------------------
+`validators/performance/licenses/python-notices.md` already records the exact
+name and version of every package in the image, and CI gates it against
+requirements.txt. Reading it here means the source archive and the attribution
+record cannot describe different closures, and avoids a second resolution that
+could drift from the first. It is also far faster than re-resolving: sdist URLs
+come from the PyPI JSON API, turning a 30-minute `pip download` into under a
+minute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import contextlib
+import gzip
+import hashlib
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+REQUIREMENTS = REPO_ROOT / "validators/performance/requirements.txt"
+
+# Must match the aiperf-bench builder stage so the resolution matches what the
+# image installs: `FROM python:3.13-slim` and the manylinux targets its wheels
+# are selected for.
+PYTHON_VERSION = "3.13"
+PLATFORM_TAGS = [
+    "manylinux2014_x86_64",
+    "manylinux_2_17_x86_64",
+    "manylinux_2_28_x86_64",
+]
+DEFAULT_OUTPUT = REPO_ROOT / "dist/aiperf-source"
+ARCHIVE_NAME = "aiperf-bench-python-source.tar.gz"
+
+# The OCI artifactType consumers filter on. Versioned so the layout can change
+# later without breaking a documented retrieval command.
+ARTIFACT_TYPE = "application/vnd.nvidia.aicr.source.v1+tar"
+
+# Packages that publish no sdist on PyPI, with where their source is instead.
+# Anything not listed here aborts the run rather than silently producing a
+# source archive with a hole in it.
+# The note is rendered into a README that ships in a public artifact, so it
+# names the source location and nothing else. aiperf's PyPI metadata also
+# carries a maintainer distribution list, deliberately not repeated here:
+# republishing another team's DL inside our compliance artifact would invite
+# external mail to it without adding anything the obligation requires.
+KNOWN_NO_SDIST = {
+    "aiperf": (
+        "NVIDIA package, wheel-only release; "
+        "source at https://github.com/ai-dynamo/aiperf"
+    ),
+}
+
+PYPI_JSON = "https://pypi.org/pypi/{name}/{version}/json"
+INDEX_ROW = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*([^|\s]+)\s*\|")
+
+# 130 metadata lookups plus 129 downloads against a third party is enough
+# requests that a transient failure is likely rather than exceptional. Without
+# retry a single blip fails the whole run.
+MAX_ATTEMPTS = 4
+BACKOFF_BASE_SECONDS = 1.0
+
+# Statuses worth retrying. 404 is deliberately absent: it is the honest answer
+# that no sdist exists for this version, and retrying it would only slow the
+# fail-closed path that reports a package as unavailable.
+RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+def with_retry(operation, description: str):
+    """Run a network operation, retrying only genuinely transient failures."""
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            return operation()
+        except urllib.error.HTTPError as err:
+            if err.code not in RETRYABLE_STATUS or attempt == MAX_ATTEMPTS:
+                raise
+            reason = f"HTTP {err.code}"
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as err:
+            if attempt == MAX_ATTEMPTS:
+                raise
+            reason = type(err).__name__
+
+        delay = BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+        print(
+            f"  retry {attempt}/{MAX_ATTEMPTS - 1} for {description} after {reason}; "
+            f"waiting {delay:.0f}s",
+            file=sys.stderr,
+        )
+        time.sleep(delay)
+    raise RuntimeError("unreachable")
+
+
+def read_closure() -> list[tuple[str, str]]:
+    """Resolve requirements.txt to the exact closure the image installs.
+
+    Resolved here rather than read from the committed notices fragment so that
+    the archive and the image derive from ONE input: the same requirements.txt
+    the Dockerfile installs. A committed snapshot is a point-in-time record that
+    silently ages out of step with what a later build resolves, which would
+    break the per-digest correspondence the referrer exists to assert.
+
+    `--dry-run --report` resolves without downloading, so this costs a resolution
+    (~90s) rather than a full install, and deps stay free to float: a rebuild
+    picks up patched transitive versions exactly as it does today, and this
+    follows it instead of pinning it.
+
+    Two known gaps, tracked separately rather than claimed away: pip and wheel
+    come from `python -m venv` and are not declared here, and the image build
+    layer-caches its own resolution (#2086), so a cached build can ship an older
+    closure than this resolves.
+    """
+    if not REQUIREMENTS.is_file():
+        raise SystemExit(f"ERROR: {REQUIREMENTS} not found.")
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as handle:
+        report = pathlib.Path(handle.name)
+
+    cmd = [
+        sys.executable, "-m", "pip", "install",
+        "--dry-run", "--quiet",
+        "--report", str(report),
+        "--only-binary=:all:",
+        "--python-version", PYTHON_VERSION,
+        "--requirement", str(REQUIREMENTS),
+    ]
+    for tag in PLATFORM_TAGS:
+        cmd += ["--platform", tag]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            sys.stderr.write(result.stdout)
+            sys.stderr.write(result.stderr)
+            raise SystemExit(f"ERROR: could not resolve {REQUIREMENTS}")
+
+        data = json.loads(report.read_text(encoding="utf-8"))
+    finally:
+        report.unlink(missing_ok=True)
+
+    packages = [
+        (entry["metadata"]["name"], entry["metadata"]["version"])
+        for entry in data.get("install", [])
+    ]
+    if not packages:
+        raise SystemExit(f"ERROR: {REQUIREMENTS} resolved to no packages")
+    return packages
+
+
+def sdist_for(name: str, version: str) -> tuple[str, str, str] | None:
+    """Return (filename, url, sha256) of the sdist for one pinned package.
+
+    Returns None only when the index genuinely lists no usable sdist. Transport
+    failures raise, so "we could not ask" is never mistaken for "there is none".
+
+    The digest is carried through and checked after download. PyPI publishes a
+    sha256 for every file it serves, and this archive is a compliance artifact:
+    accepting whatever bytes arrive from a URL, without verifying them against
+    the index's own declaration, would make the published "source" unverifiable
+    against what the package author released.
+    """
+    def lookup() -> dict:
+        with urllib.request.urlopen(
+            PYPI_JSON.format(name=name, version=version), timeout=30
+        ) as response:
+            return json.load(response)
+
+    # Deliberately NOT catching network errors here. urllib.error.HTTPError
+    # subclasses URLError, so swallowing URLError would collapse a persistent
+    # 5xx or a 403 into the same `None` a genuine "no sdist" returns. The run
+    # would then abort saying the package publishes no source and advise adding
+    # it to KNOWN_NO_SDIST -- which would permanently suppress source
+    # publication for a package that has source. Letting the failure propagate
+    # aborts with the actual transport error instead.
+    data = with_retry(lookup, f"{name}=={version} metadata")
+
+    # Sort rather than take the first match. A release normally has one sdist,
+    # but the API does not guarantee that or a stable order, and picking by
+    # arrival order would let the same inputs produce a different archive on a
+    # different day. Ordering by filename is deterministic and, for the
+    # multiple-sdist case, prefers the canonical `.tar.gz` over a legacy `.zip`
+    # by simple lexical order.
+    sdists = sorted(
+        (e for e in data.get("urls", []) if e.get("packagetype") == "sdist"),
+        key=lambda e: e.get("filename", ""),
+    )
+    for entry in sdists:
+        digest = (entry.get("digests") or {}).get("sha256")
+        if not digest:
+            # Reported as unavailable rather than downloaded unverified: an
+            # entry we cannot check is not source we can vouch for. Named
+            # distinctly from "no sdist" so the diagnostic is not misleading.
+            print(
+                f"WARNING: {name}=={version} sdist has no sha256 on PyPI",
+                file=sys.stderr,
+            )
+            return None
+        return entry["filename"], entry["url"], digest
+    return None
+
+
+# Fixed permissions for archive members. Files land via write_bytes/write_text,
+# which apply the builder's umask, so a machine running umask 002 would produce
+# different modes -- and therefore a different archive digest -- than one
+# running 022 from byte-identical inputs.
+_FILE_MODE = 0o644
+_DIR_MODE = 0o755
+
+
+def _reset(info: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Strip per-machine metadata so the archive is byte-reproducible."""
+    info.uid = info.gid = 0
+    info.uname = info.gname = "root"
+    info.mtime = 0
+    info.mode = _DIR_MODE if info.isdir() else _FILE_MODE
+    return info
+
+
+@contextlib.contextmanager
+def reproducible_tar(path: pathlib.Path):
+    """Open a .tar.gz whose bytes depend only on its contents.
+
+    `tarfile.open(mode="w:gz")` is not enough: gzip stamps the current time into
+    its own header, so two runs over identical input produce different archives
+    and therefore a different referrer digest. Driving gzip directly with
+    mtime=0 removes the last source of nondeterminism, since tarfile already
+    walks directories in sorted order and _reset zeroes per-file metadata.
+    """
+    with open(path, "wb") as raw:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as gz:
+            with tarfile.open(fileobj=gz, mode="w") as tar:
+                yield tar
+
+
+def build_archive(out_dir: pathlib.Path) -> tuple[pathlib.Path, int, list[str]]:
+    packages = read_closure()
+    print(f"Resolving sdists for {len(packages)} packages...", file=sys.stderr)
+
+    staging = out_dir / ".staging"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    resolved: dict[str, tuple[str, str, str]] = {}
+    unavailable: list[str] = []
+
+    # PyPI lookups dominate wall clock and are independent, so fan out.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {pool.submit(sdist_for, n, v): n for n, v in packages}
+        for future in concurrent.futures.as_completed(futures):
+            name = futures[future]
+            found = future.result()
+            if found is None:
+                unavailable.append(name)
+            else:
+                resolved[name] = found
+
+    unexpected = sorted(set(unavailable) - set(KNOWN_NO_SDIST))
+    if unexpected:
+        raise SystemExit(
+            "ERROR: no source distribution published for: " + ", ".join(unexpected)
+            + "\nThe image would ship binaries whose source is not available.\n"
+            "Add the package to KNOWN_NO_SDIST with a documented source location,\n"
+            "or remove the dependency."
+        )
+
+    print(f"Downloading {len(resolved)} sdists...", file=sys.stderr)
+
+    def download(item: tuple[str, tuple[str, str, str]]) -> None:
+        name, (filename, url, want_sha256) = item
+
+        def get() -> bytes:
+            with urllib.request.urlopen(url, timeout=120) as response:
+                return response.read()
+
+        # No except here on purpose: an sdist that cannot be fetched after
+        # retries must fail the run. Skipping it would produce an archive that
+        # silently omits a package whose source we are obliged to publish.
+        payload = with_retry(get, f"{name} sdist")
+
+        got_sha256 = hashlib.sha256(payload).hexdigest()
+        if got_sha256 != want_sha256:
+            raise SystemExit(
+                f"ERROR: {name} sdist failed integrity check.\n"
+                f"  expected sha256 {want_sha256}\n"
+                f"  received sha256 {got_sha256}\n"
+                "Refusing to publish source that does not match what the index declares."
+            )
+
+        (staging / filename).write_bytes(payload)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(download, sorted(resolved.items())))
+
+    (staging / "README.txt").write_text(
+        "Third-party Python source for ghcr.io/nvidia/aicr-validators/aiperf-bench\n"
+        "========================================================================\n\n"
+        f"This archive contains the source distribution of {len(resolved)} Python\n"
+        "packages installed into the aiperf-bench image. Each is the source\n"
+        "published for the exact version installed, so it corresponds to the\n"
+        "binaries the image distributes.\n\n"
+        "Not included (no source distribution published upstream):\n"
+        + "".join(f"  {n}: {KNOWN_NO_SDIST[n]}\n" for n in sorted(unavailable))
+        + "\nThe base image (nvcr.io/nvidia/distroless/python) ships its own source\n"
+        "under its own approval; it is not duplicated here.\n\n"
+        "Source for the Go components of AICR is in the GitHub release archive for\n"
+        "the matching tag at https://github.com/NVIDIA/aicr, which contains the\n"
+        "complete vendor/ tree.\n\n"
+        "License texts for all of the above are in THIRD_PARTY_NOTICES.md,\n"
+        "published as an asset on each AICR release.\n",
+        encoding="utf-8",
+    )
+
+    archive = out_dir / ARCHIVE_NAME
+    with reproducible_tar(archive) as tar:
+        for entry in sorted(p.name for p in staging.iterdir()):
+            tar.add(staging / entry, arcname=entry, filter=_reset)
+
+    shutil.rmtree(staging)
+    return archive, len(resolved), sorted(unavailable)
+
+
+def attach(archive: pathlib.Path, image: str) -> str:
+    """Attach the archive as an OCI 1.1 referrer; return the referrer digest.
+
+    The digest is returned rather than discarded because `oras attach` produces
+    an UNSIGNED artifact. Anyone with push access to the repository can add a
+    second referrer carrying the same artifactType, and a consumer selecting by
+    type alone would have no way to tell them apart (CWE-345). The caller signs
+    this exact digest so retrieval can be authenticated.
+    """
+    if shutil.which("oras") is None:
+        raise SystemExit(
+            "ERROR: oras is not installed; it is required to attach the referrer.\n"
+            "See https://oras.land/docs/installation"
+        )
+
+    print(f"Attaching to {image}...", file=sys.stderr)
+    # Run from the archive's directory and pass the bare filename. `oras attach`
+    # rejects absolute paths outright, and for good reason: the file argument
+    # becomes the layer's org.opencontainers.image.title, so an absolute path
+    # would publish the builder's local directory layout into the artifact.
+    # Passing the basename keeps that annotation to just the archive name, which
+    # is also what a consumer wants to see. Preferred over
+    # --disable-path-validation, which would suppress the check and keep the leak.
+    result = subprocess.run(
+        [
+            "oras", "attach",
+            "--artifact-type", ARTIFACT_TYPE,
+            "--annotation", "org.opencontainers.image.title=Third-party Python source",
+            image,
+            f"{archive.name}:application/gzip",
+        ],
+        cwd=archive.parent,
+        capture_output=True, text=True, check=False,
+    )
+    sys.stderr.write(result.stdout)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise SystemExit(f"ERROR: oras attach failed for {image}")
+
+    # oras reports the referrer manifest digest on the final "Digest:" line.
+    digest = ""
+    for line in result.stdout.splitlines():
+        if line.startswith("Digest:"):
+            digest = line.split(":", 1)[1].strip()
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise SystemExit(
+            "ERROR: could not read the referrer digest from oras output.\n"
+            "Without it the artifact cannot be signed, and an unsigned referrer "
+            "is indistinguishable from one an attacker attached."
+        )
+    return digest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--output-dir", type=pathlib.Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--attach",
+        metavar="IMAGE",
+        help="Attach the archive to this published image as an OCI referrer. "
+             "Prefer a digest reference; a referrer binds to one digest.",
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    archive, count, missing = build_archive(args.output_dir)
+
+    size_mb = archive.stat().st_size // 1024 // 1024
+    print(f"Wrote {archive} ({count} packages, {size_mb} MB)", file=sys.stderr)
+    for name in missing:
+        print(f"  not included: {name} - {KNOWN_NO_SDIST[name]}", file=sys.stderr)
+
+    if args.attach:
+        referrer = attach(archive, args.attach)
+        print(f"Attached referrer {referrer}", file=sys.stderr)
+        print(f"Retrieve with: oras discover --format tree {args.attach}", file=sys.stderr)
+
+        # Emitted on stdout (everything else goes to stderr) so a caller can
+        # capture it without parsing progress output. The release workflow signs
+        # this digest; an unsigned referrer cannot be told apart from one an
+        # attacker with push access attached alongside it.
+        print(referrer)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -279,6 +279,7 @@ GO_LICENSES_VERSION=$(yq '.linting.go_licenses' .settings.yaml)
 GRYPE_VERSION=$(yq '.security_tools.grype' .settings.yaml)
 COSIGN_VERSION=$(yq '.security_tools.cosign' .settings.yaml)
 SYFT_VERSION=$(yq '.security_tools.syft' .settings.yaml)
+ORAS_VERSION=$(yq '.security_tools.oras' .settings.yaml)
 KIND_VERSION=$(yq '.testing_tools.kind' .settings.yaml)
 KUBECTL_VERSION=$(yq '.testing_tools.kubectl' .settings.yaml)
 CTLPTL_VERSION=$(yq '.testing_tools.ctlptl' .settings.yaml)
@@ -693,6 +694,34 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
                 fi
             fi
             log_success "syft installed"
+        fi
+    fi
+
+    # oras (attaches the aiperf-bench third-party source archive as an OCI
+    # referrer; see tools/generate-aiperf-source. Cosign cannot attach arbitrary
+    # artifacts, so this is a separate dependency from the signing path.)
+    if command_exists oras && [[ "${UPGRADE}" != "true" ]]; then
+        log_success "oras already installed: $(oras version 2>/dev/null | grep -E '^Version:' | awk '{print $2}')"
+    else
+        log_info "Installing oras ${ORAS_VERSION}..."
+        if prompt_continue; then
+            if [[ "${OS}" == "darwin" ]]; then
+                brew install oras
+            elif [[ "${OS}" == "linux" ]]; then
+                ORAS_VER="${ORAS_VERSION#v}"
+                ORAS_TMP=$(mktemp -d)
+                ORAS_URL="https://github.com/oras-project/oras/releases/download/v${ORAS_VER}/oras_${ORAS_VER}_linux_${GO_ARCH}.tar.gz"
+                if verify_download_url "$ORAS_URL" "oras ${ORAS_VERSION} for Linux ${GO_ARCH}"; then
+                    curl -fsSL "$ORAS_URL" | tar -xzC "$ORAS_TMP"
+                    sudo mv "$ORAS_TMP/oras" /usr/local/bin/oras
+                    sudo chmod +x /usr/local/bin/oras
+                    rm -rf "$ORAS_TMP"
+                else
+                    log_error "Failed to install oras. Please install manually."
+                    rm -rf "$ORAS_TMP"
+                fi
+            fi
+            log_success "oras installed"
         fi
     fi
 


### PR DESCRIPTION
## Summary

Publishes the source of every third-party Python package installed into the `aiperf-bench` image, attached to that image as an OCI 1.1 referrer, and documents retrieval for all seven released images.

## Motivation / Context

NVIDIA's container policy requires the source of every third-party open-source component added on top of an approved base image to be retrievable by whoever pulls the image, **regardless of license**. That is a separate obligation from attribution and is not satisfied by `THIRD_PARTY_NOTICES.md`.

Six of the seven released images already comply. Their dependencies are vendored, so the GitHub release source archive for the matching tag contains `vendor/` — the complete source of every module compiled in, since builds run with `-mod=vendor`. Only `aiperf-bench` installs from wheels (built distributions), leaving nothing under NVIDIA's control that holds its source.

OSRB confirmed the referrers API is an acceptable mechanism provided retrieval is documented, since the artifact is invisible to `docker pull`.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`) — the `aiperf-bench` image
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`)
- [x] Other: release workflow, tooling

## Implementation Notes

**It does not gate the release.** `attach-source` runs *after* `publish` and is deliberately excluded from `release-check`. Attaching depends on PyPI serving 129 sdists — an uncontrolled third party on the critical path. Gating on it would turn a PyPI blip or a yanked version into a failed release and a release-day fire drill. Nothing is lost by attaching afterwards: a referrer binds to the image digest, and promotion does not change the digest, so the artifact lands on the same subject either way. A failure is a re-runnable job rather than a recut tag.

**The package list is read from the committed notices fragment**, not resolved independently, so the source archive and the attribution record cannot describe different closures. It also takes sdist URLs from the PyPI JSON API, turning a 30-minute `pip download` into ~47 seconds.

**The archive is byte-reproducible.** gzip stamps the current time into its header, so a naive `tarfile.open(mode="w:gz")` produced a different referrer digest on every run.

**Retry is transient-only.** 4 attempts with exponential backoff on both the metadata lookups and the downloads. `404` is excluded on purpose: it is the definitive answer that no sdist exists, and it feeds the fail-closed path that aborts on any package whose source cannot be published. A failed *download* aborts rather than being skipped, since skipping would produce an archive silently missing a package.

**`oras` receives a bare filename with `cwd` set.** It rejects absolute paths because the file argument becomes the layer's `org.opencontainers.image.title`; passing an absolute path would publish the builder's local directory layout. `--disable-path-validation` would have suppressed the check and kept the leak.

**No maintainer contacts ship in the artifact.** aiperf's PyPI metadata carries a maintainer distribution list; it is deliberately not repeated in the README that ships inside a public archive.

## Testing

```bash
make lint                          # pass
go test ./tests/notices/...        # 14 tests pass
golangci-lint run ./tests/notices/...  # 0 issues
```

**Verified end to end against a real registry (ttl.sh)**, not just locally: attach, `oras discover`, `oras pull`, and a byte-identical SHA256 on the retrieved 253 MB archive with all 130 entries intact. That test found the absolute-path bug, which a localhost prototype had missed.

New tests pin the properties that would otherwise rot silently: that the closure is read from the committed notices fragment, that missing source fails closed, that no `@nvidia.com` address is embedded, that `oras` gets a relative path, and the retry policy including 404 handling. The oras-path assertion is mutation-verified — reverting the fix fails it with the intended message.

**`make qualify` is not fully green on this machine**, from three pre-existing environmental failures unrelated to this change, each reproducing on a clean `main` here: `test-shell` (sandboxed `mktemp`), `tests/releasepolicy` (`timeout` is GNU coreutils, absent on macOS), `pkg/oci` (local helm 4.2.0 vs pinned 4.2.3). Every other package passes.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No image contents change and no runtime behaviour changes. The new release job runs after publish and cannot block a release. `oras` is a new pinned tool dependency (`v1.3.0`), needed because cosign cannot attach arbitrary artifacts. If the `aiperf-bench` image is replaced, this deletes cleanly: one job, one script, one docs section.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
