### PR TITLE
fix(collector): emit lossless label/taint readings

### DIFF
--- a/.agents/skills/aicr-analyzing-snapshots/SKILL.md
+++ b/.agents/skills/aicr-analyzing-snapshots/SKILL.md
@@ -137,13 +137,16 @@ entry per distinct reading, sorted by key/value (taints: key/effect/value):
 | `context.value` | Taint or label value (may be empty) |
 | `context.effect` | Taints only: `NoSchedule`, `PreferNoSchedule`, `NoExecute` |
 | `data.node-count` | True node total, including nodes dropped by truncation |
-| `data.node-list` | Comma-separated node names; may be truncated |
-| `data.truncated` | `true` when `node-list` is incomplete |
+| `data.node-list` | Comma-separated node names (one of `node-list` / `node-list-ref`) |
+| `data.node-list-ref` | Key into the subtype's `data` map whose entry holds the names (one of `node-list` / `node-list-ref`) |
+| `data.truncated` | `true` when the node list is capped and ends with `(+N more)` |
 
 Current snapshots also carry the older `data` map on both subtypes; `items` is
 authoritative. Take counts from `data.node-count` rather than splitting
 `node-list`, and read `data.truncated` rather than probing for a `(+N more)`
-suffix.
+suffix. Use `topology.LabelReadings` / `TaintReadings` to resolve items into
+hydrated readings — they expand `node-list-ref` automatically, so callers do
+not need to implement the reference logic themselves.
 
 **Older snapshots (no `items`):** fall back to the folded `data` map —
 `effect|value|node1,node2,...` for taints, `value|node1,node2,...` for labels.

--- a/.agents/skills/aicr-analyzing-snapshots/SKILL.md
+++ b/.agents/skills/aicr-analyzing-snapshots/SKILL.md
@@ -128,9 +128,37 @@ From `OS.sysctl` (key tuning parameters):
 
 From `NodeTopology.summary`: `node-count`, `taint-count`, `label-count`
 
-From `NodeTopology.taint`: Format is `effect|value|node1,node2,...`
+From `NodeTopology.taint` and `NodeTopology.label`, read the `items` list — one
+entry per distinct reading, sorted by key/value (taints: key/effect/value):
 
-From `NodeTopology.label`: Format is `value|node1,node2,...`
+| Item Field | What It Holds |
+|------------|---------------|
+| `context.key` | Taint or label key, verbatim |
+| `context.value` | Taint or label value (may be empty) |
+| `context.effect` | Taints only: `NoSchedule`, `PreferNoSchedule`, `NoExecute` |
+| `data.node-count` | True node total, including nodes dropped by truncation |
+| `data.node-list` | Comma-separated node names; may be truncated |
+| `data.truncated` | `true` when `node-list` is incomplete |
+
+Current snapshots also carry the older `data` map on both subtypes; `items` is
+authoritative. Take counts from `data.node-count` rather than splitting
+`node-list`, and read `data.truncated` rather than probing for a `(+N more)`
+suffix.
+
+**Older snapshots (no `items`):** fall back to the folded `data` map —
+`effect|value|node1,node2,...` for taints, `value|node1,node2,...` for labels.
+That encoding is lossy, so qualify anything derived from it:
+
+- A map key is ambiguous: when a key carries more than one value the value is
+  folded into the key as `<key>.<value>`, indistinguishable from a label
+  literally named that, and one of the colliding readings is dropped. Report
+  such a key verbatim instead of asserting a key/value split.
+- A taint key disambiguated the same way ends in `.<effect>` and its value has
+  only two fields (`value|nodes`); two taints sharing key and effect collapse
+  into one entry.
+- `summary.taint-count` / `label-count` count map entries there, so they
+  under-report wherever a collapse occurred, and node counts reflect only what
+  survived truncation.
 
 **High-value labels to extract** (skip `feature.node.kubernetes.io/cpu-cpuid.*`):
 

--- a/docs/contributor/collector.md
+++ b/docs/contributor/collector.md
@@ -46,7 +46,7 @@ Each subdirectory is one collector; one collector emits one
 | Kubernetes | `pkg/collector/k8s` | `TypeK8s` | Server version, image inventory, GPU Operator ClusterPolicy, node-local info, secret-safe Slinky resource topology, and official MariaDB Operator API conflict evidence. Uses the singleton `pkg/k8s/client`. |
 | OS | `pkg/collector/os` | `TypeOS` | Subtypes for `release` (`/etc/os-release`), `grub`, `kmod`, `sysctl`. |
 | SystemD | `pkg/collector/systemd` | `TypeSystemD` | D-Bus probe of configured services. Routes to Talos via factory when `os: talos`. |
