### PR TITLE
fix(ci): size the GKE UAT timeout for the bringup retry

### DIFF
--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -77,9 +77,27 @@ jobs:
     # counts the larger (serve). The teardown MUST fit in this budget: a job-level
     # timeout cancels pending always() steps, so an undersized cap would skip
     # teardown and leak the GPU node. 190 UAT + ~30 setup + ~8 failure-path debug
-    # collection (Collect cluster debug bundle) + ~40 teardown = ~268, so 280
-    # leaves the teardown headroom even on a worst-case phase run.
-    timeout-minutes: 280
+    # collection (Collect cluster debug bundle) + ~40 teardown = ~268.
+    #
+    # The Bringup Infra step retries once (#2066) and carries no step-level
+    # timeout, so a retried run costs a second provisioning attempt. The failure
+    # it retries is the actuator's own hardcoded 30m node-pool timeout, so the
+    # first attempt burns the full 30m before failing, plus the 60s backoff:
+    # ~31m on top of the ~268 above, i.e. ~299 worst case.
+    #
+    # 320 leaves ~21m over that worst case — deliberately more than the ~12m
+    # this cap carried before, because overrunning does not merely fail the run:
+    # it cancels the always() Destroy Cluster step and leaks the GPU node and its
+    # VPC network group, exactly what #2066 exists to protect. Sizing for a
+    # single attempt would let a *successful* late retry trip that.
+    #
+    # Do not reduce this cap without recomputing the whole budget. In particular
+    # #2065 does NOT justify returning to 280: raising the actuator's node-pool
+    # timeout 30m->60m makes a single provisioning attempt cost up to ~30m MORE,
+    # so the ~268 base above rises to ~298 even with the retry never firing. It
+    # trades a frequent retry for a longer first attempt; it does not free
+    # budget.
+    timeout-minutes: 320
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary

Raises `uat-gcp`'s job timeout from 280 to 320 minutes. #2066 added a second bringup attempt without adjusting the budget, which was sized for one.

## Motivation / Context

The `Bringup Infra` step has **no step-level timeout**, and the failure it retries is the actuator's own hardcoded 30m node-pool timeout — quoted from the comment #2066 added:

> The GKE actuator hardcodes a 30m node-pool create timeout (terraform/compute.tf), but a slow GPU pool can take ~35m; Terraform then fails the create even though GKE finishes

So the first attempt burns the **full 30 minutes** before failing, then sleeps 60s, then retries. That is ~31m on top of the ~268m the existing comment budgets:

> 190 UAT + ~30 setup + ~8 failure-path debug collection + ~40 teardown = ~268, so 280 leaves the teardown headroom

~299m against a 280m cap.

**The consequence is not a slow run.** From the same comment:

> The teardown MUST fit in this budget: a job-level timeout cancels pending always() steps, so an undersized cap would skip teardown and leak the GPU node.

Tripping the cap cancels the `always()` Destroy Cluster step and leaks the GPU node and its VPC network group — exactly the outcome #2066 exists to prevent. Its own rationale says a stranded cluster "leaks the GPU node and NETWORKS quota."

It only bites when the first attempt burns its full timeout **and** the retry succeeds **and** the run is otherwise near budget. Narrow, but that is precisely the path a retry is meant to rescue.

Found while reviewing #2073, where the file was pulled into the diff by mistake.

Fixes: N/A
Related: #2066, #2065

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT CI workflow

## Implementation Notes

320 preserves the original ~12m of teardown headroom over the ~299m worst case. The comment now records the arithmetic, so the next change to either number has the reasoning in front of it rather than having to re-derive it from the retry loop.

This is a stopgap. The durable fix is the upstream node-pool timeout bump 30m -> 60m tracked in #2065 (mirroring the AKS actuator, `mchmarny/cluster#31`); once that lands the retry becomes rare and the cap can drop back toward 280.

**uat-aws and uat-azure were checked and are unaffected.** Their `Bringup Infra` runs a single `apply` with no retry; their retry loops are short API-call retries (`aws eks list-clusters`, AKS auth propagation, az throttling) costing seconds to a few minutes, which the existing headroom already absorbs. Only GCP retries a 30-minute provisioning attempt.

## Testing

```bash
yamllint -c .yamllint.yaml .github/workflows/uat-gcp.yaml   # clean
actionlint .github/workflows/uat-gcp.yaml                   # no new findings
```

Comment-and-constant change only; there is no behaviour to unit test. The 3 `SC2016` findings actionlint reports on this file are pre-existing (identical count on `main`) and untouched here.

The change is only observable on a run where bringup actually retries, which is the scenario #2065 tracks eliminating.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Raising a timeout cap cannot make a passing run fail. The only effect is that a run which would have been cancelled at 280m now has room to finish and, importantly, to tear its cluster down. Worst case a genuinely hung run occupies a runner ~40m longer before being cancelled.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, timeout constant
- [x] I updated docs if user-facing behavior changed — the in-file budget comment
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
