### PR TITLE
evidence(gke): h100 inference-dynamo gpustack-gcp-managed evidence

### DIFF
--- a/recipes/evidence/allowlist.yaml
+++ b/recipes/evidence/allowlist.yaml
@@ -81,6 +81,9 @@ community:
     source: 7c4c0edc8c765a95a0f3afdb3bbb8e91
   - issuer: https://token.actions.githubusercontent.com
     source: 5bf9e82f0e90a11528ac85f4bcb866c8
+  - issuer: https://token.actions.githubusercontent.com
+    source: 3be4483c0c6e439444ba6763efe9a586
+    label: yuanchen8911
 
 # Partner: vetted partner organizations. None onboarded yet.
 partner: []

--- a/recipes/evidence/h100-gke-cos-inference-dynamo-gpustack-gcp-managed/3be4483c0c6e439444ba6763efe9a586/sha256-52dabcc7c0b12cf246f8962f66673685e68b4a95613c41987a5814a2ea01591d.yaml
+++ b/recipes/evidence/h100-gke-cos-inference-dynamo-gpustack-gcp-managed/3be4483c0c6e439444ba6763efe9a586/sha256-52dabcc7c0b12cf246f8962f66673685e68b4a95613c41987a5814a2ea01591d.yaml
@@ -1,0 +1,13 @@
+attestations:
+  - attestedAt: 2026-08-06T00:10:04Z
+    bundle:
+      digest: sha256:52dabcc7c0b12cf246f8962f66673685e68b4a95613c41987a5814a2ea01591d
+      oci: ghcr.io/yuanchen8911/aicr-evidence:h100-gke-cos-inference-dynamo-gpustack-gcp-managed-3f9bc435476a
+      predicateType: https://aicr.run/recipe-evidence/v2
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/gke-h100-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 53980091
+profile: gpuStack=gcp-managed
+recipe: h100-gke-cos-inference-dynamo-gpustack-gcp-managed
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Adds a signed recipe-evidence pointer for `h100-gke-cos-inference-dynamo` (profile `gpuStack=gcp-managed`) validated on a live GKE H100 cluster, plus the signer's `community` allowlist entry.

## Motivation / Context

First GKE inference-dynamo evidence for the gpuStack-profiled recipe family introduced by #2044. Validation ran on the held UAT cluster `aicr-uat-31054563684` (GKE, 2× a3-megagpu-8g, us-central1) from UAT run 31054563684, using a main-built CLI at `9a1064d0b` paired with the run's `uat-31054563684` validator images. All phases passed:

- deployment: 4/4 validators
- conformance: 11/11 validators
- performance: 1/1 (`inference-perf`, AIPerf against the dynamo-served vLLM deployment)

The companion training-leg evidence (`h100-gke-cos-training-kubeflow-gpustack-gcp-managed`, bundle `sha256:d07b1787…0eae48`) was signed first-party by `uat-gcp.yaml` in the same UAT run and ingested directly by CI, so it carries no committed pointer (the per-source contract forbids committed first-party pointers).

Fixes: N/A
Related: #1761, #2044

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Other: recipe evidence (`recipes/evidence/`)

## Implementation Notes

- Bundle pushed unsigned from the cluster network (`aicr validate --emit-attestation --push --no-sign`), then signed keyless in fork CI (`evidence-publish.yaml`, ambient GitHub Actions OIDC — no personal identity). Bundle: `ghcr.io/yuanchen8911/aicr-evidence@sha256:52dabcc7c0b12cf246f8962f66673685e68b4a95613c41987a5814a2ea01591d` (public package), Rekor log index 53980091.
- The signer identity is branch-scoped, so this is a new source slug `3be4483c0c6e439444ba6763efe9a586`; the pointer sits at its canonical per-source path and the slug is added under `community` in `recipes/evidence/allowlist.yaml` (label `yuanchen8911`, no cleartext identity).
- Follows `docs/contributor/evidence-publishing.md` (validate+push local → sign in fork CI → relocate → allowlist in same PR).

## Testing

```bash
# Evidence-pointer PR: scoped checks per the evidence-publishing flow
# (no Go/YAML-config code changed; the pointer contract gate is the grading CI)
go run ./tools/evidence-pointercheck   # OK — all committed pointers honor the per-source contract
go test ./pkg/evidence/allowlist/...   # ok
aicr evidence verify recipes/evidence/h100-gke-cos-inference-dynamo-gpustack-gcp-managed/3be4483c0c6e439444ba6763efe9a586/sha256-52dabcc7….yaml \
  --expected-issuer https://token.actions.githubusercontent.com \
  --expected-identity-regexp '^https://github\.com/yuanchen8911/aicr/\.github/workflows/evidence-publish\.yaml@refs/heads/evidence/gke-h100-inference$'
# → Verdict: bundle valid — all checks passed (exit 0)
```

Full `make qualify` skipped: this PR adds an evidence pointer + allowlist entry only (no Go source, no chart/CI changes); the pointer contract check and allowlist unit tests above are the checks that grade these files, both run locally and green.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — additive evidence data; consumed by the corroboration dashboard at ingest.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — scoped: `go test ./pkg/evidence/allowlist/...`
- [x] Linter passes (`make lint`) — N/A for pointer YAML; contract check run instead
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A (data-only)
- [ ] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