-| Topology | `pkg/collector/topology` | `TypeNodeTopology` | Cluster-wide taints and labels across all nodes — see [Cross-cutting topology collector](#cross-cutting-topology-collector). |
+| Topology | `pkg/collector/topology` | `TypeNodeTopology` | Cluster-wide taints and labels across all nodes, in two encodings — lossless `Items` plus the legacy folded `Data` map — see [Cross-cutting topology collector](#cross-cutting-topology-collector). |
 | Network | `pkg/collector/network` | `TypeNetworkTopology` | Ingests an l8k cluster-config (from disk via `ClusterConfigPath`, or live via `DiscoverNetwork`). **Inactive by default** — emits no measurement unless one option is set. `DiscoverNetwork` mutates cluster state (see exception note above). |
 | Talos | `pkg/collector/talos` | `TypeSystemD`, `TypeOS` | OS-specific override pair: a single shared config so one Node API fetch serves both collectors. |
 | File (helper) | `pkg/collector/file` | — | Not a registered collector. A reusable parser for delimited key=value config files (used by the OS subcollectors). |
@@ -208,7 +208,9 @@ type Subtype struct {
 (each `ItemEntry` carries its own `Data` scalars and `Context` strings) for
 subtypes that need a list of homogeneous entries — for example the network
 collector's `pfs` subtype, where each physical-function record is one
-`ItemEntry`. `ItemEntry` does not nest further `Items`.
+`ItemEntry`, or the topology collector's `label` and `taint` subtypes, where
+each aggregated reading is one. A subtype may populate both. `ItemEntry` does
+not nest further `Items`.
 
 `Reading` is a typed-scalar interface implemented by
 `Scalar[T]` (`Int`, `Int64`, `Uint`, `Uint64`, `Float64`, `Bool`,
@@ -295,6 +297,26 @@ them as a single `TypeNodeTopology` measurement. Bound by
 the factory (caps the per-entry node list to keep snapshot size
 sane).
 
+The `label` and `taint` subtypes carry **both** encodings. `Data` is the
+original folded map, kept byte-identical so older readers and snapshots keep
+working. `Items` is the lossless form — one `ItemEntry` per aggregated reading,
+shape documented in
+[NodeTopology shape](../integrator/measurement-api.md#nodetopology-shape).
+
+`Items` exists because a `Data` map key is not an identity. `encodeLabels`
+folds a multi-valued label's value into the key as `<key>.<value>`, colliding
+with a label literally named that and dropping one reading
+([#2003](https://github.com/NVIDIA/aicr/issues/2003)); `encodeTaints` counts
+entries per key but disambiguates with effect, so two taints sharing both
+collapse into one. Separate `Context` fields make either impossible.
+`summary`'s counts derive from `Items` for the same reason. Items are sorted
+because `pkg/diff` compares them positionally.
+
+Consumers read this through `topology.LabelReadings` / `TaintReadings`, never
+off `Data` directly — they prefer `Items` and fall back to decoding `Data`, so
+one call site serves both snapshot vintages. A new consumer that ranges over
+`Subtype.Data` re-introduces the collision.
+
 Treat it as the template for any future cluster-scoped collector —
 not for per-node ones.
 
@@ -380,6 +402,7 @@ Never write a test that hits a live cluster. CI runs without one.
 | Bare `return err` | Loses code on wrap chain | `errors.Wrap(errors.ErrCodeUnavailable, "<msg>", err)` |
 | New `measurement.Type` not added to `Types` slice | `ParseType` rejects it; recipe constraints can't reference it | Append both the constant and the `Types` entry |
 | `http.DefaultClient` for remote fetches | Unbounded timeout, snapshot can hang | `&http.Client{Timeout: defaults.HTTPClientTimeout}` |
+| Ranging over `NodeTopology` `Subtype.Data` directly | Colliding label keys drop a reading; truncated lists read as complete | `topology.LabelReadings` / `TaintReadings` — Items-preferred, `Data` fallback |
 
 ## See Also
 

--- a/docs/integrator/data-flow.md
+++ b/docs/integrator/data-flow.md
@@ -91,7 +91,10 @@ Each stage transforms input data into a different format:
 │   │                                                     │
 │   ├─ NodeTopology                                       │
 │   │   └─ subtypes: [summary, taint, label]              │
-│   │       └─ data: map[string]Reading                   │
+│   │       ├─ data: map[string]Reading                   │
+│   │       └─ taint/label.items: []ItemEntry             │
+│   │             (context: key/value, taint adds effect; │
+│   │              data: node-count, node-list, truncated)│
 │   │                                                     │
 │   └─ NetworkTopology (only with --cluster-config /      │
 │       │                --discover-network)              │

--- a/docs/integrator/measurement-api.md
+++ b/docs/integrator/measurement-api.md
@@ -325,14 +325,27 @@ subtypes:
       nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3|gpu-node-01,gpu-node-02 (+2 more)
 ```
 
-| Field | Where | Meaning |
-|---|---|---|
-| `key` | context | taint or label key, verbatim |
-| `value` | context | taint or label value; may be empty |
-| `effect` | context | taints only: `NoSchedule`, `PreferNoSchedule`, `NoExecute` |
-| `node-count` | data | nodes carrying the reading, counted **before** truncation |
-| `node-list` | data | node names, sorted and comma-joined, capped by `--max-nodes-per-entry` |
-| `truncated` | data | whether the cap dropped names from `node-list` |
+| Field | Where | Required | Meaning |
+|---|---|---|---|
+| `key` | context | yes | taint or label key, verbatim |
+| `value` | context | no | taint or label value; may be empty |
+| `effect` | context | taints only | `NoSchedule`, `PreferNoSchedule`, `NoExecute` |
+| `node-count` | data | yes | nodes carrying the reading, counted **before** truncation |
+| `node-list` | data | yes | node names, sorted and comma-joined, capped by `--max-nodes-per-entry` |
+| `truncated` | data | yes | whether the cap dropped names from `node-list` |
+
+An item that omits a required field is rejected. The three `data` fields must
+also agree with each other:
+
+- `truncated` is `true` exactly when `node-list` ends with `(+N more)`
+- when `truncated` is `true`, `node-count` is greater than the names in `node-list`
+- when `truncated` is `false`, `node-count` equals the names in `node-list`
+
+A count that disagrees is rejected in both directions: too low understates the
+cluster, too high lets a consumer read a partial list as a complete one.
+
+`effect` is not checked against the three values listed above, so a snapshot
+from a newer Kubernetes stays readable.
 
 `key`, `effect`, and `value` identify a reading, so they live in `context`;
 node membership is counted, so it lives in `data`. Items are sorted by

--- a/docs/integrator/measurement-api.md
+++ b/docs/integrator/measurement-api.md
@@ -300,6 +300,57 @@ The constraint path is `K8s.aks-gpu-pools.gpu-driver` in profile value
 constraints; `K8s.aks-gpu-pools.gpu-pool-count` and
 `K8s.aks-gpu-pools.gpu-pools` use the same non-item path form.
 
+## NodeTopology shape
+
+`TypeNodeTopology` is a cluster-wide aggregate: one reading per distinct taint
+and per distinct label across all nodes, plus a `summary` of the counts. The
+`taint` and `label` subtypes carry every reading twice — as `items` (lossless)
+and as the legacy folded `data` map.
+
+```yaml
+type: NodeTopology
+subtypes:
+  - subtype: summary
+    data: {node-count: 8, taint-count: 1, label-count: 1}
+  - subtype: label
+    items:
+      - context:
+          key: nvidia.com/gpu.product
+          value: NVIDIA-H100-80GB-HBM3
+        data:
+          node-count: 4
+          node-list: gpu-node-01,gpu-node-02 (+2 more)
+          truncated: true
+    data:
+      nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3|gpu-node-01,gpu-node-02 (+2 more)
+```
+
+| Field | Where | Meaning |
+|---|---|---|
+| `key` | context | taint or label key, verbatim |
+| `value` | context | taint or label value; may be empty |
+| `effect` | context | taints only: `NoSchedule`, `PreferNoSchedule`, `NoExecute` |
+| `node-count` | data | nodes carrying the reading, counted **before** truncation |
+| `node-list` | data | node names, sorted and comma-joined, capped by `--max-nodes-per-entry` |
+| `truncated` | data | whether the cap dropped names from `node-list` |
+
+`key`, `effect`, and `value` identify a reading, so they live in `context`;
+node membership is counted, so it lives in `data`. Items are sorted by
+(`key`, `value`) for labels and (`key`, `effect`, `value`) for taints, because
+`pkg/diff` compares items positionally. `summary.taint-count` and
+`summary.label-count` count items, not `data` keys.
+
+`data` is retained byte-identical to earlier releases and stays lossy: a label
+key carrying multiple values is folded to `<key>.<value>`, which collides with
+a label literally named that and drops one reading. Consumers read `items` and
+fall back to `data` only for older snapshots — `topology.LabelReadings` /
+`TaintReadings` do exactly that, and `HasLosslessReadings` reports which form a
+subtype carries. Adding `items` beside `data` is additive-only, so the snapshot
+`apiVersion` is unchanged ([ADR-011](../design/011-artifact-apiversion-policy.md) §2).
+
+Minimal evidence keeps `NodeTopology.summary` and drops `taint` and `label`;
+redaction never carries `items` across the publication boundary.
+
 ## NetworkTopology shape
 
 `TypeNetworkTopology` describes one hardware group's network layout (PFs,

--- a/docs/integrator/measurement-api.md
+++ b/docs/integrator/measurement-api.md
@@ -311,18 +311,27 @@ and as the legacy folded `data` map.
 type: NodeTopology
 subtypes:
   - subtype: summary
-    data: {node-count: 8, taint-count: 1, label-count: 1}
+    data: {node-count: 8, taint-count: 1, label-count: 3}
   - subtype: label
     items:
+      # The folded key is this reading's alone, so the names are not repeated.
       - context:
           key: nvidia.com/gpu.product
           value: NVIDIA-H100-80GB-HBM3
         data:
           node-count: 4
-          node-list: gpu-node-01,gpu-node-02 (+2 more)
+          node-list-ref: nvidia.com/gpu.product
           truncated: true
+      # Two readings fold onto "zone.us-west" — the label "zone" with value
+      # "us-west", and a label literally named "zone.us-west" — so neither can
+      # reference it and both carry their own names.
+      - context: {key: zone, value: us-west}
+        data: {node-count: 1, node-list: gpu-node-01, truncated: false}
+      - context: {key: zone.us-west, value: "true"}
+        data: {node-count: 2, node-list: "gpu-node-01,gpu-node-02", truncated: false}
     data:
       nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3|gpu-node-01,gpu-node-02 (+2 more)
+      zone.us-west: true|gpu-node-01,gpu-node-02
 ```
 
 | Field | Where | Required | Meaning |
@@ -331,21 +340,36 @@ subtypes:
 | `value` | context | no | taint or label value; may be empty |
 | `effect` | context | taints only | `NoSchedule`, `PreferNoSchedule`, `NoExecute` |
 | `node-count` | data | yes | nodes carrying the reading, counted **before** truncation |
-| `node-list` | data | yes | node names, sorted and comma-joined, capped by `--max-nodes-per-entry` |
-| `truncated` | data | yes | whether the cap dropped names from `node-list` |
+| `node-list` | data | one of these | node names, sorted and comma-joined, capped by `--max-nodes-per-entry` |
+| `node-list-ref` | data | one of these | the `data` key holding this reading's names |
+| `truncated` | data | yes | whether the cap dropped names from the node list |
 
-An item that omits a required field is rejected. The three `data` fields must
-also agree with each other:
+An item that omits a required field is rejected.
 
-- `truncated` is `true` exactly when `node-list` ends with `(+N more)`
-- when `truncated` is `true`, `node-count` is greater than the names in `node-list`
-- when `truncated` is `false`, `node-count` equals the names in `node-list`
+**Membership has exactly one source.** An item carries `node-list` or
+`node-list-ref`, never both and never neither — node lists dominate snapshot
+size, so a reading whose folded key describes it alone points at that entry
+rather than repeating the names. A reference is honored only when it names the
+key this reading folds onto *and* no other reading folds onto that key;
+anything else would resolve to a different reading's nodes. Where two readings
+collide on one key, both carry their own names, because the shared entry can
+describe only one of them and which one is not predictable.
+
+The count and the list must agree:
+
+- `truncated` is `true` exactly when the node list ends with `(+N more)`
+- `node-count` equals the names in the list plus `N` (with `N` zero when complete)
 
 A count that disagrees is rejected in both directions: too low understates the
-cluster, too high lets a consumer read a partial list as a complete one.
+cluster, too high lets a consumer read a partial list as a complete one. A
+marker whose `N` is unusable is rejected rather than read as absent.
 
 `effect` is not checked against the three values listed above, so a snapshot
 from a newer Kubernetes stays readable.
+
+Consumers do not implement any of this: `topology.LabelReadings` and
+`TaintReadings` resolve references and validate them, and return readings whose
+`Nodes` are populated either way.
 
 `key`, `effect`, and `value` identify a reading, so they live in `context`;
 node membership is counted, so it lives in `data`. Items are sorted by
@@ -360,6 +384,13 @@ fall back to `data` only for older snapshots — `topology.LabelReadings` /
 `TaintReadings` do exactly that, and `HasLosslessReadings` reports which form a
 subtype carries. Adding `items` beside `data` is additive-only, so the snapshot
 `apiVersion` is unchanged ([ADR-011](../design/011-artifact-apiversion-policy.md) §2).
+
+`data` cannot be slimmed within `v1alpha2`: binaries predating `items` read it
+directly, and ADR-011 requires its encoding and semantics to stay as published.
+That is why membership is cross-referenced rather than dropped. The next
+snapshot `apiVersion` removes `data`, at which point items become
+self-contained and `node-list-ref` is no longer emitted — the decoder keeps
+reading it for as long as `v1alpha2` snapshots are accepted.
 
 Minimal evidence keeps `NodeTopology.summary` and drops `taint` and `label`;
 redaction never carries `items` across the publication boundary.

--- a/examples/templates/snapshot-template.md.tmpl
+++ b/examples/templates/snapshot-template.md.tmpl
@@ -103,15 +103,21 @@
 {{- end }}
 
 ## Node Topology
+{{- /* Prefer the lossless Items encoding; fall back to the folded Data map
+       for snapshots captured before it existed. Data cannot represent a label
+       whose name collides with a synthesized "<key>.<value>", so the two
+       renderings can differ in row count on such a cluster. */}}
 {{- $topoSummary := dict }}
+{{- $topoTaintItems := list }}
+{{- $topoLabelItems := list }}
 {{- $topoTaints := dict }}
 {{- $topoLabels := dict }}
 {{- range .Measurements }}
   {{- if eq .Type.String "NodeTopology" }}
     {{- range .Subtypes }}
       {{- if eq .Name "summary" }}{{ $topoSummary = .Data }}{{ end }}
-      {{- if eq .Name "taint" }}{{ $topoTaints = .Data }}{{ end }}
-      {{- if eq .Name "label" }}{{ $topoLabels = .Data }}{{ end }}
+      {{- if eq .Name "taint" }}{{ $topoTaints = .Data }}{{ $topoTaintItems = .Items }}{{ end }}
+      {{- if eq .Name "label" }}{{ $topoLabels = .Data }}{{ $topoLabelItems = .Items }}{{ end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -126,18 +132,34 @@
 
 | Taint Key | Effect | Value | Nodes |
 |-----------|--------|-------|-------|
+{{- if $topoTaintItems }}
+{{- range $topoTaintItems }}
+| {{ index .Context "key" }} | {{ index .Context "effect" }} | {{ index .Context "value" }} | {{ (index .Data "node-list").String }} |
+{{- end }}
+{{- else }}
 {{- range $key, $reading := $topoTaints }}
 {{- $parts := splitList "|" $reading.String }}
+{{- if eq (len $parts) 3 }}
 | {{ $key }} | {{ index $parts 0 }} | {{ index $parts 1 }} | {{ index $parts 2 }} |
+{{- else }}
+| {{ $key }} | | {{ index $parts 0 }} | {{ index $parts 1 }} |
+{{- end }}
+{{- end }}
 {{- end }}
 
 ### Labels
 
 | Label Key | Value | Nodes |
 |-----------|-------|-------|
+{{- if $topoLabelItems }}
+{{- range $topoLabelItems }}
+| {{ index .Context "key" }} | {{ index .Context "value" }} | {{ (index .Data "node-list").String }} |
+{{- end }}
+{{- else }}
 {{- range $key, $reading := $topoLabels }}
 {{- $parts := splitList "|" $reading.String }}
 | {{ $key }} | {{ index $parts 0 }} | {{ index $parts 1 }} |
+{{- end }}
 {{- end }}
 
 ---

--- a/examples/templates/snapshot-template.md.tmpl
+++ b/examples/templates/snapshot-template.md.tmpl
@@ -142,7 +142,10 @@
 {{- if eq (len $parts) 3 }}
 | {{ $key }} | {{ index $parts 0 }} | {{ index $parts 1 }} | {{ index $parts 2 }} |
 {{- else }}
-| {{ $key }} | | {{ index $parts 0 }} | {{ index $parts 1 }} |
+{{- /* Two fields means encodeTaints moved the effect into the key to keep two
+       effects of one key apart, so the last dotted segment is the effect. */}}
+{{- $segments := splitList "." $key }}
+| {{ join "." (initial $segments) }} | {{ last $segments }} | {{ index $parts 0 }} | {{ index $parts 1 }} |
 {{- end }}
 {{- end }}
 {{- end }}

--- a/examples/templates/snapshot-template.md.tmpl
+++ b/examples/templates/snapshot-template.md.tmpl
@@ -1,3 +1,14 @@
+{{- /* An item carries its node names inline only when its folded key is
+       shared; otherwise it references the data entry holding them. The node
+       list is the final field of every folded encoding. */}}
+{{- define "nodeList" }}
+{{-   $item := index . 0 }}{{ $folded := index . 1 }}
+{{-   if index $item.Data "node-list" }}{{ (index $item.Data "node-list").String }}
+{{-   else if index $item.Data "node-list-ref" }}
+{{-     $entry := index $folded (index $item.Data "node-list-ref").String }}
+{{-     if $entry }}{{ last (splitList "|" $entry.String) }}{{ end }}
+{{-   end }}
+{{- end }}
 # Cluster Snapshot Report
 
 {{- /* Extract data from measurements */ -}}
@@ -134,7 +145,7 @@
 |-----------|--------|-------|-------|
 {{- if $topoTaintItems }}
 {{- range $topoTaintItems }}
-| {{ index .Context "key" }} | {{ index .Context "effect" }} | {{ index .Context "value" }} | {{ (index .Data "node-list").String }} |
+| {{ index .Context "key" }} | {{ index .Context "effect" }} | {{ index .Context "value" }} | {{ template "nodeList" (list . $topoTaints) }} |
 {{- end }}
 {{- else }}
 {{- range $key, $reading := $topoTaints }}
@@ -156,7 +167,7 @@
 |-----------|-------|-------|
 {{- if $topoLabelItems }}
 {{- range $topoLabelItems }}
-| {{ index .Context "key" }} | {{ index .Context "value" }} | {{ (index .Data "node-list").String }} |
+| {{ index .Context "key" }} | {{ index .Context "value" }} | {{ template "nodeList" (list . $topoLabels) }} |
 {{- end }}
 {{- else }}
 {{- range $key, $reading := $topoLabels }}

--- a/pkg/client/v1/gpu_driver_state.go
+++ b/pkg/client/v1/gpu_driver_state.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/NVIDIA/aicr/pkg/collector/topology"
 	"github.com/NVIDIA/aicr/pkg/measurement"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
@@ -350,16 +351,33 @@ func hasHeterogeneousGPUPool(snap *snapshotter.Snapshot) bool {
 		if labels == nil {
 			continue
 		}
-		for k := range labels.Data {
-			if !isDisambiguatedLabelKey(k) {
-				continue
+		if !topology.HasLosslessReadings(labels) {
+			// Folded keys: divergence can only be inferred from key shape.
+			for k := range labels.Data {
+				if !isDisambiguatedLabelKey(k) {
+					continue
+				}
+				switch {
+				case strings.HasPrefix(k, "nvidia.com/gpu."):
+					return true
+				case strings.HasPrefix(k, "node.kubernetes.io/instance-type."):
+					return true
+				}
 			}
-			switch {
-			case strings.HasPrefix(k, "nvidia.com/gpu."):
-				return true
-			case strings.HasPrefix(k, "node.kubernetes.io/instance-type."):
-				return true
-			}
+			continue
+		}
+		readings, err := topology.LabelReadings(labels)
+		if err != nil {
+			// Advisory only — degrade quietly rather than block on a damaged
+			// snapshot.
+			slog.Debug("skipping heterogeneous-pool detection: topology label readings could not be decoded",
+				slog.String("error", err.Error()))
+			continue
+		}
+		mixedGPU := hasMultipleValues(readings, gpuLabelBase)
+		mixedInstance := hasMultipleValues(readings, instanceTypeLabel)
+		if mixedGPU || mixedInstance {
+			return true
 		}
 	}
 	return false
@@ -373,6 +391,8 @@ func hasHeterogeneousGPUPool(snap *snapshotter.Snapshot) bool {
 // the encoder appended — is non-empty. For instance-type, whose
 // single-value form ends at the "instance-type" segment, presence of
 // any non-empty tail after the trailing dot is enough.
+//
+// Only reachable for legacy Data-only snapshots.
 func isDisambiguatedLabelKey(k string) bool {
 	if suffix, ok := strings.CutPrefix(k, "nvidia.com/gpu."); ok {
 		// The single-value label key ends here (e.g. "product",
@@ -384,6 +404,32 @@ func isDisambiguatedLabelKey(k string) bool {
 	}
 	if suffix, ok := strings.CutPrefix(k, "node.kubernetes.io/instance-type."); ok {
 		return len(suffix) > 0
+	}
+	return false
+}
+
+// Label keys whose divergence indicates a non-uniform GPU pool. GFD publishes
+// a family of nvidia.com/gpu.* keys, so the base matches every child.
+const (
+	gpuLabelBase      = "nvidia.com/gpu"
+	instanceTypeLabel = "node.kubernetes.io/instance-type"
+)
+
+// hasMultipleValues reports whether the named label, or any child of it,
+// carries more than one distinct value across the cluster.
+func hasMultipleValues(readings []topology.LabelReading, match string) bool {
+	values := make(map[string]map[string]struct{})
+	for _, r := range readings {
+		if r.Key != match && !strings.HasPrefix(r.Key, match+".") {
+			continue
+		}
+		if values[r.Key] == nil {
+			values[r.Key] = make(map[string]struct{})
+		}
+		values[r.Key][r.Value] = struct{}{}
+		if len(values[r.Key]) > 1 {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/client/v1/gpu_driver_state.go
+++ b/pkg/client/v1/gpu_driver_state.go
@@ -374,8 +374,9 @@ func hasHeterogeneousGPUPool(snap *snapshotter.Snapshot) bool {
 				slog.String("error", err.Error()))
 			continue
 		}
-		mixedGPU := hasMultipleValues(readings, gpuLabelBase)
-		mixedInstance := hasMultipleValues(readings, instanceTypeLabel)
+		// nvidia.com/gpu is a label family; instance-type is a complete key.
+		mixedGPU := hasMultipleValues(readings, gpuLabelBase, true)
+		mixedInstance := hasMultipleValues(readings, instanceTypeLabel, false)
 		if mixedGPU || mixedInstance {
 			return true
 		}
@@ -408,19 +409,21 @@ func isDisambiguatedLabelKey(k string) bool {
 	return false
 }
 
-// Label keys whose divergence indicates a non-uniform GPU pool. GFD publishes
-// a family of nvidia.com/gpu.* keys, so the base matches every child.
+// Label keys whose divergence indicates a non-uniform GPU pool.
 const (
 	gpuLabelBase      = "nvidia.com/gpu"
 	instanceTypeLabel = "node.kubernetes.io/instance-type"
 )
 
-// hasMultipleValues reports whether the named label, or any child of it,
-// carries more than one distinct value across the cluster.
-func hasMultipleValues(readings []topology.LabelReading, match string) bool {
+// hasMultipleValues reports whether match carries more than one distinct value
+// across the cluster. includeChildren also counts keys under match+".", each on
+// its own; use it only when match names a family rather than a label.
+func hasMultipleValues(readings []topology.LabelReading, match string, includeChildren bool) bool {
 	values := make(map[string]map[string]struct{})
 	for _, r := range readings {
-		if r.Key != match && !strings.HasPrefix(r.Key, match+".") {
+		matched := r.Key == match ||
+			(includeChildren && strings.HasPrefix(r.Key, match+"."))
+		if !matched {
 			continue
 		}
 		if values[r.Key] == nil {

--- a/pkg/client/v1/gpu_driver_state_test.go
+++ b/pkg/client/v1/gpu_driver_state_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/collector/topology"
 	"github.com/NVIDIA/aicr/pkg/measurement"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
@@ -764,5 +765,171 @@ func TestHasHeterogeneousGPUPoolLegacyFalsePositive(t *testing.T) {
 	if hasHeterogeneousGPUPool(lossless) {
 		t.Error("item path: got true, want false — the same cluster must not be reported " +
 			"heterogeneous once the encoding is lossless")
+	}
+}
+
+// topologySnapshotWithMultiNodeItems builds an item-encoded snapshot in which
+// each reading spans an explicit node set. topologySnapshotWithItems puts a
+// single node under every reading, so it cannot tell a label that is uniform
+// across the fleet from one observed on one node, and never produces a
+// node-count above 1 or a comma-joined list for the decoder to check.
+//
+// readings is keyed key -> value -> nodes. Node sets under one key must be
+// disjoint: a node carries exactly one value of a given label key, and the
+// decoder rejects items that say otherwise.
+func topologySnapshotWithMultiNodeItems(readings map[string]map[string][]string) *snapshotter.Snapshot {
+	var items []measurement.ItemEntry
+	for key, byValue := range readings {
+		for value, nodes := range byValue {
+			items = append(items, measurement.ItemEntry{
+				Context: map[string]string{"key": key, "value": value},
+				Data: map[string]measurement.Reading{
+					"node-count": measurement.Int(len(nodes)),
+					"node-list":  measurement.Str(strings.Join(nodes, ",")),
+					"truncated":  measurement.Bool(false),
+				},
+			})
+		}
+	}
+	return &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{
+			measurement.NewMeasurement(measurement.TypeNodeTopology).
+				WithSubtype(measurement.Subtype{Name: "label", Items: items}).
+				Build(),
+		},
+	}
+}
+
+// TestHasHeterogeneousGPUPoolMultiNode covers the same decision over readings
+// that span several nodes, which is the shape a real fleet produces. The
+// single-node fixtures elsewhere in this file leave node-count > 1 and
+// comma-joined node lists undecoded, and they cannot express the case that
+// matters most in practice: one label value shared by the whole fleet.
+func TestHasHeterogeneousGPUPoolMultiNode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		readings map[string]map[string][]string
+		want     bool
+	}{
+		{
+			name: "gpu.product uniform across the whole fleet",
+			readings: map[string]map[string][]string{
+				"nvidia.com/gpu.product": {
+					"NVIDIA-H100-80GB-HBM3": {"node-a", "node-b", "node-c", "node-d"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "gpu.product split across two multi-node pools",
+			readings: map[string]map[string][]string{
+				"nvidia.com/gpu.product": {
+					"NVIDIA-H100-80GB-HBM3": {"node-a", "node-b"},
+					"NVIDIA-B200":           {"node-c", "node-d"},
+				},
+			},
+			want: true,
+		},
+		{
+			// Distinct keys of one family, each uniform. Counting values per
+			// family rather than per key would read these as divergence.
+			name: "whole gpu family uniform across the fleet",
+			readings: map[string]map[string][]string{
+				"nvidia.com/gpu.product":       {"NVIDIA-H100-80GB-HBM3": {"node-a", "node-b", "node-c"}},
+				"nvidia.com/gpu.count":         {"8": {"node-a", "node-b", "node-c"}},
+				"nvidia.com/gpu.memory":        {"81559": {"node-a", "node-b", "node-c"}},
+				"nvidia.com/gpu.compute.major": {"9": {"node-a", "node-b", "node-c"}},
+			},
+			want: false,
+		},
+		{
+			name: "instance-type uniform across the fleet",
+			readings: map[string]map[string][]string{
+				"node.kubernetes.io/instance-type": {"p5.48xlarge": {"node-a", "node-b", "node-c"}},
+			},
+			want: false,
+		},
+		{
+			name: "instance-type split across two multi-node pools",
+			readings: map[string]map[string][]string{
+				"node.kubernetes.io/instance-type": {
+					"p5.48xlarge":  {"node-a", "node-b"},
+					"p4d.24xlarge": {"node-c", "node-d"},
+				},
+			},
+			want: true,
+		},
+		{
+			// A uniform GPU fleet that merely spans zones is not a mixed pool.
+			name: "unrelated label diverges across nodes",
+			readings: map[string]map[string][]string{
+				"nvidia.com/gpu.product": {"NVIDIA-H100-80GB-HBM3": {"node-a", "node-b", "node-c", "node-d"}},
+				"topology.kubernetes.io/zone": {
+					"us-east-1a": {"node-a", "node-b"},
+					"us-east-1b": {"node-c", "node-d"},
+				},
+			},
+			want: false,
+		},
+		{
+			// Divergence on one node out of many is still divergence; a
+			// majority rule would hide the pool that breaks the sample.
+			name: "single odd node in an otherwise uniform fleet",
+			readings: map[string]map[string][]string{
+				"nvidia.com/gpu.product": {
+					"NVIDIA-H100-80GB-HBM3": {"node-a", "node-b", "node-c"},
+					"NVIDIA-A100-80GB":      {"node-d"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			snap := topologySnapshotWithMultiNodeItems(tt.readings)
+
+			// hasHeterogeneousGPUPool degrades to false on a snapshot it cannot
+			// decode, so a malformed fixture would let every want:false case
+			// pass without exercising the decision. Decode first and fail loudly.
+			if _, err := topology.LabelReadings(snap.Measurements[0].GetSubtype("label")); err != nil {
+				t.Fatalf("fixture does not decode, so the result below would be vacuous: %v", err)
+			}
+
+			if got := hasHeterogeneousGPUPool(snap); got != tt.want {
+				t.Errorf("hasHeterogeneousGPUPool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasHeterogeneousGPUPoolLegacyMultiNode is the folded-encoding half:
+// several nodes per entry, where divergence is inferred from key shape rather
+// than by counting values.
+func TestHasHeterogeneousGPUPoolLegacyMultiNode(t *testing.T) {
+	t.Parallel()
+
+	uniform := topologySnapshotWith(map[string]measurement.Reading{
+		"nvidia.com/gpu.product": measurement.Str("NVIDIA-H100-80GB-HBM3|node-a,node-b,node-c"),
+		"nvidia.com/gpu.count":   measurement.Str("8|node-a,node-b,node-c"),
+	})
+	if hasHeterogeneousGPUPool(uniform) {
+		t.Error("legacy Data path: got true, want false — single-segment GFD keys over " +
+			"many nodes carry no appended value and must not read as disambiguated")
+	}
+
+	// Two products across two pools: the encoder folds both onto
+	// "<key>.<value>", which is the shape the heuristic looks for.
+	mixed := topologySnapshotWith(map[string]measurement.Reading{
+		"nvidia.com/gpu.product.NVIDIA-H100-80GB-HBM3": measurement.Str("NVIDIA-H100-80GB-HBM3|node-a,node-b"),
+		"nvidia.com/gpu.product.NVIDIA-B200":           measurement.Str("NVIDIA-B200|node-c,node-d"),
+	})
+	if !hasHeterogeneousGPUPool(mixed) {
+		t.Error("legacy Data path: got false, want true — two folded gpu.product entries " +
+			"are the divergence signal the heuristic exists to catch")
 	}
 }

--- a/pkg/client/v1/gpu_driver_state_test.go
+++ b/pkg/client/v1/gpu_driver_state_test.go
@@ -17,6 +17,7 @@ package aicr
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -630,5 +631,125 @@ func TestDriverAbsentRemedyBranches(t *testing.T) {
 	}
 	if strings.Contains(profiled, "bundle in GPU-Operator-managed mode:") {
 		t.Errorf("profiled AKS remedy still offers the bundle-time tuple: %q", profiled)
+	}
+}
+
+// topologySnapshotWithItems builds a snapshot carrying the collector's
+// lossless label encoding: one item per {key, value} reading rather than a
+// folded map key. readings maps a label key to the values it carries across
+// the cluster, one node per value.
+func topologySnapshotWithItems(readings map[string][]string) *snapshotter.Snapshot {
+	var items []measurement.ItemEntry
+	for key, values := range readings {
+		for i, v := range values {
+			items = append(items, measurement.ItemEntry{
+				Context: map[string]string{"key": key, "value": v},
+				Data: map[string]measurement.Reading{
+					"node-count": measurement.Int(1),
+					"node-list":  measurement.Str(fmt.Sprintf("node-%d", i)),
+					"truncated":  measurement.Bool(false),
+				},
+			})
+		}
+	}
+	return &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{
+			measurement.NewMeasurement(measurement.TypeNodeTopology).
+				WithSubtype(measurement.Subtype{Name: "label", Items: items}).
+				Build(),
+		},
+	}
+}
+
+// TestHasHeterogeneousGPUPoolLosslessEncoding pins the item-encoding path,
+// which decides heterogeneity by counting distinct values per label key
+// rather than by inspecting the shape of a folded map key.
+//
+// The last two cases are the false positives the shape heuristic cannot
+// avoid: a uniform GFD label whose name simply contains a dot reads as
+// disambiguated on the legacy path, so the warning fires on every
+// post-GPU-Operator re-snapshot of a perfectly uniform cluster.
+func TestHasHeterogeneousGPUPoolLosslessEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		readings map[string][]string
+		want     bool
+	}{
+		{
+			name:     "uniform gpu.product",
+			readings: map[string][]string{"nvidia.com/gpu.product": {"NVIDIA-H100-80GB-HBM3"}},
+			want:     false,
+		},
+		{
+			name:     "mixed gpu.product",
+			readings: map[string][]string{"nvidia.com/gpu.product": {"NVIDIA-H100-80GB-HBM3", "NVIDIA-B200"}},
+			want:     true,
+		},
+		{
+			name:     "mixed instance-type",
+			readings: map[string][]string{"node.kubernetes.io/instance-type": {"p5.48xlarge", "p4d.24xlarge"}},
+			want:     true,
+		},
+		{
+			name:     "uniform instance-type with dots in the value",
+			readings: map[string][]string{"node.kubernetes.io/instance-type": {"p5.48xlarge"}},
+			want:     false,
+		},
+		{
+			name:     "unrelated label with multiple values does not trigger",
+			readings: map[string][]string{"topology.kubernetes.io/zone": {"us-east-1a", "us-east-1b"}},
+			want:     false,
+		},
+		{
+			// Legacy-path false positive: the dot belongs to the label name,
+			// not to an appended value.
+			name:     "uniform gpu.compute.major is not heterogeneous",
+			readings: map[string][]string{"nvidia.com/gpu.compute.major": {"9"}},
+			want:     false,
+		},
+		{
+			name:     "uniform gpu.deploy.driver is not heterogeneous",
+			readings: map[string][]string{"nvidia.com/gpu.deploy.driver": {"true"}},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasHeterogeneousGPUPool(topologySnapshotWithItems(tt.readings)); got != tt.want {
+				t.Errorf("hasHeterogeneousGPUPool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasHeterogeneousGPUPoolLegacyFalsePositive documents what the item
+// encoding fixes: on a Data-only snapshot a uniform GFD label is reported as
+// heterogeneous, because the shape heuristic cannot tell the dot in
+// "compute.major" from a value the encoder appended.
+//
+// Asserting the wrong answer is deliberate — it pins the legacy behavior so
+// the fallback path cannot drift, and marks the divergence a reader of the
+// two tests together will notice.
+func TestHasHeterogeneousGPUPoolLegacyFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	legacy := topologySnapshotWith(map[string]measurement.Reading{
+		"nvidia.com/gpu.compute.major": measurement.Str("9|node-a,node-b"),
+	})
+	if !hasHeterogeneousGPUPool(legacy) {
+		t.Error("legacy Data path: got false, want true — the shape heuristic's known " +
+			"false positive on uniform GFD labels is being asserted here on purpose")
+	}
+
+	lossless := topologySnapshotWithItems(map[string][]string{
+		"nvidia.com/gpu.compute.major": {"9"},
+	})
+	if hasHeterogeneousGPUPool(lossless) {
+		t.Error("item path: got true, want false — the same cluster must not be reported " +
+			"heterogeneous once the encoding is lossless")
 	}
 }

--- a/pkg/client/v1/gpu_driver_state_test.go
+++ b/pkg/client/v1/gpu_driver_state_test.go
@@ -703,6 +703,19 @@ func TestHasHeterogeneousGPUPoolLosslessEncoding(t *testing.T) {
 			want:     false,
 		},
 		{
+			name:     "child of instance-type is a separate label",
+			readings: map[string][]string{"node.kubernetes.io/instance-type.tier": {"gold", "silver"}},
+			want:     false,
+		},
+		{
+			name: "uniform instance-type alongside a diverging child",
+			readings: map[string][]string{
+				"node.kubernetes.io/instance-type":      {"p5.48xlarge"},
+				"node.kubernetes.io/instance-type.tier": {"gold", "silver"},
+			},
+			want: false,
+		},
+		{
 			// Legacy-path false positive: the dot belongs to the label name,
 			// not to an appended value.
 			name:     "uniform gpu.compute.major is not heterogeneous",

--- a/pkg/collector/topology/readings.go
+++ b/pkg/collector/topology/readings.go
@@ -66,9 +66,9 @@ func LabelReadings(st *measurement.Subtype) ([]LabelReading, error) {
 		return nil, nil
 	}
 	if len(st.Items) > 0 {
-		return labelReadingsFromItems(st.Items)
+		return labelReadingsFromItems(st)
 	}
-	return labelReadingsFromData(st.Data), nil
+	return labelReadingsFromData(st.Data)
 }
 
 // TaintReadings returns the readings in a NodeTopology "taint" subtype. See
@@ -82,9 +82,9 @@ func TaintReadings(st *measurement.Subtype) ([]TaintReading, error) {
 		return nil, nil
 	}
 	if len(st.Items) > 0 {
-		return taintReadingsFromItems(st.Items)
+		return taintReadingsFromItems(st)
 	}
-	return taintReadingsFromData(st.Data), nil
+	return taintReadingsFromData(st.Data)
 }
 
 // HasLosslessReadings reports whether a subtype carries the Items form.
@@ -94,31 +94,58 @@ func HasLosslessReadings(st *measurement.Subtype) bool {
 	return st != nil && len(st.Items) > 0
 }
 
-func labelReadingsFromItems(items []measurement.ItemEntry) ([]LabelReading, error) {
+func labelReadingsFromItems(st *measurement.Subtype) ([]LabelReading, error) {
+	items := st.Items
 	out := make([]LabelReading, 0, len(items))
 	for i := range items {
 		key, err := itemContext(items[i], itemCtxKey, i)
 		if err != nil {
 			return nil, err
 		}
-		nodes, count, truncated, err := itemNodes(items[i], i)
-		if err != nil {
-			return nil, err
-		}
 		out = append(out, LabelReading{
 			// An empty label value is legal, so a missing value key and an
 			// empty one both decode to "".
-			Key:       key,
-			Value:     items[i].Context[itemCtxValue],
-			Nodes:     nodes,
-			NodeCount: count,
-			Truncated: truncated,
-			RawKey:    key,
+			Key:    key,
+			Value:  items[i].Context[itemCtxValue],
+			RawKey: key,
 		})
 	}
+	// RawKey is the data entry this reading folds onto, and membership can
+	// only be resolved once the whole set is known — folding depends on how
+	// many values a key carries.
 	applyLabelRawKeys(out)
+	folds := foldCounts(rawKeysOf(out))
+	for i := range items {
+		nodes, count, truncated, err := itemNodes(items[i], i, st.Data, out[i].RawKey, folds)
+		if err != nil {
+			return nil, err
+		}
+		out[i].Nodes, out[i].NodeCount, out[i].Truncated = nodes, count, truncated
+	}
 	return out, nil
 }
+
+// rawKeysOf and foldCounts report how many readings fold onto each data entry.
+// An entry claimed by more than one reading describes only one of them, so no
+// reading may reference it.
+func rawKeysOf[T interface{ raw() string }](readings []T) []string {
+	out := make([]string, 0, len(readings))
+	for _, r := range readings {
+		out = append(out, r.raw())
+	}
+	return out
+}
+
+func foldCounts(rawKeys []string) map[string]int {
+	out := make(map[string]int, len(rawKeys))
+	for _, k := range rawKeys {
+		out[k]++
+	}
+	return out
+}
+
+func (r LabelReading) raw() string { return r.RawKey }
+func (r TaintReading) raw() string { return r.RawKey }
 
 // applyLabelRawKeys replays encodeLabels' rule over a decoded set: a key
 // carrying more than one value renders as "<key>.<value>". Disambiguation
@@ -135,14 +162,11 @@ func applyLabelRawKeys(readings []LabelReading) {
 	}
 }
 
-func taintReadingsFromItems(items []measurement.ItemEntry) ([]TaintReading, error) {
+func taintReadingsFromItems(st *measurement.Subtype) ([]TaintReading, error) {
+	items := st.Items
 	out := make([]TaintReading, 0, len(items))
 	for i := range items {
 		key, err := itemContext(items[i], itemCtxKey, i)
-		if err != nil {
-			return nil, err
-		}
-		nodes, count, truncated, err := itemNodes(items[i], i)
 		if err != nil {
 			return nil, err
 		}
@@ -154,16 +178,21 @@ func taintReadingsFromItems(items []measurement.ItemEntry) ([]TaintReading, erro
 			return nil, err
 		}
 		out = append(out, TaintReading{
-			Key:       key,
-			Effect:    effect,
-			Value:     items[i].Context[itemCtxValue],
-			Nodes:     nodes,
-			NodeCount: count,
-			Truncated: truncated,
-			RawKey:    key,
+			Key:    key,
+			Effect: effect,
+			Value:  items[i].Context[itemCtxValue],
+			RawKey: key,
 		})
 	}
 	applyTaintRawKeys(out)
+	folds := foldCounts(rawKeysOf(out))
+	for i := range items {
+		nodes, count, truncated, err := itemNodes(items[i], i, st.Data, out[i].RawKey, folds)
+		if err != nil {
+			return nil, err
+		}
+		out[i].Nodes, out[i].NodeCount, out[i].Truncated = nodes, count, truncated
+	}
 	return out, nil
 }
 
@@ -191,19 +220,93 @@ func itemContext(item measurement.ItemEntry, field string, idx int) (string, err
 	return v, nil
 }
 
-func itemNodes(item measurement.ItemEntry, idx int) (nodes []string, count int, truncated bool, err error) {
-	raw, ok := item.Data[itemDataNodeList]
+// itemRef reads the optional reference to a data entry, reporting whether one
+// is present.
+func itemRef(item measurement.ItemEntry, idx int) (string, bool, error) {
+	r, ok := item.Data[itemDataNodeRef]
 	if !ok {
-		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("topology item %d: missing required data field %q", idx, itemDataNodeList))
+		return "", false, nil
 	}
-	list, ok := raw.Any().(string)
+	ref, ok := r.Any().(string)
+	if !ok || ref == "" {
+		return "", false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: data field %q is not a non-empty string", idx, itemDataNodeRef))
+	}
+	return ref, true, nil
+}
+
+// resolveNodeList returns the encoded node list for an item: the inline copy
+// when it carries one, or the data entry it names.
+//
+// An item carries exactly one of the two. Inferring the reference from an
+// absent node-list would make a producer's omission indistinguishable from a
+// deliberate reference, so the reference is explicit and its absence alongside
+// an absent list is a decode failure.
+//
+// A reference is only honored when it names this reading's own fold key and
+// no other reading folds onto that key — the condition under which the entry
+// describes this reading and no other. Anything else would resolve to another
+// reading's nodes: well formed and wrong, the failure this encoding removes.
+func resolveNodeList(item measurement.ItemEntry, idx int, data map[string]measurement.Reading, rawKey string, folds map[string]int) (string, error) {
+	inline, hasList := item.Data[itemDataNodeList]
+	ref, hasRef, err := itemRef(item, idx)
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case hasList && hasRef:
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: carries both %q and %q; membership has one source",
+				idx, itemDataNodeList, itemDataNodeRef))
+	case !hasList && !hasRef:
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: carries neither %q nor %q", idx, itemDataNodeList, itemDataNodeRef))
+	case hasList:
+		list, ok := inline.Any().(string)
+		if !ok {
+			return "", errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("topology item %d: data field %q is not a string", idx, itemDataNodeList))
+		}
+		return list, nil
+	}
+
+	if ref != rawKey {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: %q names %q but this reading folds onto %q",
+				idx, itemDataNodeRef, ref, rawKey))
+	}
+	if folds[ref] != 1 {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: %d readings fold onto %q, so it cannot be referenced",
+				idx, folds[ref], ref))
+	}
+	entry, ok := data[ref]
 	if !ok {
-		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("topology item %d: data field %q is not a string", idx, itemDataNodeList))
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: %q %q names no data entry", idx, itemDataNodeRef, ref))
+	}
+	// The node list is the final field of every folded encoding: "<value>|
+	// <nodes>" for labels and disambiguated taints, "<effect>|<value>|<nodes>"
+	// otherwise.
+	parts := strings.Split(entry.String(), "|")
+	return parts[len(parts)-1], nil
+}
+
+// itemNodes resolves and validates one item's node membership. The three
+// fields describe the same node set from different angles, so a disagreement
+// makes the item unreadable rather than imprecise.
+func itemNodes(item measurement.ItemEntry, idx int, data map[string]measurement.Reading, rawKey string, folds map[string]int) (nodes []string, count int, truncated bool, err error) {
+	list, err := resolveNodeList(item, idx, data, rawKey, folds)
+	if err != nil {
+		return nil, 0, false, err
 	}
 	nodes = splitNodeList(list)
-	hidden, marker := truncatedNodeListRemainder(list)
+	hidden, marker, err := truncatedNodeListRemainder(list)
+	if err != nil {
+		return nil, 0, false, errors.Wrap(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d", idx), err)
+	}
 
 	count, err = itemInt(item, itemDataNodeCount, idx)
 	if err != nil {
@@ -214,20 +317,20 @@ func itemNodes(item measurement.ItemEntry, idx int) (nodes []string, count int, 
 		return nil, 0, false, err
 	}
 
-	// The list states the pre-truncation total exactly — the names it still
-	// renders plus the N its marker withholds — so node-count is checked for
-	// equality rather than for a direction. A complete list has hidden == 0,
-	// which collapses to "count equals the names".
+	// The list states the pre-truncation total exactly — the names it renders
+	// plus the N its marker withholds — so node-count is checked for equality
+	// rather than for a direction. A complete list has hidden == 0, which
+	// collapses to "count equals the names".
 	switch {
 	case marker != truncated:
 		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("topology item %d: %q is %v but %q %s the truncation marker",
-				idx, itemDataTruncated, truncated, itemDataNodeList,
+			fmt.Sprintf("topology item %d: %q is %v but the node list %s the truncation marker",
+				idx, itemDataTruncated, truncated,
 				map[bool]string{true: "carries", false: "does not carry"}[marker]))
 	case count != len(nodes)+hidden:
 		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("topology item %d: %q is %d but %q names %d nodes and withholds %d",
-				idx, itemDataNodeCount, count, itemDataNodeList, len(nodes), hidden))
+			fmt.Sprintf("topology item %d: %q is %d but the node list names %d and withholds %d",
+				idx, itemDataNodeCount, count, len(nodes), hidden))
 	}
 	return nodes, count, truncated, nil
 }
@@ -287,15 +390,19 @@ func readingInt(r measurement.Reading) (int, bool) {
 // labelReadingsFromData decodes the legacy "<value>|<nodes>" encoding. Key is
 // the map key verbatim: whether it is a true label name or a synthesized
 // "<key>.<value>" cannot be determined from the encoding alone.
-func labelReadingsFromData(data map[string]measurement.Reading) []LabelReading {
+func labelReadingsFromData(data map[string]measurement.Reading) ([]LabelReading, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]LabelReading, 0, len(data))
 	for key, reading := range data {
 		value, list, _ := strings.Cut(reading.String(), "|")
 		nodes := splitNodeList(list)
-		hidden, truncated := truncatedNodeListRemainder(list)
+		hidden, truncated, err := truncatedNodeListRemainder(list)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("label reading %q", key), err)
+		}
 		out = append(out, LabelReading{
 			Key:       key,
 			Value:     value,
@@ -306,35 +413,44 @@ func labelReadingsFromData(data map[string]measurement.Reading) []LabelReading {
 		})
 	}
 	sortLabelReadings(out)
-	return out
+	return out, nil
 }
 
 // taintReadingsFromData decodes the legacy taint encoding, whose two shapes
 // are told apart by field count: "<effect>|<value>|<nodes>" for a plain key,
 // "<value>|<nodes>" for a disambiguated one where the effect is the key suffix.
-func taintReadingsFromData(data map[string]measurement.Reading) []TaintReading {
+func taintReadingsFromData(data map[string]measurement.Reading) ([]TaintReading, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]TaintReading, 0, len(data))
-	for key, reading := range data {
+	for rawKey, reading := range data {
+		key := rawKey
 		var effect, value, list string
 		parts := strings.SplitN(reading.String(), "|", 3)
 		switch len(parts) {
 		case 3:
 			effect, value, list = parts[0], parts[1], parts[2]
 		case 2:
-			// Splitting the effect back off the key is ambiguous for a taint
-			// key that legitimately contains a dot — the defect Items removes.
+			// Two fields exist only because encodeTaints moved the effect into
+			// the key, so the final segment is the effect and the prefix is the
+			// key — the same identity the item path reports. Which is still a
+			// guess for a taint key that legitimately contains a dot: the
+			// ambiguity the item encoding removes.
 			value, list = parts[0], parts[1]
-			if i := strings.LastIndex(key, "."); i >= 0 {
-				effect = key[i+1:]
+			if i := strings.LastIndex(rawKey, "."); i >= 0 {
+				effect = rawKey[i+1:]
+				key = rawKey[:i]
 			}
 		default:
 			value = parts[0]
 		}
 		nodes := splitNodeList(list)
-		hidden, truncated := truncatedNodeListRemainder(list)
+		hidden, truncated, err := truncatedNodeListRemainder(list)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("taint reading %q", rawKey), err)
+		}
 		out = append(out, TaintReading{
 			Key:       key,
 			Effect:    effect,
@@ -342,11 +458,11 @@ func taintReadingsFromData(data map[string]measurement.Reading) []TaintReading {
 			Nodes:     nodes,
 			NodeCount: len(nodes) + hidden,
 			Truncated: truncated,
-			RawKey:    key,
+			RawKey:    rawKey,
 		})
 	}
 	sortTaintReadings(out)
-	return out
+	return out, nil
 }
 
 // sortLabelReadings matches the collector's emission order so callers see the
@@ -379,4 +495,76 @@ func splitNodeList(list string) []string {
 		return nil
 	}
 	return strings.Split(list, ",")
+}
+
+// Subtype names carrying a folded counterpart.
+const (
+	subtypeLabel = "label"
+	subtypeTaint = "taint"
+)
+
+// HydrateItems returns st's items with every referenced node list resolved
+// inline, so a consumer comparing items sees node membership regardless of how
+// the snapshot chose to encode it. It also reports the folded keys that more
+// than one reading maps onto: entries the folded encoding cannot describe
+// unambiguously, and whose value therefore depends on map iteration order.
+//
+// Returns nil when st carries no items. Subtypes other than "label" and
+// "taint" are returned unchanged, having no folded counterpart.
+func HydrateItems(st *measurement.Subtype) (items []measurement.ItemEntry, ambiguous map[string]bool, err error) {
+	if st == nil || len(st.Items) == 0 {
+		return nil, nil, nil
+	}
+
+	var nodes [][]string
+	var rawKeys []string
+	switch st.Name {
+	case subtypeLabel:
+		readings, err := LabelReadings(st)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, r := range readings {
+			nodes, rawKeys = append(nodes, r.Nodes), append(rawKeys, r.RawKey)
+		}
+	case subtypeTaint:
+		readings, err := TaintReadings(st)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, r := range readings {
+			nodes, rawKeys = append(nodes, r.Nodes), append(rawKeys, r.RawKey)
+		}
+	default:
+		return st.Items, nil, nil
+	}
+
+	folds := foldCounts(rawKeys)
+	ambiguous = make(map[string]bool)
+	for k, n := range folds {
+		if n > 1 {
+			ambiguous[k] = true
+		}
+	}
+
+	if len(nodes) != len(st.Items) {
+		return nil, nil, errors.New(errors.ErrCodeInternal,
+			"hydration produced a different number of readings than items")
+	}
+	items = make([]measurement.ItemEntry, len(st.Items))
+	for i := range st.Items {
+		data := make(map[string]measurement.Reading, len(st.Items[i].Data))
+		for k, v := range st.Items[i].Data {
+			if k == itemDataNodeRef {
+				continue
+			}
+			data[k] = v
+		}
+		// Joining reproduces the encoded list exactly, marker included: the
+		// suffix is space-joined onto the final name rather than being an
+		// element of its own.
+		data[itemDataNodeList] = measurement.Str(strings.Join(nodes[i], ","))
+		items[i] = measurement.ItemEntry{Context: st.Items[i].Context, Data: data}
+	}
+	return items, ambiguous, nil
 }

--- a/pkg/collector/topology/readings.go
+++ b/pkg/collector/topology/readings.go
@@ -94,6 +94,8 @@ func HasLosslessReadings(st *measurement.Subtype) bool {
 	return st != nil && len(st.Items) > 0
 }
 
+// labelReadingsFromItems preserves item order: readings[i] always describes
+// items[i]. HydrateItems relies on this to pair node lists with items by index.
 func labelReadingsFromItems(st *measurement.Subtype) ([]LabelReading, error) {
 	items := st.Items
 	out := make([]LabelReading, 0, len(items))
@@ -162,6 +164,8 @@ func applyLabelRawKeys(readings []LabelReading) {
 	}
 }
 
+// taintReadingsFromItems preserves item order: readings[i] always describes
+// items[i]. HydrateItems relies on this to pair node lists with items by index.
 func taintReadingsFromItems(st *measurement.Subtype) ([]TaintReading, error) {
 	items := st.Items
 	out := make([]TaintReading, 0, len(items))
@@ -443,7 +447,8 @@ func taintReadingsFromData(data map[string]measurement.Reading) ([]TaintReading,
 				key = rawKey[:i]
 			}
 		default:
-			value = parts[0]
+			return nil, errors.New(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("taint reading %q: expected 2 or 3 pipe-separated fields, got 1", rawKey))
 		}
 		nodes := splitNodeList(list)
 		hidden, truncated, err := truncatedNodeListRemainder(list)

--- a/pkg/collector/topology/readings.go
+++ b/pkg/collector/topology/readings.go
@@ -203,7 +203,7 @@ func itemNodes(item measurement.ItemEntry, idx int) (nodes []string, count int, 
 			fmt.Sprintf("topology item %d: data field %q is not a string", idx, itemDataNodeList))
 	}
 	nodes = splitNodeList(list)
-	marker := IsTruncatedNodeList(list)
+	hidden, marker := truncatedNodeListRemainder(list)
 
 	count, err = itemInt(item, itemDataNodeCount, idx)
 	if err != nil {
@@ -214,24 +214,20 @@ func itemNodes(item measurement.ItemEntry, idx int) (nodes []string, count int, 
 		return nil, 0, false, err
 	}
 
-	// All three describe the same node set, so a disagreement makes the item
-	// unreadable rather than imprecise. Both count directions matter: too low
-	// understates the cluster, too high lets a consumer read a partial list as
-	// a complete one.
+	// The list states the pre-truncation total exactly — the names it still
+	// renders plus the N its marker withholds — so node-count is checked for
+	// equality rather than for a direction. A complete list has hidden == 0,
+	// which collapses to "count equals the names".
 	switch {
 	case marker != truncated:
 		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("topology item %d: %q is %v but %q %s the truncation marker",
 				idx, itemDataTruncated, truncated, itemDataNodeList,
 				map[bool]string{true: "carries", false: "does not carry"}[marker]))
-	case truncated && count <= len(nodes):
+	case count != len(nodes)+hidden:
 		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("topology item %d: %q is truncated but %q (%d) does not exceed the %d nodes named",
-				idx, itemDataNodeList, itemDataNodeCount, count, len(nodes)))
-	case !truncated && count != len(nodes):
-		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("topology item %d: %q is complete but %q is %d against %d nodes named",
-				idx, itemDataNodeList, itemDataNodeCount, count, len(nodes)))
+			fmt.Sprintf("topology item %d: %q is %d but %q names %d nodes and withholds %d",
+				idx, itemDataNodeCount, count, itemDataNodeList, len(nodes), hidden))
 	}
 	return nodes, count, truncated, nil
 }
@@ -299,12 +295,13 @@ func labelReadingsFromData(data map[string]measurement.Reading) []LabelReading {
 	for key, reading := range data {
 		value, list, _ := strings.Cut(reading.String(), "|")
 		nodes := splitNodeList(list)
+		hidden, truncated := truncatedNodeListRemainder(list)
 		out = append(out, LabelReading{
 			Key:       key,
 			Value:     value,
 			Nodes:     nodes,
-			NodeCount: len(nodes),
-			Truncated: IsTruncatedNodeList(list),
+			NodeCount: len(nodes) + hidden,
+			Truncated: truncated,
 			RawKey:    key,
 		})
 	}
@@ -337,13 +334,14 @@ func taintReadingsFromData(data map[string]measurement.Reading) []TaintReading {
 			value = parts[0]
 		}
 		nodes := splitNodeList(list)
+		hidden, truncated := truncatedNodeListRemainder(list)
 		out = append(out, TaintReading{
 			Key:       key,
 			Effect:    effect,
 			Value:     value,
 			Nodes:     nodes,
-			NodeCount: len(nodes),
-			Truncated: IsTruncatedNodeList(list),
+			NodeCount: len(nodes) + hidden,
+			Truncated: truncated,
 			RawKey:    key,
 		})
 	}

--- a/pkg/collector/topology/readings.go
+++ b/pkg/collector/topology/readings.go
@@ -1,0 +1,329 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topology
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/measurement"
+)
+
+// LabelReading is one aggregated label reading.
+type LabelReading struct {
+	Key   string
+	Value string
+	// Nodes carry Key=Value. When Truncated, the list is incomplete and its
+	// last element holds the "(+N more)" marker.
+	Nodes []string
+	// NodeCount is the true total, including nodes omitted by truncation.
+	NodeCount int
+	Truncated bool
+	// RawKey is the Data map key this reading corresponds to, so callers can
+	// keep diagnostics identical across both encodings. Not an identity.
+	RawKey string
+}
+
+// TaintReading is one aggregated taint reading.
+type TaintReading struct {
+	Key       string
+	Effect    string
+	Value     string
+	Nodes     []string
+	NodeCount int
+	Truncated bool
+	RawKey    string
+}
+
+// LabelReadings returns the readings in a NodeTopology "label" subtype,
+// preferring the lossless Items form and falling back to decoding Data for
+// snapshots captured before it existed.
+//
+// The paths are not equivalent. Data folds key and value into one map key when
+// a label carries multiple values, which collides with a label literally named
+// "<key>.<value>" (#2003); on that path a reading's Key is whatever the map
+// key says. The ambiguity is inherent to the old encoding and cannot be undone
+// here.
+//
+// Validating node names is caller policy — see pkg/constraints, which fails
+// closed on malformed tokens.
+func LabelReadings(st *measurement.Subtype) ([]LabelReading, error) {
+	if st == nil {
+		return nil, nil
+	}
+	if len(st.Items) > 0 {
+		return labelReadingsFromItems(st.Items)
+	}
+	return labelReadingsFromData(st.Data), nil
+}
+
+// TaintReadings returns the readings in a NodeTopology "taint" subtype. See
+// LabelReadings for the Items-preferred contract.
+//
+// Data is doubly ambiguous for taints: encodeTaints counts entries per key but
+// disambiguates with effect, so two taints sharing both collapse into one
+// entry.
+func TaintReadings(st *measurement.Subtype) ([]TaintReading, error) {
+	if st == nil {
+		return nil, nil
+	}
+	if len(st.Items) > 0 {
+		return taintReadingsFromItems(st.Items)
+	}
+	return taintReadingsFromData(st.Data), nil
+}
+
+// HasLosslessReadings reports whether a subtype carries the Items form.
+// Callers that keep a heuristic meaningful only against folded Data keys use
+// this rather than inspecting Items directly.
+func HasLosslessReadings(st *measurement.Subtype) bool {
+	return st != nil && len(st.Items) > 0
+}
+
+func labelReadingsFromItems(items []measurement.ItemEntry) ([]LabelReading, error) {
+	out := make([]LabelReading, 0, len(items))
+	for i := range items {
+		key, err := itemContext(items[i], itemCtxKey, i)
+		if err != nil {
+			return nil, err
+		}
+		nodes, count, truncated, err := itemNodes(items[i], i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, LabelReading{
+			// An empty label value is legal, so a missing value key and an
+			// empty one both decode to "".
+			Key:       key,
+			Value:     items[i].Context[itemCtxValue],
+			Nodes:     nodes,
+			NodeCount: count,
+			Truncated: truncated,
+			RawKey:    key,
+		})
+	}
+	applyLabelRawKeys(out)
+	return out, nil
+}
+
+// applyLabelRawKeys replays encodeLabels' rule over a decoded set: a key
+// carrying more than one value renders as "<key>.<value>". Disambiguation
+// depends on the whole set, not one reading.
+func applyLabelRawKeys(readings []LabelReading) {
+	values := make(map[string]int, len(readings))
+	for i := range readings {
+		values[readings[i].Key]++
+	}
+	for i := range readings {
+		if values[readings[i].Key] > 1 {
+			readings[i].RawKey = readings[i].Key + "." + readings[i].Value
+		}
+	}
+}
+
+func taintReadingsFromItems(items []measurement.ItemEntry) ([]TaintReading, error) {
+	out := make([]TaintReading, 0, len(items))
+	for i := range items {
+		key, err := itemContext(items[i], itemCtxKey, i)
+		if err != nil {
+			return nil, err
+		}
+		nodes, count, truncated, err := itemNodes(items[i], i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, TaintReading{
+			Key:       key,
+			Effect:    items[i].Context[itemCtxEffect],
+			Value:     items[i].Context[itemCtxValue],
+			Nodes:     nodes,
+			NodeCount: count,
+			Truncated: truncated,
+			RawKey:    key,
+		})
+	}
+	applyTaintRawKeys(out)
+	return out, nil
+}
+
+// applyTaintRawKeys replays encodeTaints' rule. It keys on entries sharing a
+// key rather than on distinct effects because that is what encodeTaints does —
+// RawKey mirrors the old output rather than correcting it.
+func applyTaintRawKeys(readings []TaintReading) {
+	seen := make(map[string]int, len(readings))
+	for i := range readings {
+		seen[readings[i].Key]++
+	}
+	for i := range readings {
+		if seen[readings[i].Key] > 1 {
+			readings[i].RawKey = readings[i].Key + "." + readings[i].Effect
+		}
+	}
+}
+
+func itemContext(item measurement.ItemEntry, field string, idx int) (string, error) {
+	v, ok := item.Context[field]
+	if !ok || v == "" {
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: missing required context field %q", idx, field))
+	}
+	return v, nil
+}
+
+func itemNodes(item measurement.ItemEntry, idx int) (nodes []string, count int, truncated bool, err error) {
+	raw, ok := item.Data[itemDataNodeList]
+	if !ok {
+		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: missing required data field %q", idx, itemDataNodeList))
+	}
+	list, ok := raw.Any().(string)
+	if !ok {
+		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: data field %q is not a string", idx, itemDataNodeList))
+	}
+	nodes = splitNodeList(list)
+
+	count = len(nodes)
+	if r, ok := item.Data[itemDataNodeCount]; ok {
+		if n, ok := readingInt(r); ok {
+			count = n
+		}
+	}
+	// Default to the rendered suffix — the only signal Data ever carried — so an
+	// item that omits or mistypes the field still reads as truncated. A declared
+	// bool wins when it is one.
+	truncated = IsTruncatedNodeList(list)
+	if r, ok := item.Data[itemDataTruncated]; ok {
+		if b, ok := r.Any().(bool); ok {
+			truncated = b
+		}
+	}
+	return nodes, count, truncated, nil
+}
+
+// readingInt accepts the integer shapes a Reading can hold; JSON decoders
+// deliver integers as float64.
+func readingInt(r measurement.Reading) (int, bool) {
+	switch v := r.Any().(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case float64:
+		if v != float64(int64(v)) {
+			return 0, false
+		}
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+// labelReadingsFromData decodes the legacy "<value>|<nodes>" encoding. Key is
+// the map key verbatim: whether it is a true label name or a synthesized
+// "<key>.<value>" cannot be determined from the encoding alone.
+func labelReadingsFromData(data map[string]measurement.Reading) []LabelReading {
+	if len(data) == 0 {
+		return nil
+	}
+	out := make([]LabelReading, 0, len(data))
+	for key, reading := range data {
+		value, list, _ := strings.Cut(reading.String(), "|")
+		nodes := splitNodeList(list)
+		out = append(out, LabelReading{
+			Key:       key,
+			Value:     value,
+			Nodes:     nodes,
+			NodeCount: len(nodes),
+			Truncated: IsTruncatedNodeList(list),
+			RawKey:    key,
+		})
+	}
+	sortLabelReadings(out)
+	return out
+}
+
+// taintReadingsFromData decodes the legacy taint encoding, whose two shapes
+// are told apart by field count: "<effect>|<value>|<nodes>" for a plain key,
+// "<value>|<nodes>" for a disambiguated one where the effect is the key suffix.
+func taintReadingsFromData(data map[string]measurement.Reading) []TaintReading {
+	if len(data) == 0 {
+		return nil
+	}
+	out := make([]TaintReading, 0, len(data))
+	for key, reading := range data {
+		var effect, value, list string
+		parts := strings.SplitN(reading.String(), "|", 3)
+		switch len(parts) {
+		case 3:
+			effect, value, list = parts[0], parts[1], parts[2]
+		case 2:
+			// Splitting the effect back off the key is ambiguous for a taint
+			// key that legitimately contains a dot — the defect Items removes.
+			value, list = parts[0], parts[1]
+			if i := strings.LastIndex(key, "."); i >= 0 {
+				effect = key[i+1:]
+			}
+		default:
+			value = parts[0]
+		}
+		nodes := splitNodeList(list)
+		out = append(out, TaintReading{
+			Key:       key,
+			Effect:    effect,
+			Value:     value,
+			Nodes:     nodes,
+			NodeCount: len(nodes),
+			Truncated: IsTruncatedNodeList(list),
+			RawKey:    key,
+		})
+	}
+	sortTaintReadings(out)
+	return out
+}
+
+// sortLabelReadings matches the collector's emission order so callers see the
+// same order from either encoding; the Data path iterates a Go map.
+func sortLabelReadings(readings []LabelReading) {
+	sort.Slice(readings, func(i, j int) bool {
+		if readings[i].Key != readings[j].Key {
+			return readings[i].Key < readings[j].Key
+		}
+		return readings[i].Value < readings[j].Value
+	})
+}
+
+func sortTaintReadings(readings []TaintReading) {
+	sort.Slice(readings, func(i, j int) bool {
+		if readings[i].Key != readings[j].Key {
+			return readings[i].Key < readings[j].Key
+		}
+		if readings[i].Effect != readings[j].Effect {
+			return readings[i].Effect < readings[j].Effect
+		}
+		return readings[i].Value < readings[j].Value
+	})
+}
+
+// splitNodeList splits a rendered node list. A truncated list keeps its
+// "(+N more)" marker in the final element; callers consult Truncated.
+func splitNodeList(list string) []string {
+	if list == "" {
+		return nil
+	}
+	return strings.Split(list, ",")
+}

--- a/pkg/collector/topology/readings.go
+++ b/pkg/collector/topology/readings.go
@@ -146,9 +146,16 @@ func taintReadingsFromItems(items []measurement.ItemEntry) ([]TaintReading, erro
 		if err != nil {
 			return nil, err
 		}
+		// Required so an empty Effect cannot satisfy a caller matching on one.
+		// Not checked against the known effects — a newer Kubernetes must
+		// still decode.
+		effect, err := itemContext(items[i], itemCtxEffect, i)
+		if err != nil {
+			return nil, err
+		}
 		out = append(out, TaintReading{
 			Key:       key,
-			Effect:    items[i].Context[itemCtxEffect],
+			Effect:    effect,
 			Value:     items[i].Context[itemCtxValue],
 			Nodes:     nodes,
 			NodeCount: count,
@@ -196,23 +203,71 @@ func itemNodes(item measurement.ItemEntry, idx int) (nodes []string, count int, 
 			fmt.Sprintf("topology item %d: data field %q is not a string", idx, itemDataNodeList))
 	}
 	nodes = splitNodeList(list)
+	marker := IsTruncatedNodeList(list)
 
-	count = len(nodes)
-	if r, ok := item.Data[itemDataNodeCount]; ok {
-		if n, ok := readingInt(r); ok {
-			count = n
-		}
+	count, err = itemInt(item, itemDataNodeCount, idx)
+	if err != nil {
+		return nil, 0, false, err
 	}
-	// Default to the rendered suffix — the only signal Data ever carried — so an
-	// item that omits or mistypes the field still reads as truncated. A declared
-	// bool wins when it is one.
-	truncated = IsTruncatedNodeList(list)
-	if r, ok := item.Data[itemDataTruncated]; ok {
-		if b, ok := r.Any().(bool); ok {
-			truncated = b
-		}
+	truncated, err = itemBool(item, itemDataTruncated, idx)
+	if err != nil {
+		return nil, 0, false, err
+	}
+
+	// All three describe the same node set, so a disagreement makes the item
+	// unreadable rather than imprecise. Both count directions matter: too low
+	// understates the cluster, too high lets a consumer read a partial list as
+	// a complete one.
+	switch {
+	case marker != truncated:
+		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: %q is %v but %q %s the truncation marker",
+				idx, itemDataTruncated, truncated, itemDataNodeList,
+				map[bool]string{true: "carries", false: "does not carry"}[marker]))
+	case truncated && count <= len(nodes):
+		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: %q is truncated but %q (%d) does not exceed the %d nodes named",
+				idx, itemDataNodeList, itemDataNodeCount, count, len(nodes)))
+	case !truncated && count != len(nodes):
+		return nil, 0, false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: %q is complete but %q is %d against %d nodes named",
+				idx, itemDataNodeList, itemDataNodeCount, count, len(nodes)))
 	}
 	return nodes, count, truncated, nil
+}
+
+// itemInt reads a required non-negative integer data field.
+func itemInt(item measurement.ItemEntry, field string, idx int) (int, error) {
+	r, ok := item.Data[field]
+	if !ok {
+		return 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: missing required data field %q", idx, field))
+	}
+	v, ok := readingInt(r)
+	if !ok {
+		return 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: data field %q is not an integer", idx, field))
+	}
+	if v < 0 {
+		return 0, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: data field %q is negative (%d)", idx, field, v))
+	}
+	return v, nil
+}
+
+// itemBool reads a required boolean data field.
+func itemBool(item measurement.ItemEntry, field string, idx int) (bool, error) {
+	r, ok := item.Data[field]
+	if !ok {
+		return false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: missing required data field %q", idx, field))
+	}
+	v, ok := r.Any().(bool)
+	if !ok {
+		return false, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("topology item %d: data field %q is not a boolean", idx, field))
+	}
+	return v, nil
 }
 
 // readingInt accepts the integer shapes a Reading can hold; JSON decoders

--- a/pkg/collector/topology/readings.go
+++ b/pkg/collector/topology/readings.go
@@ -441,11 +441,15 @@ func taintReadingsFromData(data map[string]measurement.Reading) ([]TaintReading,
 			// key — the same identity the item path reports. Which is still a
 			// guess for a taint key that legitimately contains a dot: the
 			// ambiguity the item encoding removes.
-			value, list = parts[0], parts[1]
-			if i := strings.LastIndex(rawKey, "."); i >= 0 {
-				effect = rawKey[i+1:]
-				key = rawKey[:i]
+			// A key with no separator, or nothing after it, carries no effect
+			// to recover — decoding it would hand back Effect:"".
+			i := strings.LastIndex(rawKey, ".")
+			if i < 0 || i == len(rawKey)-1 {
+				return nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("taint reading %q: two-field form requires an effect suffix in the key", rawKey))
 			}
+			value, list = parts[0], parts[1]
+			effect, key = rawKey[i+1:], rawKey[:i]
 		default:
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("taint reading %q: expected 2 or 3 pipe-separated fields, got 1", rawKey))

--- a/pkg/collector/topology/readings_test.go
+++ b/pkg/collector/topology/readings_test.go
@@ -450,6 +450,29 @@ func TestTaintReadingsRequireEffect(t *testing.T) {
 	}
 }
 
+// TestTaintDataPathRejectsSingleField is the folded-encoding half of
+// TestTaintReadingsRequireEffect. encodeTaints always writes at least one pipe,
+// so a value without one cannot come from this collector — but a snapshot is a
+// file a caller supplies, and a pipe-less value carries no effect to recover.
+// Decoding it would hand back Effect:"" and satisfy a caller matching on one.
+func TestTaintDataPathRejectsSingleField(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		entry string
+	}{
+		{"no separator", "NoSchedule"},
+		{"empty value", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := TaintReadings(&measurement.Subtype{
+				Name: "taint",
+				Data: map[string]measurement.Reading{"dedicated": measurement.Str(tt.entry)},
+			})
+			assertDecodeRejected(t, err, "TaintReadings() [data path]")
+		})
+	}
+}
+
 // TestTaintReadingsAcceptUnknownEffect pins that the decoder does not gate on
 // the effects Kubernetes defines today, so a newer cluster stays readable.
 func TestTaintReadingsAcceptUnknownEffect(t *testing.T) {
@@ -610,6 +633,53 @@ func TestReadingsRejectMalformedReference(t *testing.T) {
 			name: "node-count disagrees with the referenced entry",
 			mutate: func(st *measurement.Subtype) {
 				st.Items[0].Data[itemDataNodeCount] = measurement.Int(9)
+			},
+		},
+		{
+			// Two readings produce the same fold key (zone=us-west with a sibling
+			// zone=us-east makes applyLabelRawKeys suffix both to zone.us-west /
+			// zone.us-east; the label literally named zone.us-west also gets
+			// rawKey=zone.us-west). That makes folds["zone.us-west"]==2, so the
+			// reference on item[0] is rejected even though ref==rawKey.
+			name: "reference fold key is shared with another reading",
+			mutate: func(st *measurement.Subtype) {
+				// Three items: zone=us-west (ref), zone=us-east (inline),
+				// zone.us-west=true (inline). applyLabelRawKeys sees two zone
+				// readings, so zone=us-west → rawKey "zone.us-west", same as
+				// the literal key. folds["zone.us-west"]==2 → rejected.
+				*st = measurement.Subtype{
+					Name: "label",
+					Data: map[string]measurement.Reading{
+						"zone.us-west": measurement.Str("us-west|gpu-a,gpu-b"),
+						"zone.us-east": measurement.Str("us-east|gpu-b"),
+					},
+					Items: []measurement.ItemEntry{
+						{
+							Context: map[string]string{itemCtxKey: "zone", itemCtxValue: "us-west"},
+							Data: map[string]measurement.Reading{
+								itemDataNodeCount: measurement.Int(2),
+								itemDataNodeRef:   measurement.Str("zone.us-west"),
+								itemDataTruncated: measurement.Bool(false),
+							},
+						},
+						{
+							Context: map[string]string{itemCtxKey: "zone", itemCtxValue: "us-east"},
+							Data: map[string]measurement.Reading{
+								itemDataNodeCount: measurement.Int(1),
+								itemDataNodeList:  measurement.Str("gpu-b"),
+								itemDataTruncated: measurement.Bool(false),
+							},
+						},
+						{
+							Context: map[string]string{itemCtxKey: "zone.us-west", itemCtxValue: "true"},
+							Data: map[string]measurement.Reading{
+								itemDataNodeCount: measurement.Int(2),
+								itemDataNodeList:  measurement.Str("gpu-a,gpu-b"),
+								itemDataTruncated: measurement.Bool(false),
+							},
+						},
+					},
+				}
 			},
 		},
 	} {

--- a/pkg/collector/topology/readings_test.go
+++ b/pkg/collector/topology/readings_test.go
@@ -16,13 +16,31 @@ package topology
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/measurement"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// assertDecodeRejected fails unless err carries the code the exported
+// accessors promise for a structurally invalid item. Callers branch on the
+// code, not the message, so asserting only err != nil would let the contract
+// change silently.
+func assertDecodeRejected(t *testing.T, err error, accessor string) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("%s error = nil, want a decode error", accessor)
+		return
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("%s error = %v, want code %s", accessor, err, errors.ErrCodeInvalidRequest)
+	}
+}
 
 // collectSubtypes runs the real collector over a fake cluster and returns its
 // label and taint subtypes. Readings are asserted against collector output
@@ -72,7 +90,9 @@ func TestLabelReadingsRecoversEveryReading(t *testing.T) {
 			t.Errorf("reading %d = {%q %q n=%d}, want {%q %q n=%d}",
 				i, got.Key, got.Value, got.NodeCount, w.Key, w.Value, w.NodeCount)
 		}
-		if len(got.Nodes) != len(w.Nodes) {
+		// Names, not just the count: a collision's characteristic failure is
+		// the right number of nodes attributed to the wrong reading.
+		if !slices.Equal(got.Nodes, w.Nodes) {
 			t.Errorf("reading %d nodes = %v, want %v", i, got.Nodes, w.Nodes)
 		}
 	}
@@ -248,14 +268,19 @@ func TestReadingsTruncation(t *testing.T) {
 		t.Errorf("NodeCount = %d, want 3 (the pre-truncation total)", readings[0].NodeCount)
 	}
 
-	// The legacy path can only infer truncation from the rendered suffix, and
-	// cannot recover the true count — it reports what it can see.
+	// The marker states how many names were dropped, so the legacy path
+	// recovers the same total: NodeCount means one thing regardless of which
+	// encoding a snapshot carries.
 	legacy, err := LabelReadings(dataOnly(labelSt))
 	if err != nil {
 		t.Fatalf("legacy LabelReadings(): %v", err)
 	}
 	if !legacy[0].Truncated {
 		t.Error("legacy Truncated = false, want true (suffix detection)")
+	}
+	if legacy[0].NodeCount != readings[0].NodeCount {
+		t.Errorf("legacy NodeCount = %d, want %d — the two encodings must agree",
+			legacy[0].NodeCount, readings[0].NodeCount)
 	}
 }
 
@@ -327,6 +352,25 @@ func TestReadingsMalformedItems(t *testing.T) {
 			},
 		},
 		{
+			// "n1,n2 (+3 more)" states 2 + 3 = 5. A count above the names but
+			// below that total passes a direction check and fails an equality
+			// one — the case a ">" rule cannot see.
+			name: "truncated node-count below the total the suffix states",
+			mutate: func(i *measurement.ItemEntry) {
+				i.Data[itemDataNodeList] = measurement.Str("n1,n2 (+3 more)")
+				i.Data[itemDataTruncated] = measurement.Bool(true)
+				i.Data[itemDataNodeCount] = measurement.Int(3)
+			},
+		},
+		{
+			name: "truncated node-count above the total the suffix states",
+			mutate: func(i *measurement.ItemEntry) {
+				i.Data[itemDataNodeList] = measurement.Str("n1,n2 (+3 more)")
+				i.Data[itemDataTruncated] = measurement.Bool(true)
+				i.Data[itemDataNodeCount] = measurement.Int(900)
+			},
+		},
+		{
 			name:   "missing truncated",
 			mutate: func(i *measurement.ItemEntry) { delete(i.Data, itemDataTruncated) },
 		},
@@ -354,12 +398,10 @@ func TestReadingsMalformedItems(t *testing.T) {
 			item := validItem()
 			tt.mutate(&item)
 			st := &measurement.Subtype{Name: "label", Items: []measurement.ItemEntry{item}}
-			if _, err := LabelReadings(st); err == nil {
-				t.Error("LabelReadings() error = nil, want a decode error")
-			}
-			if _, err := TaintReadings(st); err == nil {
-				t.Error("TaintReadings() error = nil, want a decode error")
-			}
+			_, labelErr := LabelReadings(st)
+			assertDecodeRejected(t, labelErr, "LabelReadings()")
+			_, taintErr := TaintReadings(st)
+			assertDecodeRejected(t, taintErr, "TaintReadings()")
 		})
 	}
 }
