### PR TITLE
fix(testgrid-publish): reject null and zero-timestamp predicates

### DIFF
--- a/tools/testgrid-publish/bundle.go
+++ b/tools/testgrid-publish/bundle.go
@@ -119,8 +119,9 @@ func parseCriteria(bundleDir string) (RecipeCriteria, error) {
 }
 
 // loadPredicate reads the in-toto Statement from the bundle and returns
-// the decoded Predicate. Returns an error when the file is absent or
-// malformed — callers should fall back to sensible defaults.
+// the decoded Predicate. Returns ErrCodeNotFound when the file is absent —
+// the only case callers may fall back on — and ErrCodeInvalidRequest for a
+// malformed predicate, which must fail closed.
 func loadPredicate(bundleDir string) (*attestation.Predicate, error) {
 	path := filepath.Join(bundleDir, attestation.StatementFilename)
 	data, err := readBoundedFile(path, defaults.MaxBundlePOSTBytes)
@@ -144,18 +145,31 @@ func loadPredicate(bundleDir string) (*attestation.Predicate, error) {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "statement has no predicate field")
 	}
 
-	var pred attestation.Predicate
+	// Decode into a pointer: a JSON-literal `null` predicate unmarshals to a
+	// nil pointer (a struct target would silently stay zero-valued and later
+	// fabricate a year-1 attestation timestamp), so reject it here.
+	var pred *attestation.Predicate
 	if err := json.Unmarshal(stmt.Predicate, &pred); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
 			"failed to decode predicate", err)
+	}
+	if pred == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "statement predicate is null")
+	}
+	// Same fail-closed rule for an empty predicate object: every supported
+	// producer stamps attestedAt (attestation.Build defaults it to now), so
+	// a zero value means the bundle is broken and would otherwise publish a
+	// fabricated year-1 timestamp and build ID.
+	if pred.AttestedAt.IsZero() {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "statement predicate has no attestedAt")
 	}
 	// The shared bidirectional contract, not just a type allowlist: v1 must
 	// not carry a profile block, v2 must carry a well-formed one, anything
 	// else (including an absent predicateType) is unknown. Without it a v1
 	// statement smuggling a profile block — evidence every other consumer
 	// rejects — would publish to TestGrid.
-	if err := attestation.ValidatePredicateTypeCoherence(stmt.PredicateType, &pred); err != nil {
+	if err := attestation.ValidatePredicateTypeCoherence(stmt.PredicateType, pred); err != nil {
 		return nil, err
 	}
-	return &pred, nil
+	return pred, nil
 }

--- a/tools/testgrid-publish/bundle_test.go
+++ b/tools/testgrid-publish/bundle_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
 )
 
@@ -261,6 +263,42 @@ func TestLoadPredicate(t *testing.T) {
 			t.Fatal("expected error for invalid JSON")
 		}
 	})
+
+	invalidPredicates := []struct {
+		name            string
+		predicate       any
+		wantErrContains string
+	}{
+		{"null predicate returns error", nil, "statement predicate is null"},
+		{"empty predicate object returns error", map[string]any{}, "statement predicate has no attestedAt"},
+	}
+	for _, tt := range invalidPredicates {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			stmt := map[string]any{
+				"_type":         "https://in-toto.io/Statement/v0.1",
+				"predicateType": attestation.PredicateTypeV1,
+				"predicate":     tt.predicate,
+			}
+			stmtBytes, _ := json.Marshal(stmt)
+			if err := os.WriteFile(
+				filepath.Join(dir, attestation.StatementFilename),
+				stmtBytes, 0o600,
+			); err != nil {
+				t.Fatal(err)
+			}
+			_, err := loadPredicate(dir)
+			if err == nil {
+				t.Fatal("expected error for invalid predicate")
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error code = %v, want ErrCodeInvalidRequest", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Errorf("error = %v, want message containing %q", err, tt.wantErrContains)
+			}
+		})
+	}
 
 	t.Run("statement with no predicate field returns error", func(t *testing.T) {
 		dir := t.TempDir()


### PR DESCRIPTION
## Summary

`tools/testgrid-publish` now rejects an in-toto statement whose `predicate` is the JSON literal `null`, and one whose `attestedAt` is zero (e.g. an empty `{}` predicate), instead of publishing TestGrid results with a fabricated year-1 attestation timestamp and blank metadata.

## Motivation / Context

`loadPredicate` decoded the raw predicate into a value struct, so `json.Unmarshal([]byte("null"), &pred)` was a silent no-op: the zero-value predicate passed the presence and coherence checks and reached the publisher, defeating the loader's documented fail-closed intent. An empty predicate object reaches the same fabricated-timestamp state through a different door — it decodes to a non-nil zero value. Both are reachable via the manual `testgrid-publish.yml` dispatch, which accepts an externally supplied digest-pinned bundle without provenance validation, and neither can be produced by a supported producer (`attestation.Build` defaults a zero `attestedAt` to the current time before the statement is built).

Fixes: #2053
Related: #2044 (review round that surfaced the defect)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Other: `tools/testgrid-publish`

## Implementation Notes

Decode into `var pred *attestation.Predicate`: a JSON-literal `null` unmarshals to a nil pointer (whereas a struct target silently stays zero-valued), and a nil guard rejects it with `ErrCodeInvalidRequest` before `ValidatePredicateTypeCoherence`. A second guard rejects `pred.AttestedAt.IsZero()` for the same reason — a zero timestamp means the bundle is broken, and would otherwise flow into the published `started.Timestamp` and the derived build ID. Both rejection cases are covered by a table-driven regression test alongside the existing `loadPredicate` subtests.

## Testing

```bash
go test ./tools/testgrid-publish/...            # ok
go test -race ./tools/testgrid-publish/...      # ok
golangci-lint run -c .golangci.yaml ./tools/testgrid-publish/...  # 0 issues
```

Coverage: `tools/testgrid-publish`: 77.8% → 78.1% (+0.3%). Full `make qualify` will be run before this PR leaves draft.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — tightens input validation in a CI publishing tool; no user-facing surface.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
