### PR TITLE
fix(tests): derive releasepolicy script deadlines from test timeout

### DIFF
--- a/tests/releasepolicy/release_scripts_test.go
+++ b/tests/releasepolicy/release_scripts_test.go
@@ -165,7 +165,8 @@ func TestReleaseSbomSignaturesAreAllowlisted(t *testing.T) {
 // allowlist rather than a copy of it.
 func shellReleaseAssetNames(t *testing.T, tag string) []string {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	budget := scriptBudget(t)
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 	text := string(readFile(t, ".github/scripts/release-images.sh"))
 	const marker = "expected_release_asset_names() {"
@@ -183,7 +184,7 @@ func shellReleaseAssetNames(t *testing.T, tag string) []string {
 	command.Env = append(os.Environ(), "RELEASE_TAG="+tag)
 	output, err := command.CombinedOutput()
 	if ctx.Err() != nil {
-		t.Fatalf("evaluate expected_release_asset_names exceeded test deadline: %v\n%s", ctx.Err(), output)
+		t.Fatalf("evaluate expected_release_asset_names exceeded %v budget (derived from -timeout): %v\n%s", budget, ctx.Err(), output)
 	}
 	if err != nil {
 		t.Fatalf("evaluate expected_release_asset_names: %v\n%s", err, output)
@@ -230,8 +231,9 @@ func TestReleaseSignSbomBehavior(t *testing.T) {
 				t.Fatalf("create fake bin: %v", err)
 			}
 			writeExecutable(t, filepath.Join(bin, "cosign"), fakeCosign)
-			// The retry loop backs off 5s then 10s, which would outrun the
-			// harness deadline; a PATH shim keeps the waits instantaneous.
+			// The retry loop backs off 5s then 10s; a PATH shim keeps the
+			// waits instantaneous so the test stays fast regardless of the
+			// per-script budget.
 			writeExecutable(t, filepath.Join(bin, "sleep"), noopSleep)
 
 			sbomPath := filepath.Join(dir, "aicr_1.2.3_linux_amd64.sbom.json")
@@ -1677,15 +1679,82 @@ type scriptResult struct {
 	err    error
 }
 
+// scriptHangCap bounds a single script invocation. Genuine hangs (stuck
+// prompt, infinite loop) exceed this by orders of magnitude, while
+// slow-but-correct runs under full-suite -race load stay well inside it
+// (see issue #1974).
+const scriptHangCap = 90 * time.Second
+
+// deadlineReportMargin is reserved from the test binary's -timeout so a
+// killed script still fails via t.Fatalf with its captured output instead
+// of being torn down by the test runner's deadline panic.
+const deadlineReportMargin = 30 * time.Second
+
+// scriptBudget derives the per-script deadline from the test binary's own
+// deadline so the budget inherits whatever -timeout the environment (gate,
+// CI, dev machine) was provisioned with, capped at hang-detection scale.
+func scriptBudget(t *testing.T) time.Duration {
+	t.Helper()
+	deadline, ok := t.Deadline()
+	if !ok {
+		return scriptHangCap
+	}
+	return scriptBudgetFor(time.Until(deadline))
+}
+
+// scriptBudgetFor computes the budget for the given time remaining before the
+// binary deadline. It reserves deadlineReportMargin for t.Fatalf to report
+// before the runner's deadline panic, but never takes more than half the
+// remaining time as margin — a short -timeout (e.g. 25s on a targeted run)
+// must still yield a usable budget rather than collapse it. Once the deadline
+// has passed the result goes non-positive and the context expires
+// immediately, failing fast with the script-timeout message instead of
+// starting doomed work.
+func scriptBudgetFor(remaining time.Duration) time.Duration {
+	budget := remaining - deadlineReportMargin
+	if half := remaining / 2; budget < half {
+		budget = half
+	}
+	if budget > scriptHangCap {
+		budget = scriptHangCap
+	}
+	return budget
+}
+
+func TestScriptBudgetFor(t *testing.T) {
+	tests := []struct {
+		name      string
+		remaining time.Duration
+		expected  time.Duration
+	}{
+		{"ample time hits hang cap", 10 * time.Minute, scriptHangCap},
+		{"cap boundary", scriptHangCap + deadlineReportMargin, scriptHangCap},
+		{"full margin reserved", 100 * time.Second, 70 * time.Second},
+		{"full-margin/half tie at 2x margin", 2 * deadlineReportMargin, deadlineReportMargin},
+		{"margin capped at half", 50 * time.Second, 25 * time.Second},
+		{"short targeted -timeout", 25 * time.Second, 12500 * time.Millisecond},
+		{"nearly exhausted", time.Second, 500 * time.Millisecond},
+		{"expired deadline fails fast", -10 * time.Second, -5 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scriptBudgetFor(tt.remaining); got != tt.expected {
+				t.Errorf("scriptBudgetFor(%v) = %v, want %v", tt.remaining, got, tt.expected)
+			}
+		})
+	}
+}
+
 func runScript(t *testing.T, environment []string, relative string, args ...string) scriptResult {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	budget := scriptBudget(t)
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 	command := exec.CommandContext(ctx, repositoryPath(t, relative), args...)
 	command.Env = environment
 	output, err := command.CombinedOutput()
 	if ctx.Err() != nil {
-		t.Fatalf("script exceeded test deadline: %v\n%s", ctx.Err(), output)
+		t.Fatalf("script exceeded %v budget (derived from -timeout): %v\n%s", budget, ctx.Err(), output)
 	}
 	return scriptResult{output: string(output), err: err}
 }

--- a/tests/releasepolicy/release_workflow_test.go
+++ b/tests/releasepolicy/release_workflow_test.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -589,7 +588,8 @@ func TestReleaseOpenVEXValidation(t *testing.T) {
 // annotations and the GITHUB_OUTPUT contents) alongside the exit status.
 func runOpenVEXGuard(t *testing.T, script, workspace string) (string, error) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	budget := scriptBudget(t)
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 	outputs := filepath.Join(t.TempDir(), "outputs")
 	command := exec.CommandContext(ctx, "bash", "-c", script)
@@ -600,7 +600,7 @@ func runOpenVEXGuard(t *testing.T, script, workspace string) (string, error) {
 	)
 	combined, err := command.CombinedOutput()
 	if ctx.Err() != nil {
-		t.Fatalf("OpenVEX guard exceeded test deadline: %v\n%s", ctx.Err(), combined)
+		t.Fatalf("OpenVEX guard exceeded %v budget (derived from -timeout): %v\n%s", budget, ctx.Err(), combined)
 	}
 	written, readErr := os.ReadFile(outputs)
 	if readErr != nil && !os.IsNotExist(readErr) {


### PR DESCRIPTION
## Summary

Replace the hardcoded 10-second per-script deadlines in `tests/releasepolicy` with a budget derived from the test binary's own deadline (`t.Deadline()`), capped at a hang-detection-sized 90 seconds.

## Motivation / Context

The fixed 10s wall-clock deadline measures the machine and its concurrent load, not the script's correctness. Under full-suite `make test` parallelism (`-race`, `-covermode=atomic`), individual script runs starve past that margin on developer machines and fail with `script exceeded test deadline` — intermittently breaking the documented pre-push `make qualify` gate. The deadline exists to catch a *hung* script, and hangs sit orders of magnitude above slow-but-working runs, so a tight constant buys no detection value.

Fixes: #1974
Related: #2056

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] Other: `tests/releasepolicy` (release script shell tests)

## Implementation Notes

- `scriptBudget(t)` grants `max(remaining − 30s margin, remaining/2)`, capped at a 90s hang-detection ceiling (`scriptHangCap`). The margin (`deadlineReportMargin`) is reserved so a killed script still fails via `t.Fatalf` with its captured output instead of the test runner's deadline panic — but never more than half the remaining time is taken as margin, so a short targeted `-timeout` (e.g. 25s) still yields a usable budget instead of collapsing to a false failure.
- The budget never exceeds the real remaining time, and once the deadline has passed it goes non-positive: the context expires immediately, failing fast with the script-timeout message instead of starting doomed work.
- The calculation is a pure helper, `scriptBudgetFor(remaining)`, with `scriptBudget(t)` keeping only the `t.Deadline()` handling — pinned by a table-driven boundary test (`TestScriptBudgetFor`: hang cap, cap boundary, full margin, half-margin cap, short `-timeout`, nearly exhausted, expired).
- All three subprocess helpers in the package share the derived budget: `runScript` (~31 invocations), `shellReleaseAssetNames`, and `runOpenVEXGuard`. No fixed-deadline subprocess sites remain in the package.
- The budget inherits whatever `-timeout` the environment (gate, CI, dev machine) was provisioned with — no per-machine constant to re-tune. Timeouts use named constants per the #2056 convention.

## Testing

```bash
AICR_CRITERIA_STRICT=1 go test -short -count=1 -race ./tests/releasepolicy/   # ok, ~170s
golangci-lint run -c .golangci.yaml ./tests/releasepolicy/...                 # 0 issues
# short targeted -timeout must not collapse the budget (review-round repro):
go test -count=1 -run '^TestReleaseStablePromotionConvergesAndRerunsWithoutMutation$' \
  -timeout=25s ./tests/releasepolicy                                          # ok, ~12s
make qualify
```

Coverage gate: test-only change in a test-only package (`_test.go`); no exported production code affected, no coverage delta.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — test-infrastructure only; no user-facing behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