@@ -378,9 +420,8 @@ func TestTaintReadingsRequireEffect(t *testing.T) {
 			item := validItem()
 			tt.mutate(&item)
 			st := &measurement.Subtype{Name: "taint", Items: []measurement.ItemEntry{item}}
-			if _, err := TaintReadings(st); err == nil {
-				t.Error("TaintReadings() error = nil, want a decode error")
-			}
+			_, taintErr := TaintReadings(st)
+			assertDecodeRejected(t, taintErr, "TaintReadings()")
 			if _, err := LabelReadings(st); err != nil {
 				t.Errorf("LabelReadings() error = %v, want nil — labels have no effect", err)
 			}

--- a/pkg/collector/topology/readings_test.go
+++ b/pkg/collector/topology/readings_test.go
@@ -259,46 +259,101 @@ func TestReadingsTruncation(t *testing.T) {
 	}
 }
 
+// validItem is a well-formed item for both decoders. The tables below mutate
+// one field of it, so each case fails for the reason it names.
+func validItem() measurement.ItemEntry {
+	return measurement.ItemEntry{
+		Context: map[string]string{
+			itemCtxKey:    "k",
+			itemCtxValue:  "v",
+			itemCtxEffect: "NoSchedule",
+		},
+		Data: map[string]measurement.Reading{
+			itemDataNodeCount: measurement.Int(2),
+			itemDataNodeList:  measurement.Str("n1,n2"),
+			itemDataTruncated: measurement.Bool(false),
+		},
+	}
+}
+
 // TestReadingsMalformedItems pins that a structurally broken item is rejected
 // rather than decoded into a partial reading a caller might trust.
 func TestReadingsMalformedItems(t *testing.T) {
 	tests := []struct {
-		name string
-		item measurement.ItemEntry
+		name   string
+		mutate func(*measurement.ItemEntry)
 	}{
 		{
-			name: "missing key",
-			item: measurement.ItemEntry{
-				Context: map[string]string{itemCtxValue: "v"},
-				Data:    map[string]measurement.Reading{itemDataNodeList: measurement.Str("n1")},
+			name:   "missing key",
+			mutate: func(i *measurement.ItemEntry) { delete(i.Context, itemCtxKey) },
+		},
+		{
+			name:   "empty key",
+			mutate: func(i *measurement.ItemEntry) { i.Context[itemCtxKey] = "" },
+		},
+		{
+			name:   "missing node-list",
+			mutate: func(i *measurement.ItemEntry) { delete(i.Data, itemDataNodeList) },
+		},
+		{
+			name:   "node-list is not a string",
+			mutate: func(i *measurement.ItemEntry) { i.Data[itemDataNodeList] = measurement.Int(3) },
+		},
+		{
+			name:   "missing node-count",
+			mutate: func(i *measurement.ItemEntry) { delete(i.Data, itemDataNodeCount) },
+		},
+		{
+			name:   "node-count is not an integer",
+			mutate: func(i *measurement.ItemEntry) { i.Data[itemDataNodeCount] = measurement.Str("2") },
+		},
+		{
+			name:   "node-count is negative",
+			mutate: func(i *measurement.ItemEntry) { i.Data[itemDataNodeCount] = measurement.Int(-1) },
+		},
+		{
+			name:   "node-count is below the named nodes",
+			mutate: func(i *measurement.ItemEntry) { i.Data[itemDataNodeCount] = measurement.Int(1) },
+		},
+		{
+			name:   "node-count exceeds a complete list",
+			mutate: func(i *measurement.ItemEntry) { i.Data[itemDataNodeCount] = measurement.Int(40) },
+		},
+		{
+			name: "truncated list whose count does not exceed the names",
+			mutate: func(i *measurement.ItemEntry) {
+				i.Data[itemDataNodeList] = measurement.Str("n1,n2 (+3 more)")
+				i.Data[itemDataTruncated] = measurement.Bool(true)
 			},
 		},
 		{
-			name: "empty key",
-			item: measurement.ItemEntry{
-				Context: map[string]string{itemCtxKey: "", itemCtxValue: "v"},
-				Data:    map[string]measurement.Reading{itemDataNodeList: measurement.Str("n1")},
+			name:   "missing truncated",
+			mutate: func(i *measurement.ItemEntry) { delete(i.Data, itemDataTruncated) },
+		},
+		{
+			name:   "truncated is not a boolean",
+			mutate: func(i *measurement.ItemEntry) { i.Data[itemDataTruncated] = measurement.Str("false") },
+		},
+		{
+			name: "truncated is false against a truncated list",
+			mutate: func(i *measurement.ItemEntry) {
+				i.Data[itemDataNodeList] = measurement.Str("n1,n2 (+3 more)")
+				i.Data[itemDataNodeCount] = measurement.Int(5)
 			},
 		},
 		{
-			name: "missing node-list",
-			item: measurement.ItemEntry{
-				Context: map[string]string{itemCtxKey: "k", itemCtxValue: "v"},
-				Data:    map[string]measurement.Reading{},
-			},
-		},
-		{
-			name: "node-list is not a string",
-			item: measurement.ItemEntry{
-				Context: map[string]string{itemCtxKey: "k", itemCtxValue: "v"},
-				Data:    map[string]measurement.Reading{itemDataNodeList: measurement.Int(3)},
+			name: "truncated is true against a complete list",
+			mutate: func(i *measurement.ItemEntry) {
+				i.Data[itemDataTruncated] = measurement.Bool(true)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			st := &measurement.Subtype{Name: "label", Items: []measurement.ItemEntry{tt.item}}
+			item := validItem()
+			tt.mutate(&item)
+			st := &measurement.Subtype{Name: "label", Items: []measurement.ItemEntry{item}}
 			if _, err := LabelReadings(st); err == nil {
 				t.Error("LabelReadings() error = nil, want a decode error")
 			}
@@ -306,6 +361,48 @@ func TestReadingsMalformedItems(t *testing.T) {
 				t.Error("TaintReadings() error = nil, want a decode error")
 			}
 		})
+	}
+}
+
+// TestTaintReadingsRequireEffect pins that effect is mandatory for taints and
+// ignored for labels.
+func TestTaintReadingsRequireEffect(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*measurement.ItemEntry)
+	}{
+		{"missing effect", func(i *measurement.ItemEntry) { delete(i.Context, itemCtxEffect) }},
+		{"empty effect", func(i *measurement.ItemEntry) { i.Context[itemCtxEffect] = "" }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			item := validItem()
+			tt.mutate(&item)
+			st := &measurement.Subtype{Name: "taint", Items: []measurement.ItemEntry{item}}
+			if _, err := TaintReadings(st); err == nil {
+				t.Error("TaintReadings() error = nil, want a decode error")
+			}
+			if _, err := LabelReadings(st); err != nil {
+				t.Errorf("LabelReadings() error = %v, want nil — labels have no effect", err)
+			}
+		})
+	}
+}
+
+// TestTaintReadingsAcceptUnknownEffect pins that the decoder does not gate on
+// the effects Kubernetes defines today, so a newer cluster stays readable.
+func TestTaintReadingsAcceptUnknownEffect(t *testing.T) {
+	item := validItem()
+	item.Context[itemCtxEffect] = "SomeFutureEffect"
+
+	readings, err := TaintReadings(&measurement.Subtype{
+		Name:  "taint",
+		Items: []measurement.ItemEntry{item},
+	})
+	if err != nil {
+		t.Fatalf("TaintReadings() error = %v, want nil", err)
+	}
+	if readings[0].Effect != "SomeFutureEffect" {
+		t.Errorf("Effect = %q, want it preserved verbatim", readings[0].Effect)
 	}
 }
 

--- a/pkg/collector/topology/readings_test.go
+++ b/pkg/collector/topology/readings_test.go
@@ -450,23 +450,25 @@ func TestTaintReadingsRequireEffect(t *testing.T) {
 	}
 }
 
-// TestTaintDataPathRejectsSingleField is the folded-encoding half of
-// TestTaintReadingsRequireEffect. encodeTaints always writes at least one pipe,
-// so a value without one cannot come from this collector — but a snapshot is a
-// file a caller supplies, and a pipe-less value carries no effect to recover.
-// Decoding it would hand back Effect:"" and satisfy a caller matching on one.
-func TestTaintDataPathRejectsSingleField(t *testing.T) {
+// TestTaintDataPathRejectsUnrecoverableEffect is the folded-encoding half of
+// TestTaintReadingsRequireEffect. encodeTaints writes the two-field form only
+// under a "<key>.<effect>" map key and the three-field form otherwise, so none
+// of these can come from this collector — but a snapshot is a file a caller
+// supplies, and each shape below leaves no effect to recover. Decoding one
+// would hand back Effect:"" and satisfy a caller matching on one.
+func TestTaintDataPathRejectsUnrecoverableEffect(t *testing.T) {
 	for _, tt := range []struct {
-		name  string
-		entry string
+		name, key, entry string
 	}{
-		{"no separator", "NoSchedule"},
-		{"empty value", ""},
+		{"one field, no separator", "dedicated", "NoSchedule"},
+		{"one field, empty", "dedicated", ""},
+		{"two fields, key carries no effect suffix", "dedicated", "sys|gpu-a"},
+		{"two fields, key ends in the separator", "dedicated.", "sys|gpu-a"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := TaintReadings(&measurement.Subtype{
 				Name: "taint",
-				Data: map[string]measurement.Reading{"dedicated": measurement.Str(tt.entry)},
+				Data: map[string]measurement.Reading{tt.key: measurement.Str(tt.entry)},
 			})
 			assertDecodeRejected(t, err, "TaintReadings() [data path]")
 		})

--- a/pkg/collector/topology/readings_test.go
+++ b/pkg/collector/topology/readings_test.go
@@ -1,0 +1,390 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topology
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/measurement"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// collectSubtypes runs the real collector over a fake cluster and returns its
+// label and taint subtypes. Readings are asserted against collector output
+// rather than hand-built fixtures so the encoder and the decoder cannot drift.
+func collectSubtypes(t *testing.T, maxNodes int, nodes ...*corev1.Node) (labelSt, taintSt *measurement.Subtype) {
+	t.Helper()
+
+	m, err := newFakeCollector(nodes, maxNodes).Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect() failed: %v", err)
+	}
+	return m.GetSubtype("label"), m.GetSubtype("taint")
+}
+
+// dataOnly strips Items, producing the shape a snapshot captured before the
+// lossless encoding carries. This is the legacy-compatibility fixture.
+func dataOnly(st *measurement.Subtype) *measurement.Subtype {
+	return &measurement.Subtype{Name: st.Name, Data: st.Data}
+}
+
+// TestLabelReadingsRecoversEveryReading is the core guarantee: every label
+// present on a node appears exactly once in the decoded readings, including
+// the #2003 case where a synthesized "<key>.<value>" key collides with a label
+// literally named that.
+func TestLabelReadingsRecoversEveryReading(t *testing.T) {
+	labelSt, _ := collectSubtypes(t, 0,
+		makeNode("gpu-a", nil, map[string]string{"zone": "us-west", "zone.us-west": "true"}),
+		makeNode("gpu-b", nil, map[string]string{"zone": "us-east", "zone.us-west": "true"}),
+	)
+
+	readings, err := LabelReadings(labelSt)
+	if err != nil {
+		t.Fatalf("LabelReadings() error: %v", err)
+	}
+
+	want := []LabelReading{
+		{Key: "zone", Value: "us-east", Nodes: []string{"gpu-b"}, NodeCount: 1},
+		{Key: "zone", Value: "us-west", Nodes: []string{"gpu-a"}, NodeCount: 1},
+		{Key: "zone.us-west", Value: "true", Nodes: []string{"gpu-a", "gpu-b"}, NodeCount: 2},
+	}
+	if len(readings) != len(want) {
+		t.Fatalf("got %d readings, want %d: %+v", len(readings), len(want), readings)
+	}
+	for i, w := range want {
+		got := readings[i]
+		if got.Key != w.Key || got.Value != w.Value || got.NodeCount != w.NodeCount {
+			t.Errorf("reading %d = {%q %q n=%d}, want {%q %q n=%d}",
+				i, got.Key, got.Value, got.NodeCount, w.Key, w.Value, w.NodeCount)
+		}
+		if len(got.Nodes) != len(w.Nodes) {
+			t.Errorf("reading %d nodes = %v, want %v", i, got.Nodes, w.Nodes)
+		}
+	}
+
+	// The same subtype without Items loses one reading — the defect this
+	// encoding exists to fix. Pinned so a regression in the Items path cannot
+	// pass by quietly falling back.
+	legacy, err := LabelReadings(dataOnly(labelSt))
+	if err != nil {
+		t.Fatalf("legacy LabelReadings() error: %v", err)
+	}
+	if len(legacy) >= len(readings) {
+		t.Errorf("legacy Data decode returned %d readings; expected fewer than the %d "+
+			"in the lossless form (the collision is what #2003 reports)", len(legacy), len(readings))
+	}
+}
+
+// TestTaintReadingsRecoversEveryReading covers the taint-side collision, which
+// needs no dotted key: encodeTaints counts per key but disambiguates with
+// effect, so two taints sharing both collapse into one Data entry.
+func TestTaintReadingsRecoversEveryReading(t *testing.T) {
+	_, taintSt := collectSubtypes(t, 0,
+		makeNode("node-1", []corev1.Taint{
+			{Key: "dedicated", Value: "team-a", Effect: corev1.TaintEffectNoSchedule},
+		}, nil),
+		makeNode("node-2", []corev1.Taint{
+			{Key: "dedicated", Value: "team-b", Effect: corev1.TaintEffectNoSchedule},
+		}, nil),
+	)
+
+	readings, err := TaintReadings(taintSt)
+	if err != nil {
+		t.Fatalf("TaintReadings() error: %v", err)
+	}
+	if len(readings) != 2 {
+		t.Fatalf("got %d taint readings, want 2: %+v", len(readings), readings)
+	}
+	for i, want := range []struct{ value, node string }{{"team-a", "node-1"}, {"team-b", "node-2"}} {
+		got := readings[i]
+		if got.Key != "dedicated" || got.Effect != "NoSchedule" || got.Value != want.value {
+			t.Errorf("reading %d = {%q %q %q}, want {dedicated NoSchedule %q}",
+				i, got.Key, got.Effect, got.Value, want.value)
+		}
+		if len(got.Nodes) != 1 || got.Nodes[0] != want.node {
+			t.Errorf("reading %d nodes = %v, want [%s]", i, got.Nodes, want.node)
+		}
+	}
+
+	legacy, err := TaintReadings(dataOnly(taintSt))
+	if err != nil {
+		t.Fatalf("legacy TaintReadings() error: %v", err)
+	}
+	if len(legacy) != 1 {
+		t.Errorf("legacy Data decode returned %d taint readings, want 1 "+
+			"(both collapse onto dedicated.NoSchedule)", len(legacy))
+	}
+}
+
+// TestReadingsAgreeWhenEncodingIsUnambiguous pins that the two paths return
+// the same thing whenever the Data encoding is capable of representing the
+// readings — i.e. every case except a collision. Without this, a divergence
+// introduced on either path would only surface as a consumer bug.
+func TestReadingsAgreeWhenEncodingIsUnambiguous(t *testing.T) {
+	labelSt, taintSt := collectSubtypes(t, 0,
+		makeNode("node-1",
+			[]corev1.Taint{{Key: "dedicated", Value: "sys", Effect: corev1.TaintEffectNoSchedule}},
+			map[string]string{"kubernetes.io/arch": "arm64", "zone": "us-west"},
+		),
+		makeNode("node-2", nil,
+			map[string]string{"kubernetes.io/arch": "arm64", "zone": "us-east"},
+		),
+	)
+
+	items, err := LabelReadings(labelSt)
+	if err != nil {
+		t.Fatalf("items path: %v", err)
+	}
+	legacy, err := LabelReadings(dataOnly(labelSt))
+	if err != nil {
+		t.Fatalf("data path: %v", err)
+	}
+	if len(items) != len(legacy) {
+		t.Fatalf("label reading counts differ: items=%d data=%d", len(items), len(legacy))
+	}
+	for i := range items {
+		// The Data path cannot recover a disambiguated key's true name, so
+		// compare on RawKey — the identity both encodings do agree on.
+		if items[i].RawKey != legacy[i].RawKey {
+			t.Errorf("label %d RawKey: items=%q data=%q", i, items[i].RawKey, legacy[i].RawKey)
+		}
+		if items[i].Value != legacy[i].Value {
+			t.Errorf("label %d value: items=%q data=%q", i, items[i].Value, legacy[i].Value)
+		}
+	}
+
+	taintItems, err := TaintReadings(taintSt)
+	if err != nil {
+		t.Fatalf("taint items path: %v", err)
+	}
+	taintLegacy, err := TaintReadings(dataOnly(taintSt))
+	if err != nil {
+		t.Fatalf("taint data path: %v", err)
+	}
+	if len(taintItems) != len(taintLegacy) {
+		t.Fatalf("taint reading counts differ: items=%d data=%d", len(taintItems), len(taintLegacy))
+	}
+	for i := range taintItems {
+		if taintItems[i].Key != taintLegacy[i].Key || taintItems[i].Effect != taintLegacy[i].Effect {
+			t.Errorf("taint %d: items={%q %q} data={%q %q}",
+				i, taintItems[i].Key, taintItems[i].Effect, taintLegacy[i].Key, taintLegacy[i].Effect)
+		}
+	}
+}
+
+// TestRawKeyMatchesDataMapKey pins that RawKey reproduces the legacy map key,
+// so a consumer quoting it in a diagnostic emits the same bytes on both paths.
+func TestRawKeyMatchesDataMapKey(t *testing.T) {
+	labelSt, taintSt := collectSubtypes(t, 0,
+		makeNode("node-1",
+			[]corev1.Taint{
+				{Key: "dedicated", Value: "sys", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "dedicated", Value: "sys", Effect: corev1.TaintEffectNoExecute},
+			},
+			map[string]string{"zone": "us-west", "kubernetes.io/arch": "arm64"},
+		),
+		makeNode("node-2", nil, map[string]string{"zone": "us-east"}),
+	)
+
+	readings, err := LabelReadings(labelSt)
+	if err != nil {
+		t.Fatalf("LabelReadings(): %v", err)
+	}
+	for _, r := range readings {
+		if _, ok := labelSt.Data[r.RawKey]; !ok {
+			t.Errorf("label RawKey %q is not a key in the Data map (keys: %v)",
+				r.RawKey, sortedKeysOf(labelSt.Data))
+		}
+	}
+
+	taints, err := TaintReadings(taintSt)
+	if err != nil {
+		t.Fatalf("TaintReadings(): %v", err)
+	}
+	for _, r := range taints {
+		if _, ok := taintSt.Data[r.RawKey]; !ok {
+			t.Errorf("taint RawKey %q is not a key in the Data map (keys: %v)",
+				r.RawKey, sortedKeysOf(taintSt.Data))
+		}
+	}
+}
+
+// TestReadingsTruncation pins that a capped node list reports the true total
+// and says it is truncated, on both paths. Consumers that must not act on
+// partial membership (issue #1755) depend on this.
+func TestReadingsTruncation(t *testing.T) {
+	labelSt, _ := collectSubtypes(t, 1,
+		makeNode("node-1", nil, map[string]string{"shared": "yes"}),
+		makeNode("node-2", nil, map[string]string{"shared": "yes"}),
+		makeNode("node-3", nil, map[string]string{"shared": "yes"}),
+	)
+
+	readings, err := LabelReadings(labelSt)
+	if err != nil {
+		t.Fatalf("LabelReadings(): %v", err)
+	}
+	if len(readings) != 1 {
+		t.Fatalf("got %d readings, want 1", len(readings))
+	}
+	if !readings[0].Truncated {
+		t.Error("Truncated = false, want true under --max-nodes-per-entry=1")
+	}
+	if readings[0].NodeCount != 3 {
+		t.Errorf("NodeCount = %d, want 3 (the pre-truncation total)", readings[0].NodeCount)
+	}
+
+	// The legacy path can only infer truncation from the rendered suffix, and
+	// cannot recover the true count — it reports what it can see.
+	legacy, err := LabelReadings(dataOnly(labelSt))
+	if err != nil {
+		t.Fatalf("legacy LabelReadings(): %v", err)
+	}
+	if !legacy[0].Truncated {
+		t.Error("legacy Truncated = false, want true (suffix detection)")
+	}
+}
+
+// TestReadingsMalformedItems pins that a structurally broken item is rejected
+// rather than decoded into a partial reading a caller might trust.
+func TestReadingsMalformedItems(t *testing.T) {
+	tests := []struct {
+		name string
+		item measurement.ItemEntry
+	}{
+		{
+			name: "missing key",
+			item: measurement.ItemEntry{
+				Context: map[string]string{itemCtxValue: "v"},
+				Data:    map[string]measurement.Reading{itemDataNodeList: measurement.Str("n1")},
+			},
+		},
+		{
+			name: "empty key",
+			item: measurement.ItemEntry{
+				Context: map[string]string{itemCtxKey: "", itemCtxValue: "v"},
+				Data:    map[string]measurement.Reading{itemDataNodeList: measurement.Str("n1")},
+			},
+		},
+		{
+			name: "missing node-list",
+			item: measurement.ItemEntry{
+				Context: map[string]string{itemCtxKey: "k", itemCtxValue: "v"},
+				Data:    map[string]measurement.Reading{},
+			},
+		},
+		{
+			name: "node-list is not a string",
+			item: measurement.ItemEntry{
+				Context: map[string]string{itemCtxKey: "k", itemCtxValue: "v"},
+				Data:    map[string]measurement.Reading{itemDataNodeList: measurement.Int(3)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &measurement.Subtype{Name: "label", Items: []measurement.ItemEntry{tt.item}}
+			if _, err := LabelReadings(st); err == nil {
+				t.Error("LabelReadings() error = nil, want a decode error")
+			}
+			if _, err := TaintReadings(st); err == nil {
+				t.Error("TaintReadings() error = nil, want a decode error")
+			}
+		})
+	}
+}
+
+// TestReadingsNilAndEmpty pins that absent topology data is not a decode
+// failure — callers distinguish "no readings" from "bad readings".
+func TestReadingsNilAndEmpty(t *testing.T) {
+	for _, st := range []*measurement.Subtype{
+		nil,
+		{Name: "label"},
+		{Name: "label", Data: map[string]measurement.Reading{}},
+	} {
+		labels, err := LabelReadings(st)
+		if err != nil {
+			t.Errorf("LabelReadings(%v) error = %v, want nil", st, err)
+		}
+		if len(labels) != 0 {
+			t.Errorf("LabelReadings(%v) = %d readings, want 0", st, len(labels))
+		}
+		taints, err := TaintReadings(st)
+		if err != nil {
+			t.Errorf("TaintReadings(%v) error = %v, want nil", st, err)
+		}
+		if len(taints) != 0 {
+			t.Errorf("TaintReadings(%v) = %d readings, want 0", st, len(taints))
+		}
+	}
+}
+
+// TestHasLosslessReadings pins the discriminator consumers use to decide
+// whether a legacy-only heuristic still applies.
+func TestHasLosslessReadings(t *testing.T) {
+	labelSt, _ := collectSubtypes(t, 0,
+		makeNode("node-1", nil, map[string]string{"zone": "us-west"}))
+
+	if !HasLosslessReadings(labelSt) {
+		t.Error("HasLosslessReadings(collector output) = false, want true")
+	}
+	if HasLosslessReadings(dataOnly(labelSt)) {
+		t.Error("HasLosslessReadings(legacy Data-only) = true, want false")
+	}
+	if HasLosslessReadings(nil) {
+		t.Error("HasLosslessReadings(nil) = true, want false")
+	}
+}
+
+// TestItemsAreDeterministic pins the emission order. pkg/diff compares Items
+// positionally, so an unstable order would surface as phantom drift between
+// two runs against an unchanged cluster.
+func TestItemsAreDeterministic(t *testing.T) {
+	nodes := []*corev1.Node{
+		makeNode("node-1",
+			[]corev1.Taint{
+				{Key: "b", Value: "1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "a", Value: "2", Effect: corev1.TaintEffectNoExecute},
+			},
+			map[string]string{"z": "1", "a": "2", "m": "3"},
+		),
+		makeNode("node-2", nil, map[string]string{"z": "9", "a": "2"}),
+	}
+
+	var first string
+	for i := 0; i < 50; i++ {
+		labelSt, taintSt := collectSubtypes(t, 0, nodes...)
+		got := fmt.Sprintf("%v|%v", labelSt.Items, taintSt.Items)
+		if i == 0 {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Fatalf("Items order is not deterministic on run %d:\n first: %s\n got:   %s", i, first, got)
+		}
+	}
+}
+
+func sortedKeysOf(data map[string]measurement.Reading) []string {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/collector/topology/readings_test.go
+++ b/pkg/collector/topology/readings_test.go
@@ -301,6 +301,27 @@ func validItem() measurement.ItemEntry {
 	}
 }
 
+// refSubtype is a well-formed subtype whose single item references a data entry
+// instead of carrying node names inline.
+func refSubtype(name, key, value, entry string, count int) *measurement.Subtype {
+	ctx := map[string]string{itemCtxKey: key, itemCtxValue: value}
+	if name == "taint" {
+		ctx[itemCtxEffect] = "NoSchedule"
+	}
+	return &measurement.Subtype{
+		Name: name,
+		Data: map[string]measurement.Reading{key: measurement.Str(entry)},
+		Items: []measurement.ItemEntry{{
+			Context: ctx,
+			Data: map[string]measurement.Reading{
+				itemDataNodeCount: measurement.Int(count),
+				itemDataNodeRef:   measurement.Str(key),
+				itemDataTruncated: measurement.Bool(false),
+			},
+		}},
+	}
+}
+
 // TestReadingsMalformedItems pins that a structurally broken item is rejected
 // rather than decoded into a partial reading a caller might trust.
 func TestReadingsMalformedItems(t *testing.T) {
@@ -525,4 +546,208 @@ func sortedKeysOf(data map[string]measurement.Reading) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// TestReadingsResolveReference pins the cross-reference round trip: an item
+// naming a data entry decodes to the same reading an inline copy would.
+func TestReadingsResolveReference(t *testing.T) {
+	st := refSubtype("label", "zone", "us-west", "us-west|gpu-a,gpu-b", 2)
+	readings, err := LabelReadings(st)
+	if err != nil {
+		t.Fatalf("LabelReadings() error = %v", err)
+	}
+	if len(readings) != 1 {
+		t.Fatalf("got %d readings, want 1", len(readings))
+	}
+	if got := readings[0].Nodes; !slices.Equal(got, []string{"gpu-a", "gpu-b"}) {
+		t.Errorf("Nodes = %v, want [gpu-a gpu-b] resolved from the data entry", got)
+	}
+	if readings[0].NodeCount != 2 {
+		t.Errorf("NodeCount = %d, want 2", readings[0].NodeCount)
+	}
+}
+
+// TestReadingsRejectMalformedReference pins the guards on the reference form.
+// A reference that resolves to another reading's nodes would be well formed
+// and wrong, which is the failure this encoding exists to remove.
+func TestReadingsRejectMalformedReference(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*measurement.Subtype)
+	}{
+		{
+			name: "reference names no data entry",
+			mutate: func(st *measurement.Subtype) {
+				st.Data = map[string]measurement.Reading{}
+			},
+		},
+		{
+			name: "reference names an entry this reading does not fold onto",
+			mutate: func(st *measurement.Subtype) {
+				st.Data["elsewhere"] = measurement.Str("other|gpu-z")
+				st.Items[0].Data[itemDataNodeRef] = measurement.Str("elsewhere")
+			},
+		},
+		{
+			name: "reference is not a string",
+			mutate: func(st *measurement.Subtype) {
+				st.Items[0].Data[itemDataNodeRef] = measurement.Int(3)
+			},
+		},
+		{
+			name: "carries both a list and a reference",
+			mutate: func(st *measurement.Subtype) {
+				st.Items[0].Data[itemDataNodeList] = measurement.Str("gpu-a,gpu-b")
+			},
+		},
+		{
+			name: "carries neither a list nor a reference",
+			mutate: func(st *measurement.Subtype) {
+				delete(st.Items[0].Data, itemDataNodeRef)
+			},
+		},
+		{
+			name: "node-count disagrees with the referenced entry",
+			mutate: func(st *measurement.Subtype) {
+				st.Items[0].Data[itemDataNodeCount] = measurement.Int(9)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			st := refSubtype("label", "zone", "us-west", "us-west|gpu-a,gpu-b", 2)
+			tt.mutate(st)
+			_, err := LabelReadings(st)
+			assertDecodeRejected(t, err, "LabelReadings()")
+		})
+	}
+}
+
+// TestReadingsRejectUnusableTruncationMarker pins that a marker whose count
+// does not fit an int fails the decode. Reporting "no marker" would let a
+// visibly truncated list read as complete.
+func TestReadingsRejectUnusableTruncationMarker(t *testing.T) {
+	item := validItem()
+	item.Data[itemDataNodeList] = measurement.Str("n1 (+9223372036854775808 more)")
+	item.Data[itemDataNodeCount] = measurement.Int(1)
+	item.Data[itemDataTruncated] = measurement.Bool(false)
+
+	st := &measurement.Subtype{Name: "label", Items: []measurement.ItemEntry{item}}
+	_, err := LabelReadings(st)
+	assertDecodeRejected(t, err, "LabelReadings()")
+
+	// The same shape on the folded path must fail too.
+	_, err = LabelReadings(&measurement.Subtype{
+		Name: "label",
+		Data: map[string]measurement.Reading{"zone": measurement.Str("us-west|n1 (+9223372036854775808 more)")},
+	})
+	assertDecodeRejected(t, err, "LabelReadings() [data path]")
+}
+
+// TestTaintDataPathReportsLogicalKey pins that the folded taint decoder
+// reports the taint's real key rather than the synthesized "<key>.<effect>".
+// The item path reports the logical key, and two decoders disagreeing on
+// identity would surface as a phantom diff or a missed constraint match.
+func TestTaintDataPathReportsLogicalKey(t *testing.T) {
+	_, taintSt := collectSubtypes(t, 0,
+		makeNode("gpu-a", []corev1.Taint{
+			{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoSchedule},
+			{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoExecute},
+		}, nil),
+	)
+
+	legacy, err := TaintReadings(dataOnly(taintSt))
+	if err != nil {
+		t.Fatalf("TaintReadings() error = %v", err)
+	}
+	for _, r := range legacy {
+		if r.Key != "node.kubernetes.io/unreachable" {
+			t.Errorf("Key = %q, want the logical key without the effect suffix", r.Key)
+		}
+		if r.RawKey == r.Key {
+			t.Errorf("RawKey = %q, want the folded map key", r.RawKey)
+		}
+	}
+}
+
+// TestHydrateItems pins the helper pkg/diff uses to compare membership across
+// encodings: referenced lists are resolved inline so a caller sees node names
+// regardless of how the snapshot stored them, and keys carrying more than one
+// reading are reported as unusable for comparison.
+func TestHydrateItems(t *testing.T) {
+	t.Run("resolves a reference into an inline list", func(t *testing.T) {
+		st := refSubtype("label", "zone", "us-west", "us-west|gpu-a,gpu-b", 2)
+		items, ambiguous, err := HydrateItems(st)
+		if err != nil {
+			t.Fatalf("HydrateItems() error = %v", err)
+		}
+		if got := items[0].Data[itemDataNodeList].String(); got != "gpu-a,gpu-b" {
+			t.Errorf("node-list = %q, want the resolved names", got)
+		}
+		if _, still := items[0].Data[itemDataNodeRef]; still {
+			t.Error("hydrated item still carries the reference")
+		}
+		if len(ambiguous) != 0 {
+			t.Errorf("ambiguous = %v, want none", ambiguous)
+		}
+	})
+
+	t.Run("reports keys carrying more than one reading", func(t *testing.T) {
+		labelSt, _ := collectSubtypes(t, 0,
+			makeNode("gpu-a", nil, map[string]string{"zone": "us-west", "zone.us-west": "true"}),
+			makeNode("gpu-b", nil, map[string]string{"zone": "us-east", "zone.us-west": "true"}),
+		)
+		_, ambiguous, err := HydrateItems(labelSt)
+		if err != nil {
+			t.Fatalf("HydrateItems() error = %v", err)
+		}
+		if !ambiguous["zone.us-west"] {
+			t.Errorf("ambiguous = %v, want zone.us-west — two readings fold onto it", ambiguous)
+		}
+	})
+
+	t.Run("round-trips a truncated list", func(t *testing.T) {
+		labelSt, _ := collectSubtypes(t, 1,
+			makeNode("n1", nil, map[string]string{"shared": "yes"}),
+			makeNode("n2", nil, map[string]string{"shared": "yes"}),
+			makeNode("n3", nil, map[string]string{"shared": "yes"}),
+		)
+		items, _, err := HydrateItems(labelSt)
+		if err != nil {
+			t.Fatalf("HydrateItems() error = %v", err)
+		}
+		if got := items[0].Data[itemDataNodeList].String(); got != "n1 (+2 more)" {
+			t.Errorf("node-list = %q, want the marker preserved", got)
+		}
+	})
+
+	t.Run("taints hydrate too", func(t *testing.T) {
+		st := refSubtype("taint", "dedicated", "sys", "NoSchedule|sys|gpu-a", 1)
+		items, _, err := HydrateItems(st)
+		if err != nil {
+			t.Fatalf("HydrateItems() error = %v", err)
+		}
+		if got := items[0].Data[itemDataNodeList].String(); got != "gpu-a" {
+			t.Errorf("node-list = %q, want gpu-a", got)
+		}
+	})
+
+	t.Run("absent, foreign and malformed inputs", func(t *testing.T) {
+		if items, _, err := HydrateItems(nil); items != nil || err != nil {
+			t.Errorf("nil subtype = (%v, %v), want (nil, nil)", items, err)
+		}
+		if items, _, err := HydrateItems(&measurement.Subtype{Name: "label"}); items != nil || err != nil {
+			t.Errorf("no items = (%v, %v), want (nil, nil)", items, err)
+		}
+		other := &measurement.Subtype{Name: "summary", Items: []measurement.ItemEntry{validItem()}}
+		if items, _, err := HydrateItems(other); err != nil || len(items) != 1 {
+			t.Errorf("foreign subtype = (%v, %v), want its items unchanged", items, err)
+		}
+		bad := &measurement.Subtype{Name: "label", Items: []measurement.ItemEntry{{
+			Context: map[string]string{itemCtxKey: "k"},
+			Data:    map[string]measurement.Reading{itemDataNodeList: measurement.Str("n1")},
+		}}}
+		if _, _, err := HydrateItems(bad); err == nil {
+			t.Error("malformed items decoded without error")
+		}
+	})
 }

--- a/pkg/collector/topology/template_test.go
+++ b/pkg/collector/topology/template_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topology_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/collector/topology"
+	"github.com/NVIDIA/aicr/pkg/measurement"
+	"github.com/NVIDIA/aicr/pkg/serializer"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// shippedTemplate is the example template documented in
+// docs/user/cli-reference.md. Nothing else in the tree renders it — the
+// chainsaw case only asserts the output file exists — so its field names are
+// checked here or not at all.
+const shippedTemplate = "../../../examples/templates/snapshot-template.md.tmpl"
+
+// TestShippedTemplateRendersBothEncodings renders the shipped template over
+// real collector output in both encodings.
+//
+// The legacy case uses a taint key carrying two effects: encodeTaints emits
+// those in its two-field form, which the template indexed as three and aborted
+// the whole report on. node.kubernetes.io/unreachable does this on any NotReady
+// node, so it is routine rather than exotic.
+func TestShippedTemplateRendersBothEncodings(t *testing.T) {
+	t.Parallel()
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "gpu-a",
+				Labels: map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3"},
+			},
+			Spec: corev1.NodeSpec{Taints: []corev1.Taint{
+				{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoExecute},
+			}},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "gpu-b",
+				Labels: map[string]string{"nvidia.com/gpu.product": "NVIDIA-B200"},
+			},
+			Spec: corev1.NodeSpec{Taints: []corev1.Taint{
+				{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoSchedule},
+			}},
+		},
+	}
+
+	m, err := (&topology.Collector{ClientSet: fake.NewClientset(nodes...)}).Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect() failed: %v", err)
+	}
+	snap := &snapshotter.Snapshot{Measurements: []*measurement.Measurement{m}}
+
+	render := func(t *testing.T) string {
+		t.Helper()
+		var sb strings.Builder
+		if err := serializer.NewTemplateWriter(shippedTemplate, &sb).Serialize(context.Background(), snap); err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+		return sb.String()
+	}
+
+	out := render(t)
+	for _, want := range []string{
+		"NVIDIA-H100-80GB-HBM3",
+		"node.kubernetes.io/unreachable",
+		"NoExecute",
+		"NoSchedule",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("item rendering is missing %q\n%s", want, out)
+		}
+	}
+	// The true taint key, not the disambiguated map key.
+	if strings.Contains(out, "unreachable.NoExecute") {
+		t.Errorf("item rendering leaked a folded map key\n%s", out)
+	}
+
+	// Strip Items to exercise the legacy branch, which must render rather than
+	// abort on the two-field taint shape.
+	for i := range snap.Measurements[0].Subtypes {
+		snap.Measurements[0].Subtypes[i].Items = nil
+	}
+	if legacy := render(t); !strings.Contains(legacy, "gpu-a") {
+		t.Errorf("legacy rendering is missing node names\n%s", legacy)
+	}
+}

--- a/pkg/collector/topology/template_test.go
+++ b/pkg/collector/topology/template_test.go
@@ -83,7 +83,11 @@ func TestShippedTemplateRendersBothEncodings(t *testing.T) {
 
 	out := render(t)
 	for _, want := range []string{
+		// Both values of nvidia.com/gpu.product: one reading surviving proves
+		// nothing, since the folded encoding also renders one. The second is
+		// the reading this encoding exists to keep.
 		"NVIDIA-H100-80GB-HBM3",
+		"NVIDIA-B200",
 		"node.kubernetes.io/unreachable",
 		"NoExecute",
 		"NoSchedule",
@@ -102,7 +106,22 @@ func TestShippedTemplateRendersBothEncodings(t *testing.T) {
 	for i := range snap.Measurements[0].Subtypes {
 		snap.Measurements[0].Subtypes[i].Items = nil
 	}
-	if legacy := render(t); !strings.Contains(legacy, "gpu-a") {
+	legacy := render(t)
+	if !strings.Contains(legacy, "gpu-a") {
 		t.Errorf("legacy rendering is missing node names\n%s", legacy)
+	}
+	// The two-field shape exists only because encodeTaints moved the effect
+	// into the key, so the row is recoverable: the key column must hold the
+	// true key and the effect must land in its own column.
+	for _, want := range []string{
+		"| node.kubernetes.io/unreachable | NoExecute |",
+		"| node.kubernetes.io/unreachable | NoSchedule |",
+	} {
+		if !strings.Contains(legacy, want) {
+			t.Errorf("legacy rendering is missing row %q\n%s", want, legacy)
+		}
+	}
+	if strings.Contains(legacy, "unreachable.NoExecute |") {
+		t.Errorf("legacy rendering leaked the folded key into the Taint Key column\n%s", legacy)
 	}
 }

--- a/pkg/collector/topology/topology.go
+++ b/pkg/collector/topology/topology.go
@@ -201,8 +201,55 @@ const (
 
 	itemDataNodeCount = "node-count"
 	itemDataNodeList  = "node-list"
+	itemDataNodeRef   = "node-list-ref"
 	itemDataTruncated = "truncated"
 )
+
+// labelMapKeys replays encodeLabels' folding rule, returning the data map key
+// each reading writes to. Two readings sharing one key are the collision the
+// folded encoding cannot represent: its entry can describe only one of them,
+// so neither may reference it.
+func labelMapKeys(labels map[labelID][]string) map[labelID]string {
+	keyValues := make(map[string]int, len(labels))
+	for id := range labels {
+		keyValues[id.Key]++
+	}
+	out := make(map[labelID]string, len(labels))
+	for id := range labels {
+		if keyValues[id.Key] > 1 {
+			out[id] = id.Key + "." + id.Value
+			continue
+		}
+		out[id] = id.Key
+	}
+	return out
+}
+
+// taintMapKeys replays encodeTaints' folding rule. See labelMapKeys.
+func taintMapKeys(taints map[taintID][]string) map[taintID]string {
+	keyEffects := make(map[string]int, len(taints))
+	for id := range taints {
+		keyEffects[id.Key]++
+	}
+	out := make(map[taintID]string, len(taints))
+	for id := range taints {
+		if keyEffects[id.Key] > 1 {
+			out[id] = id.Key + "." + id.Effect
+			continue
+		}
+		out[id] = id.Key
+	}
+	return out
+}
+
+// refCounts counts how many readings fold onto each data map key.
+func refCounts[K comparable](mapKeys map[K]string) map[string]int {
+	out := make(map[string]int, len(mapKeys))
+	for _, mk := range mapKeys {
+		out[mk]++
+	}
+	return out
+}
 
 // encodeLabelItems renders one ItemEntry per aggregated label reading, keeping
 // key and value in separate fields so the collision encodeLabels cannot avoid
@@ -225,6 +272,9 @@ func encodeLabelItems(labels map[labelID][]string, maxNodes int) []measurement.I
 		return ids[i].Value < ids[j].Value
 	})
 
+	mapKeys := labelMapKeys(labels)
+	counts := refCounts(mapKeys)
+
 	items := make([]measurement.ItemEntry, 0, len(ids))
 	for _, id := range ids {
 		nodes := labels[id]
@@ -233,7 +283,7 @@ func encodeLabelItems(labels map[labelID][]string, maxNodes int) []measurement.I
 				itemCtxKey:   id.Key,
 				itemCtxValue: id.Value,
 			},
-			Data: nodeListData(nodes, maxNodes),
+			Data: membershipData(nodes, maxNodes, mapKeys[id], counts),
 		})
 	}
 	return items
@@ -261,6 +311,9 @@ func encodeTaintItems(taints map[taintID][]string, maxNodes int) []measurement.I
 		return ids[i].Value < ids[j].Value
 	})
 
+	mapKeys := taintMapKeys(taints)
+	counts := refCounts(mapKeys)
+
 	items := make([]measurement.ItemEntry, 0, len(ids))
 	for _, id := range ids {
 		nodes := taints[id]
@@ -270,10 +323,27 @@ func encodeTaintItems(taints map[taintID][]string, maxNodes int) []measurement.I
 				itemCtxValue:  id.Value,
 				itemCtxEffect: id.Effect,
 			},
-			Data: nodeListData(nodes, maxNodes),
+			Data: membershipData(nodes, maxNodes, mapKeys[id], counts),
 		})
 	}
 	return items
+}
+
+// membershipData renders one reading's node membership. When the reading is
+// the only one folding onto mapKey, the data entry describes it exactly, so
+// the item references that entry instead of repeating the names — the node
+// lists dominate snapshot size and are otherwise written twice. A reading
+// sharing mapKey keeps its own copy, because the shared entry can describe
+// only one of them and which one is not predictable.
+func membershipData(nodes []string, maxNodes int, mapKey string, counts map[string]int) map[string]measurement.Reading {
+	if counts[mapKey] != 1 {
+		return nodeListData(nodes, maxNodes)
+	}
+	return map[string]measurement.Reading{
+		itemDataNodeCount: measurement.Int(len(nodes)),
+		itemDataNodeRef:   measurement.Str(mapKey),
+		itemDataTruncated: measurement.Bool(maxNodes > 0 && len(nodes) > maxNodes),
+	}
 }
 
 // nodeListData renders one reading's node membership. node-count is the true
@@ -306,19 +376,20 @@ func IsTruncatedNodeList(nodes string) bool {
 // whether the suffix is present and parsable. N plus the names still rendered
 // is the pre-truncation total, so a decoder can check a declared node-count
 // against the list rather than merely against its length.
-func truncatedNodeListRemainder(nodes string) (int, bool) {
+func truncatedNodeListRemainder(nodes string) (n int, marked bool, err error) {
 	m := truncatedNodeListRE.FindStringSubmatch(nodes)
 	if m == nil {
-		return 0, false
+		return 0, false, nil
 	}
-	n, err := strconv.Atoi(m[1])
-	if err != nil {
-		// Only reachable when N overflows int; treat as unparsable so the
-		// caller's marker/flag comparison fails closed rather than reading
-		// the suffix as absent.
-		return 0, false
+	n, convErr := strconv.Atoi(m[1])
+	if convErr != nil {
+		// The suffix matched but its count does not fit an int. Reporting
+		// "no marker" would let the list read as complete, so the caller is
+		// told the list is marked and unreadable.
+		return 0, true, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("node list truncation marker %q is not a usable count", m[1]))
 	}
-	return n, true
+	return n, true, nil
 }
 
 // formatNodeList joins sorted node names with commas, optionally truncating.

--- a/pkg/collector/topology/topology.go
+++ b/pkg/collector/topology/topology.go
@@ -119,22 +119,26 @@ func (c *Collector) Collect(ctx context.Context) (*measurement.Measurement, erro
 
 	taintData := encodeTaints(taints, c.MaxNodesPerEntry)
 	labelData := encodeLabels(labels, c.MaxNodesPerEntry)
+	taintItems := encodeTaintItems(taints, c.MaxNodesPerEntry)
+	labelItems := encodeLabelItems(labels, c.MaxNodesPerEntry)
 
+	// Counts come from the items, not the maps: folded keys collapse colliding
+	// readings, so len(data) under-reports. Mirrors slinky-slurm.
 	res := measurement.NewMeasurement(measurement.TypeNodeTopology).
 		WithSubtypeBuilder(
 			measurement.NewSubtypeBuilder("summary").
 				Set("node-count", measurement.Int(nodeCount)).
-				Set("taint-count", measurement.Int(len(taintData))).
-				Set("label-count", measurement.Int(len(labelData))),
+				Set("taint-count", measurement.Int(len(taintItems))).
+				Set("label-count", measurement.Int(len(labelItems))),
 		).
-		WithSubtype(measurement.Subtype{Name: "taint", Data: taintData}).
-		WithSubtype(measurement.Subtype{Name: "label", Data: labelData}).
+		WithSubtype(measurement.Subtype{Name: "taint", Data: taintData, Items: taintItems}).
+		WithSubtype(measurement.Subtype{Name: "label", Data: labelData, Items: labelItems}).
 		Build()
 
 	slog.Info("node topology collection complete",
 		slog.Int("nodes", nodeCount),
-		slog.Int("taints", len(taintData)),
-		slog.Int("labels", len(labelData)))
+		slog.Int("taints", len(taintItems)),
+		slog.Int("labels", len(labelItems)))
 
 	return res, nil
 }
@@ -184,6 +188,103 @@ func encodeLabels(labels map[labelID][]string, maxNodes int) map[string]measurem
 		data[mapKey] = measurement.Str(fmt.Sprintf("%s|%s", id.Value, nodeStr))
 	}
 	return data
+}
+
+// Item field names, kebab-case to match the k8s slinky-slurm subtype and the
+// existing summary keys. Placement follows measurement-api.md: context
+// identifies a record, data is measured or counted.
+const (
+	itemCtxKey    = "key"
+	itemCtxValue  = "value"
+	itemCtxEffect = "effect"
+
+	itemDataNodeCount = "node-count"
+	itemDataNodeList  = "node-list"
+	itemDataTruncated = "truncated"
+)
+
+// encodeLabelItems renders one ItemEntry per aggregated label reading, keeping
+// key and value in separate fields so the collision encodeLabels cannot avoid
+// (#2003) is structurally impossible.
+//
+// Sorted by (key, value): pkg/diff compares Items positionally.
+func encodeLabelItems(labels map[labelID][]string, maxNodes int) []measurement.ItemEntry {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	ids := make([]labelID, 0, len(labels))
+	for id := range labels {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		if ids[i].Key != ids[j].Key {
+			return ids[i].Key < ids[j].Key
+		}
+		return ids[i].Value < ids[j].Value
+	})
+
+	items := make([]measurement.ItemEntry, 0, len(ids))
+	for _, id := range ids {
+		nodes := labels[id]
+		items = append(items, measurement.ItemEntry{
+			Context: map[string]string{
+				itemCtxKey:   id.Key,
+				itemCtxValue: id.Value,
+			},
+			Data: nodeListData(nodes, maxNodes),
+		})
+	}
+	return items
+}
+
+// encodeTaintItems renders one ItemEntry per aggregated taint reading. It also
+// closes a second collision: encodeTaints counts entries per key but
+// disambiguates with effect, so two taints sharing both synthesize one map key.
+func encodeTaintItems(taints map[taintID][]string, maxNodes int) []measurement.ItemEntry {
+	if len(taints) == 0 {
+		return nil
+	}
+
+	ids := make([]taintID, 0, len(taints))
+	for id := range taints {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		if ids[i].Key != ids[j].Key {
+			return ids[i].Key < ids[j].Key
+		}
+		if ids[i].Effect != ids[j].Effect {
+			return ids[i].Effect < ids[j].Effect
+		}
+		return ids[i].Value < ids[j].Value
+	})
+
+	items := make([]measurement.ItemEntry, 0, len(ids))
+	for _, id := range ids {
+		nodes := taints[id]
+		items = append(items, measurement.ItemEntry{
+			Context: map[string]string{
+				itemCtxKey:    id.Key,
+				itemCtxValue:  id.Value,
+				itemCtxEffect: id.Effect,
+			},
+			Data: nodeListData(nodes, maxNodes),
+		})
+	}
+	return items
+}
+
+// nodeListData renders one reading's node membership. node-count is the true
+// pre-truncation total and truncated states the fact outright, replacing the
+// regex probe Data requires (#2002).
+func nodeListData(nodes []string, maxNodes int) map[string]measurement.Reading {
+	truncated := maxNodes > 0 && len(nodes) > maxNodes
+	return map[string]measurement.Reading{
+		itemDataNodeCount: measurement.Int(len(nodes)),
+		itemDataNodeList:  measurement.Str(formatNodeList(nodes, maxNodes)),
+		itemDataTruncated: measurement.Bool(truncated),
+	}
 }
 
 // truncatedNodeListRE matches the suffix formatNodeList appends when a node

--- a/pkg/collector/topology/topology.go
+++ b/pkg/collector/topology/topology.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
@@ -293,12 +294,31 @@ func nodeListData(nodes []string, maxNodes int) map[string]measurement.Reading {
 // membership lists (pkg/constraints' node-set form, issue #1755) call
 // IsTruncatedNodeList instead of re-encoding this knowledge. A structured
 // marker is tracked in #2002.
-var truncatedNodeListRE = regexp.MustCompile(`\(\+\d+ more\)$`)
+var truncatedNodeListRE = regexp.MustCompile(`\(\+(\d+) more\)$`)
 
 // IsTruncatedNodeList reports whether an encoded node list carries the
 // truncation suffix formatNodeList appends under --max-nodes-per-entry.
 func IsTruncatedNodeList(nodes string) bool {
 	return truncatedNodeListRE.MatchString(nodes)
+}
+
+// truncatedNodeListRemainder returns the N from the "(+N more)" suffix, and
+// whether the suffix is present and parsable. N plus the names still rendered
+// is the pre-truncation total, so a decoder can check a declared node-count
+// against the list rather than merely against its length.
+func truncatedNodeListRemainder(nodes string) (int, bool) {
+	m := truncatedNodeListRE.FindStringSubmatch(nodes)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		// Only reachable when N overflows int; treat as unparsable so the
+		// caller's marker/flag comparison fails closed rather than reading
+		// the suffix as absent.
+		return 0, false
+	}
+	return n, true
 }
 
 // formatNodeList joins sorted node names with commas, optionally truncating.

--- a/pkg/collector/topology/topology_test.go
+++ b/pkg/collector/topology/topology_test.go
@@ -317,6 +317,52 @@ func TestCollect(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Issue #2003: synthesized "zone.us-west" collides with the
+			// literal label of that name; one reading is dropped.
+			name: "label key collides with a disambiguated key",
+			nodes: []*corev1.Node{
+				makeNode("gpu-a", nil,
+					map[string]string{
+						"zone":         "us-west",
+						"zone.us-west": "true",
+					},
+				),
+				makeNode("gpu-b", nil,
+					map[string]string{
+						"zone":         "us-east",
+						"zone.us-west": "true",
+					},
+				),
+			},
+			wantNodeCount:  2,
+			wantTaintCount: 0,
+			// {zone,us-west}, {zone,us-east}, {zone.us-west,true}
+			wantLabelCount: 3,
+		},
+		{
+			// Issue #2003: encodeTaints counts per Key but disambiguates with
+			// Effect, so both entries synthesize "dedicated.NoSchedule".
+			name: "same taint key and effect with different values",
+			nodes: []*corev1.Node{
+				makeNode("node-1",
+					[]corev1.Taint{
+						{Key: "dedicated", Value: "team-a", Effect: corev1.TaintEffectNoSchedule},
+					},
+					nil,
+				),
+				makeNode("node-2",
+					[]corev1.Taint{
+						{Key: "dedicated", Value: "team-b", Effect: corev1.TaintEffectNoSchedule},
+					},
+					nil,
+				),
+			},
+			wantNodeCount: 2,
+			// {dedicated,NoSchedule,team-a}, {dedicated,NoSchedule,team-b}
+			wantTaintCount: 2,
+			wantLabelCount: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/constraints/gpu_nodes.go
+++ b/pkg/constraints/gpu_nodes.go
@@ -214,8 +214,9 @@ func decodeLabelEntriesFromItems(labels *measurement.Subtype, key string) ([]lab
 		if r.Key != key {
 			continue
 		}
-		// Truncated readings skip token validation: the "(+N more)" tail is
-		// not a node name by design.
+		// Rejected outright rather than validated: a partial node list cannot
+		// support a node-set predicate, and its "(+N more)" tail is not a node
+		// name anyway.
 		if r.Truncated {
 			return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("label reading %q is truncated — node-set constraints cannot be evaluated on a partial "+

--- a/pkg/constraints/gpu_nodes.go
+++ b/pkg/constraints/gpu_nodes.go
@@ -235,6 +235,29 @@ func decodeLabelEntriesFromItems(labels *measurement.Subtype, key string) ([]lab
 			truncated: false,
 		})
 	}
+
+	// A node carries exactly one value of a given label key, so the entries
+	// must partition their nodes. Overlap means the snapshot records no real
+	// cluster, and accepting it lets one node satisfy key=a and key=b at once
+	// because evaluateEveryGPUNodeHasValue skips the non-matching entry.
+	// Mirrors the folded encoding's guard in decodeLabelEntriesFromData.
+	//
+	// Compared on value, not mere reappearance: a node repeated under the same
+	// value is redundant rather than contradictory, and the Data path accepts
+	// that shape.
+	seen := make(map[string]string, len(entries))
+	for _, e := range entries {
+		for _, n := range e.nodes {
+			if prev, dup := seen[n]; dup && prev != e.value {
+				return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("label readings for %q are inconsistent: node %q appears under both value %q and "+
+						"value %q, but a node carries exactly one value per label key — the snapshot is corrupt "+
+						"or hand-edited; regenerate it with a current aicr build", key, n, prev, e.value),
+					map[string]any{ctxConstraint: GPUNodesLabelConstraintName, keyKey: key, "node": n})
+			}
+			seen[n] = e.value
+		}
+	}
 	return entries, nil
 }
 

--- a/pkg/constraints/gpu_nodes.go
+++ b/pkg/constraints/gpu_nodes.go
@@ -92,7 +92,7 @@ func evaluateGPUNodesLabel(value string, snap *snapshotter.Snapshot) EvalResult 
 			"snapshot carries no NodeTopology label readings — re-capture with a current aicr build and verify the snapshot agent can list nodes")}
 	}
 
-	universeEntries, err := decodeLabelEntries(labels.Data, gpuNodeUniverseLabel)
+	universeEntries, err := decodeLabelEntries(labels, gpuNodeUniverseLabel)
 	if err != nil {
 		return EvalResult{Error: err}
 	}
@@ -111,7 +111,7 @@ func evaluateGPUNodesLabel(value string, snap *snapshotter.Snapshot) EvalResult 
 			map[string]any{ctxConstraint: GPUNodesLabelConstraintName})}
 	}
 
-	targetEntries, err := decodeLabelEntries(labels.Data, key)
+	targetEntries, err := decodeLabelEntries(labels, key)
 	if err != nil {
 		return EvalResult{Error: err}
 	}
@@ -184,11 +184,64 @@ func findLabelSubtype(snap *snapshotter.Snapshot) *measurement.Subtype {
 	return nil
 }
 
-// decodeLabelEntries collects the decoded entries for one label key from the
-// topology collector's encoding ("<value>|<node1,node2,...>"). It handles
-// both encoded shapes: the plain key, and the "<key>.<value>" disambiguation
-// encodeLabels applies when the key carries multiple distinct values across
-// the cluster.
+// decodeLabelEntries collects the decoded entries for one label key. The item
+// encoding keeps key and value apart, so the impostor and collision reasoning
+// in decodeLabelEntriesFromData cannot arise there; older Data-only snapshots
+// still need it in full.
+//
+// Both paths reject truncated node lists and non-canonical node names
+// (#1755) — the item encoding removes ambiguity in the key, not the
+// possibility of a corrupted list.
+func decodeLabelEntries(labels *measurement.Subtype, key string) ([]labelNodeSet, error) {
+	if topology.HasLosslessReadings(labels) {
+		return decodeLabelEntriesFromItems(labels, key)
+	}
+	return decodeLabelEntriesFromData(labels.Data, key)
+}
+
+// decodeLabelEntriesFromItems matches the key exactly — nothing to
+// disambiguate, no impostor to reject.
+func decodeLabelEntriesFromItems(labels *measurement.Subtype, key string) ([]labelNodeSet, error) {
+	readings, err := topology.LabelReadings(labels)
+	if err != nil {
+		return nil, errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+			"failed to decode NodeTopology label readings", err,
+			map[string]any{ctxConstraint: GPUNodesLabelConstraintName, keyKey: key})
+	}
+
+	var entries []labelNodeSet
+	for _, r := range readings {
+		if r.Key != key {
+			continue
+		}
+		// Truncated readings skip token validation: the "(+N more)" tail is
+		// not a node name by design.
+		if r.Truncated {
+			return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("label reading %q is truncated — node-set constraints cannot be evaluated on a partial "+
+					"node list; regenerate the snapshot without --max-nodes-per-entry", r.RawKey),
+				map[string]any{ctxConstraint: GPUNodesLabelConstraintName, ctxReading: r.RawKey})
+		}
+		if !validNodeNames(r.Nodes) {
+			return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("label reading %q is malformed (nodes %v) — expected canonical node names; "+
+					"regenerate the snapshot with a current aicr build", r.RawKey, r.Nodes),
+				map[string]any{ctxConstraint: GPUNodesLabelConstraintName, ctxReading: r.RawKey})
+		}
+		entries = append(entries, labelNodeSet{
+			value:     r.Value,
+			nodes:     r.Nodes,
+			raw:       r.RawKey,
+			truncated: false,
+		})
+	}
+	return entries, nil
+}
+
+// decodeLabelEntriesFromData decodes the legacy folded encoding
+// ("<value>|<node1,node2,...>"). It handles both encoded shapes: the plain
+// key, and the "<key>.<value>" disambiguation encodeLabels applies when the
+// key carries multiple distinct values across the cluster.
 //
 // The encoding is lossy: a *different* label key literally named
 // "<key>.<v>" whose value is "<v>" produces the same map entry as a genuine
@@ -229,7 +282,7 @@ func findLabelSubtype(snap *snapshotter.Snapshot) *measurement.Subtype {
 // universe member, letting the negated predicate pass vacuously. Truncated
 // readings skip token validation — their "(+N more)" tail is not a node
 // name by design — and keep their distinct truncation diagnostic.
-func decodeLabelEntries(data map[string]measurement.Reading, key string) ([]labelNodeSet, error) {
+func decodeLabelEntriesFromData(data map[string]measurement.Reading, key string) ([]labelNodeSet, error) {
 	prefix := key + "."
 	var plain, prefixed []labelNodeSet
 	for k, reading := range data {
@@ -310,12 +363,24 @@ func splitNodes(nodesRaw string) ([]string, bool) {
 		return nil, false
 	}
 	nodes := strings.Split(nodesRaw, ",")
-	for _, n := range nodes {
-		if len(validation.IsDNS1123Subdomain(n)) > 0 {
-			return nil, false
-		}
+	if !validNodeNames(nodes) {
+		return nil, false
 	}
 	return nodes, true
+}
+
+// validNodeNames reports whether every token is a canonical Kubernetes node
+// name. Shared by both decode paths so the fail-closed rule cannot drift.
+func validNodeNames(nodes []string) bool {
+	if len(nodes) == 0 {
+		return false
+	}
+	for _, n := range nodes {
+		if len(validation.IsDNS1123Subdomain(n)) > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // cutLabelEncoding splits the topology collector's "<value>|<nodes>"

--- a/pkg/constraints/gpu_nodes_test.go
+++ b/pkg/constraints/gpu_nodes_test.go
@@ -798,3 +798,187 @@ func TestGPUNodesLabelLegacyDataSnapshotStillEvaluates(t *testing.T) {
 		t.Errorf("legacy Data-only snapshot: Passed = false, want true (actual=%q)", result.Actual)
 	}
 }
+
+// labelItem is one hand-written label reading. The real collector aggregates
+// through map[labelID][]string and so can never place a node under two values
+// of one key; forging the item list is the only way to reach the guard.
+type labelItem struct{ key, value, nodes string }
+
+func itemsSnapshot(items ...labelItem) *snapshotter.Snapshot {
+	entries := make([]measurement.ItemEntry, 0, len(items))
+	for _, it := range items {
+		names := strings.Split(it.nodes, ",")
+		entries = append(entries, measurement.ItemEntry{
+			Context: map[string]string{"key": it.key, "value": it.value},
+			Data: map[string]measurement.Reading{
+				"node-count": measurement.Int(len(names)),
+				"node-list":  measurement.Str(it.nodes),
+				"truncated":  measurement.Bool(false),
+			},
+		})
+	}
+	return &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{{
+			Type:     measurement.TypeNodeTopology,
+			Subtypes: []measurement.Subtype{{Name: "label", Items: entries}},
+		}},
+	}
+}
+
+// TestGPUNodesLabelRejectsNonPartitionedItems pins that entries for one label
+// key must partition their nodes. Without it a node listed under both "true"
+// and "false" passes "=true": evaluateEveryGPUNodeHasValue skips the entry
+// whose value does not match, so the contradiction never reaches the tally and
+// a readiness gate returns PASS on a cluster that cannot exist.
+func TestGPUNodesLabelRejectsNonPartitionedItems(t *testing.T) {
+	t.Parallel()
+
+	const accel = "cloud.google.com/gke-accelerator"
+	universe := []labelItem{{accel, "nvidia-h100-80gb", "gpu-a,gpu-b"}}
+
+	tests := []struct {
+		name    string
+		items   []labelItem
+		wantErr bool
+		// Checked only when wantErr is false.
+		wantPassed bool
+	}{
+		{
+			name:    "node under two values of the target key",
+			items:   append(universe, labelItem{optOutLabel, "true", "gpu-a,gpu-b"}, labelItem{optOutLabel, "false", "gpu-a"}),
+			wantErr: true,
+		},
+		{
+			// Order must not matter: the contradiction is the same fact.
+			name:    "node under two values, contradicting entry first",
+			items:   append(universe, labelItem{optOutLabel, "false", "gpu-a"}, labelItem{optOutLabel, "true", "gpu-a,gpu-b"}),
+			wantErr: true,
+		},
+		{
+			// The guard also covers the universe key, which is decoded by the
+			// same function before the target key is read.
+			name: "node under two values of the universe key",
+			items: []labelItem{
+				{accel, "nvidia-h100-80gb", "gpu-a"},
+				{accel, "nvidia-a100-80gb", "gpu-a"},
+				{optOutLabel, "true", "gpu-a"},
+			},
+			wantErr: true,
+		},
+		{
+			// Redundant, not contradictory — and the folded encoding accepts
+			// it, so rejecting here would split the two paths.
+			name:       "node repeated under the same value",
+			items:      append(universe, labelItem{optOutLabel, "true", "gpu-a,gpu-b"}, labelItem{optOutLabel, "true", "gpu-a"}),
+			wantErr:    false,
+			wantPassed: true,
+		},
+		{
+			name:       "node repeated within a single entry",
+			items:      append(universe, labelItem{optOutLabel, "true", "gpu-a,gpu-a,gpu-b"}),
+			wantErr:    false,
+			wantPassed: true,
+		},
+		{
+			// The guard must not turn an honest disagreement into an error:
+			// disjoint node sets are a real cluster that simply fails.
+			name:       "honest mixed cluster still fails rather than errors",
+			items:      append(universe, labelItem{optOutLabel, "true", "gpu-a"}, labelItem{optOutLabel, "false", "gpu-b"}),
+			wantErr:    false,
+			wantPassed: false,
+		},
+	}
+
+	c := recipe.Constraint{Name: GPUNodesLabelConstraintName, Value: optOutLabel + "=true"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := Evaluate(c, itemsSnapshot(tt.items...))
+
+			if !tt.wantErr {
+				if result.Error != nil {
+					t.Fatalf("unexpected error: %v", result.Error)
+				}
+				if result.Passed != tt.wantPassed {
+					t.Errorf("passed = %v, want %v (actual: %q)", result.Passed, tt.wantPassed, result.Actual)
+				}
+				return
+			}
+			if result.Error == nil {
+				t.Fatalf("expected an error, got passed=%v actual=%q", result.Passed, result.Actual)
+			}
+			if !stderrors.Is(result.Error, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error code = %v, want %s", result.Error, errors.ErrCodeInvalidRequest)
+			}
+		})
+	}
+}
+
+// rawItemsSnapshot builds a label subtype from items given verbatim, so a test
+// can express shapes itemsSnapshot's well-formed builder cannot.
+func rawItemsSnapshot(items ...measurement.ItemEntry) *snapshotter.Snapshot {
+	return &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{{
+			Type:     measurement.TypeNodeTopology,
+			Subtypes: []measurement.Subtype{{Name: "label", Items: items}},
+		}},
+	}
+}
+
+// TestGPUNodesLabelItemsFailClosed pins the two rejection paths on the item
+// side. Both must surface as an evaluation error rather than a verdict: a
+// snapshot the decoder cannot read is not evidence that the cluster is ready.
+func TestGPUNodesLabelItemsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	const accel = "cloud.google.com/gke-accelerator"
+	wellFormed := func(key, value, nodes string) measurement.ItemEntry {
+		return measurement.ItemEntry{
+			Context: map[string]string{"key": key, "value": value},
+			Data: map[string]measurement.Reading{
+				"node-count": measurement.Int(len(strings.Split(nodes, ","))),
+				"node-list":  measurement.Str(nodes),
+				"truncated":  measurement.Bool(false),
+			},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		items []measurement.ItemEntry
+	}{
+		{
+			// A structurally broken item fails the shared accessor, and the
+			// constraint must wrap rather than treat it as "no readings".
+			name: "item rejected by the decoder",
+			items: []measurement.ItemEntry{{
+				Context: map[string]string{"key": accel, "value": "nvidia-h100-80gb"},
+				Data:    map[string]measurement.Reading{"node-list": measurement.Str("gpu-a")},
+			}},
+		},
+		{
+			// Structurally valid, but the node token is not a node name. A
+			// name that can never equal a universe member would make the
+			// negated predicate pass vacuously.
+			name: "node token is not a canonical node name",
+			items: []measurement.ItemEntry{
+				wellFormed(accel, "nvidia-h100-80gb", "gpu-a"),
+				wellFormed(optOutLabel, "true", "gpu a"),
+			},
+		},
+	}
+
+	c := recipe.Constraint{Name: GPUNodesLabelConstraintName, Value: optOutLabel + "=true"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := Evaluate(c, rawItemsSnapshot(tt.items...))
+			if result.Error == nil {
+				t.Fatalf("expected an error, got passed=%v actual=%q", result.Passed, result.Actual)
+			}
+			if !stderrors.Is(result.Error, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error code = %v, want %s", result.Error, errors.ErrCodeInvalidRequest)
+			}
+		})
+	}
+}

--- a/pkg/constraints/gpu_nodes_test.go
+++ b/pkg/constraints/gpu_nodes_test.go
@@ -681,3 +681,120 @@ func TestGPUNodesLabelRoundTripsCollectorEncoding(t *testing.T) {
 		}
 	})
 }
+
+// TestGPUNodesLabelLosslessEncodingResolvesCollision pins the #2003 fix at the
+// evaluator boundary.
+//
+// The cluster carries two distinct labels whose folded map keys collide: the
+// opt-out label with two values across the nodes (which encodeLabels
+// disambiguates to "<key>.true" and "<key>.false"), and a separate label
+// literally named "<key>.true". In the folded encoding one reading silently
+// overwrites the other by map iteration order, so the same snapshot evaluated
+// twice can disagree. The item encoding keeps key and value apart, so the
+// target label's readings are recovered exactly and the verdict is stable.
+//
+// Repeated because the failure it guards against is a race on map ordering: a
+// single run can pass by luck.
+func TestGPUNodesLabelLosslessEncodingResolvesCollision(t *testing.T) {
+	t.Parallel()
+
+	node := func(name string, labels map[string]string) *corev1.Node {
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+	}
+	gpuLabels := func(optOut string) map[string]string {
+		return map[string]string{
+			"cloud.google.com/gke-accelerator": "nvidia-h100-80gb",
+			optOutLabel:                        optOut,
+			// A distinct label whose name equals the disambiguated form of
+			// optOutLabel + ".true" — the collision.
+			optOutLabel + ".true": "true",
+		}
+	}
+
+	const runs = 50
+	verdicts := make(map[string]int)
+	for i := 0; i < runs; i++ {
+		c := &topology.Collector{
+			ClientSet: fake.NewClientset(
+				node("gpu-a", gpuLabels("true")),
+				node("gpu-b", gpuLabels("false")),
+			),
+		}
+		m, err := c.Collect(context.Background())
+		if err != nil {
+			t.Fatalf("Collect() failed: %v", err)
+		}
+		snap := &snapshotter.Snapshot{Measurements: []*measurement.Measurement{m}}
+
+		// gpu-b carries "false", so "=true" must fail — deterministically,
+		// and for the right reason rather than by a lost reading.
+		result := Evaluate(recipe.Constraint{
+			Name:  GPUNodesLabelConstraintName,
+			Value: optOutLabel + "=true",
+		}, snap)
+
+		switch {
+		case result.Error != nil:
+			verdicts["error"]++
+		case result.Passed:
+			verdicts["passed"]++
+		default:
+			verdicts["failed"]++
+		}
+	}
+
+	if len(verdicts) != 1 {
+		t.Fatalf("verdict is not deterministic across %d runs: %v — the collision is still "+
+			"reaching the evaluator", runs, verdicts)
+	}
+	if verdicts["failed"] != runs {
+		t.Errorf("verdicts = %v, want all %d runs to report failed (gpu-b carries %q=false)",
+			verdicts, runs, optOutLabel)
+	}
+}
+
+// TestGPUNodesLabelLegacyDataSnapshotStillEvaluates pins backward
+// compatibility: a snapshot captured before the item encoding carries only the
+// folded Data map, and must keep evaluating exactly as it did. Without this
+// the Data fallback could rot unnoticed, since every other test now exercises
+// the item path via the real collector.
+func TestGPUNodesLabelLegacyDataSnapshotStillEvaluates(t *testing.T) {
+	t.Parallel()
+
+	node := func(name string, labels map[string]string) *corev1.Node {
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+	}
+	c := &topology.Collector{
+		ClientSet: fake.NewClientset(
+			node("gpu-a", map[string]string{
+				"cloud.google.com/gke-accelerator": "nvidia-h100-80gb",
+				optOutLabel:                        "true",
+			}),
+			node("gpu-b", map[string]string{
+				"cloud.google.com/gke-accelerator": "nvidia-h100-80gb",
+				optOutLabel:                        "true",
+			}),
+		),
+	}
+	m, err := c.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect() failed: %v", err)
+	}
+
+	// Strip Items, leaving the shape an older aicr wrote.
+	for i := range m.Subtypes {
+		m.Subtypes[i].Items = nil
+	}
+	snap := &snapshotter.Snapshot{Measurements: []*measurement.Measurement{m}}
+
+	result := Evaluate(recipe.Constraint{
+		Name:  GPUNodesLabelConstraintName,
+		Value: optOutLabel + "=true",
+	}, snap)
+	if result.Error != nil {
+		t.Fatalf("legacy Data-only snapshot: unexpected error: %v", result.Error)
+	}
+	if !result.Passed {
+		t.Errorf("legacy Data-only snapshot: Passed = false, want true (actual=%q)", result.Actual)
+	}
+}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -194,6 +194,8 @@ func indexMeasurements(measurements []*measurement.Measurement) map[string]*meas
 func compareMeasurements(base, target *measurement.Measurement) []Change {
 	var changes []Change
 
+	base, target = alignTopologyEncoding(base, target)
+
 	baseByName := indexSubtypes(base.Subtypes)
 	targetByName := indexSubtypes(target.Subtypes)
 

--- a/pkg/diff/topology.go
+++ b/pkg/diff/topology.go
@@ -14,7 +14,10 @@
 
 package diff
 
-import "github.com/NVIDIA/aicr/pkg/measurement"
+import (
+	"github.com/NVIDIA/aicr/pkg/collector/topology"
+	"github.com/NVIDIA/aicr/pkg/measurement"
+)
 
 // NodeTopology carries every label and taint reading twice: as items, and as
 // the legacy folded data map. Diffing both halves makes an aicr upgrade look
@@ -53,10 +56,7 @@ func alignTopologyEncoding(base, target *measurement.Measurement) (*measurement.
 	baseIdx := indexSubtypes(base.Subtypes)
 	targetIdx := indexSubtypes(target.Subtypes)
 
-	// Count keys whose value must be restated because the two sides counted on
-	// different bases: older builds sized the folded map, newer ones the items.
-	restate := map[string]string{}
-	drop := map[string]bool{}
+	plan := map[string]subtypePlan{}
 	for subtype, countKey := range map[string]string{
 		topologyLabelSubtype: topologyLabelCountKey,
 		topologyTaintSubtype: topologyTaintCountKey,
@@ -68,22 +68,52 @@ func alignTopologyEncoding(base, target *measurement.Measurement) (*measurement.
 		baseHas, targetHas := len(b.Items) > 0, len(t.Items) > 0
 		switch {
 		case baseHas && targetHas:
-			drop[subtype] = true // items are richer and stable; ignore the map
+			// Items are the richer record and, once hydrated, carry node
+			// membership on both sides. The folded map adds nothing and is not
+			// stable even within one build, since a collision resolves by map
+			// iteration order.
+			plan[subtype] = subtypePlan{hydrate: true, dropData: true}
 		case baseHas != targetHas:
-			restate[subtype] = countKey // one side predates items
+			// One side predates items. Drop items and compare the folded map.
+			// Exclude collision-ambiguous keys: Go map iteration decides the
+			// winner, so an unchanged cluster can write different values on each
+			// side across an upgrade/rollback.
+			_, ambiguous, err := topology.HydrateItems(itemSide(b, t))
+			if err != nil {
+				plan[subtype] = subtypePlan{dropItems: true, countKey: countKey}
+				continue
+			}
+			plan[subtype] = subtypePlan{dropItems: true, countKey: countKey, skipKeys: ambiguous}
 		}
 		// Neither carries items: one vintage, nothing to reconcile. Restating
 		// the count here would mask a corrupted one rather than report it.
 	}
-	if len(restate) == 0 && len(drop) == 0 {
+	if len(plan) == 0 {
 		return base, target
 	}
 
-	return alignMeasurement(base, restate, drop), alignMeasurement(target, restate, drop)
+	return alignMeasurement(base, plan), alignMeasurement(target, plan)
+}
+
+// subtypePlan is how one subtype is reduced before comparison.
+type subtypePlan struct {
+	hydrate   bool            // resolve referenced node lists into the items
+	dropData  bool            // compare items only
+	dropItems bool            // compare the folded map only
+	countKey  string          // summary count to restate over the folded map
+	skipKeys  map[string]bool // folded keys too ambiguous to compare safely
+}
+
+// itemSide returns whichever subtype carries items.
+func itemSide(a, b *measurement.Subtype) *measurement.Subtype {
+	if len(a.Items) > 0 {
+		return a
+	}
+	return b
 }
 
 // alignMeasurement copies m with the topology subtypes reduced as directed.
-func alignMeasurement(m *measurement.Measurement, restate map[string]string, drop map[string]bool) *measurement.Measurement {
+func alignMeasurement(m *measurement.Measurement, plan map[string]subtypePlan) *measurement.Measurement {
 	out := *m
 	out.Subtypes = make([]measurement.Subtype, len(m.Subtypes))
 	copy(out.Subtypes, m.Subtypes)
@@ -91,12 +121,34 @@ func alignMeasurement(m *measurement.Measurement, restate map[string]string, dro
 	folded := map[string]int{}
 	for i := range out.Subtypes {
 		st := &out.Subtypes[i]
-		switch {
-		case drop[st.Name]:
+		p, ok := plan[st.Name]
+		if !ok {
+			continue
+		}
+		if p.hydrate {
+			if items, _, err := topology.HydrateItems(st); err == nil {
+				st.Items = items
+			} else {
+				p.dropData = false // keep data when hydration fails
+			}
+		}
+		if p.dropData {
 			st.Data = nil
-		case restate[st.Name] != "":
-			folded[restate[st.Name]] = len(st.Data)
+		}
+		if p.dropItems {
 			st.Items = nil
+		}
+		if p.countKey != "" {
+			folded[p.countKey] = len(st.Data)
+		}
+		if len(p.skipKeys) > 0 && st.Data != nil {
+			data := make(map[string]measurement.Reading, len(st.Data))
+			for k, v := range st.Data {
+				if !p.skipKeys[k] {
+					data[k] = v
+				}
+			}
+			st.Data = data
 		}
 	}
 	if len(folded) == 0 {

--- a/pkg/diff/topology.go
+++ b/pkg/diff/topology.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import "github.com/NVIDIA/aicr/pkg/measurement"
+
+// NodeTopology carries every label and taint reading twice: as items, and as
+// the legacy folded data map. Diffing both halves makes an aicr upgrade look
+// like cluster drift, because a snapshot captured by an older build has no
+// items at all and every field of every item reads as added.
+const (
+	topologySummarySubtype = "summary"
+	topologyLabelSubtype   = "label"
+	topologyTaintSubtype   = "taint"
+
+	topologyLabelCountKey = "label-count"
+	topologyTaintCountKey = "taint-count"
+)
+
+// alignTopologyEncoding returns copies of base and target reduced to the one
+// representation both carry, so a comparison reports cluster change rather
+// than encoding change. Inputs are not modified.
+//
+// Per subtype: when both sides carry items, data is dropped — items are the
+// authoritative record, and the folded map is not even stable between runs of
+// one build, since a key collision resolves by Go map iteration order. When
+// either side predates items, items are dropped instead and the summary count
+// is restated over the folded map, which is the basis the older build used.
+//
+// The cost is that a mixed-vintage comparison sees only what the folded
+// encoding could express, which is the accuracy the older snapshot was
+// captured with. Once both sides carry items the comparison is exact.
+func alignTopologyEncoding(base, target *measurement.Measurement) (*measurement.Measurement, *measurement.Measurement) {
+	if base == nil || target == nil {
+		return base, target
+	}
+	if base.Type != measurement.TypeNodeTopology || target.Type != measurement.TypeNodeTopology {
+		return base, target
+	}
+
+	baseIdx := indexSubtypes(base.Subtypes)
+	targetIdx := indexSubtypes(target.Subtypes)
+
+	// Count keys whose value must be restated because the two sides counted on
+	// different bases: older builds sized the folded map, newer ones the items.
+	restate := map[string]string{}
+	drop := map[string]bool{}
+	for subtype, countKey := range map[string]string{
+		topologyLabelSubtype: topologyLabelCountKey,
+		topologyTaintSubtype: topologyTaintCountKey,
+	} {
+		b, t := baseIdx[subtype], targetIdx[subtype]
+		if b == nil || t == nil {
+			continue
+		}
+		baseHas, targetHas := len(b.Items) > 0, len(t.Items) > 0
+		switch {
+		case baseHas && targetHas:
+			drop[subtype] = true // items are richer and stable; ignore the map
+		case baseHas != targetHas:
+			restate[subtype] = countKey // one side predates items
+		}
+		// Neither carries items: one vintage, nothing to reconcile. Restating
+		// the count here would mask a corrupted one rather than report it.
+	}
+	if len(restate) == 0 && len(drop) == 0 {
+		return base, target
+	}
+
+	return alignMeasurement(base, restate, drop), alignMeasurement(target, restate, drop)
+}
+
+// alignMeasurement copies m with the topology subtypes reduced as directed.
+func alignMeasurement(m *measurement.Measurement, restate map[string]string, drop map[string]bool) *measurement.Measurement {
+	out := *m
+	out.Subtypes = make([]measurement.Subtype, len(m.Subtypes))
+	copy(out.Subtypes, m.Subtypes)
+
+	folded := map[string]int{}
+	for i := range out.Subtypes {
+		st := &out.Subtypes[i]
+		switch {
+		case drop[st.Name]:
+			st.Data = nil
+		case restate[st.Name] != "":
+			folded[restate[st.Name]] = len(st.Data)
+			st.Items = nil
+		}
+	}
+	if len(folded) == 0 {
+		return &out
+	}
+
+	for i := range out.Subtypes {
+		st := &out.Subtypes[i]
+		if st.Name != topologySummarySubtype || st.Data == nil {
+			continue
+		}
+		data := make(map[string]measurement.Reading, len(st.Data))
+		for k, v := range st.Data {
+			data[k] = v
+		}
+		for key, count := range folded {
+			if _, ok := data[key]; ok {
+				data[key] = measurement.Int(count)
+			}
+		}
+		st.Data = data
+	}
+	return &out
+}

--- a/pkg/diff/topology_test.go
+++ b/pkg/diff/topology_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/measurement"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
+)
+
+// topologySnap builds a NodeTopology measurement in one of the two encodings.
+// withItems mirrors what a current build writes — both halves, with the
+// summary count sized off the items. Without it the shape is what a build
+// predating the item encoding wrote: the folded map only, counted by its size.
+func topologySnap(labels map[string]string, items []measurement.ItemEntry, withItems bool) *snapshotter.Snapshot {
+	data := make(map[string]measurement.Reading, len(labels))
+	for k, v := range labels {
+		data[k] = measurement.Str(v)
+	}
+	labelSt := measurement.Subtype{Name: "label", Data: data}
+	count := len(data)
+	if withItems {
+		labelSt.Items = items
+		count = len(items)
+	}
+	return &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{{
+			Type: measurement.TypeNodeTopology,
+			Subtypes: []measurement.Subtype{
+				{Name: "summary", Data: map[string]measurement.Reading{
+					"node-count":  measurement.Int(2),
+					"label-count": measurement.Int(count),
+				}},
+				labelSt,
+			},
+		}},
+	}
+}
+
+func labelItem(key, value, nodes string) measurement.ItemEntry {
+	return measurement.ItemEntry{
+		Context: map[string]string{"key": key, "value": value},
+		Data:    map[string]measurement.Reading{"node-list": measurement.Str(nodes)},
+	}
+}
+
+// A cluster whose "zone" label carries two values, plus a distinct label named
+// zone.us-west. The folded encoding collides those onto one key and reports
+// two entries where there are three readings, so both halves differ between
+// the vintages — the count as well as the presence of items.
+func collidingCluster() (map[string]string, []measurement.ItemEntry) {
+	return map[string]string{
+			"zone.us-west": "true|gpu-a,gpu-b",
+			"zone.us-east": "us-east|gpu-b",
+		}, []measurement.ItemEntry{
+			labelItem("zone", "us-east", "gpu-b"),
+			labelItem("zone", "us-west", "gpu-a"),
+			labelItem("zone.us-west", "true", "gpu-a,gpu-b"),
+		}
+}
+
+// TestSnapshots_UpgradeIsNotDrift pins that capturing a baseline with an older
+// aicr and a target with a current one reports no change for an unchanged
+// cluster. Without this, every drift gate in CI fails the morning after an
+// upgrade: compareItems sees zero items against N and reports every field of
+// every item as added, and the summary counts disagree because the older build
+// sized them off the folded map.
+func TestSnapshots_UpgradeIsNotDrift(t *testing.T) {
+	labels, items := collidingCluster()
+
+	for _, tt := range []struct {
+		name            string
+		labels          map[string]string
+		items           []measurement.ItemEntry
+		baseHas, tgtHas bool
+	}{
+		{"upgrade", labels, items, false, true},
+		// A rollback is the same problem mirrored, and must be as quiet.
+		{"rollback", labels, items, true, false},
+		{"same old version", labels, items, false, false},
+		{"same new version", labels, items, true, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Snapshots(
+				topologySnap(tt.labels, tt.items, tt.baseHas),
+				topologySnap(tt.labels, tt.items, tt.tgtHas),
+			)
+			if result.HasDrift() {
+				t.Errorf("unchanged cluster reports drift across encodings: %v", paths(result))
+			}
+		})
+	}
+}
+
+// TestSnapshots_RealChangeSurvivesAlignment is the other half: suppressing the
+// encoding difference must not suppress the cluster difference. A gate that
+// never fires is worse than one that fires spuriously.
+func TestSnapshots_RealChangeSurvivesAlignment(t *testing.T) {
+	labels, items := collidingCluster()
+
+	changedLabels := map[string]string{}
+	for k, v := range labels {
+		changedLabels[k] = v
+	}
+	changedLabels["accelerator"] = "h100|gpu-a,gpu-b"
+	changedItems := append(append([]measurement.ItemEntry{}, items...),
+		labelItem("accelerator", "h100", "gpu-a,gpu-b"))
+
+	for _, tt := range []struct {
+		name            string
+		baseHas, tgtHas bool
+	}{
+		{"both current", true, true},
+		{"baseline predates items", false, true},
+		{"target predates items", true, false},
+		{"both predate items", false, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Snapshots(
+				topologySnap(labels, items, tt.baseHas),
+				topologySnap(changedLabels, changedItems, tt.tgtHas),
+			)
+			if !result.HasDrift() {
+				t.Error("a new label was not reported as drift")
+			}
+		})
+	}
+}
+
+// TestSnapshots_AlignmentDoesNotMutateInputs pins that diffing is read-only.
+// Callers reuse snapshots after comparing them — aicr diff renders the target
+// afterwards — so dropping a half for comparison must not drop it for them.
+func TestSnapshots_AlignmentDoesNotMutateInputs(t *testing.T) {
+	labels, items := collidingCluster()
+	base := topologySnap(labels, items, false)
+	target := topologySnap(labels, items, true)
+
+	_ = Snapshots(base, target)
+
+	tgtLabel := target.Measurements[0].Subtypes[1]
+	if len(tgtLabel.Items) != len(items) {
+		t.Errorf("target lost %d items to the comparison", len(items)-len(tgtLabel.Items))
+	}
+	if len(tgtLabel.Data) != len(labels) {
+		t.Errorf("target lost data entries to the comparison")
+	}
+	if got := target.Measurements[0].Subtypes[0].Data["label-count"]; got.String() != "3" {
+		t.Errorf("target label-count = %s, want 3 — the restated value leaked into the input", got.String())
+	}
+}
+
+// TestSnapshots_AlignmentIgnoresOtherMeasurements pins that the rule is scoped
+// to NodeTopology. Other measurement types also carry items, and a one-sided
+// item list there is a real difference rather than an encoding artifact.
+func TestSnapshots_AlignmentIgnoresOtherMeasurements(t *testing.T) {
+	withItems := &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{{
+			Type: measurement.Type("Network"),
+			Subtypes: []measurement.Subtype{{
+				Name:  "PF",
+				Items: []measurement.ItemEntry{labelItem("name", "pf0", "")},
+			}},
+		}},
+	}
+	without := &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{{
+			Type:     measurement.Type("Network"),
+			Subtypes: []measurement.Subtype{{Name: "PF"}},
+		}},
+	}
+	if !Snapshots(without, withItems).HasDrift() {
+		t.Error("a one-sided item list outside NodeTopology must still report drift")
+	}
+}
+
+// TestSnapshots_LegacyPairCountIsNotRestated pins that two snapshots of one
+// vintage are compared as written. There is no encoding mismatch to reconcile,
+// so a summary count that disagrees with the map is a real difference and must
+// be reported rather than normalized away.
+func TestSnapshots_LegacyPairCountIsNotRestated(t *testing.T) {
+	labels, items := collidingCluster()
+	base := topologySnap(labels, items, false)
+	target := topologySnap(labels, items, false)
+	target.Measurements[0].Subtypes[0].Data["label-count"] = measurement.Int(99)
+
+	result := Snapshots(base, target)
+	if !result.HasDrift() {
+		t.Error("a corrupted label-count between two legacy snapshots was not reported")
+	}
+}
+
+// TestSnapshots_ItemsAuthoritativeOverData pins the other half of the rule:
+// when both sides carry items, the folded map is not compared at all. It is
+// not merely redundant — encodeLabels resolves a key collision by Go map
+// iteration order, so two runs of one build against an unchanged cluster can
+// write different maps. Comparing it would report drift that no cluster
+// change caused.
+func TestSnapshots_ItemsAuthoritativeOverData(t *testing.T) {
+	_, items := collidingCluster()
+
+	withData := func(data map[string]string) *snapshotter.Snapshot {
+		readings := make(map[string]measurement.Reading, len(data))
+		for k, v := range data {
+			readings[k] = measurement.Str(v)
+		}
+		return &snapshotter.Snapshot{
+			Measurements: []*measurement.Measurement{{
+				Type: measurement.TypeNodeTopology,
+				Subtypes: []measurement.Subtype{
+					{Name: "summary", Data: map[string]measurement.Reading{
+						"label-count": measurement.Int(len(items)),
+					}},
+					{Name: "label", Data: readings, Items: items},
+				},
+			}},
+		}
+	}
+
+	// Same three readings both times; only which one won the folded key differs.
+	base := withData(map[string]string{
+		"zone.us-west": "true|gpu-a,gpu-b",
+		"zone.us-east": "us-east|gpu-b",
+	})
+	target := withData(map[string]string{
+		"zone.us-west": "us-west|gpu-a",
+		"zone.us-east": "us-east|gpu-b",
+	})
+
+	if result := Snapshots(base, target); result.HasDrift() {
+		t.Errorf("collision flapping in the folded map was reported as drift: %v", paths(result))
+	}
+
+	// The converse: a genuine item difference must still surface.
+	changed := withData(map[string]string{
+		"zone.us-west": "true|gpu-a,gpu-b",
+		"zone.us-east": "us-east|gpu-b",
+	})
+	changed.Measurements[0].Subtypes[1].Items = append(
+		append([]measurement.ItemEntry{}, items...),
+		labelItem("accelerator", "h100", "gpu-a"))
+	if !Snapshots(base, changed).HasDrift() {
+		t.Error("an added item was not reported as drift")
+	}
+}

--- a/pkg/diff/topology_test.go
+++ b/pkg/diff/topology_test.go
@@ -15,6 +15,7 @@
 package diff
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/measurement"
@@ -51,9 +52,32 @@ func topologySnap(labels map[string]string, items []measurement.ItemEntry, withI
 }
 
 func labelItem(key, value, nodes string) measurement.ItemEntry {
+	names := 0
+	if nodes != "" {
+		names = len(strings.Split(nodes, ","))
+	}
 	return measurement.ItemEntry{
 		Context: map[string]string{"key": key, "value": value},
-		Data:    map[string]measurement.Reading{"node-list": measurement.Str(nodes)},
+		Data: map[string]measurement.Reading{
+			"node-count": measurement.Int(names),
+			"node-list":  measurement.Str(nodes),
+			"truncated":  measurement.Bool(false),
+		},
+	}
+}
+
+// refLabelItem builds a label item that references its node list from the data
+// map rather than carrying it inline. dataKey must be the folded key that
+// encodeLabels would produce for this reading, and must not be shared with any
+// other reading (folds == 1), or the decoder will reject the reference.
+func refLabelItem(key, value, dataKey string, count int) measurement.ItemEntry {
+	return measurement.ItemEntry{
+		Context: map[string]string{"key": key, "value": value},
+		Data: map[string]measurement.Reading{
+			"node-count":    measurement.Int(count),
+			"node-list-ref": measurement.Str(dataKey),
+			"truncated":     measurement.Bool(false),
+		},
 	}
 }
 
@@ -253,5 +277,99 @@ func TestSnapshots_ItemsAuthoritativeOverData(t *testing.T) {
 		labelItem("accelerator", "h100", "gpu-a"))
 	if !Snapshots(base, changed).HasDrift() {
 		t.Error("an added item was not reported as drift")
+	}
+}
+
+// TestSnapshots_MixedVintageCollisionWinnerIsNotDrift pins that an upgrade or
+// rollback of an unchanged collision cluster is silent even when the two
+// snapshots captured different collision winners for the same key.
+func TestSnapshots_MixedVintageCollisionWinnerIsNotDrift(t *testing.T) {
+	labels, items := collidingCluster()
+
+	// Same cluster; the other reading won the contested zone.us-west key.
+	otherWinner := make(map[string]string, len(labels))
+	for k, v := range labels {
+		otherWinner[k] = v
+	}
+	otherWinner["zone.us-west"] = "us-west|gpu-a"
+
+	for _, tt := range []struct {
+		name            string
+		baseHas, tgtHas bool
+	}{
+		{"upgrade", false, true},
+		{"rollback", true, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Snapshots(
+				topologySnap(otherWinner, items, tt.baseHas),
+				topologySnap(labels, items, tt.tgtHas),
+			)
+			if result.HasDrift() {
+				t.Errorf("collision winner differing across vintages reported as drift: %v", paths(result))
+			}
+		})
+	}
+}
+
+// TestSnapshots_HydratedItemsCompareMembership pins that node membership is
+// still compared when both sides carry items. Referenced lists must be
+// resolved first: comparing raw items would compare a reference string, so a
+// node moving between labels would go unreported.
+func TestSnapshots_HydratedItemsCompareMembership(t *testing.T) {
+	labels, items := collidingCluster()
+
+	moved := make([]measurement.ItemEntry, len(items))
+	copy(moved, items)
+	for i := range moved {
+		if moved[i].Context["value"] == "us-east" {
+			moved[i] = labelItem("zone", "us-east", "gpu-c")
+		}
+	}
+
+	result := Snapshots(topologySnap(labels, items, true), topologySnap(labels, moved, true))
+	if !result.HasDrift() {
+		t.Error("a node moving between readings was not reported as drift")
+	}
+}
+
+// TestSnapshots_HydrationResolvesReferences pins that node-list-ref items are
+// resolved before comparison so that node membership changes are detected.
+func TestSnapshots_HydrationResolvesReferences(t *testing.T) {
+	// Single-value key: fold key == key, folds["accelerator"]==1, so the
+	// encoder emits node-list-ref rather than node-list.
+	dataKey := "accelerator"
+	data := map[string]string{dataKey: "h100|gpu-a,gpu-b"}
+
+	refItem := refLabelItem("accelerator", "h100", dataKey, 2)
+	unchanged := []measurement.ItemEntry{refItem}
+
+	changedData := map[string]string{dataKey: "h100|gpu-a"}
+	changedItem := refLabelItem("accelerator", "h100", dataKey, 1)
+	changed := []measurement.ItemEntry{changedItem}
+
+	buildSnap := func(d map[string]string, its []measurement.ItemEntry) *snapshotter.Snapshot {
+		readings := make(map[string]measurement.Reading, len(d))
+		for k, v := range d {
+			readings[k] = measurement.Str(v)
+		}
+		return &snapshotter.Snapshot{
+			Measurements: []*measurement.Measurement{{
+				Type: measurement.TypeNodeTopology,
+				Subtypes: []measurement.Subtype{
+					{Name: "summary", Data: map[string]measurement.Reading{
+						"label-count": measurement.Int(len(its)),
+					}},
+					{Name: "label", Data: readings, Items: its},
+				},
+			}},
+		}
+	}
+
+	if result := Snapshots(buildSnap(data, unchanged), buildSnap(data, unchanged)); result.HasDrift() {
+		t.Errorf("identical reference items reported as drift: %v", paths(result))
+	}
+	if result := Snapshots(buildSnap(data, unchanged), buildSnap(changedData, changed)); !result.HasDrift() {
+		t.Error("a node leaving a reference item was not reported as drift")
 	}
 }

--- a/pkg/evidence/redact/redact_test.go
+++ b/pkg/evidence/redact/redact_test.go
@@ -566,3 +566,56 @@ func sortedUnique(s []string) bool {
 	}
 	return true
 }
+
+// TestSnapshotDropsItemsFromAllowlistedSubtype pins the second redaction layer.
+//
+// The allowlist drops label/taint by name, so Items on those never reach
+// copySubtype. This covers the other case: an *allowlisted* subtype that
+// carries Items. copySubtype rebuilds the subtype from the allowlisted Data
+// keys alone and never assigns Items, so node names or other identifiers
+// attached as items cannot cross the publication boundary.
+//
+// Without this, a future "carry Items through" change would be a one-line
+// fail-open with a fully green suite.
+func TestSnapshotDropsItemsFromAllowlistedSubtype(t *testing.T) {
+	snap := &snapshotter.Snapshot{
+		Measurements: []*measurement.Measurement{
+			measurement.NewMeasurement(measurement.TypeNodeTopology).
+				WithSubtype(measurement.Subtype{
+					Name: "summary",
+					Data: map[string]measurement.Reading{
+						"node-count":  measurement.Int(3),
+						"label-count": measurement.Int(9),
+					},
+					// Identifiers deliberately attached to an allowlisted subtype.
+					Items: []measurement.ItemEntry{{
+						Context: map[string]string{"key": "kubernetes.io/hostname", "value": "gpu-node-01"},
+						Data:    map[string]measurement.Reading{"node-list": measurement.Str("gpu-node-01,gpu-node-02")},
+					}},
+				}).
+				Build(),
+		},
+	}
+
+	got, _ := redact.Snapshot(snap)
+
+	for _, m := range got.Measurements {
+		for i := range m.Subtypes {
+			st := &m.Subtypes[i]
+			if len(st.Items) != 0 {
+				t.Errorf("subtype %q retained %d items after redaction; Items must never cross "+
+					"the publication boundary", st.Name, len(st.Items))
+			}
+		}
+	}
+
+	// The allowlisted Data keys must still survive — this is a drop of Items,
+	// not of the subtype.
+	st := got.Measurements[0].GetSubtype("summary")
+	if st == nil {
+		t.Fatal("allowlisted summary subtype was dropped entirely")
+	}
+	if _, err := st.GetInt64("node-count"); err != nil {
+		t.Errorf("allowlisted key node-count did not survive redaction: %v", err)
+	}
+}

--- a/pkg/evidence/redact/redact_test.go
+++ b/pkg/evidence/redact/redact_test.go
@@ -590,7 +590,11 @@ func TestSnapshotDropsItemsFromAllowlistedSubtype(t *testing.T) {
 					// Identifiers deliberately attached to an allowlisted subtype.
 					Items: []measurement.ItemEntry{{
 						Context: map[string]string{"key": "kubernetes.io/hostname", "value": "gpu-node-01"},
-						Data:    map[string]measurement.Reading{"node-list": measurement.Str("gpu-node-01,gpu-node-02")},
+						Data: map[string]measurement.Reading{
+							"node-count": measurement.Int(2),
+							"node-list":  measurement.Str("gpu-node-01,gpu-node-02"),
+							"truncated":  measurement.Bool(false),
+						},
 					}},
 				}).
 				Build(),

--- a/pkg/fingerprint/from_measurements.go
+++ b/pkg/fingerprint/from_measurements.go
@@ -15,17 +15,19 @@
 package fingerprint
 
 import (
+	"log/slog"
 	"slices"
+	"sort"
 	"strings"
 
+	"github.com/NVIDIA/aicr/pkg/collector/topology"
 	"github.com/NVIDIA/aicr/pkg/measurement"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/recipe/oskind"
 )
 
-// Subtype names referenced from collector outputs. Kept as local
-// constants because the collector packages keep them unexported and we
-// don't want to import them just for the names.
+// Subtype names referenced from collector outputs, kept as local constants
+// because the collector packages keep them unexported.
 const (
 	serviceOKE              = "oke"
 	serviceLKE              = "lke"
@@ -162,6 +164,11 @@ func reconcileAccelerator(fp *Fingerprint, topo *measurement.Measurement) {
 		return
 	}
 
+	if topology.HasLosslessReadings(st) {
+		reconcileAcceleratorFromItems(fp, st)
+		return
+	}
+
 	if hasMultiValueKeys(st, labelKeyGPUProduct) {
 		fp.Accelerator = Dimension{Source: sourceTopologyGPU, Note: noteMultiGPU}
 		return
@@ -183,6 +190,54 @@ func reconcileAccelerator(fp *Fingerprint, topo *measurement.Measurement) {
 	if fp.Accelerator.Note == "" {
 		fp.Accelerator = Dimension{Source: sourceTopologyGPU, Note: noteUnknownSKU}
 	}
+}
+
+// reconcileAcceleratorFromItems is the lossless-encoding path. It matches the
+// label key exactly, so a distinct label whose name merely shares the
+// nvidia.com/gpu.product prefix can no longer be counted as a second value and
+// clear the accelerator with a spurious multi-gpu note.
+func reconcileAcceleratorFromItems(fp *Fingerprint, st *measurement.Subtype) {
+	values := distinctLabelValues(st, labelKeyGPUProduct)
+	if len(values) > 1 {
+		fp.Accelerator = Dimension{Source: sourceTopologyGPU, Note: noteMultiGPU}
+		return
+	}
+	if fp.Accelerator.Value != "" || len(values) == 0 {
+		return
+	}
+	if sku := ParseGPUSKU(values[0]); sku != "" {
+		fp.Accelerator = Dimension{Value: sku, Source: sourceTopologyGPU}
+		return
+	}
+	if fp.Accelerator.Note == "" {
+		fp.Accelerator = Dimension{Source: sourceTopologyGPU, Note: noteUnknownSKU}
+	}
+}
+
+// distinctLabelValues returns the sorted distinct values of one label key.
+// Decode failures degrade to no values: the fingerprint is advisory and must
+// never fail a caller that has no way to handle an error.
+func distinctLabelValues(st *measurement.Subtype, key string) []string {
+	readings, err := topology.LabelReadings(st)
+	if err != nil {
+		slog.Debug("topology label readings could not be decoded; fingerprint dimension left empty",
+			slog.String("label", key), slog.String("error", err.Error()))
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var values []string
+	for _, r := range readings {
+		if r.Key != key {
+			continue
+		}
+		if _, dup := seen[r.Value]; dup {
+			continue
+		}
+		seen[r.Value] = struct{}{}
+		values = append(values, r.Value)
+	}
+	sort.Strings(values)
+	return values
 }
 
 // parseLabelEncoding splits the topology collector's label value
@@ -279,6 +334,9 @@ func populateFromTopology(fp *Fingerprint, m *measurement.Measurement) {
 // label value is encoded as "<value>|<node1,node2,...>" so the node
 // list is parsed out and unioned across all matching keys.
 func countGPUNodes(st *measurement.Subtype) int {
+	if topology.HasLosslessReadings(st) {
+		return countGPUNodesFromItems(st)
+	}
 	nodes := make(map[string]struct{})
 	prefix := labelKeyGPUProduct + "."
 	for k, v := range st.Data {
@@ -299,6 +357,27 @@ func countGPUNodes(st *measurement.Subtype) int {
 	return len(nodes)
 }
 
+// countGPUNodesFromItems sums the per-reading node counts. A node carries one
+// value of a given label, so the values partition the nodes and the sum is the
+// true total — including nodes withheld from the rendered list by
+// --max-nodes-per-entry, which the Data path cannot see and therefore
+// under-reports as the cap.
+func countGPUNodesFromItems(st *measurement.Subtype) int {
+	readings, err := topology.LabelReadings(st)
+	if err != nil {
+		slog.Debug("topology label readings could not be decoded; GPU node count left at zero",
+			slog.String("error", err.Error()))
+		return 0
+	}
+	total := 0
+	for _, r := range readings {
+		if r.Key == labelKeyGPUProduct {
+			total += r.NodeCount
+		}
+	}
+	return total
+}
+
 // extractRegion reads the topology.kubernetes.io/region label value
 // from the topology measurement's "label" subtype. The topology
 // collector encodes single-valued labels under the plain key with
@@ -310,6 +389,17 @@ func extractRegion(m *measurement.Measurement) (region string, multi bool) {
 	st := m.GetSubtype(subtypeTopologyLabel)
 	if st == nil {
 		return "", false
+	}
+	if topology.HasLosslessReadings(st) {
+		values := distinctLabelValues(st, labelKeyRegion)
+		switch len(values) {
+		case 0:
+			return "", false
+		case 1:
+			return values[0], false
+		default:
+			return "", true
+		}
 	}
 	if hasMultiValueKeys(st, labelKeyRegion) {
 		return "", true

--- a/pkg/fingerprint/from_measurements_test.go
+++ b/pkg/fingerprint/from_measurements_test.go
@@ -491,11 +491,17 @@ func topologyItemsMeasurement(nodeCount int, readings map[string][]string, count
 			for i := 0; i < n && i < 3; i++ {
 				names = append(names, fmt.Sprintf("node-%d", i))
 			}
+			// Render the list the way formatNodeList does — marker included —
+			// so the fixture stays consistent with the truncated flag.
+			list := strings.Join(names, ",")
+			if n > len(names) {
+				list += fmt.Sprintf(" (+%d more)", n-len(names))
+			}
 			items = append(items, measurement.ItemEntry{
 				Context: map[string]string{"key": key, "value": v},
 				Data: map[string]measurement.Reading{
 					"node-count": measurement.Int(n),
-					"node-list":  measurement.Str(strings.Join(names, ",")),
+					"node-list":  measurement.Str(list),
 					"truncated":  measurement.Bool(n > len(names)),
 				},
 			})

--- a/pkg/fingerprint/from_measurements_test.go
+++ b/pkg/fingerprint/from_measurements_test.go
@@ -640,3 +640,51 @@ func TestFromMeasurements_ItemsRegion(t *testing.T) {
 		})
 	}
 }
+
+// malformedItemSubtype returns a label subtype whose single item omits a
+// required field, so the shared accessor rejects the whole subtype.
+func malformedItemSubtype() *measurement.Subtype {
+	return &measurement.Subtype{
+		Name: "label",
+		Items: []measurement.ItemEntry{{
+			Context: map[string]string{"key": labelKeyGPUProduct, "value": "NVIDIA-H100-80GB-HBM3"},
+			Data:    map[string]measurement.Reading{"node-list": measurement.Str("gpu-a")},
+		}},
+	}
+}
+
+// TestItemReadersDegradeOnDecodeError pins that a rejected subtype yields an
+// empty dimension rather than a partial one. Both readers deliberately swallow
+// the error — the fingerprint is advisory — so nothing else would notice if
+// they started returning half-decoded data instead.
+func TestItemReadersDegradeOnDecodeError(t *testing.T) {
+	st := malformedItemSubtype()
+
+	if got := distinctLabelValues(st, labelKeyGPUProduct); got != nil {
+		t.Errorf("distinctLabelValues() = %v, want nil on a rejected subtype", got)
+	}
+	if got := countGPUNodesFromItems(st); got != 0 {
+		t.Errorf("countGPUNodesFromItems() = %d, want 0 on a rejected subtype", got)
+	}
+}
+
+// TestDistinctLabelValuesDedupes pins that two readings sharing a key and a
+// value collapse to one. The collector cannot emit that pair, but a hand-built
+// snapshot can, and counting it twice would read as a heterogeneous cluster.
+func TestDistinctLabelValuesDedupes(t *testing.T) {
+	item := func(nodes string) measurement.ItemEntry {
+		return measurement.ItemEntry{
+			Context: map[string]string{"key": labelKeyGPUProduct, "value": "NVIDIA-H100-80GB-HBM3"},
+			Data: map[string]measurement.Reading{
+				"node-count": measurement.Int(1),
+				"node-list":  measurement.Str(nodes),
+				"truncated":  measurement.Bool(false),
+			},
+		}
+	}
+	st := &measurement.Subtype{Name: "label", Items: []measurement.ItemEntry{item("gpu-a"), item("gpu-b")}}
+
+	if got := distinctLabelValues(st, labelKeyGPUProduct); len(got) != 1 {
+		t.Errorf("distinctLabelValues() = %v, want one distinct value", got)
+	}
+}

--- a/pkg/fingerprint/from_measurements_test.go
+++ b/pkg/fingerprint/from_measurements_test.go
@@ -15,6 +15,8 @@
 package fingerprint
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/measurement"
@@ -470,5 +472,165 @@ func TestFromMeasurements_LabelRecognizedWithUnknownPCI(t *testing.T) {
 	}
 	if got.GPUModel.Value != "a10" {
 		t.Errorf("GPUModel.Value = %q, want a10 (PCI discovery)", got.GPUModel.Value)
+	}
+}
+
+// topologyItemsMeasurement builds a TypeNodeTopology measurement carrying the
+// collector's lossless label encoding. readings maps a label key to the values
+// it carries; each value's node count is taken from counts (default 1), so a
+// truncated reading can be expressed without a node list.
+func topologyItemsMeasurement(nodeCount int, readings map[string][]string, counts map[string]int) *measurement.Measurement {
+	var items []measurement.ItemEntry
+	for key, values := range readings {
+		for _, v := range values {
+			n := 1
+			if c, ok := counts[key+"="+v]; ok {
+				n = c
+			}
+			names := make([]string, 0, n)
+			for i := 0; i < n && i < 3; i++ {
+				names = append(names, fmt.Sprintf("node-%d", i))
+			}
+			items = append(items, measurement.ItemEntry{
+				Context: map[string]string{"key": key, "value": v},
+				Data: map[string]measurement.Reading{
+					"node-count": measurement.Int(n),
+					"node-list":  measurement.Str(strings.Join(names, ",")),
+					"truncated":  measurement.Bool(n > len(names)),
+				},
+			})
+		}
+	}
+	return measurement.NewMeasurement(measurement.TypeNodeTopology).
+		WithSubtypeBuilder(
+			measurement.NewSubtypeBuilder("summary").
+				Set("node-count", measurement.Int(nodeCount)),
+		).
+		WithSubtype(measurement.Subtype{Name: "label", Items: items}).
+		Build()
+}
+
+// TestFromMeasurements_ItemsAccelerator pins the item path for the accelerator
+// dimension, including the false positive the folded encoding cannot avoid:
+// two distinct labels sharing the nvidia.com/gpu.product prefix are counted as
+// two values by hasMultiValueKeys, clearing the accelerator with a spurious
+// multi-gpu note. Accelerator drives overlay selection, so that matters more
+// than any count.
+func TestFromMeasurements_ItemsAccelerator(t *testing.T) {
+	tests := []struct {
+		name      string
+		readings  map[string][]string
+		wantValue string
+		wantNote  string
+	}{
+		{
+			name:      "single recognized SKU",
+			readings:  map[string][]string{labelKeyGPUProduct: {"NVIDIA-H100-80GB-HBM3"}},
+			wantValue: "h100",
+		},
+		{
+			name:     "two SKUs is genuinely multi-gpu",
+			readings: map[string][]string{labelKeyGPUProduct: {"NVIDIA-H100-80GB-HBM3", "NVIDIA-B200"}},
+			wantNote: noteMultiGPU,
+		},
+		{
+			name:     "unrecognized SKU",
+			readings: map[string][]string{labelKeyGPUProduct: {"NVIDIA-SOMETHING-NEW"}},
+			wantNote: noteUnknownSKU,
+		},
+		{
+			// Prefix siblings, not values of gpu.product.
+			name: "distinct labels sharing the prefix are not extra values",
+			readings: map[string][]string{
+				labelKeyGPUProduct:             {"NVIDIA-H100-80GB-HBM3"},
+				labelKeyGPUProduct + ".tier":   {"premium"},
+				labelKeyGPUProduct + ".vendor": {"nvidia"},
+			},
+			wantValue: "h100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromMeasurements([]*measurement.Measurement{
+				topologyItemsMeasurement(2, tt.readings, nil),
+			})
+			if got.Accelerator.Value != tt.wantValue {
+				t.Errorf("Accelerator.Value = %q, want %q", got.Accelerator.Value, tt.wantValue)
+			}
+			if got.Accelerator.Note != tt.wantNote {
+				t.Errorf("Accelerator.Note = %q, want %q", got.Accelerator.Note, tt.wantNote)
+			}
+			if got.Accelerator.Source != sourceTopologyGPU {
+				t.Errorf("Accelerator.Source = %q, want %q — source strings are pinned",
+					got.Accelerator.Source, sourceTopologyGPU)
+			}
+		})
+	}
+}
+
+// TestFromMeasurements_ItemsGPUNodeCountUnderTruncation pins the correction:
+// the folded encoding derives the count by splitting the rendered node list on
+// commas, so under --max-nodes-per-entry it reports the cap. node-count is the
+// true pre-truncation total.
+func TestFromMeasurements_ItemsGPUNodeCountUnderTruncation(t *testing.T) {
+	m := topologyItemsMeasurement(40,
+		map[string][]string{labelKeyGPUProduct: {"NVIDIA-H100-80GB-HBM3"}},
+		map[string]int{labelKeyGPUProduct + "=NVIDIA-H100-80GB-HBM3": 40},
+	)
+
+	got := FromMeasurements([]*measurement.Measurement{m})
+	if got.GPUNodeCount.Value != 40 {
+		t.Errorf("GPUNodeCount = %d, want 40 (the true total, not the rendered list length)",
+			got.GPUNodeCount.Value)
+	}
+	if got.GPUNodeCount.Source != sourceTopologyGPU {
+		t.Errorf("GPUNodeCount.Source = %q, want %q", got.GPUNodeCount.Source, sourceTopologyGPU)
+	}
+}
+
+// TestFromMeasurements_ItemsRegion pins the item path for region detection,
+// including the prefix-sibling false positive that today yields multi-region
+// on a single-region cluster.
+func TestFromMeasurements_ItemsRegion(t *testing.T) {
+	tests := []struct {
+		name       string
+		readings   map[string][]string
+		wantRegion string
+		wantNote   string
+	}{
+		{
+			name:       "single region",
+			readings:   map[string][]string{labelKeyRegion: {"us-west-2"}},
+			wantRegion: "us-west-2",
+		},
+		{
+			name:     "two regions",
+			readings: map[string][]string{labelKeyRegion: {"us-west-2", "us-east-1"}},
+			wantNote: noteMultiRegion,
+		},
+		{
+			name: "distinct labels sharing the prefix are not extra regions",
+			readings: map[string][]string{
+				labelKeyRegion:             {"us-west-2"},
+				labelKeyRegion + ".legacy": {"true"},
+				labelKeyRegion + ".zone":   {"a"},
+			},
+			wantRegion: "us-west-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromMeasurements([]*measurement.Measurement{
+				topologyItemsMeasurement(2, tt.readings, nil),
+			})
+			if got.Region.Value != tt.wantRegion {
+				t.Errorf("Region.Value = %q, want %q", got.Region.Value, tt.wantRegion)
+			}
+			if got.Region.Note != tt.wantNote {
+				t.Errorf("Region.Note = %q, want %q", got.Region.Note, tt.wantNote)
+			}
+		})
 	}
 }

--- a/pkg/snapshotter/snapshot.go
+++ b/pkg/snapshotter/snapshot.go
@@ -293,7 +293,7 @@ func (n *NodeSnapshotter) measure(ctx context.Context) error {
 // deliver integers as float64).
 func hasGPUData(snap *Snapshot) bool {
 	for _, m := range snap.Measurements {
-		if m.Type != measurement.TypeGPU {
+		if m == nil || m.Type != measurement.TypeGPU {
 			continue
 		}
 		for i := range m.Subtypes {
@@ -324,7 +324,7 @@ func verifyGPUCollected(snap *Snapshot) error {
 // "nvidia.com/gpu", which satisfies the prefix with no NFD label present.
 func hasGPUNodesInTopology(snap *Snapshot) bool {
 	for _, m := range snap.Measurements {
-		if m.Type != measurement.TypeNodeTopology {
+		if m == nil || m.Type != measurement.TypeNodeTopology {
 			continue
 		}
 		readings, err := topology.LabelReadings(m.GetSubtype("label"))

--- a/pkg/snapshotter/snapshot.go
+++ b/pkg/snapshotter/snapshot.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/collector"
 	"github.com/NVIDIA/aicr/pkg/collector/k8s"
+	"github.com/NVIDIA/aicr/pkg/collector/topology"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/fingerprint"
 	"github.com/NVIDIA/aicr/pkg/header"
@@ -317,17 +318,25 @@ func verifyGPUCollected(snap *Snapshot) error {
 
 // hasGPUNodesInTopology returns true when any topology label key starts with
 // gpuNodeLabelPrefix (covers both gpu.present and gpu.product NFD labels).
+//
+// The test is against the label's true key: the folded encoding synthesizes
+// "nvidia.com/gpu.true" from a multi-valued label named exactly
+// "nvidia.com/gpu", which satisfies the prefix with no NFD label present.
 func hasGPUNodesInTopology(snap *Snapshot) bool {
 	for _, m := range snap.Measurements {
 		if m.Type != measurement.TypeNodeTopology {
 			continue
 		}
-		labels := m.GetSubtype("label")
-		if labels == nil {
+		readings, err := topology.LabelReadings(m.GetSubtype("label"))
+		if err != nil {
+			// Advisory hint only — degrade quietly rather than fail an
+			// otherwise complete snapshot.
+			slog.Debug("skipping GPU placement detection: topology label readings could not be decoded",
+				slog.String("error", err.Error()))
 			continue
 		}
-		for key := range labels.Data {
-			if strings.HasPrefix(key, gpuNodeLabelPrefix) {
+		for _, r := range readings {
+			if strings.HasPrefix(r.Key, gpuNodeLabelPrefix) {
 				return true
 			}
 		}

--- a/pkg/snapshotter/snapshot_test.go
+++ b/pkg/snapshotter/snapshot_test.go
@@ -619,3 +619,71 @@ func TestParseOSEnv(t *testing.T) {
 		})
 	}
 }
+
+// TestDetectGPUPlacementMismatchLosslessEncoding pins the item-encoding path,
+// where the prefix test runs against the label's true key.
+//
+// The last case is the false positive the folded encoding cannot avoid: a
+// label named exactly "nvidia.com/gpu" carrying two values synthesizes the map
+// key "nvidia.com/gpu.true", which satisfies the "nvidia.com/gpu." prefix even
+// though no NFD label is present — so the placement warning fires on a cluster
+// that has no GPU nodes.
+func TestDetectGPUPlacementMismatchLosslessEncoding(t *testing.T) {
+	itemsSnapshot := func(readings map[string][]string) *Snapshot {
+		var items []measurement.ItemEntry
+		for key, values := range readings {
+			for i, v := range values {
+				items = append(items, measurement.ItemEntry{
+					Context: map[string]string{"key": key, "value": v},
+					Data: map[string]measurement.Reading{
+						"node-count": measurement.Int(1),
+						"node-list":  measurement.Str(fmt.Sprintf("node%d", i)),
+						"truncated":  measurement.Bool(false),
+					},
+				})
+			}
+		}
+		return &Snapshot{Measurements: []*measurement.Measurement{
+			{Type: measurement.TypeNodeTopology, Subtypes: []measurement.Subtype{{
+				Name: "label", Items: items,
+			}}},
+		}}
+	}
+
+	tests := []struct {
+		name     string
+		readings map[string][]string
+		want     bool
+	}{
+		{
+			name:     "gpu.present label detected",
+			readings: map[string][]string{"nvidia.com/gpu.present": {"true"}},
+			want:     true,
+		},
+		{
+			name:     "gpu.product label detected",
+			readings: map[string][]string{"nvidia.com/gpu.product": {"NVIDIA-H100-80GB-HBM3"}},
+			want:     true,
+		},
+		{
+			name:     "unrelated labels only",
+			readings: map[string][]string{"kubernetes.io/arch": {"amd64"}},
+			want:     false,
+		},
+		{
+			// Folded encoding would synthesize "nvidia.com/gpu.true" here and
+			// match the prefix; the true key does not.
+			name:     "multi-valued label named exactly nvidia.com/gpu does not match",
+			readings: map[string][]string{"nvidia.com/gpu": {"true", "false"}},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectGPUPlacementMismatch(itemsSnapshot(tt.readings)); got != tt.want {
+				t.Errorf("detectGPUPlacementMismatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The topology collector encodes a label's key and value into a single snapshot key, so two different readings can produce the same key and one is silently dropped. Adds an `items` encoding that keeps each reading's fields separate; the existing `data` map is unchanged.

## Motivation / Context

`encodeLabels` renders a multi-valued label as `<key>.<value>`, which collides with a label literally named that. `encodeTaints` has a second defect: it counts entries per key but disambiguates with effect, so two taints sharing both collapse into one entry. 

`items` carries key, value, effect and node membership as separate fields. Nothing is manufactured, so nothing can collide.

Fixes: #2003
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/constraints`, `pkg/fingerprint`, `pkg/client/v1`, `pkg/evidence/redact`

## Implementation Notes

**Additive, not a migration.** `data` is byte-identical to before — verified by capturing the same cluster with the released binary and this build and diffing both subtypes. Consumers that are not migrated cannot regress.

**No `apiVersion` bump.** Adding an optional field beside an existing one is additive-only under [ADR-011](docs/design/011-artifact-apiversion-policy.md)  matching how `da21e227` introduced `Subtype.Items`.

**One decode path.** `topology.LabelReadings` / `TaintReadings` prefer `items` and fall back to `data`, so the branch exists once rather than in each consumer. `pkg/constraints`, `pkg/fingerprint`, `pkg/snapshotter`, `pkg/client/v1` and the
shipped template all read through it. Every legacy path is untouched and still exercised by tests, so pre-existing snapshots evaluate exactly as they did.


## Testing


```bash
make qualify        # exit 0, all six stages
```

Also verified against a live 3-node Kind cluster: `data` output byte-identical between the released binary and this build, `items` present and correct, and `--max-nodes-per-entry` still capping the rendered list.

New coverage includes collision determinism (50 and 200 iterations, since the failure being guarded is a race on map ordering), legacy `data`-only compatibility, and the first rendering test for the shipped snapshot template.

## Risk Assessment


- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — 
