### PR TITLE
fix(sdk): context-aware selector, route snapshot Jobs through facade

### DIFF
--- a/docs/contributor/cli.md
+++ b/docs/contributor/cli.md
@@ -140,7 +140,7 @@ packages (`pkg/recipe`, `pkg/bundler`, `pkg/snapshotter`,
 | `ResolveRecipeFromSnapshot(ctx, *Criteria, *Snapshot)` | `validate`, `recipe --snapshot` |
 | `LoadRecipe(ctx, path, kubeconfig)` | `bundle`, `validate`, `diff` (read a previously emitted recipe file) |
 | `BundleComponents(ctx, *RecipeResult)` | `bundle` |
-| `CollectSnapshot(ctx, *AgentConfig)` | `snapshot` |
+| `CollectSnapshot(ctx, *AgentConfig)` | `snapshot`, `validate` (Job-mode capture only; local `AICR_AGENT_MODE` collection deploys no Job and stays on `snapshotter.NodeSnapshotter`) |
 | `ValidateState(ctx, ...)` | `validate` |
 
 Construction in CLI happens via `recipeClientFromCmd(cmd, cfg)` in

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -97,9 +97,20 @@ telemetry hooks.
 ```go
 // CollectSnapshot deploys a snapshotter Job to the target cluster and
 // returns the resulting Snapshot. cfg is a facade-owned struct that
-// mirrors most fields of the underlying pkg/snapshotter.AgentConfig
-// (the in-pod network-discovery fields ClusterConfigPath and
-// DiscoverNetwork are not surfaced on the facade).
+// mirrors pkg/snapshotter.AgentConfig field for field; the mirror is
+// enforced by a test, so a field added upstream cannot silently stay at
+// its zero value here.
+//
+// The returned Snapshot carries the parsed form plus Snapshot.Raw — the
+// exact bytes the agent emitted. Persist Raw rather than re-serializing
+// the parsed snapshot: a newer agent image can emit fields this module
+// version does not model, and a typed round trip drops them silently.
+//
+// CollectSnapshot itself writes the snapshot nowhere unless AgentConfig.Output
+// names a ConfigMap (cm://namespace/name), in which case the agent Job stages
+// it there directly. To persist it anywhere else, hand Raw to
+// snapshotter.DeliverSnapshot — a file, stdout, a ConfigMap, or a Go template
+// render — which is what `aicr snapshot` does.
 //
 // On AKS, set AKSGPUPoolsPath to an `az aks nodepool list -o json` dump
 // on the machine running this client: the pool projection is merged
@@ -370,19 +381,59 @@ required default, and sorted value names; it is nil when the composition is
 unprofiled.
 
 To extract a single value from a resolved recipe, use
-`SelectFromRecipe` with a dot-path selector. It hydrates the recipe's
-component values and returns the value at the path; an empty selector
-returns the entire hydrated structure, and a `nil` `*RecipeResult`
-returns `ErrCodeInvalidRequest`. This mirrors the `aicr query` CLI
-command:
+`SelectFromRecipeWithContext` with a dot-path selector. It hydrates the
+recipe's component values and returns the value at the path; an empty
+selector returns the entire hydrated structure, and a `nil` `*RecipeResult`
+returns `ErrCodeInvalidRequest`. Hydration reads values files through the
+recipe's `DataProvider`, so the context bounds real I/O — cancel it and the
+hydration aborts. This is the same call the `aicr query` CLI command and the
+REST query handler run:
 
 ```go
-v, err := aicr.SelectFromRecipe(rec, "components.gpu-operator.values.driver.version")
+v, err := aicr.SelectFromRecipeWithContext(ctx, rec, "components.gpu-operator.values.driver.version")
 if err != nil {
 	log.Fatalf("select: %v", err)
 }
 log.Printf("driver version: %v", v)
 ```
+
+`SelectFromRecipe` is the context-less form, kept for source compatibility.
+It derives a `defaults.FileReadTimeout`-bounded context internally, so the
+reads stay bounded but the caller cannot cancel them. Prefer the
+context-aware form wherever a `context.Context` is available.
+
+The **outermost** structured code distinguishes the two failure stages, so a
+caller can shape a response without reimplementing hydrate-then-select:
+`ErrCodeNotFound` means the selector path does not exist, and any other code
+(`ErrCodeInternal`, `ErrCodeTimeout`, ...) means hydration failed. Match with
+`errors.As` on the outermost error rather than `errors.Is` — `Is` walks the
+wrap chain and would match an `ErrCodeNotFound` cause nested inside a
+hydration failure.
+
+### Delivering a collected snapshot
+
+`snapshotter.DeliverSnapshot(ctx, raw, snapshotter.SnapshotDelivery{...})`
+writes captured bytes to a destination independent of where the agent staged
+them:
+
+```go
+err = snapshotter.DeliverSnapshot(snapCtx, snap.Raw, snapshotter.SnapshotDelivery{
+	Output:     "snapshot.yaml",                 // file; "" or "-" for stdout; cm://ns/name for a ConfigMap
+	Kubeconfig: "/path/to/target-kubeconfig",    // only used for a cm:// Output
+})
+```
+
+A `cm://` destination is written, not assumed — including when it differs from
+the `AgentConfig.Output` used at collection time. Set `TemplatePath` to render
+through a Go template instead of copying bytes; `Output` then names the
+rendered report.
+
+`WrapResolved` turns a `*pkg/recipe.RecipeResult` — typically one taken from
+`RecipeResult.Resolved()` and then projected by the caller — back into a
+facade `*RecipeResult` that `SelectFromRecipeWithContext` accepts. The result
+is queryable only: it carries no owning `Client`, so `MakeBundle`,
+`BundleComponents`, and `ValidateState` reject it. Use `Client.AdoptRecipe`
+when you need a bundle-able result.
 
 ## Errors
 
@@ -416,8 +467,12 @@ passing a tighter deadline keeps it; a caller passing
 Per-operation caps:
 
 - `ResolveRecipe` / `BundleComponents`: `defaults.RecipeOperationTimeout`
-- `CollectSnapshot`: caller-controlled via `AgentConfig.Timeout`,
-  falling back to `defaults.SnapshotOperationTimeout` when unset
+- `CollectSnapshot`: caller-controlled via `AgentConfig.Timeout` (falling
+  back to `defaults.SnapshotOperationTimeout` when unset), plus
+  `defaults.SnapshotOperationGrace`. The grace exists because
+  `AgentConfig.Timeout` budgets Job *completion* only — deployment and
+  result retrieval sit outside it, so a bare cap would silently shrink the
+  completion budget you asked for.
 - `ValidateState`: `defaults.ValidationOperationTimeout`
 - `MakeBundle`: opt-in via `BundleOptions.Timeout`. When unset (`0`) the
   caller's context governs unchanged — large bundles, `--vendor-charts`,

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -132,13 +132,10 @@ Use in shell scripts:
 				return err
 			}
 
-			hydrated, err := recipe.HydrateResultWithContext(ctx, result.Resolved())
-			if err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to hydrate recipe", err)
-			}
-
-			selector := cmd.String("selector")
-			selected, err := recipe.Select(hydrated, selector)
+			// Hydrate + select through the facade so the CLI, the REST
+			// query handler, and out-of-tree SDK callers all run the same
+			// implementation; ctx bounds the values reads hydration performs.
+			selected, err := aicr.SelectFromRecipeWithContext(ctx, result, cmd.String("selector"))
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/urfave/cli/v3"
 	corev1 "k8s.io/api/core/v1"
 
+	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	"github.com/NVIDIA/aicr/pkg/collector"
 	"github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/defaults"
@@ -120,10 +121,15 @@ type snapshotCmdOptions struct {
 	tmplOpts        *snapshotTemplateOptions
 }
 
-// toAgentConfig converts the resolved options into the snapshotter.AgentConfig
-// the snapshotter deploy path expects.
-func (o *snapshotCmdOptions) toAgentConfig() *snapshotter.AgentConfig {
-	return &snapshotter.AgentConfig{
+// toAgentConfig converts the resolved options into the facade AgentConfig that
+// Client.CollectSnapshot consumes. The facade type — not
+// snapshotter.AgentConfig — is the single spelling the CLI builds, so the
+// facade/internal mirror is exercised on every snapshot run instead of only
+// by SDK consumers. Job mode is its only consumer: local (in-pod) collection
+// deploys no Job and builds a collector.Factory and serializer.Serializer from
+// opts directly, so it never needs an AgentConfig.
+func (o *snapshotCmdOptions) toAgentConfig() *aicr.AgentConfig {
+	return &aicr.AgentConfig{
 		Kubeconfig:         o.kubeconfig,
 		Namespace:          o.namespace,
 		Image:              o.image,
@@ -507,59 +513,88 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 				return err
 			}
 
-			// Create factory. Network-collector options come from the
-			// flags we just parsed; their env-var Sources mean a Job
-			// running our binary inside the cluster picks up
-			// AICR_CLUSTER_CONFIG_PATH / AICR_DISCOVER_NETWORK
-			// straight into opts before we get here, so this single
-			// builder serves both the local-mode bypass and the
-			// inside-the-Job rerun without a separate rebuild path.
-			factory := collector.NewDefaultFactory(
-				collector.WithMaxNodesPerEntry(opts.maxNodesPerEntry),
-				collector.WithOS(opts.os),
-				collector.WithClusterConfigPath(opts.clusterConfigPath),
-				collector.WithDiscoverNetwork(opts.discoverNetwork),
-				collector.WithKubeconfigPath(opts.kubeconfig),
-			)
-
-			// Create output serializer
-			ser, err := createSnapshotSerializer(opts.tmplOpts, opts.kubeconfig)
-			if err != nil {
-				return errors.Wrap(errors.ErrCodeInternal, "failed to create output serializer", err)
-			}
-			if c, ok := ser.(serializer.Closer); ok {
-				defer func() {
-					if closeErr := c.Close(); closeErr != nil {
-						slog.Warn("failed to close snapshot serializer", "error", closeErr)
-					}
-				}()
-			}
-
-			// Build snapshotter configuration
-			ns := snapshotter.NodeSnapshotter{
-				Version:         version,
-				Factory:         factory,
-				Serializer:      ser,
-				RequireGPU:      opts.requireGPU,
-				AKSGPUPoolsPath: opts.aksGPUPoolsPath,
-			}
+			agentCfg := opts.toAgentConfig()
 
 			// When running inside an agent Job, collect locally instead of
-			// deploying another agent (prevents infinite nesting). The
-			// already-built `factory` above carries every CLI-resolved
-			// option — opts.clusterConfigPath, opts.discoverNetwork,
-			// opts.kubeconfig, opts.os, opts.maxNodesPerEntry — so we
-			// reuse it directly. The flags' cli.EnvVars Sources have
-			// already populated opts from the Job-set env vars before
-			// we reach this point, which keeps the dev-bypass case
-			// (`AICR_AGENT_MODE=true aicr snapshot --cluster-config
-			// <path>`) consistent with the in-pod path.
+			// deploying another agent (prevents infinite nesting). This path
+			// deploys nothing, so it stays on pkg/snapshotter directly — it
+			// needs a collector.Factory and a serializer.Serializer, which the
+			// semver-stable facade deliberately does not expose (see the
+			// Client.CollectSnapshot godoc).
+			//
+			// The factory carries every CLI-resolved option —
+			// opts.clusterConfigPath, opts.discoverNetwork, opts.kubeconfig,
+			// opts.os, opts.maxNodesPerEntry. The flags' cli.EnvVars Sources
+			// have already populated opts from the Job-set env vars before we
+			// reach this point, which keeps the dev-bypass case
+			// (`AICR_AGENT_MODE=true aicr snapshot --cluster-config <path>`)
+			// consistent with the in-pod path.
+			//
+			// Both the factory and the serializer are built HERE rather than
+			// above the branch: createSnapshotSerializer opens the destination
+			// with os.Create, which truncates it. Building it on the Job path —
+			// which never uses it, delivering raw agent bytes instead — would
+			// erase an existing snapshot file before the Job had produced a
+			// replacement, so a failed collection would destroy the previous
+			// capture. Job-mode destinations are instead validated without
+			// side effects: parseSnapshotCmdOptions checks the template, and
+			// DeployAndCollect parses a cm:// URI before touching the cluster.
 			if os.Getenv("AICR_AGENT_MODE") == "true" {
+				factory := collector.NewDefaultFactory(
+					collector.WithMaxNodesPerEntry(opts.maxNodesPerEntry),
+					collector.WithOS(opts.os),
+					collector.WithClusterConfigPath(opts.clusterConfigPath),
+					collector.WithDiscoverNetwork(opts.discoverNetwork),
+					collector.WithKubeconfigPath(opts.kubeconfig),
+				)
+
+				ser, serErr := createSnapshotSerializer(opts.tmplOpts, opts.kubeconfig)
+				if serErr != nil {
+					return errors.Wrap(errors.ErrCodeInternal, "failed to create output serializer", serErr)
+				}
+				if c, ok := ser.(serializer.Closer); ok {
+					defer func() {
+						if closeErr := c.Close(); closeErr != nil {
+							slog.Warn("failed to close snapshot serializer", "error", closeErr)
+						}
+					}()
+				}
+
+				ns := snapshotter.NodeSnapshotter{
+					Version:         version,
+					Factory:         factory,
+					Serializer:      ser,
+					RequireGPU:      opts.requireGPU,
+					AKSGPUPoolsPath: opts.aksGPUPoolsPath,
+				}
 				return ns.Measure(ctx)
 			}
 
-			ns.AgentConfig = opts.toAgentConfig()
-			return ns.Measure(ctx)
+			// Job mode goes through the facade so `aicr snapshot`, `aicr
+			// validate`, and SDK consumers all deploy the agent the same way.
+			// The recipe source is irrelevant here — CollectSnapshot does not
+			// consult the Client's DataProvider — so the embedded source keeps
+			// construction free of cluster- or flag-dependent setup.
+			client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			snap, err := client.CollectSnapshot(ctx, agentCfg)
+			if err != nil {
+				return err
+			}
+
+			// Deliver the RAW agent bytes, never a re-serialization of the
+			// parsed snapshot: a newer agent image can emit fields this
+			// binary's Snapshot type does not model, and a typed round trip
+			// would silently drop them.
+			return snapshotter.DeliverSnapshot(ctx, snap.Raw, snapshotter.SnapshotDelivery{
+				Output:       agentCfg.Output,
+				TemplatePath: agentCfg.TemplatePath,
+				Kubeconfig:   agentCfg.Kubeconfig,
+			})
 		},
 	}
 }

--- a/pkg/cli/snapshot_config_test.go
+++ b/pkg/cli/snapshot_config_test.go
@@ -528,9 +528,10 @@ spec:
 // === toAgentConfig conversion sanity check ===
 
 // TestSnapshotCmdOptions_ToAgentConfig pins the field-by-field
-// translation from snapshotCmdOptions to snapshotter.AgentConfig.
+// translation from snapshotCmdOptions to the facade aicr.AgentConfig.
 // Regression guard: silent drops would manifest as default empty values
-// reaching the deployer.
+// reaching the deployer. The facade→snapshotter half of the projection is
+// pinned separately by TestAgentConfigMirrorsInternal in pkg/client/v1.
 func TestSnapshotCmdOptions_ToAgentConfig(t *testing.T) {
 	opts := &snapshotCmdOptions{
 		kubeconfig:         "/kube/config",
@@ -549,6 +550,9 @@ func TestSnapshotCmdOptions_ToAgentConfig(t *testing.T) {
 		runtimeClass:       "nvidia",
 		os:                 "ubuntu",
 		maxNodesPerEntry:   5,
+		clusterConfigPath:  "/l8k/cluster-config.yaml",
+		aksGPUPoolsPath:    "/aks/pools.json",
+		discoverNetwork:    true,
 		requests:           corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 		limits:             corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("2Gi")},
 		tmplOpts: &snapshotTemplateOptions{
@@ -581,6 +585,9 @@ func TestSnapshotCmdOptions_ToAgentConfig(t *testing.T) {
 		{"Output", ac.Output, "snapshot.yaml"},
 		{"TemplatePath", ac.TemplatePath, "tpl.tmpl"},
 		{"NodeSelector[k]", ac.NodeSelector["k"], "v"},
+		{"ClusterConfigPath", ac.ClusterConfigPath, "/l8k/cluster-config.yaml"},
+		{"AKSGPUPoolsPath", ac.AKSGPUPoolsPath, "/aks/pools.json"},
+		{"DiscoverNetwork", ac.DiscoverNetwork, true},
 	}
 	for _, w := range wants {
 		if !reflect.DeepEqual(w.got, w.want) {

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -151,38 +151,49 @@ func resolveValidateTolerations(cmd *cli.Command, resolved *config.ValidateResol
 	return resolved.Tolerations, nil
 }
 
+// toAgentConfig projects the validate command's resolved flags onto the
+// facade AgentConfig that Client.CollectSnapshot consumes. Privileged is
+// unconditional here: the validation snapshot needs the GPU and SystemD
+// collectors, which do not work in restricted mode.
+func (c *validateAgentConfig) toAgentConfig() *aicr.AgentConfig {
+	return &aicr.AgentConfig{
+		Kubeconfig:         c.kubeconfig,
+		Namespace:          c.namespace,
+		Image:              c.image,
+		ImagePullSecrets:   c.imagePullSecrets,
+		JobName:            c.jobName,
+		ServiceAccountName: c.serviceAccountName,
+		NodeSelector:       c.nodeSelector,
+		Tolerations:        c.tolerations,
+		Timeout:            c.timeout,
+		Cleanup:            c.cleanup,
+		Debug:              c.debug,
+		Privileged:         true,
+		RequireGPU:         c.requireGPU,
+		AKSGPUPoolsPath:    c.aksGPUPoolsPath,
+	}
+}
+
 // deployAgentForValidation deploys an agent to capture a snapshot and returns the Snapshot.
 // The agent deployer creates the namespace itself (ensureNamespace, with the
 // managed-by label) using the same explicit kubeconfig (#1787), so no
 // pre-create happens here — deployAndWaitForResult's up-front pool-file
 // projection must run before ANY cluster mutation so a malformed
 // --aks-gpu-pools file fails without side effects.
-func deployAgentForValidation(ctx context.Context, cfg *validateAgentConfig) (*snapshotter.Snapshot, error) {
-	agentConfig := &snapshotter.AgentConfig{
-		Kubeconfig:         cfg.kubeconfig,
-		Namespace:          cfg.namespace,
-		Image:              cfg.image,
-		ImagePullSecrets:   cfg.imagePullSecrets,
-		JobName:            cfg.jobName,
-		ServiceAccountName: cfg.serviceAccountName,
-		NodeSelector:       cfg.nodeSelector,
-		Tolerations:        cfg.tolerations,
-		Timeout:            cfg.timeout,
-		Cleanup:            cfg.cleanup,
-		Debug:              cfg.debug,
-		Privileged:         true,
-		RequireGPU:         cfg.requireGPU,
-		AKSGPUPoolsPath:    cfg.aksGPUPoolsPath,
-	}
-
-	snap, err := snapshotter.DeployAndGetSnapshot(ctx, agentConfig)
+//
+// Collection runs through the same Client.CollectSnapshot that `aicr snapshot`
+// uses, rather than a second hand-rolled snapshotter.AgentConfig, so the facade
+// mirror is exercised here too. Output is left empty: validate consumes the
+// snapshot in memory and never writes it out.
+func deployAgentForValidation(ctx context.Context, client *aicr.Client, cfg *validateAgentConfig) (*snapshotter.Snapshot, error) {
+	snap, err := client.CollectSnapshot(ctx, cfg.toAgentConfig())
 	if err != nil {
 		// PropagateOrWrap: a structured error (e.g. ErrCodeInvalidRequest
 		// from a malformed --aks-gpu-pools file) keeps its code.
 		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to capture snapshot")
 	}
 
-	return snap, nil
+	return snap.Unwrap(), nil
 }
 
 // validationConfig holds all parameters for a validation run.
@@ -812,7 +823,7 @@ constraint (e.g. K8s version) is not met — --fail-on-error scopes to phase che
 				agentCfg := parseValidateAgentConfig(cmd, resolved, shared)
 
 				var deployErr error
-				snap, deployErr = deployAgentForValidation(ctx, agentCfg)
+				snap, deployErr = deployAgentForValidation(ctx, client, agentCfg)
 				if deployErr != nil {
 					return deployErr
 				}

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 )
@@ -451,7 +452,13 @@ func TestDeployAgentForValidation_ExplicitKubeconfigFailsFast(t *testing.T) {
 		jobName:    "aicr-validate-test",
 	}
 
-	_, err := deployAgentForValidation(t.Context(), cfg)
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = deployAgentForValidation(t.Context(), client, cfg)
 	if err == nil {
 		t.Fatal("expected error for nonexistent explicit kubeconfig, got nil")
 	}

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -1119,6 +1119,18 @@ func (c *Client) LoadRecipe(ctx context.Context, path, kubeconfig string) (*Reci
 // and component registry were already per-Client at the time and
 // stayed correct throughout, so ResolveRecipe results never drifted.
 //
+// # Read-once value coherence
+//
+// Each component's effective Helm values are resolved exactly once per
+// call, and that same snapshot feeds the accounting check, the
+// registry-declared component validations (including the gpu-operator
+// driver-ownership coherence gate), and the returned ComponentBundle. A
+// DataProvider need not be stable — LayeredDataProvider re-reads external
+// --data files on every call — so a gate that resolved values
+// independently could validate one set of values while a different set was
+// returned. Pinning the snapshot removes that window: what the gates
+// examined is what you get back (issue #1873 item A).
+//
 // # Synchronization
 //
 // Read-locks Client.mu so a concurrent Close can't race the values
@@ -1177,23 +1189,6 @@ func (c *Client) BundleComponents(ctx context.Context, r *RecipeResult) ([]Compo
 		return nil, errors.Wrap(errors.ErrCodeTimeout, "context cancelled before bundling", err)
 	}
 
-	// Component preflight: run the registry-declared component validations
-	// before handing back component values. DefaultBundler.Make runs the
-	// same gate (runComponentValidations) before writing a bundle; without
-	// it here the SDK path would return values the bundle path refuses to
-	// render — e.g. the gpu-operator driver-ownership coherence check
-	// (severity: error) on a recipe resolved from a snapshot that observed
-	// no NVIDIA kernel driver. This path has no bundle-time --set
-	// overrides, so the bundler config is nil; validations that act solely
-	// on bundle-time flags no-op on a nil config.
-	preflightWarnings, preflightErr := validations.RunComponentValidations(ctx, r.internal, nil)
-	for _, warning := range preflightWarnings {
-		slog.Warn(warning, "source", "component-validation")
-	}
-	if preflightErr != nil {
-		return nil, preflightErr
-	}
-
 	// Agree with DefaultBundler.Make (bundler.go), which fails closed with
 	// ErrCodeInvalidRequest whenever there is nothing to deploy — whether
 	// that's every component disabled or a zero-componentRef recipe. An
@@ -1204,15 +1199,42 @@ func (c *Client) BundleComponents(ctx context.Context, r *RecipeResult) ([]Compo
 			"recipe has no enabled components")
 	}
 
-	// Resolve the complete Helm-value inventory before emitting any component.
-	// Accounting ownership spans multiple charts, so validating one chart at a
-	// time could return a partial SDK bundle that DefaultBundler.Make rejects.
+	// Resolve the complete Helm-value inventory ONCE, before any gate runs and
+	// before emitting any component. Two properties depend on this ordering:
+	//
+	//  1. Accounting ownership spans multiple charts, so validating one chart
+	//     at a time could return a partial SDK bundle that
+	//     DefaultBundler.Make rejects.
+	//  2. Read-once coherence (#1873 item A). A LayeredDataProvider re-reads
+	//     external --data files on every call, so a gate that resolves values
+	//     independently can validate one set and let a different set be
+	//     emitted. Pinning the resolved maps onto the recipe result the gates
+	//     see makes the values they examine, by construction, the values
+	//     returned below.
 	helmValues, err := resolveHelmComponentValues(ctx, r)
 	if err != nil {
 		return nil, err
 	}
-	if err := bundler.ValidateAccountingValues(r.internal, helmValues); err != nil {
+	pinned := r.internal.WithResolvedValues(helmValues)
+	if err := bundler.ValidateAccountingValues(pinned, helmValues); err != nil {
 		return nil, err
+	}
+
+	// Component preflight: run the registry-declared component validations
+	// before handing back component values. DefaultBundler.Make runs the
+	// same gate (runComponentValidations) before writing a bundle; without
+	// it here the SDK path would return values the bundle path refuses to
+	// render — e.g. the gpu-operator driver-ownership coherence check
+	// (severity: error) on a recipe resolved from a snapshot that observed
+	// no NVIDIA kernel driver. This path has no bundle-time --set
+	// overrides, so the bundler config is nil; validations that act solely
+	// on bundle-time flags no-op on a nil config.
+	preflightWarnings, preflightErr := validations.RunComponentValidations(ctx, pinned, nil)
+	for _, warning := range preflightWarnings {
+		slog.Warn(warning, "source", "component-validation")
+	}
+	if preflightErr != nil {
+		return nil, preflightErr
 	}
 
 	bundles := make([]ComponentBundle, 0, len(r.Components))
@@ -1345,6 +1367,10 @@ func resolveHelmComponentValues(
 // CollectSnapshot deploys the snapshotter Job to the cluster identified
 // by cfg.Kubeconfig and returns the captured Snapshot.
 //
+// This is the single Job-mode collection path in the tree: `aicr snapshot`
+// and `aicr validate` both run it, so the facade AgentConfig mirror is
+// exercised on every snapshot AICR takes.
+//
 // CollectSnapshot does NOT consult the Client's recipe data provider —
 // the Client is required only to keep the facade surface uniform
 // (every public operation goes through a Client) and to leave room
@@ -1355,6 +1381,54 @@ func resolveHelmComponentValues(
 // cfg.Kubeconfig is the path (or empty for in-cluster). cfg.Namespace,
 // cfg.Image, cfg.ServiceAccountName must be set; other fields fall
 // back to package defaults documented on snapshotter.AgentConfig.
+//
+// # Output and delivery
+//
+// The returned Snapshot carries both the parsed form and, in Snapshot.Raw,
+// the exact bytes the agent emitted. CollectSnapshot does not write them
+// anywhere except when cfg.Output names a ConfigMap (cm://namespace/name),
+// which the Job writes directly. Persisting to a file, stdout, or a Go
+// template is the caller's step — pass Snapshot.Raw to
+// snapshotter.DeliverSnapshot, as `aicr snapshot` does. Delivering Raw rather
+// than re-serializing the parsed snapshot is what keeps the output
+// byte-identical to the agent's when a newer agent image emits fields this
+// binary does not model.
+//
+// # Fail-before-mutate
+//
+// Inputs that can be rejected without contacting the cluster are checked
+// before the Kubernetes client is built, so a rejection never leaves RBAC or
+// a Job behind (with cfg.Cleanup false — the zero value — they would
+// persist). That covers a malformed cfg.Output ConfigMap URI and a non-empty
+// cfg.ClusterConfigPath, both ErrCodeInvalidRequest.
+//
+// # Deliberately outside this method
+//
+// Two snapshot capabilities are NOT reachable through CollectSnapshot, by
+// design, because neither deploys a Job:
+//
+//   - Local (in-pod) collection — the mode the agent container itself runs
+//     under AICR_AGENT_MODE=true, and the dev bypass of the same name. It
+//     runs collectors in-process against the local node instead of deploying
+//     an agent, so it needs a collector.Factory and a serializer.Serializer,
+//     types the semver-stable facade deliberately does not expose. Use
+//     snapshotter.NodeSnapshotter directly, as pkg/cli/snapshot.go does. It
+//     takes no AgentConfig, so leaving it out costs no coverage of the field
+//     mirror: every deployed Job still projects through this method.
+//   - cfg.ClusterConfigPath — an l8k cluster-config.yaml ingested by the
+//     in-pod network collector. The path must resolve inside the pod and the
+//     Job does not mount it, so Job mode rejects a non-empty value with
+//     ErrCodeInvalidRequest. Use cfg.DiscoverNetwork for live discovery from
+//     a Job, or the local mode above to read a host file.
+//
+// # Timeout
+//
+// The operation is bounded by cfg.Timeout + defaults.SnapshotOperationGrace
+// (or defaults.SnapshotOperationTimeout + grace when cfg.Timeout is unset),
+// so a caller passing context.Background() still gets a bounded run. The
+// grace exists because cfg.Timeout budgets Job completion only — deployment
+// and result retrieval sit outside it, and a bare cap would silently shrink
+// the completion budget. A tighter caller deadline always wins.
 //
 // Errors:
 //   - ErrCodeInvalidRequest when the Client is nil, cfg is nil, or
@@ -1392,20 +1466,26 @@ func (c *Client) CollectSnapshot(ctx context.Context, cfg *AgentConfig) (*Snapsh
 	// still gets a bounded operation. Preference order:
 	//   1. cfg.Timeout — caller-controlled, wins when set.
 	//   2. SnapshotOperationTimeout — package default (matches CLISnapshotTimeout).
+	// SnapshotOperationGrace is added on top because the chosen value budgets
+	// Job COMPLETION only: deploy, pool projection, and ConfigMap retrieval
+	// happen outside it, so a bare cap would quietly shrink the caller's
+	// completion budget by however long deployment took.
 	// context.WithTimeout honors the smaller of the parent deadline and
 	// the value supplied here, so callers with a tighter context keep it.
-	cap := cfg.Timeout
-	if cap <= 0 {
-		cap = defaults.SnapshotOperationTimeout
+	budget := cfg.Timeout
+	if budget <= 0 {
+		budget = defaults.SnapshotOperationTimeout
 	}
-	ctx, cancel := context.WithTimeout(ctx, cap)
+	ctx, cancel := context.WithTimeout(ctx, budget+defaults.SnapshotOperationGrace)
 	defer cancel()
 
-	snap, err := snapshotter.DeployAndGetSnapshot(ctx, toInternalAgentConfig(cfg))
+	snap, raw, err := snapshotter.DeployAndCollect(ctx, toInternalAgentConfig(cfg))
 	if err != nil {
 		return nil, err
 	}
-	return fromInternalSnapshot(snap), nil
+	out := fromInternalSnapshot(snap)
+	out.Raw = raw
+	return out, nil
 }
 
 // ValidateState evaluates a resolved recipe against an observed cluster

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -66,6 +66,42 @@ func (b *blockingDataProvider) Source(path string) string {
 	return b.underlying.Source(path)
 }
 
+// mutatingValuesProvider models a LayeredDataProvider whose backing file
+// changes underfoot: reads of watchPath return contents[0], contents[1], ...
+// in order (the last entry repeating once exhausted), and every other path
+// delegates to the embedded FS so the component registry still loads.
+//
+// It exists to make the read-once guarantee observable. An operation that
+// resolves a component's values twice — once to validate, once to emit —
+// sees two DIFFERENT value sets here, which is exactly the window issue
+// #1873 item A describes.
+type mutatingValuesProvider struct {
+	underlying recipe.DataProvider
+	watchPath  string
+	contents   [][]byte
+	reads      atomic.Int64
+}
+
+func (p *mutatingValuesProvider) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if path != p.watchPath {
+		return p.underlying.ReadFile(ctx, path)
+	}
+	n := p.reads.Add(1)
+	index := int(n) - 1
+	if index >= len(p.contents) {
+		index = len(p.contents) - 1
+	}
+	return p.contents[index], nil
+}
+
+func (p *mutatingValuesProvider) WalkDir(ctx context.Context, root string, fn fs.WalkDirFunc) error {
+	return p.underlying.WalkDir(ctx, root, fn)
+}
+
+func (p *mutatingValuesProvider) Source(path string) string {
+	return p.underlying.Source(path)
+}
+
 // newRecipeResultForBundleTest builds a facade RecipeResult with its
 // unexported internal field populated, side-stepping the requirement
 // that callers obtain RecipeResults via ResolveRecipe. This is
@@ -521,6 +557,113 @@ func TestBundleComponents_RejectsZeroComponentRefs(t *testing.T) {
 	}
 }
 
+// TestBundleComponents_ResolvesValuesOnce is the regression guard for the
+// values TOCTOU (#1873 item A, closed for the SDK path by #2021).
+//
+// gpu-operator carries a severity:error CheckDriverOwnershipCoherence
+// validation in recipes/registry.yaml, so BundleComponents runs a gate that
+// needs the component's effective values AND returns those values to the
+// caller. Before the fix those were two independent reads: the gate resolved
+// its own copy and the emit path resolved another. Against a provider whose
+// backing file changes between reads — the LayeredDataProvider behavior, which
+// re-reads external --data files on every call — the gate could therefore
+// approve one set of values while a different set was handed back.
+//
+// The provider below returns a different document on every read of the
+// component's values file, which makes the divergence directly observable:
+//
+//   - exactly one read means gate and emit share a single resolution;
+//   - the emitted values must be the FIRST document, i.e. the one the gate saw.
+//
+// Pre-fix this test fails on both assertions (2 reads, "second" emitted).
+func TestBundleComponents_ResolvesValuesOnce(t *testing.T) {
+	t.Parallel()
+
+	const valuesPath = "components/gpu-operator/values.yaml"
+
+	provider := &mutatingValuesProvider{
+		underlying: recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "."),
+		watchPath:  valuesPath,
+		contents: [][]byte{
+			[]byte("driver:\n  version: first\n"),
+			[]byte("driver:\n  version: second\n"),
+		},
+	}
+
+	client := newClientForBundleTest(t)
+	r := newRecipeResultForBundleTest(client,
+		[]recipe.ComponentRef{{
+			Name:       "gpu-operator",
+			Type:       recipe.ComponentTypeHelm,
+			ValuesFile: valuesPath,
+		}},
+		[]ComponentRef{{Name: "gpu-operator", Kind: "Helm"}},
+	)
+	r.internal.BindDataProvider(provider)
+
+	bundles, err := client.BundleComponents(context.Background(), r)
+	if err != nil {
+		t.Fatalf("BundleComponents: %v", err)
+	}
+	if len(bundles) != 1 {
+		t.Fatalf("BundleComponents() returned %d bundles, want 1", len(bundles))
+	}
+
+	if got := provider.reads.Load(); got != 1 {
+		t.Errorf("values file read %d times, want exactly 1 — the coherence gate and the "+
+			"emitted bundle must share a single resolution, or a provider mutation between "+
+			"reads can slip different values past the gate", got)
+	}
+
+	emitted := string(bundles[0].HelmValues)
+	if !strings.Contains(emitted, "first") {
+		t.Errorf("emitted HelmValues = %q, want the values the gate validated (driver.version=first)", emitted)
+	}
+	if strings.Contains(emitted, "second") {
+		t.Errorf("emitted HelmValues = %q carry a post-gate re-read; the returned values "+
+			"must be exactly the ones validated", emitted)
+	}
+}
+
+// TestBundleComponents_PinnedValuesSurviveGateMutation proves the pinned
+// snapshot is not corrupted by a gate that mutates the map it receives.
+// CheckDriverOwnershipCoherence layers bundle-time --set overrides onto the
+// values map it resolves, so serving the gate a shared reference would let
+// those overrides leak into the emitted bundle. The pin hands out deep
+// copies; a second BundleComponents call must therefore see the same values.
+func TestBundleComponents_PinnedValuesSurviveGateMutation(t *testing.T) {
+	t.Parallel()
+
+	const valuesPath = "components/gpu-operator/values.yaml"
+
+	client := newClientForBundleTest(t)
+	newResult := func() *RecipeResult {
+		r := newRecipeResultForBundleTest(client,
+			[]recipe.ComponentRef{{
+				Name:       "gpu-operator",
+				Type:       recipe.ComponentTypeHelm,
+				ValuesFile: valuesPath,
+			}},
+			[]ComponentRef{{Name: "gpu-operator", Kind: "Helm"}},
+		)
+		r.internal.BindDataProvider(recipe.NewEmbeddedDataProvider(recipe.GetEmbeddedFS(), "."))
+		return r
+	}
+
+	first, err := client.BundleComponents(context.Background(), newResult())
+	if err != nil {
+		t.Fatalf("BundleComponents (first): %v", err)
+	}
+	second, err := client.BundleComponents(context.Background(), newResult())
+	if err != nil {
+		t.Fatalf("BundleComponents (second): %v", err)
+	}
+	if string(first[0].HelmValues) != string(second[0].HelmValues) {
+		t.Errorf("HelmValues drifted between calls:\nfirst:\n%s\nsecond:\n%s",
+			first[0].HelmValues, second[0].HelmValues)
+	}
+}
+
 // TestRecipeResultFromInternal_PlumbsHelmFields locks in that the
 // translation from pkg/recipe.ComponentRef into the facade's
 // ComponentRef carries Source, Chart, and Namespace through. Without
@@ -621,7 +764,7 @@ func TestCollectSnapshot_RejectsNilConfig(t *testing.T) {
 // TestCollectSnapshot_RejectsClosedClient locks in the closed-Client
 // guard. After Close() clears the builder, CollectSnapshot must
 // surface that as ErrCodeInvalidRequest rather than calling through
-// to snapshotter.DeployAndGetSnapshot with stale state.
+// to snapshotter.DeployAndCollect with stale state.
 func TestCollectSnapshot_RejectsClosedClient(t *testing.T) {
 	t.Parallel()
 
@@ -1647,5 +1790,81 @@ func TestFacadeResultFromInternal_OmitsDisabledComponents(t *testing.T) {
 	}
 	if out.Components[0].Name != "enabled-a" {
 		t.Errorf("got component %q, want enabled-a", out.Components[0].Name)
+	}
+}
+
+// TestCollectSnapshot_RejectsBeforeClusterAccess pins the facade half of the
+// fail-before-mutate contract documented on CollectSnapshot. Both inputs are
+// rejectable without a cluster, and both must be rejected BEFORE the
+// Kubernetes client is built — otherwise a caller with an unusable kubeconfig
+// sees a connection error instead of the documented ErrCodeInvalidRequest,
+// and a caller with a REACHABLE cluster gets RBAC and a Job created before the
+// input is ever examined. With AgentConfig.Cleanup false (the zero value SDK
+// callers get unless they opt in) those resources — including a cluster-admin
+// binding — are left behind.
+func TestCollectSnapshot_RejectsBeforeClusterAccess(t *testing.T) {
+	t.Parallel()
+
+	badKubeconfig := filepath.Join(t.TempDir(), "does-not-exist.kubeconfig")
+
+	tests := []struct {
+		name    string
+		cfg     *AgentConfig
+		wantMsg string
+	}{
+		{
+			name: "malformed ConfigMap output URI",
+			cfg: &AgentConfig{
+				Namespace:  "default",
+				Kubeconfig: badKubeconfig,
+				Output:     "cm://aicr-snapshot", // name without namespace
+			},
+			wantMsg: "invalid ConfigMap output URI",
+		},
+		{
+			name: "cluster-config path is Job-mode unsupported",
+			cfg: &AgentConfig{
+				Namespace:         "default",
+				Kubeconfig:        badKubeconfig,
+				ClusterConfigPath: "/host/cluster-config.yaml",
+			},
+			wantMsg: "--cluster-config is not supported in agent Job mode",
+		},
+		{
+			// The Job, its RBAC, and the result ConfigMap all land in
+			// Namespace; empty would only fail once the internal
+			// "cm:///aicr-snapshot" URI was parsed, after those exist.
+			name: "empty namespace",
+			cfg: &AgentConfig{
+				Kubeconfig: badKubeconfig,
+			},
+			wantMsg: "Namespace is required",
+		},
+	}
+
+	client := newClientForBundleTest(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := client.CollectSnapshot(context.Background(), tt.cfg)
+			if err == nil {
+				t.Fatal("CollectSnapshot() = nil error, want rejection")
+			}
+			if got != nil {
+				t.Errorf("expected nil Snapshot on error, got %v", got)
+			}
+			var se *aicrerrors.StructuredError
+			if !stderrors.As(err, &se) {
+				t.Fatalf("expected *aicrerrors.StructuredError, got %T: %v", err, err)
+			}
+			if se.Code != aicrerrors.ErrCodeInvalidRequest {
+				t.Errorf("code = %s, want %s", se.Code, aicrerrors.ErrCodeInvalidRequest)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error = %v, want it to mention %q (a kubeconfig failure here means "+
+					"the input check ran after the cluster client was built)", err, tt.wantMsg)
+			}
+		})
 	}
 }

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1553,6 +1554,157 @@ func TestSelectFromRecipe(t *testing.T) {
 	}
 }
 
+// TestSelectFromRecipeWithContextCancellation proves the context-aware
+// selector honors caller cancellation: hydration reads each component's
+// values through the DataProvider, so an already-canceled context must abort
+// the hydration rather than run it to completion under a self-created
+// context.Background (the defect #2020 tracked).
+//
+// The failure is classified as a hydration failure, not a selector-path
+// failure: the outermost code is never ErrCodeNotFound, which is what lets
+// the REST handler map hydrate → 5xx and selector → 404 without a parallel
+// hydrate+select implementation.
+func TestSelectFromRecipeWithContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	crit, err := recipe.BuildCriteriaWithRegistry(nil,
+		recipe.WithServiceRegistry("eks"),
+		recipe.WithAcceleratorRegistry("h100"),
+		recipe.WithIntentRegistry("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+	rec, err := c.ResolveRecipeFromCriteria(t.Context(), aicr.WrapCriteria(crit))
+	if err != nil {
+		t.Fatalf("ResolveRecipeFromCriteria: %v", err)
+	}
+
+	// Sanity: the selector resolves under a live context, so a failure below
+	// is attributable to cancellation rather than a bad selector.
+	if _, liveErr := aicr.SelectFromRecipeWithContext(t.Context(), rec,
+		"components.gpu-operator.values.driver.version"); liveErr != nil {
+		t.Fatalf("SelectFromRecipeWithContext(live ctx): %v", liveErr)
+	}
+
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = aicr.SelectFromRecipeWithContext(canceled, rec,
+		"components.gpu-operator.values.driver.version")
+	if err == nil {
+		t.Fatal("SelectFromRecipeWithContext(canceled ctx) = nil error, want hydration abort")
+	}
+
+	var se *aicrerrors.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("SelectFromRecipeWithContext(canceled ctx) error = %v, want *StructuredError", err)
+	}
+	if se.Code == aicrerrors.ErrCodeNotFound {
+		t.Fatalf("hydration failure surfaced outermost code %s; the facade contract reserves "+
+			"ErrCodeNotFound for selector-path failures so callers can map it to 404", se.Code)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("SelectFromRecipeWithContext(canceled ctx) error = %v, want context.Canceled in chain", err)
+	}
+}
+
+// TestSelectFromRecipeNotFoundIsOutermostCode pins the error contract the
+// REST query handler maps on: a missing selector path surfaces
+// ErrCodeNotFound as the OUTERMOST structured code.
+func TestSelectFromRecipeNotFoundIsOutermostCode(t *testing.T) {
+	t.Parallel()
+
+	c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	crit, err := recipe.BuildCriteriaWithRegistry(nil,
+		recipe.WithServiceRegistry("eks"),
+		recipe.WithAcceleratorRegistry("h100"),
+		recipe.WithIntentRegistry("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+	rec, err := c.ResolveRecipeFromCriteria(t.Context(), aicr.WrapCriteria(crit))
+	if err != nil {
+		t.Fatalf("ResolveRecipeFromCriteria: %v", err)
+	}
+
+	_, err = aicr.SelectFromRecipeWithContext(t.Context(), rec, "components.no-such-component")
+	if err == nil {
+		t.Fatal("SelectFromRecipeWithContext(missing path) = nil error, want ErrCodeNotFound")
+	}
+	var se *aicrerrors.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("error = %v, want *StructuredError", err)
+	}
+	if se.Code != aicrerrors.ErrCodeNotFound {
+		t.Errorf("outermost code = %s, want %s", se.Code, aicrerrors.ErrCodeNotFound)
+	}
+}
+
+// TestWrapResolvedIsQueryable proves the projection path the REST query
+// handler depends on: a pkg/recipe.RecipeResult obtained from Resolved()
+// (and possibly re-projected by the caller) round-trips back into a
+// queryable facade RecipeResult without an owning Client.
+func TestWrapResolvedIsQueryable(t *testing.T) {
+	t.Parallel()
+
+	c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	crit, err := recipe.BuildCriteriaWithRegistry(nil,
+		recipe.WithServiceRegistry("eks"),
+		recipe.WithAcceleratorRegistry("h100"),
+		recipe.WithIntentRegistry("training"),
+	)
+	if err != nil {
+		t.Fatalf("BuildCriteria: %v", err)
+	}
+	rec, err := c.ResolveRecipeFromCriteria(t.Context(), aicr.WrapCriteria(crit))
+	if err != nil {
+		t.Fatalf("ResolveRecipeFromCriteria: %v", err)
+	}
+
+	if aicr.WrapResolved(nil) != nil {
+		t.Error("WrapResolved(nil) = non-nil, want nil")
+	}
+
+	selector := "components.gpu-operator.values.driver.version"
+	want, err := aicr.SelectFromRecipeWithContext(t.Context(), rec, selector)
+	if err != nil {
+		t.Fatalf("SelectFromRecipeWithContext(resolved): %v", err)
+	}
+
+	wrapped := aicr.WrapResolved(rec.Resolved())
+	got, err := aicr.SelectFromRecipeWithContext(t.Context(), wrapped, selector)
+	if err != nil {
+		t.Fatalf("SelectFromRecipeWithContext(WrapResolved): %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("WrapResolved selector = %v, want %v", got, want)
+	}
+
+	// Queryable only: the wrapped result carries no owning Client, so the
+	// bundle path rejects it rather than silently bundling an unowned recipe.
+	if _, err := c.BundleComponents(t.Context(), wrapped); err == nil {
+		t.Error("BundleComponents(WrapResolved) = nil error, want ownership rejection")
+	}
+}
+
 // componentNames extracts a slice of component names from a
 // RecipeResult, suitable for error-message diagnostics. Keeps the
 // assertion logic above readable.
@@ -2294,5 +2446,45 @@ func TestBundleComponentsValidatesEffectiveAccountingValues(t *testing.T) {
 	_, err = client.BundleComponents(t.Context(), result)
 	if err == nil || !strings.Contains(err.Error(), "accounting-owned value") {
 		t.Fatalf("BundleComponents() error = %v, want accounting contract rejection", err)
+	}
+}
+
+// TestSnapshotUnwrapRoundTrips covers the accessor the CLI's validate path
+// relies on to reach measurement-level detail the facade does not project.
+// WrapSnapshot must hand the SAME pointer back — a reconstruction would drop
+// the measurements validate reads.
+func TestSnapshotUnwrapRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	internal := &snapshotter.Snapshot{}
+	internal.APIVersion = "aicr.run/v1alpha2"
+	internal.Kind = "Snapshot"
+	internal.Metadata = map[string]string{"version": "v9.9.9"}
+
+	wrapped := aicr.WrapSnapshot(internal)
+	if wrapped.Unwrap() != internal {
+		t.Error("WrapSnapshot(x).Unwrap() returned a different pointer; the measurement payload must round-trip by reference")
+	}
+
+	// A Snapshot built outside the facade has no internal payload; Unwrap
+	// rebuilds a minimal one so callers never nil-check a non-nil receiver.
+	bare := &aicr.Snapshot{APIVersion: "aicr.run/v1alpha2", Kind: "Snapshot"}
+	rebuilt := bare.Unwrap()
+	if rebuilt == nil {
+		t.Fatal("Unwrap() on a facade-constructed Snapshot = nil, want a minimal reconstruction")
+	}
+	if rebuilt.APIVersion != "aicr.run/v1alpha2" || string(rebuilt.Kind) != "Snapshot" {
+		t.Errorf("Unwrap() lost public fields: %+v", rebuilt)
+	}
+
+	var nilSnap *aicr.Snapshot
+	if nilSnap.Unwrap() != nil {
+		t.Error("Unwrap() on a nil receiver = non-nil, want nil")
+	}
+
+	// Raw is only populated by CollectSnapshot; every other construction path
+	// leaves it empty so callers can tell "no agent bytes" from "empty document".
+	if len(wrapped.Raw) != 0 {
+		t.Errorf("WrapSnapshot() populated Raw (%d bytes); only CollectSnapshot sets it", len(wrapped.Raw))
 	}
 }

--- a/pkg/client/v1/query.go
+++ b/pkg/client/v1/query.go
@@ -15,30 +15,73 @@
 package aicr
 
 import (
+	"context"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
-// SelectFromRecipe hydrates a resolved recipe and extracts a dot-path selector
-// (e.g. "components.gpu-operator.values.driver.version"). An empty selector
-// returns the entire hydrated structure. Mirrors `aicr query`.
+// SelectFromRecipeWithContext hydrates a resolved recipe and extracts a
+// dot-path selector (e.g. "components.gpu-operator.values.driver.version").
+// An empty selector returns the entire hydrated structure. Mirrors
+// `aicr query`, and is the implementation both the CLI query command and
+// the REST query handler run.
 //
-// The recipe must have been produced by a Client (so its internal
-// pkg/recipe.RecipeResult is populated). A facade RecipeResult constructed
-// outside ResolveRecipe / LoadRecipe / AdoptRecipe is rejected with
-// ErrCodeInvalidRequest.
-func SelectFromRecipe(r *RecipeResult, selector string) (any, error) {
+// Hydration reads each component's values through the DataProvider bound to
+// the recipe, so ctx bounds real I/O: a canceled or expired context aborts
+// the hydration rather than running to completion.
+//
+// The recipe must carry internal pkg/recipe state — obtain one from
+// Client.ResolveRecipe, Client.LoadRecipe, Client.AdoptRecipe, or
+// WrapResolved. A facade RecipeResult constructed any other way is rejected
+// with ErrCodeInvalidRequest.
+//
+// # Error contract
+//
+// The OUTERMOST structured error code distinguishes the two failure stages,
+// so a caller (e.g. an HTTP handler mapping to a status code) can shape its
+// response without a parallel hydrate+select implementation:
+//
+//   - ErrCodeNotFound — the selector path does not exist in the hydrated
+//     recipe. This code is only ever produced by the selection stage.
+//   - ErrCodeInvalidRequest — ctx or r is nil, or r carries no internal state.
+//   - Anything else (ErrCodeInternal, ErrCodeTimeout, ...) — hydration failed.
+//     Hydration never surfaces ErrCodeNotFound as the outermost code:
+//     pkg/recipe.HydrateResultWithContext wraps every per-component values
+//     failure as ErrCodeInternal, so a missing values file cannot be mistaken
+//     for a missing selector path.
+//
+// Inspect the outermost code with stderrors.As, NOT stderrors.Is — Is walks
+// the wrap chain and would match an ErrCodeNotFound cause nested inside a
+// hydration failure.
+func SelectFromRecipeWithContext(ctx context.Context, r *RecipeResult, selector string) (any, error) {
+	if ctx == nil {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
+	}
 	if r == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "nil recipe")
 	}
 	internal := r.Resolved()
 	if internal == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			"RecipeResult has no internal recipe state — call Client.ResolveRecipe, LoadRecipe, or AdoptRecipe to obtain a queryable RecipeResult")
+			"RecipeResult has no internal recipe state — call Client.ResolveRecipe, LoadRecipe, or AdoptRecipe, or wrap one with WrapResolved, to obtain a queryable RecipeResult")
 	}
-	hydrated, err := recipe.HydrateResult(internal)
+	hydrated, err := recipe.HydrateResultWithContext(ctx, internal)
 	if err != nil {
 		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "hydrate recipe")
 	}
 	return recipe.Select(hydrated, selector)
+}
+
+// SelectFromRecipe is the context-less form of SelectFromRecipeWithContext,
+// kept for source compatibility. It derives a defaults.FileReadTimeout-bounded
+// context so hydration's values reads stay bounded, but the caller cannot
+// cancel them.
+//
+// Prefer SelectFromRecipeWithContext wherever a context.Context is available.
+func SelectFromRecipe(r *RecipeResult, selector string) (any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return SelectFromRecipeWithContext(ctx, r, selector)
 }

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -210,6 +210,7 @@ func TestStability_TypesAndAliases(t *testing.T) {
 	_ = aicr.AllowLists{}
 	_ = aicr.AgentConfig{}
 	_ = aicr.Snapshot{}
+	_ = aicr.Snapshot{}.Raw
 	_ = aicr.ReportSummary{}
 	_ = aicr.PhaseResult{}
 	_ = aicr.ComponentBundle{}
@@ -242,6 +243,7 @@ func TestStability_Translations(t *testing.T) {
 	t.Parallel()
 
 	requireSignature[func(*snapshotter.Snapshot) *aicr.Snapshot](aicr.WrapSnapshot)
+	requireSignature[func(*aicr.Snapshot) *snapshotter.Snapshot]((*aicr.Snapshot).Unwrap)
 	requireSignature[func(*recipe.Criteria) *aicr.Criteria](aicr.WrapCriteria)
 	requireSignature[func(*recipe.AllowLists) *aicr.AllowLists](aicr.WrapAllowLists)
 	requireSignature[func(*aicr.AllowLists) *recipe.AllowLists](aicr.ToInternalAllowLists)
@@ -256,9 +258,14 @@ func TestStability_HealthAndEvidence(t *testing.T) {
 	requireSignature[func(*aicr.Client, context.Context, *aicr.RecipeResult, *aicr.Snapshot, []*aicr.PhaseResult, aicr.EvidenceOptions) error]((*aicr.Client).EmitRecipeEvidence)
 }
 
-// TestStability_Query pins the package-level query selector.
+// TestStability_Query pins the package-level query selector, in both its
+// context-aware and legacy context-less spellings, plus the WrapResolved
+// constructor that makes an externally-projected pkg/recipe.RecipeResult
+// queryable through the facade.
 func TestStability_Query(t *testing.T) {
 	t.Parallel()
 
 	requireSignature[func(*aicr.RecipeResult, string) (any, error)](aicr.SelectFromRecipe)
+	requireSignature[func(context.Context, *aicr.RecipeResult, string) (any, error)](aicr.SelectFromRecipeWithContext)
+	requireSignature[func(*recipe.RecipeResult) *aicr.RecipeResult](aicr.WrapResolved)
 }

--- a/pkg/client/v1/translate.go
+++ b/pkg/client/v1/translate.go
@@ -26,8 +26,19 @@ import (
 )
 
 // toInternalAgentConfig copies every public field of the facade AgentConfig
-// onto a fresh snapshotter.AgentConfig. Field-for-field mirror; a future
-// field added to either side stays at its zero value until plumbed through.
+// onto a fresh snapshotter.AgentConfig.
+//
+// The two structs are a field-for-field mirror, enforced by
+// TestAgentConfigMirrorsInternal rather than by convention: adding a field to
+// either side without plumbing it here fails that test instead of silently
+// leaving the new field at its zero value on every snapshot run.
+//
+// Deliberately unexported. CollectSnapshot is the only projection point, and
+// every in-tree snapshot Job goes through it; an exported spelling with no
+// caller outside this package is the drift #2021 exists to remove, not add.
+// The CLI's local (in-pod) collection path does not need it — it deploys no
+// Job and builds a collector.Factory and serializer.Serializer from its own
+// options instead.
 func toInternalAgentConfig(cfg *AgentConfig) *snapshotter.AgentConfig {
 	if cfg == nil {
 		return nil
@@ -51,6 +62,8 @@ func toInternalAgentConfig(cfg *AgentConfig) *snapshotter.AgentConfig {
 		TemplatePath:       cfg.TemplatePath,
 		MaxNodesPerEntry:   cfg.MaxNodesPerEntry,
 		OS:                 cfg.OS,
+		ClusterConfigPath:  cfg.ClusterConfigPath,
+		DiscoverNetwork:    cfg.DiscoverNetwork,
 		Requests:           cfg.Requests,
 		Limits:             cfg.Limits,
 		AKSGPUPoolsPath:    cfg.AKSGPUPoolsPath,
@@ -62,6 +75,33 @@ func toInternalAgentConfig(cfg *AgentConfig) *snapshotter.AgentConfig {
 // a YAML file) can pass them to facade methods. Returns nil for nil input.
 func WrapSnapshot(s *snapshotter.Snapshot) *Snapshot {
 	return fromInternalSnapshot(s)
+}
+
+// WrapResolved wraps an already-resolved pkg/recipe.RecipeResult — typically
+// one obtained from RecipeResult.Resolved() and then projected by the caller —
+// back into the facade shape so it can be handed to SelectFromRecipeWithContext.
+// Returns nil for nil input.
+//
+// The wrapped result is QUERYABLE ONLY. It carries no owning Client, so
+// Client.MakeBundle, Client.BundleComponents, and Client.ValidateState reject
+// it with ErrCodeInvalidRequest; use Client.AdoptRecipe for those. The
+// caller-supplied result keeps whatever DataProvider it was already bound to,
+// so hydration resolves against the same source that produced it — no deep
+// copy, no re-validation, no provider rebinding.
+//
+// The REST query handler is the motivating in-tree caller: it projects a
+// legacy (/v1) view of a resolved recipe before selecting, and WrapResolved
+// lets it run the facade's selector rather than an inlined hydrate+select
+// pair that can drift.
+func WrapResolved(r *recipe.RecipeResult) *RecipeResult {
+	if r == nil {
+		return nil
+	}
+	var name string
+	if r.Criteria != nil {
+		name = r.Criteria.String()
+	}
+	return facadeResultFromInternal(r, name)
 }
 
 // fromInternalSnapshot wraps a pkg/snapshotter.Snapshot in the facade

--- a/pkg/client/v1/translate_test.go
+++ b/pkg/client/v1/translate_test.go
@@ -15,10 +15,14 @@
 package aicr
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
 
 // TestWrapCriteria_Nil verifies that wrapping a nil upstream criteria
@@ -265,4 +269,134 @@ func TestToInternalAgentConfig_ProjectsAKSGPUPoolsPath(t *testing.T) {
 	if toInternalAgentConfig(nil) != nil {
 		t.Fatal("toInternalAgentConfig(nil) should stay nil")
 	}
+}
+
+// TestAgentConfigMirrorsInternal turns the facade AgentConfig ↔
+// snapshotter.AgentConfig mirror from a convention into an invariant.
+//
+// The mirror used to be maintained by hand, and its own doc comment conceded
+// that "a future field added to either side stays at its zero value until
+// plumbed through" — which is exactly what happened: ClusterConfigPath and
+// DiscoverNetwork existed upstream while the facade silently dropped them.
+// Two assertions close that gap:
+//
+//  1. Shape — every field of one struct has a same-named, same-typed field on
+//     the other. Adding, removing, or retyping a field on either side fails
+//     here.
+//  2. Value — every facade field set to a distinct non-zero value must arrive
+//     on the internal struct. This catches a field that exists on both sides
+//     but is missing from (or misassigned in) toInternalAgentConfig, which a
+//     shape check alone cannot see.
+//
+// A new field of a type the value generator does not model fails loudly
+// rather than being skipped, so extending the mirror always forces a
+// deliberate update here.
+func TestAgentConfigMirrorsInternal(t *testing.T) {
+	facadeType := reflect.TypeOf(AgentConfig{})
+	internalType := reflect.TypeOf(snapshotter.AgentConfig{})
+
+	fieldTypes := func(t reflect.Type) map[string]reflect.Type {
+		out := make(map[string]reflect.Type, t.NumField())
+		for i := range t.NumField() {
+			f := t.Field(i)
+			out[f.Name] = f.Type
+		}
+		return out
+	}
+
+	facadeFields := fieldTypes(facadeType)
+	internalFields := fieldTypes(internalType)
+
+	for name, ft := range facadeFields {
+		it, ok := internalFields[name]
+		if !ok {
+			t.Errorf("facade AgentConfig.%s has no counterpart on snapshotter.AgentConfig — "+
+				"remove it or add the upstream field", name)
+			continue
+		}
+		if ft != it {
+			t.Errorf("AgentConfig.%s type mismatch: facade %s, internal %s", name, ft, it)
+		}
+	}
+	for name := range internalFields {
+		if _, ok := facadeFields[name]; !ok {
+			t.Errorf("snapshotter.AgentConfig.%s is not mirrored on the facade AgentConfig — "+
+				"SDK and CLI callers cannot set it, so it stays at its zero value on every run", name)
+		}
+	}
+
+	// Value round-trip: fill every facade field with a distinct non-zero
+	// value, project, and require it to land.
+	cfg := &AgentConfig{}
+	filled := reflect.ValueOf(cfg).Elem()
+	for i := range facadeType.NumField() {
+		field := facadeType.Field(i)
+		filled.Field(i).Set(nonZeroFieldValue(t, field.Name, field.Type, i))
+	}
+
+	projected := reflect.ValueOf(toInternalAgentConfig(cfg)).Elem()
+	for name, want := range facadeFields {
+		_ = want
+		src := filled.FieldByName(name)
+		dst := projected.FieldByName(name)
+		if !dst.IsValid() {
+			continue // already reported by the shape check above
+		}
+		if !reflect.DeepEqual(src.Interface(), dst.Interface()) {
+			t.Errorf("toInternalAgentConfig dropped or misassigned %s: got %v, want %v",
+				name, dst.Interface(), src.Interface())
+		}
+	}
+}
+
+// nonZeroFieldValue builds a distinct non-zero value for a mirror field.
+// seed makes every string unique so a copy-paste misassignment (JobName set
+// from Namespace, say) is caught rather than compared equal. Unmodeled kinds
+// fail the test: a new field type must be handled deliberately, never skipped.
+func nonZeroFieldValue(t *testing.T, name string, typ reflect.Type, seed int) reflect.Value {
+	t.Helper()
+
+	// resource.Quantity has unexported state, so it cannot be built by
+	// generic reflection — parse a real quantity instead.
+	if typ == reflect.TypeOf(resource.Quantity{}) {
+		return reflect.ValueOf(resource.MustParse(fmt.Sprintf("%d", seed+1)))
+	}
+
+	//nolint:exhaustive // The default branch fails the test for any unmodeled
+	// kind on purpose: a new AgentConfig field type must be handled here
+	// deliberately rather than silently skipped by the round-trip.
+	switch typ.Kind() {
+	case reflect.String:
+		return reflect.ValueOf(fmt.Sprintf("mirror-%s-%d", name, seed)).Convert(typ)
+	case reflect.Bool:
+		return reflect.ValueOf(true).Convert(typ)
+	case reflect.Int, reflect.Int64:
+		return reflect.ValueOf(int64(seed + 1)).Convert(typ)
+	case reflect.Slice:
+		slice := reflect.MakeSlice(typ, 1, 1)
+		slice.Index(0).Set(nonZeroFieldValue(t, name, typ.Elem(), seed))
+		return slice
+	case reflect.Map:
+		m := reflect.MakeMap(typ)
+		m.SetMapIndex(
+			nonZeroFieldValue(t, name+"-key", typ.Key(), seed),
+			nonZeroFieldValue(t, name+"-value", typ.Elem(), seed+1),
+		)
+		return m
+	case reflect.Struct:
+		v := reflect.New(typ).Elem()
+		for i := range typ.NumField() {
+			f := typ.Field(i)
+			if f.Type.Kind() == reflect.String && v.Field(i).CanSet() {
+				v.Field(i).Set(nonZeroFieldValue(t, name+"."+f.Name, f.Type, seed))
+				return v
+			}
+		}
+		t.Fatalf("AgentConfig.%s: struct type %s has no settable string field; "+
+			"extend nonZeroFieldValue so the mirror round-trip stays meaningful", name, typ)
+	default:
+		t.Fatalf("AgentConfig.%s: unhandled field kind %s; extend nonZeroFieldValue "+
+			"so the new field is actually round-tripped", name, typ.Kind())
+	}
+	return reflect.Value{}
 }

--- a/pkg/client/v1/types.go
+++ b/pkg/client/v1/types.go
@@ -77,6 +77,16 @@ type Snapshot struct {
 	Kind       string
 	CapturedAt time.Time
 
+	// Raw is the exact YAML document the collection agent emitted, set by
+	// Client.CollectSnapshot and empty on snapshots obtained any other way
+	// (WrapSnapshot, a hand-constructed Snapshot).
+	//
+	// Persist THESE bytes rather than re-serializing the parsed snapshot: a
+	// newer agent image can emit fields this binary's Snapshot type does not
+	// model, and a typed round trip silently drops them. `aicr snapshot`
+	// writes Raw for exactly that reason.
+	Raw []byte
+
 	// internal holds the upstream pkg/snapshotter.Snapshot so the
 	// facade can re-pass the snapshot to ValidateState without
 	// reserializing. Tests that construct &Snapshot{} have internal == nil;
@@ -85,11 +95,31 @@ type Snapshot struct {
 	internal *snapshotter.Snapshot
 }
 
+// Unwrap returns the underlying pkg/snapshotter.Snapshot — the inverse of
+// WrapSnapshot, and the analog of RecipeResult.Resolved(). In-tree callers
+// (the CLI's validate path) use it to reach measurement-level detail the
+// facade's public fields intentionally do not project.
+//
+// A Snapshot constructed outside the facade (no internal payload) yields a
+// minimal pkg/snapshotter.Snapshot rebuilt from the public fields, so callers
+// never have to nil-check the result of a non-nil receiver. Returns nil for a
+// nil receiver. The returned pointer is the facade's own — treat it as
+// read-only.
+func (s *Snapshot) Unwrap() *snapshotter.Snapshot {
+	return toInternalSnapshot(s)
+}
+
 // AgentConfig is the deployment-time configuration for the snapshot-
 // collection Job passed to Client.CollectSnapshot. Facade-owned;
 // field-for-field mirror of pkg/snapshotter.AgentConfig. Tolerations
 // keep k8s.io/api/core/v1.Toleration since kubernetes/api is itself
 // stable.
+//
+// The mirror is enforced, not conventional: TestAgentConfigMirrorsInternal
+// fails when either struct gains, drops, or retypes a field, and every
+// in-tree snapshot Job (`aicr snapshot`, `aicr validate`) is deployed through
+// this type — so an unplumbed field is a test failure rather than a silent
+// zero value.
 type AgentConfig struct {
 	Kubeconfig         string
 	Namespace          string
@@ -101,7 +131,6 @@ type AgentConfig struct {
 	Tolerations        []corev1.Toleration
 	Timeout            time.Duration
 	Cleanup            bool
-	Output             string
 	Debug              bool
 	Privileged         bool
 	RequireGPU         bool
@@ -111,6 +140,31 @@ type AgentConfig struct {
 	OS                 string
 	Requests           corev1.ResourceList
 	Limits             corev1.ResourceList
+
+	// Output selects where the agent Job stages its result. A cm://namespace/name
+	// URI makes that ConfigMap the delivery vehicle — the Job writes there and
+	// CollectSnapshot leaves it in place. A malformed cm:// URI is rejected
+	// with ErrCodeInvalidRequest before any cluster access, so a typo never
+	// costs a deployed Job. Any other value (including empty) stages to an
+	// internal ConfigMap in Namespace; delivering the snapshot to a file,
+	// stdout, or a template is then the caller's job — pass Snapshot.Raw to
+	// snapshotter.DeliverSnapshot.
+	Output string
+
+	// ClusterConfigPath asks the in-pod network collector to ingest a
+	// pre-existing k8s-launch-kit (l8k) cluster-config.yaml at this path.
+	// The path must resolve INSIDE the agent pod, which the Job does not yet
+	// mount — so CollectSnapshot rejects a non-empty value with
+	// ErrCodeInvalidRequest. Use DiscoverNetwork for live discovery from a
+	// Job. Local (in-pod) collection honors the file, but that path is
+	// outside the facade; see Client.CollectSnapshot.
+	ClusterConfigPath string
+
+	// DiscoverNetwork enables the in-pod network collector's live l8k
+	// discovery. Discovery is NOT read-only — it writes
+	// nvidia.kubernetes-launch-kit.* node labels and patches NicClusterPolicy
+	// via server-side-apply, so the agent's RBAC must allow those writes.
+	DiscoverNetwork bool
 
 	// AKSGPUPoolsPath points at an operator-supplied
 	// `az aks nodepool list -o json` dump on the machine running this

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -110,6 +110,19 @@ const (
 	// deadline already on the parent context.
 	SnapshotOperationTimeout = 5 * time.Minute
 
+	// SnapshotOperationGrace is the headroom Client.CollectSnapshot adds on
+	// top of AgentConfig.Timeout when bounding the whole operation.
+	//
+	// AgentConfig.Timeout budgets ONE step — waiting for the agent Job to
+	// complete. Deploying RBAC and the Job, projecting an --aks-gpu-pools
+	// file, and retrieving the result ConfigMap all sit outside it. Capping
+	// the operation at exactly AgentConfig.Timeout would silently shrink the
+	// Job-completion budget by however long deployment took, so a Job that
+	// legitimately needs its full timeout on a slow cluster would fail. The
+	// grace keeps the operation bounded for callers that pass an unbounded
+	// context without eating into the budget the caller asked for.
+	SnapshotOperationGrace = 1 * time.Minute
+
 	// ValidationOperationTimeout is the facade-level upper bound for
 	// Client.ValidateState when the caller's context has no deadline
 	// (controller/library callers; the CLI runs uncapped). It must exceed the

--- a/pkg/recipe/adapter.go
+++ b/pkg/recipe/adapter.go
@@ -184,16 +184,66 @@ func (r *RecipeResult) GetValuesForComponent(name string) (map[string]any, error
 // File lookups route through the DataProvider bound to this result (set when
 // the result was built by a Builder via WithDataProvider). When no provider
 // is bound, lookups fall back to the package-level embedded-data singleton.
+//
+// On a result returned by WithResolvedValues, a component present in the
+// pinned snapshot is served from that snapshot instead — no provider read.
 func (r *RecipeResult) GetValuesForComponentWithContext(ctx context.Context, name string) (map[string]any, error) {
 	ref := r.GetComponentRef(name)
 	if ref == nil {
 		return nil, errors.New(errors.ErrCodeNotFound, fmt.Sprintf("component %q not found in recipe", name))
 	}
 
+	// A pinned snapshot short-circuits the provider read so every consumer
+	// within one operation observes the same values. Hand back a deep copy:
+	// callers own (and some mutate) the returned map — the bundler's
+	// coherence gate layers --set overrides onto it — and a shared map would
+	// leak those mutations into the snapshot and into every later reader.
+	if values, pinned := r.resolvedValues[name]; pinned {
+		if err := ctx.Err(); err != nil {
+			return nil, errors.Wrap(errors.ErrCodeTimeout,
+				fmt.Sprintf("context canceled before reading values for %q", name), err)
+		}
+		return serializer.DeepCopyAnyMap(values), nil
+	}
+
 	// Prefer the result-bound provider (per-tenant isolation); resolveComponentValues
 	// falls back to the embedded-data singleton when it is nil (e.g. the result was
 	// decoded from a recipe file before BindDataProvider was called).
 	return resolveComponentValues(ctx, r.provider, ref)
+}
+
+// WithResolvedValues returns a shallow copy of r whose
+// GetValuesForComponent / GetValuesForComponentWithContext serve the supplied
+// pre-resolved maps instead of re-reading them through the DataProvider.
+// Components absent from values keep the normal provider-backed path.
+//
+// # Why
+//
+// A DataProvider is not required to be stable: LayeredDataProvider re-reads
+// external `--data` files on every call. An operation that resolves a
+// component's values twice — once to validate, once to emit — can therefore
+// validate one set of values and emit a different set, so a mutation landing
+// between the two reads slips past the gate (issue #1873 item A). Pinning the
+// snapshot makes the whole operation read-once: the values a gate examines
+// are, by construction, the values the operation emits.
+//
+// # Semantics
+//
+// The copy shares r's slices, maps, and bound DataProvider — it is a
+// read-only view for the duration of one operation, not an independent
+// recipe. Do not mutate either side while the view is in use; use DeepCopy
+// when independent state is needed. Returns nil for a nil receiver, and r
+// unchanged when values is empty.
+func (r *RecipeResult) WithResolvedValues(values map[string]map[string]any) *RecipeResult {
+	if r == nil {
+		return nil
+	}
+	if len(values) == 0 {
+		return r
+	}
+	pinned := *r
+	pinned.resolvedValues = values
+	return &pinned
 }
 
 // GetComponentValues resolves the effective Helm values for a single

--- a/pkg/recipe/adapter_test.go
+++ b/pkg/recipe/adapter_test.go
@@ -873,3 +873,120 @@ func TestGetManifestContentWithProvider_NotFound(t *testing.T) {
 		t.Errorf("expected wrap chain to preserve fs.ErrNotExist, got %v", err)
 	}
 }
+
+// TestWithResolvedValues covers the read-once view that lets one operation
+// pin a component's effective values so a gate and the emitted artifact
+// cannot observe different results from a mutable DataProvider (#1873 A).
+func TestWithResolvedValues(t *testing.T) {
+	t.Parallel()
+
+	newResult := func() *RecipeResult {
+		return &RecipeResult{
+			Kind:       "RecipeResult",
+			APIVersion: RecipeAPIVersion,
+			ComponentRefs: []ComponentRef{
+				{Name: "pinned", Type: ComponentTypeHelm, Overrides: map[string]any{"from": "provider"}},
+				{Name: "unpinned", Type: ComponentTypeHelm, Overrides: map[string]any{"from": "provider"}},
+			},
+		}
+	}
+
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		t.Parallel()
+		var r *RecipeResult
+		if got := r.WithResolvedValues(map[string]map[string]any{"x": {}}); got != nil {
+			t.Errorf("WithResolvedValues() on nil receiver = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty snapshot returns receiver unchanged", func(t *testing.T) {
+		t.Parallel()
+		r := newResult()
+		if got := r.WithResolvedValues(nil); got != r {
+			t.Error("WithResolvedValues(nil) returned a copy, want the receiver unchanged")
+		}
+	})
+
+	t.Run("pinned component bypasses the provider, unpinned does not", func(t *testing.T) {
+		t.Parallel()
+		r := newResult()
+		pinned := r.WithResolvedValues(map[string]map[string]any{
+			"pinned": {"from": "snapshot", "nested": map[string]any{"k": "v"}},
+		})
+
+		got, err := pinned.GetValuesForComponentWithContext(context.Background(), "pinned")
+		if err != nil {
+			t.Fatalf("GetValuesForComponentWithContext(pinned): %v", err)
+		}
+		if got["from"] != "snapshot" {
+			t.Errorf("pinned component values = %v, want the snapshot value", got)
+		}
+
+		got, err = pinned.GetValuesForComponentWithContext(context.Background(), "unpinned")
+		if err != nil {
+			t.Fatalf("GetValuesForComponentWithContext(unpinned): %v", err)
+		}
+		if got["from"] != "provider" {
+			t.Errorf("unpinned component values = %v, want the provider-resolved value", got)
+		}
+
+		// The receiver is untouched: WithResolvedValues returns a view.
+		got, err = r.GetValuesForComponentWithContext(context.Background(), "pinned")
+		if err != nil {
+			t.Fatalf("GetValuesForComponentWithContext(receiver): %v", err)
+		}
+		if got["from"] != "provider" {
+			t.Errorf("receiver values = %v, want the provider-resolved value", got)
+		}
+	})
+
+	t.Run("callers receive deep copies", func(t *testing.T) {
+		t.Parallel()
+		snapshot := map[string]map[string]any{
+			"pinned": {"nested": map[string]any{"k": "original"}, "list": []any{"a"}},
+		}
+		pinned := newResult().WithResolvedValues(snapshot)
+
+		first, err := pinned.GetValuesForComponentWithContext(context.Background(), "pinned")
+		if err != nil {
+			t.Fatalf("GetValuesForComponentWithContext: %v", err)
+		}
+		// Mutate exactly as the coherence gate does when it layers --set
+		// overrides onto the values it resolved.
+		first["nested"].(map[string]any)["k"] = "mutated"
+		first["list"].([]any)[0] = "mutated"
+
+		second, err := pinned.GetValuesForComponentWithContext(context.Background(), "pinned")
+		if err != nil {
+			t.Fatalf("GetValuesForComponentWithContext (second): %v", err)
+		}
+		if got := second["nested"].(map[string]any)["k"]; got != "original" {
+			t.Errorf("nested map leaked a caller mutation: got %v, want %q", got, "original")
+		}
+		if got := second["list"].([]any)[0]; got != "a" {
+			t.Errorf("slice leaked a caller mutation: got %v, want %q", got, "a")
+		}
+	})
+
+	t.Run("canceled context is honored", func(t *testing.T) {
+		t.Parallel()
+		pinned := newResult().WithResolvedValues(map[string]map[string]any{"pinned": {"from": "snapshot"}})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := pinned.GetValuesForComponentWithContext(ctx, "pinned"); err == nil {
+			t.Error("GetValuesForComponentWithContext(canceled) = nil error, want cancellation")
+		}
+	})
+
+	t.Run("DeepCopy drops the pin", func(t *testing.T) {
+		t.Parallel()
+		pinned := newResult().WithResolvedValues(map[string]map[string]any{"pinned": {"from": "snapshot"}})
+		got, err := pinned.DeepCopy().GetValuesForComponentWithContext(context.Background(), "pinned")
+		if err != nil {
+			t.Fatalf("GetValuesForComponentWithContext on DeepCopy: %v", err)
+		}
+		if got["from"] != "provider" {
+			t.Errorf("DeepCopy values = %v, want the provider-resolved value (the pin scopes one operation)", got)
+		}
+	})
+}

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -956,6 +956,14 @@ type RecipeResult struct {
 	// via BindDataProvider and consume read-only without going through
 	// ownership-checked entry points.
 	owner *Builder
+
+	// resolvedValues pins per-component effective Helm values for the
+	// duration of one operation, keyed by component name. Set only by
+	// WithResolvedValues (which returns a shallow copy — a builder-produced
+	// result is never pinned in place); nil on every other result, in which
+	// case GetValuesForComponent* resolves through the DataProvider as
+	// before. See WithResolvedValues for why read-once matters.
+	resolvedValues map[string]map[string]any
 }
 
 // DataProvider returns the DataProvider that produced this result. A
@@ -1075,6 +1083,8 @@ func (r *RecipeResult) DeepCopy() *RecipeResult {
 		// AssertOwnedBy rejects it. The facade's AdoptRecipe path rebinds
 		// the provider but does not rebind owner — adopted recipes can be
 		// read but not consumed via ownership-checked entry points.
+		// resolvedValues intentionally left nil: a pinned snapshot scopes one
+		// operation's read-once view, so an independent copy resolves fresh.
 	}
 
 	// Metadata: scalar fields, the SelectedProfile

--- a/pkg/server/recipe_handler.go
+++ b/pkg/server/recipe_handler.go
@@ -491,24 +491,29 @@ func (h *recipeHandler) handleQuery(w http.ResponseWriter, r *http.Request, v2 b
 	}
 	resolved := normalizeLegacyRecipeResult(rec.Resolved(), v2)
 
-	// Hydrate and select as two steps (rather than the combined
-	// aicr.SelectFromRecipe) to preserve the legacy handler's distinct error
-	// mapping: a hydrate failure surfaces via its own error code (5xx), while a
-	// missing selector path is a 404. The legacy projection preserves the
-	// resolved result's bound DataProvider so hydration uses the same source.
-	hydrated, err := recipe.HydrateResultWithContext(ctx, resolved)
+	// Hydrate + select through the facade, then shape the response here.
+	// The legacy projection keeps the resolved result's bound DataProvider,
+	// so WrapResolved hydrates against the same source. The handler's
+	// distinct error mapping — a missing selector path is 404, a hydrate
+	// failure is its own (5xx) code — is a handler-level mapping over the
+	// facade's documented outermost-code contract, not a second
+	// hydrate+select implementation.
+	selected, err := aicr.SelectFromRecipeWithContext(ctx, aicr.WrapResolved(resolved), selector)
 	if err != nil {
+		// Match on the OUTERMOST structured code: stderrors.Is walks the
+		// wrap chain and would misread a hydration failure whose cause
+		// happens to carry ErrCodeNotFound (e.g. a missing values file) as
+		// a missing selector path.
+		var se *aicrerrors.StructuredError
+		if stderrors.As(err, &se) && se.Code == aicrerrors.ErrCodeNotFound {
+			WriteError(w, r, http.StatusNotFound, aicrerrors.ErrCodeNotFound,
+				"Selector path not found", false, map[string]any{
+					"selector": selector,
+					keyError:   err.Error(),
+				})
+			return
+		}
 		WriteErrorFromErr(w, r, err, "Failed to hydrate recipe", nil)
-		return
-	}
-
-	selected, err := recipe.Select(hydrated, selector)
-	if err != nil {
-		WriteError(w, r, http.StatusNotFound, aicrerrors.ErrCodeNotFound,
-			"Selector path not found", false, map[string]any{
-				"selector": selector,
-				keyError:   err.Error(),
-			})
 		return
 	}
 

--- a/pkg/snapshotter/agent.go
+++ b/pkg/snapshotter/agent.go
@@ -151,20 +151,6 @@ type AgentConfig struct {
 // It creates the deployer, deploys RBAC and the Job, streams logs, waits for completion,
 // and retrieves the snapshot data from the result ConfigMap.
 func deployAndWaitForResult(ctx context.Context, clientset k8sclient.Interface, config *AgentConfig, agentOutput string, deliverViaConfigMap bool) ([]byte, error) {
-	// Job mode forwards --cluster-config as an env var into the pod
-	// (AICR_CLUSTER_CONFIG_PATH) without mounting the host file: the
-	// caller's filesystem isn't reachable from inside the Job, and the
-	// in-pod CLI would fail to open the path. Reject the combination
-	// up front instead of producing a confusing failure deep in the
-	// network collector. ConfigMap-backed file forwarding is tracked
-	// as a follow-up; until then --cluster-config is local-mode-only
-	// (AICR_AGENT_MODE=true) and --discover-network is the supported
-	// Job-mode path.
-	if config.ClusterConfigPath != "" {
-		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
-			"--cluster-config is not supported in agent Job mode (the host path is not visible to the in-pod CLI); use --discover-network for live cluster discovery, or run with AICR_AGENT_MODE=true to use --cluster-config locally",
-			map[string]any{"path": config.ClusterConfigPath})
-	}
 	// The pool projection is pure file processing on the caller's host —
 	// project it BEFORE deploying so a bad file fails in milliseconds,
 	// not after a Job round-trip, and merge it into the returned snapshot
@@ -413,37 +399,203 @@ func getKubeClient(kubeconfig string) (k8sclient.Interface, error) {
 	return clientset, nil
 }
 
-// DeployAndGetSnapshot deploys an agent to capture a snapshot and returns the Snapshot struct.
-// This is used by commands that need to capture a snapshot but also process the data
-// (e.g., validate command that needs to run validation on the captured snapshot).
-func DeployAndGetSnapshot(ctx context.Context, config *AgentConfig) (*Snapshot, error) {
+// DeployAndCollect deploys the agent Job, waits for it, and returns both the
+// parsed Snapshot and the RAW bytes the agent emitted. It is the single
+// deploy-and-retrieve implementation behind every caller — the aicr.Client
+// facade's CollectSnapshot (and therefore `aicr snapshot` and `aicr validate`)
+// and NodeSnapshotter.measureWithAgent.
+//
+// # Why both return values
+//
+// The parsed *Snapshot is what consumers reason about; the raw bytes are what
+// gets written out. They are NOT interchangeable: re-serializing the typed
+// struct drops any field a newer agent image emitted that this binary's
+// Snapshot type does not know about. Callers that persist the snapshot must
+// deliver the raw bytes (see DeliverSnapshot) so `aicr snapshot` output stays
+// byte-identical to what the agent produced.
+//
+// # Where the agent writes
+//
+// The Job always stages its result in a ConfigMap. When config.Output is a
+// cm:// URI that ConfigMap IS the user's destination, so the Job writes there
+// directly; otherwise the Job writes to an internal ConfigMap in
+// config.Namespace and the caller delivers the returned bytes.
+//
+// # Fail-before-mutate
+//
+// Every input that can be rejected without contacting the cluster is checked
+// up front — before the Kubernetes client is even built, so a rejection is
+// never masked by a kubeconfig error and never leaves RBAC or a Job behind
+// (with Cleanup false, the zero value, they would persist). That covers a
+// malformed cm:// Output, an empty Namespace, and a Job-mode
+// ClusterConfigPath.
+//
+// The *Snapshot return has no consumer inside this package —
+// measureWithAgent only delivers the bytes — but it is the value
+// aicr.Client.CollectSnapshot hands to SDK callers and to `aicr validate`,
+// hence the unparam exemption below. Keep the rationale in prose: gofmt moves
+// //nolint (a directive-shaped comment) to the end of the doc block, so
+// continuation lines written under it get hoisted above and orphaned.
+//
+//nolint:unparam // *Snapshot is consumed across the package boundary; see above.
+func DeployAndCollect(ctx context.Context, config *AgentConfig) (*Snapshot, []byte, error) {
 	if config == nil {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "agent config is required")
+		return nil, nil, errors.New(errors.ErrCodeInvalidRequest, "agent config is required")
+	}
+
+	// Job mode forwards --cluster-config as an env var into the pod
+	// (AICR_CLUSTER_CONFIG_PATH) without mounting the host file: the
+	// caller's filesystem isn't reachable from inside the Job, and the
+	// in-pod CLI would fail to open the path. Reject the combination
+	// up front instead of producing a confusing failure deep in the
+	// network collector. ConfigMap-backed file forwarding is tracked
+	// as a follow-up; until then --cluster-config is local-mode-only
+	// (AICR_AGENT_MODE=true) and --discover-network is the supported
+	// Job-mode path.
+	if config.ClusterConfigPath != "" {
+		return nil, nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"--cluster-config is not supported in agent Job mode (the host path is not visible to the in-pod CLI); use --discover-network for live cluster discovery, or run with AICR_AGENT_MODE=true to use --cluster-config locally",
+			map[string]any{"path": config.ClusterConfigPath})
+	}
+
+	// The Job, its RBAC, and the internal result ConfigMap all live in
+	// config.Namespace. Empty (or whitespace) would build the invalid URI
+	// "cm:///aicr-snapshot", which only fails when it is finally parsed —
+	// after RBAC and the Job exist. The CLI always supplies a default, so
+	// this is the SDK-caller path.
+	if strings.TrimSpace(config.Namespace) == "" {
+		return nil, nil, errors.New(errors.ErrCodeInvalidRequest,
+			"Namespace is required: it is where the agent Job, its RBAC, and the result ConfigMap are created")
+	}
+
+	// Resolve (and validate) the Job's ConfigMap target before any cluster
+	// access: a malformed cm:// Output must not cost the caller a deployed
+	// Job and a cluster-admin binding.
+	agentOutput, deliverViaConfigMap, err := agentConfigMapTarget(config)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	slog.Debug("starting agent deployment for snapshot capture")
 
 	clientset, err := getKubeClient(config.Kubeconfig)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	agentOutput := fmt.Sprintf("%s%s/aicr-snapshot", serializer.ConfigMapURIScheme, config.Namespace)
-
-	// SDK path: the consumer uses the returned Snapshot; the ConfigMap is internal.
-	snapshotData, err := deployAndWaitForResult(ctx, clientset, config, agentOutput, false)
+	snapshotData, err := deployAndWaitForResult(ctx, clientset, config, agentOutput, deliverViaConfigMap)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var snap Snapshot
 	if err := yaml.Unmarshal(snapshotData, &snap); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to parse snapshot data", err)
+		return nil, nil, errors.Wrap(errors.ErrCodeInternal, "failed to parse snapshot data", err)
 	}
 
 	warnOnGPUPlacementMismatch(&snap)
 
-	return &snap, nil
+	return &snap, snapshotData, nil
+}
+
+// agentConfigMapTarget resolves where the agent Job stages its result and
+// whether that ConfigMap is the user's delivery vehicle.
+//
+// The Job always writes to a ConfigMap. When config.Output is a cm:// URI the
+// user asked for that exact ConfigMap, so the Job targets it directly and
+// deliverViaConfigMap is true — which makes a failed AKS-pool-merge rewrite
+// fatal rather than a warning, because the bytes the user will read live
+// there. Any other Output (file, stdout, template, or unset) stages to an
+// internal ConfigMap in config.Namespace that the caller never sees.
+//
+// A cm:// Output is fully parsed here, not merely prefix-matched. The
+// namespace/name only has to be well-formed for the in-pod writer much later,
+// so a typo like "cm://aicr-snapshot" (no namespace) would otherwise surface
+// as a Job failure — after RBAC and the Job exist, and with Cleanup false
+// (the zero value) they stay behind. Returns ErrCodeInvalidRequest instead.
+func agentConfigMapTarget(config *AgentConfig) (uri string, deliverViaConfigMap bool, err error) {
+	if strings.HasPrefix(config.Output, serializer.ConfigMapURIScheme) {
+		if _, _, parseErr := pod.ParseConfigMapURI(config.Output); parseErr != nil {
+			// Wrap with the same code rather than PropagateOrWrap: the inner
+			// error says "invalid configmap URI", which does not tell the
+			// caller WHICH input was wrong. Naming the field is the point.
+			return "", false, errors.Wrap(errors.ErrCodeInvalidRequest,
+				fmt.Sprintf("invalid ConfigMap output URI %q (expected cm://namespace/name)", config.Output),
+				parseErr)
+		}
+		return config.Output, true, nil
+	}
+	return fmt.Sprintf("%s%s/aicr-snapshot", serializer.ConfigMapURIScheme, config.Namespace), false, nil
+}
+
+// SnapshotDelivery describes where DeliverSnapshot writes captured bytes.
+// Mirrors the delivery-relevant subset of AgentConfig so callers that already
+// hold one can forward it, and callers that hold only bytes (an SDK consumer
+// with a Snapshot.Raw) can construct one directly.
+type SnapshotDelivery struct {
+	// Output is the destination: empty, "-", or the stdout URI for stdout;
+	// a cm://namespace/name URI for a ConfigMap; any other value is a file
+	// path.
+	Output string
+
+	// TemplatePath, when set, renders the snapshot through a Go template
+	// instead of copying bytes. Takes precedence over the Output scheme —
+	// Output then names the rendered report's destination.
+	TemplatePath string
+
+	// Kubeconfig is the path used to reach the cluster for a cm:// Output.
+	// Empty means in-cluster or the standard discovery chain. Ignored for
+	// every other destination.
+	Kubeconfig string
+}
+
+// DeliverSnapshot writes captured snapshot bytes to the user's destination:
+// a Go template render when TemplatePath is set, otherwise stdout (Output
+// empty, "-", or the stdout URI), a ConfigMap (cm://namespace/name), or a
+// file.
+//
+// data must be the RAW bytes from DeployAndCollect, not a re-serialization of
+// the parsed Snapshot — see DeployAndCollect for why. The one exception is the
+// template path, which necessarily parses the document to expose fields to the
+// template.
+//
+// # ConfigMap destinations
+//
+// A cm:// Output is WRITTEN here, not assumed. When the snapshot came from
+// DeployAndCollect with the same URI as AgentConfig.Output the agent Job
+// already staged those bytes, so this apply is redundant but idempotent —
+// and it is what makes the function total: a caller that collected to the
+// default internal ConfigMap and then delivers to cm://ns/name gets the
+// artifact it asked for instead of a silent no-op. Failures surface; a
+// destination the caller named is not something to log and skip past.
+func DeliverSnapshot(ctx context.Context, data []byte, dest SnapshotDelivery) error {
+	if dest.TemplatePath != "" {
+		return deliverWithTemplate(ctx, data, dest.TemplatePath, dest.Output)
+	}
+
+	switch {
+	case dest.Output == "" || dest.Output == "-" || dest.Output == serializer.StdoutURI:
+		// Output snapshot data to stdout for consumption by caller. A short write
+		// or broken pipe must surface, not silently drop the snapshot.
+		if _, err := os.Stdout.Write(data); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
+		}
+		if _, err := os.Stdout.Write([]byte("\n")); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
+		}
+	case strings.HasPrefix(dest.Output, serializer.ConfigMapURIScheme):
+		if err := writeSnapshotConfigMap(ctx, dest.Output, dest.Kubeconfig, data); err != nil {
+			return err
+		}
+		slog.Info("snapshot saved to ConfigMap", slog.String("uri", dest.Output))
+	default:
+		if err := serializer.WriteToFile(dest.Output, data); err != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to file", err)
+		}
+		slog.Info("snapshot saved to file", slog.String("path", dest.Output))
+	}
+
+	return nil
 }
 
 // ParseResourceList converts a comma-separated "name=quantity" list
@@ -645,74 +797,31 @@ func ParseTaint(taintStr string) (*corev1.Taint, error) {
 	return taint, nil
 }
 
-// measureWithAgent deploys a Kubernetes Job to capture snapshot on cluster nodes.
+// measureWithAgent deploys a Kubernetes Job to capture snapshot on cluster
+// nodes and writes the result to the user's destination. It is the
+// deploy-then-deliver composition of DeployAndCollect and DeliverSnapshot,
+// which is also what the aicr.Client facade path runs — so both spellings
+// emit the same bytes by construction.
+//
+// One behavior converged when the two paths merged: a snapshot document this
+// binary cannot unmarshal is now an error. Previously this path parsed
+// best-effort (skipping only the GPU-placement warning) and delivered the
+// bytes anyway, while the SDK path already failed. Strict is the correct
+// side to converge on — a document `aicr snapshot` cannot parse is one
+// `aicr validate` and `aicr recipe --snapshot` would reject too, so writing
+// it out and exiting 0 reports a success the artifact cannot back.
 func (n *NodeSnapshotter) measureWithAgent(ctx context.Context) error {
-	slog.Debug("starting agent deployment")
-
-	clientset, err := getKubeClient(n.AgentConfig.Kubeconfig)
+	_, snapshotData, err := DeployAndCollect(ctx, n.AgentConfig)
 	if err != nil {
 		return err
 	}
-
-	// The user's final output destination (file, stdout, or ConfigMap)
-	finalOutput := n.AgentConfig.Output
-
-	// Agent Job always writes to a ConfigMap internally.
-	// If user specified a ConfigMap URI, use that; otherwise use a default ConfigMap.
-	agentOutput := fmt.Sprintf("%s%s/aicr-snapshot", serializer.ConfigMapURIScheme, n.AgentConfig.Namespace)
-	deliverViaConfigMap := strings.HasPrefix(finalOutput, serializer.ConfigMapURIScheme)
-	if deliverViaConfigMap {
-		// User explicitly wants ConfigMap output, use their URI
-		agentOutput = finalOutput
-	}
-
-	snapshotData, err := deployAndWaitForResult(ctx, clientset, n.AgentConfig, agentOutput, deliverViaConfigMap)
-	if err != nil {
-		return err
-	}
-
-	// Post-collection safety net: warn if no GPU data but cluster shows GPU nodes.
-	// Unmarshal into a local Snapshot for the check only; output path uses raw bytes.
-	var snapForCheck Snapshot
-	if unmarshalErr := yaml.Unmarshal(snapshotData, &snapForCheck); unmarshalErr == nil {
-		warnOnGPUPlacementMismatch(&snapForCheck)
-	}
-
-	// If template is specified, process the snapshot through the template
-	if n.AgentConfig.TemplatePath != "" {
-		return n.processWithTemplate(ctx, snapshotData, finalOutput)
-	}
-
-	// Write snapshot to final destination
-	switch {
-	case finalOutput == "" || finalOutput == "-" || finalOutput == serializer.StdoutURI:
-		// Output snapshot data to stdout for consumption by caller. A short write
-		// or broken pipe must surface, not silently drop the snapshot.
-		if _, err := os.Stdout.Write(snapshotData); err != nil {
-			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
-		}
-		if _, err := os.Stdout.Write([]byte("\n")); err != nil {
-			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
-		}
-	case strings.HasPrefix(finalOutput, serializer.ConfigMapURIScheme):
-		// Written by the Job; when --aks-gpu-pools was supplied,
-		// deployAndWaitForResult has already rewritten it with the
-		// merged bytes.
-		slog.Info("snapshot saved to ConfigMap", slog.String("uri", finalOutput))
-	default:
-		// Write to file
-		if err := serializer.WriteToFile(finalOutput, snapshotData); err != nil {
-			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to file", err)
-		}
-		slog.Info("snapshot saved to file", slog.String("path", finalOutput))
-	}
-
-	return nil
+	return DeliverSnapshot(ctx, snapshotData, SnapshotDelivery{
+		Output:       n.AgentConfig.Output,
+		TemplatePath: n.AgentConfig.TemplatePath,
+		Kubeconfig:   n.AgentConfig.Kubeconfig,
+	})
 }
 
-// rewriteSnapshotConfigMap re-serializes merged snapshot bytes into the
-// user-requested ConfigMap destination, replacing the pre-merge content the
-// agent Job stored there.
 // rewriteMergedSnapshotConfigMap applies the merged snapshot bytes back to
 // the result ConfigMap and encodes the delivery contract: when the ConfigMap
 // is the user's delivery vehicle (cm:// output) a rewrite failure fails the
@@ -720,7 +829,7 @@ func (n *NodeSnapshotter) measureWithAgent(ctx context.Context) error {
 // carry the merged reading, and a transient Apply failure on the internal
 // hygiene rewrite must not discard an already-captured snapshot.
 func rewriteMergedSnapshotConfigMap(ctx context.Context, uri, kubeconfig string, snapshotData []byte, deliverViaConfigMap bool) error {
-	err := rewriteSnapshotConfigMap(ctx, uri, kubeconfig, snapshotData)
+	err := writeSnapshotConfigMap(ctx, uri, kubeconfig, snapshotData)
 	if err == nil {
 		return nil
 	}
@@ -733,7 +842,11 @@ func rewriteMergedSnapshotConfigMap(ctx context.Context, uri, kubeconfig string,
 	return nil
 }
 
-func rewriteSnapshotConfigMap(ctx context.Context, uri, kubeconfig string, snapshotData []byte) error {
+// writeSnapshotConfigMap applies snapshot bytes to a cm://namespace/name
+// destination, replacing whatever is there. Shared by DeliverSnapshot (the
+// caller's chosen destination) and the AKS-pool merge rewrite (replacing the
+// pre-merge content the agent Job stored).
+func writeSnapshotConfigMap(ctx context.Context, uri, kubeconfig string, snapshotData []byte) error {
 	namespace, name, err := pod.ParseConfigMapURI(uri)
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse snapshot ConfigMap URI", err)
@@ -744,11 +857,11 @@ func rewriteSnapshotConfigMap(ctx context.Context, uri, kubeconfig string, snaps
 	// populated from the document header.
 	var doc map[string]any
 	if err := yaml.Unmarshal(snapshotData, &doc); err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to parse merged snapshot for ConfigMap rewrite", err)
+		return errors.Wrap(errors.ErrCodeInternal, "failed to parse snapshot for ConfigMap write", err)
 	}
 	writer := serializer.NewConfigMapWriterWithKubeconfig(namespace, name, kubeconfig, serializer.FormatYAML)
 	if err := writer.Serialize(ctx, rawSnapshotDoc{doc: doc}); err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to rewrite snapshot ConfigMap with AKS GPU pools merge", err)
+		return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot ConfigMap", err)
 	}
 	return nil
 }
@@ -780,8 +893,10 @@ func (r rawSnapshotDoc) GetMetadata() map[string]string {
 	return out
 }
 
-// processWithTemplate processes snapshot data through a Go template.
-func (n *NodeSnapshotter) processWithTemplate(ctx context.Context, snapshotData []byte, output string) (err error) {
+// deliverWithTemplate renders snapshot data through a Go template. Unlike the
+// other delivery modes this one must parse the document, because the template
+// addresses the Snapshot struct's fields.
+func deliverWithTemplate(ctx context.Context, snapshotData []byte, templatePath, output string) (err error) {
 	// Unmarshal YAML to Snapshot struct
 	var snap Snapshot
 	if err = yaml.Unmarshal(snapshotData, &snap); err != nil {
@@ -789,7 +904,7 @@ func (n *NodeSnapshotter) processWithTemplate(ctx context.Context, snapshotData 
 	}
 
 	// Create template writer
-	tw, err := serializer.NewTemplateFileWriter(n.AgentConfig.TemplatePath, output)
+	tw, err := serializer.NewTemplateFileWriter(templatePath, output)
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to create template writer", err)
 	}

--- a/pkg/snapshotter/agent_test.go
+++ b/pkg/snapshotter/agent_test.go
@@ -18,6 +18,7 @@ import (
 	stderrors "errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -457,13 +458,13 @@ func TestParseTolerationsOperator(t *testing.T) {
 	}
 }
 
+// TestAgentOutputURILogic exercises agentConfigMapTarget — the rule that
+// decides where the agent Job stages its result:
+//  1. A file path leaves the Job on the default ConfigMap in its namespace.
+//  2. A cm:// URI makes that ConfigMap the Job's target AND the delivery
+//     vehicle, so a rewrite failure must be fatal rather than a warning.
+//  3. Stdout (empty or "-") behaves like a file path.
 func TestAgentOutputURILogic(t *testing.T) {
-	// Test the logic for determining agentOutput based on user's finalOutput
-	// This tests the rules:
-	// 1. If user specifies a file path, agent uses default ConfigMap in agent's namespace
-	// 2. If user specifies a ConfigMap URI, agent uses that URI
-	// 3. If user specifies stdout, agent uses default ConfigMap in agent's namespace
-
 	tests := []struct {
 		name               string
 		agentNamespace     string
@@ -508,18 +509,14 @@ func TestAgentOutputURILogic(t *testing.T) {
 		},
 	}
 
-	const configMapURIScheme = "cm://"
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Simulate the logic from measureWithAgent
-			finalOutput := tt.userOutput
-			agentOutput := configMapURIScheme + tt.agentNamespace + "/aicr-snapshot"
-
-			hasConfigMapPrefix := len(finalOutput) >= len(configMapURIScheme) &&
-				finalOutput[:len(configMapURIScheme)] == configMapURIScheme
-			if hasConfigMapPrefix {
-				agentOutput = finalOutput
+			agentOutput, deliverViaConfigMap, err := agentConfigMapTarget(&AgentConfig{
+				Namespace: tt.agentNamespace,
+				Output:    tt.userOutput,
+			})
+			if err != nil {
+				t.Fatalf("agentConfigMapTarget: %v", err)
 			}
 
 			if tt.wantUsesUserOutput {
@@ -530,6 +527,11 @@ func TestAgentOutputURILogic(t *testing.T) {
 				if agentOutput != tt.wantAgentOutputHas {
 					t.Errorf("agentOutput = %q, want %q", agentOutput, tt.wantAgentOutputHas)
 				}
+			}
+			if deliverViaConfigMap != tt.wantUsesUserOutput {
+				t.Errorf("deliverViaConfigMap = %v, want %v — the flag must track whether the "+
+					"ConfigMap is the user's delivery vehicle, since it decides whether an "+
+					"AKS-pool-merge rewrite failure is fatal", deliverViaConfigMap, tt.wantUsesUserOutput)
 			}
 		})
 	}
@@ -545,5 +547,254 @@ func TestAgentConfigWithTemplatePath(t *testing.T) {
 
 	if cfg.TemplatePath != "/path/to/template.tmpl" {
 		t.Errorf("AgentConfig.TemplatePath = %q, want %q", cfg.TemplatePath, "/path/to/template.tmpl")
+	}
+}
+
+// snapshotFixture is a minimal but realistic agent document. The
+// "unmodeledField" key stands in for a field a NEWER agent image emits that
+// this binary's Snapshot type does not know about — the reason delivery must
+// write raw bytes instead of re-serializing the parsed struct.
+const snapshotFixture = `apiVersion: aicr.run/v1alpha2
+kind: Snapshot
+metadata:
+  version: v9.9.9
+  source: node-1
+unmodeledField:
+  fromANewerAgent: true
+measurements: []
+`
+
+// TestDeliverSnapshot_FileIsByteIdentical is the byte-identity guarantee that
+// routing `aicr snapshot` through the facade had to preserve: what lands on
+// disk is exactly what the agent emitted, including fields this binary's
+// Snapshot type does not model. A re-serialization of the parsed struct would
+// drop unmodeledField and reorder keys.
+func TestDeliverSnapshot_FileIsByteIdentical(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "snapshot.yaml")
+
+	if err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{Output: out}); err != nil {
+		t.Fatalf("DeliverSnapshot: %v", err)
+	}
+
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read delivered snapshot: %v", err)
+	}
+	if string(got) != snapshotFixture {
+		t.Errorf("delivered bytes differ from the agent's output\n got:\n%s\nwant:\n%s", got, snapshotFixture)
+	}
+}
+
+// TestDeliverSnapshot_ConfigMapRejectsMalformedURI proves a cm:// destination
+// is parsed rather than prefix-matched, and — critically — that delivery to a
+// ConfigMap is not a silent no-op. It used to log success and return nil, so
+// an SDK caller that collected to the default internal ConfigMap and then
+// delivered to cm://ns/name got no artifact AND no error.
+//
+// A malformed URI is the assertion that needs no cluster: it must fail with
+// ErrCodeInvalidRequest, which is only reachable if delivery actually tries to
+// resolve and write the destination.
+func TestDeliverSnapshot_ConfigMapRejectsMalformedURI(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"scheme only", "cm://"},
+		{"namespace without name", "cm://aicr-snapshot"},
+		{"empty namespace", "cm:///aicr-snapshot"},
+		{"empty name", "cm://default/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{Output: tt.uri})
+			if err == nil {
+				t.Fatalf("DeliverSnapshot(%q) = nil error, want a rejection; a ConfigMap "+
+					"destination must never report success without writing one", tt.uri)
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+// TestDeliverSnapshot_ConfigMapWritesNoLocalFile guards the destination
+// dispatch: a cm:// Output must not fall through to the file branch and drop a
+// literal "cm:..." file in the working directory. The delivery below cannot
+// reach a cluster, so it is expected to fail — what matters is that it failed
+// on the ConfigMap path and left the filesystem alone.
+func TestDeliverSnapshot_ConfigMapWritesNoLocalFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Point at an unreachable apiserver so the write fails fast and
+	// deterministically instead of picking up an ambient kubeconfig.
+	unreachable := filepath.Join(dir, "does-not-exist.kubeconfig")
+	err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+		Output:     "cm://default/aicr-snapshot",
+		Kubeconfig: unreachable,
+	})
+	if err == nil {
+		t.Fatal("DeliverSnapshot(cm://) with an unusable kubeconfig = nil error, want a write failure")
+	}
+
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("read working dir: %v", readErr)
+	}
+	for _, e := range entries {
+		if e.Name() != filepath.Base(unreachable) {
+			t.Errorf("cm:// delivery created local file %q; the ConfigMap branch must not "+
+				"fall through to file output", e.Name())
+		}
+	}
+}
+
+// TestDeliverSnapshot_Template renders through a Go template rather than
+// copying bytes — the one delivery mode that must parse the document, since
+// the template addresses Snapshot fields.
+func TestDeliverSnapshot_Template(t *testing.T) {
+	dir := t.TempDir()
+	tmpl := filepath.Join(dir, "snapshot.tmpl")
+	if err := os.WriteFile(tmpl, []byte("version={{ .Metadata.version }}\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	out := filepath.Join(dir, "report.md")
+
+	if err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+		Output:       out,
+		TemplatePath: tmpl,
+	}); err != nil {
+		t.Fatalf("DeliverSnapshot(template): %v", err)
+	}
+
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read rendered report: %v", err)
+	}
+	if string(got) != "version=v9.9.9\n" {
+		t.Errorf("rendered report = %q, want %q", got, "version=v9.9.9\n")
+	}
+}
+
+// TestDeliverSnapshot_TemplateRejectsUnparseableDocument confirms the template
+// mode fails loudly rather than emitting a half-rendered report: it is the
+// only mode that depends on the document parsing.
+func TestDeliverSnapshot_TemplateRejectsUnparseableDocument(t *testing.T) {
+	dir := t.TempDir()
+	tmpl := filepath.Join(dir, "snapshot.tmpl")
+	if err := os.WriteFile(tmpl, []byte("{{ .Metadata.version }}\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	err := DeliverSnapshot(t.Context(), []byte("\tnot: [valid yaml"), SnapshotDelivery{
+		Output:       filepath.Join(dir, "report.md"),
+		TemplatePath: tmpl,
+	})
+	if err == nil {
+		t.Fatal("DeliverSnapshot(unparseable) = nil error, want a parse failure")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInternal, "")) {
+		t.Errorf("error = %v, want code ErrCodeInternal", err)
+	}
+}
+
+// TestAgentConfigMapTargetRejectsMalformedURI is the fail-before-mutate guard.
+// The Job's ConfigMap target used to be accepted on the "cm://" prefix alone,
+// so a typo like "cm://aicr-snapshot" (name, no namespace) was only caught by
+// the in-pod writer — after RBAC and the Job had been created. With Cleanup
+// false (the zero value, and what SDK callers get unless they opt in) those
+// resources, including a cluster-admin binding, stay behind.
+func TestAgentConfigMapTargetRejectsMalformedURI(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{"scheme only", "cm://"},
+		{"namespace without name", "cm://aicr-snapshot"},
+		{"empty namespace", "cm:///aicr-snapshot"},
+		{"empty name", "cm://default/"},
+		{"whitespace name", "cm://default/   "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := agentConfigMapTarget(&AgentConfig{Namespace: "default", Output: tt.output})
+			if err == nil {
+				t.Fatalf("agentConfigMapTarget(%q) = nil error, want rejection before any cluster access", tt.output)
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+}
+
+// TestDeployAndCollectRejectsBeforeClusterAccess proves the rejections above
+// happen before the Kubernetes client is built: with a kubeconfig that cannot
+// be loaded, a valid-but-rejected config must still surface its own
+// ErrCodeInvalidRequest rather than a kubeconfig failure. If the order were
+// reversed, the documented contract would be masked whenever cluster access
+// was also unavailable — and, worse, a reachable cluster would get RBAC and a
+// Job before the input was ever checked.
+func TestDeployAndCollectRejectsBeforeClusterAccess(t *testing.T) {
+	badKubeconfig := filepath.Join(t.TempDir(), "does-not-exist.kubeconfig")
+
+	tests := []struct {
+		name    string
+		config  *AgentConfig
+		wantMsg string
+	}{
+		{
+			name: "malformed ConfigMap output",
+			config: &AgentConfig{
+				Namespace:  "default",
+				Kubeconfig: badKubeconfig,
+				Output:     "cm://aicr-snapshot",
+			},
+			wantMsg: "invalid ConfigMap output URI",
+		},
+		{
+			name: "cluster-config path in Job mode",
+			config: &AgentConfig{
+				Namespace:         "default",
+				Kubeconfig:        badKubeconfig,
+				ClusterConfigPath: "/host/cluster-config.yaml",
+			},
+			wantMsg: "--cluster-config is not supported in agent Job mode",
+		},
+		{
+			// Empty Namespace would build the invalid internal URI
+			// "cm:///aicr-snapshot", which only fails when it is finally
+			// parsed — after RBAC and the Job exist. The CLI always supplies
+			// a default, so this is the SDK-caller path.
+			name: "empty namespace",
+			config: &AgentConfig{
+				Kubeconfig: badKubeconfig,
+			},
+			wantMsg: "Namespace is required",
+		},
+		{
+			name: "whitespace-only namespace",
+			config: &AgentConfig{
+				Namespace:  "   ",
+				Kubeconfig: badKubeconfig,
+			},
+			wantMsg: "Namespace is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := DeployAndCollect(t.Context(), tt.config)
+			if err == nil {
+				t.Fatal("DeployAndCollect() = nil error, want rejection")
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error = %v, want it to mention %q (a kubeconfig failure here means the "+
+					"input check ran too late)", err, tt.wantMsg)
+			}
+		})
 	}
 }

--- a/pkg/snapshotter/aksgpupools_test.go
+++ b/pkg/snapshotter/aksgpupools_test.go
@@ -205,14 +205,14 @@ measurements:
 	}
 }
 
-// TestRewriteSnapshotConfigMapRejectsBadInput pins the guard branches; the
+// TestWriteSnapshotConfigMapRejectsBadInput pins the guard branches; the
 // live write path requires a cluster and is covered by e2e.
-func TestRewriteSnapshotConfigMapRejectsBadInput(t *testing.T) {
-	if err := rewriteSnapshotConfigMap(t.Context(), "not-a-cm-uri", "", []byte("{}")); err == nil {
-		t.Fatal("rewriteSnapshotConfigMap(bad URI) = nil, want error")
+func TestWriteSnapshotConfigMapRejectsBadInput(t *testing.T) {
+	if err := writeSnapshotConfigMap(t.Context(), "not-a-cm-uri", "", []byte("{}")); err == nil {
+		t.Fatal("writeSnapshotConfigMap(bad URI) = nil, want error")
 	}
-	if err := rewriteSnapshotConfigMap(t.Context(), "cm://ns/name", "", []byte("{not yaml")); err == nil {
-		t.Fatal("rewriteSnapshotConfigMap(garbage snapshot) = nil, want parse error")
+	if err := writeSnapshotConfigMap(t.Context(), "cm://ns/name", "", []byte("{not yaml")); err == nil {
+		t.Fatal("writeSnapshotConfigMap(garbage snapshot) = nil, want parse error")
 	}
 }
 

--- a/pkg/snapshotter/doc.go
+++ b/pkg/snapshotter/doc.go
@@ -37,6 +37,25 @@
 //
 //	func (n *NodeSnapshotter) Measure(ctx context.Context) error
 //
+// # Job-mode collection
+//
+// Deploying the agent as a Kubernetes Job is split into two exported steps so
+// callers that need the captured bytes and callers that need them written out
+// share one implementation:
+//
+//	func DeployAndCollect(ctx context.Context, config *AgentConfig) (*Snapshot, []byte, error)
+//	func DeliverSnapshot(ctx context.Context, data []byte, dest SnapshotDelivery) error
+//
+// NodeSnapshotter.Measure composes them when AgentConfig is set. Most callers
+// should instead go through the aicr.Client facade's CollectSnapshot, which
+// wraps DeployAndCollect (`aicr snapshot` and `aicr validate` both do); reach
+// for NodeSnapshotter directly only for LOCAL collection, which deploys no Job
+// and needs a collector.Factory and serializer.Serializer.
+//
+// Deliver the RAW bytes DeployAndCollect returns, not a re-serialization of
+// the parsed Snapshot: a newer agent image can emit fields the local Snapshot
+// type does not model, and a typed round trip drops them silently.
+//
 // Snapshot: Captured configuration data
 //
 //	type Snapshot struct {


### PR DESCRIPTION
## Summary

Close two pre-stability drift items on the `pkg/client/v1` facade: make the
dot-path selector context-aware and route every in-tree snapshot Job through
`Client.CollectSnapshot`, with the facade↔internal `AgentConfig` mirror now
enforced by a test.

## Motivation / Context

Both issues are children of #2016 (facade parity before the surface is
declared stable) and overlap in `pkg/client/v1` + `pkg/cli`, so they land
together.

While implementing, the drift turned out to be worse than the issues
described:

- The facade `AgentConfig` was **already missing** `ClusterConfigPath` and
  `DiscoverNetwork` — exactly the silent-zero-value failure the mirror's own
  doc comment predicted.
- `AgentConfig.Output` was a **dead field**: `DeployAndGetSnapshot` computed
  its own ConfigMap target and ignored it.
- A **third** hand-rolled mirror existed at `pkg/cli/validate.go:161`, which
  built a `snapshotter.AgentConfig` inline and bypassed `CollectSnapshot` too.
- For the TOCTOU, `BundleComponents` already resolved values once for
  *emission*; the divergent read is in the gate
  (`validations.effectiveComponentValues`), which re-resolves independently.

Fixes: #2020
Fixes: #2021
Related: #2016, #1873

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK facade (`pkg/client/v1`)

## Implementation Notes

### #2020 — context-aware selector

`SelectFromRecipeWithContext(ctx, *RecipeResult, selector)` is now the single
implementation; `SelectFromRecipe` remains as a documented wrapper that derives
a `defaults.FileReadTimeout`-bounded context, for source compatibility.

`pkg/cli/query.go` and `pkg/server/recipe_handler.go` both call it. The
server's 404-vs-5xx requirement is met as a **handler-level mapping** over a
documented contract rather than a second code path: selector-path failures
carry `ErrCodeNotFound` as the **outermost** structured code, hydration
failures never do (`HydrateResultWithContext` hard-wraps every per-component
failure as `ErrCodeInternal`).

The handler matches with `stderrors.As` on the outermost node, **not**
`stderrors.Is` — `Is` walks the wrap chain and would misread a hydration
failure whose cause happens to carry `ErrCodeNotFound` (a missing values file)
as a missing selector path. This is a deliberate deviation from the repo's
usual "prefer `errors.Is` for code matching" rule, commented at the call site.

`WrapResolved(*recipe.RecipeResult) *RecipeResult` is new: the query handler
projects a legacy (`/v1`) view of the resolved recipe before selecting, and
needs to re-enter the facade with it. The wrapped result is **queryable only**
— no owning Client, so `MakeBundle` / `BundleComponents` / `ValidateState`
reject it.

### #2021 item A — snapshot routing

`pkg/snapshotter` splits Job-mode collection into two exported steps:

- `DeployAndCollect(ctx, cfg) (*Snapshot, []byte, error)` — deploy, wait,
  parse, and return **both** the typed snapshot and the raw agent bytes.
- `DeliverSnapshot(ctx, data, templatePath, output) error` — template /
  stdout / ConfigMap / file delivery.

`NodeSnapshotter.measureWithAgent` is now the composition of the two, so the
CLI and facade paths emit the same bytes **by construction**. `Snapshot.Raw`
carries the agent's exact document; delivering it (rather than re-serializing
the parsed struct) is what keeps `aicr snapshot` output byte-identical when a
newer agent image emits fields this binary does not model.

`aicr snapshot` (Job mode) and `aicr validate` both now go through
`Client.CollectSnapshot`. `Snapshot.Unwrap()` (inverse of `WrapSnapshot`, analog
of `RecipeResult.Resolved()`) gives validate the measurement-level payload it
needs.

**Deliberately left outside the facade**, named in the `CollectSnapshot` godoc
with reasons, per the issue's acceptance criteria:

- Local (`AICR_AGENT_MODE`) collection — deploys no Job; needs a
  `collector.Factory` and `serializer.Serializer`, types the semver-stable
  facade does not expose. It projects config down via the now-exported
  `ToInternalAgentConfig` rather than assembling a second copy.
- `ClusterConfigPath` in Job mode — the path must resolve inside the pod and
  the Job does not mount it; rejected with `ErrCodeInvalidRequest` as before.

`TestAgentConfigMirrorsInternal` makes the mirror an invariant with two
assertions: **shape** (same-named, same-typed fields both ways) and **value**
(every field set to a distinct non-zero value must survive the projection —
catching a field present on both sides but missing from
`ToInternalAgentConfig`). A new field of an unmodeled type fails the test
rather than being skipped. Both halves were verified to fail against
deliberately introduced drift before being kept.

### #2021 item B — values TOCTOU (`#1873` item A, SDK path)

`BundleComponents` now resolves the Helm-value inventory **once**, before any
gate, and pins it onto the recipe result the gates see via the new
`RecipeResult.WithResolvedValues` (a shallow copy serving deep copies, so a
gate that layers `--set` overrides onto what it reads cannot corrupt the
emitted map). Scoped to the SDK path as #2021 specifies; `DefaultBundler.Make`
remains open under #1873.

### Review-round fixes

Three hazards surfaced in review, all closed in this branch:

1. **Malformed `cm://` output accepted by prefix only.** `agentConfigMapTarget`
   matched the scheme and passed the string straight to the Job, so
   `cm://aicr-snapshot` (name, no namespace) only failed inside the pod —
   after RBAC and the Job existed, and with `Cleanup` false (the zero value
   SDK callers get) they persist, including a cluster-admin binding. The URI
   is now fully parsed with `pod.ParseConfigMapURI`, and both it and a
   Job-mode `ClusterConfigPath` are rejected **before the Kubernetes client is
   built** — so a rejection is never masked by a kubeconfig error and never
   mutates the cluster. `TestDeployAndCollectRejectsBeforeClusterAccess` and
   `TestCollectSnapshot_RejectsBeforeClusterAccess` assert the *ordering* by
   passing an unusable kubeconfig and requiring the input error to win.
   (The duplicate `ClusterConfigPath` check inside `deployAndWaitForResult`
   was removed — it now has a single caller.)

2. **`DeliverSnapshot`'s `cm://` branch logged success without writing.** That
   is only correct when the same URI was `AgentConfig.Output` at collection
   time; an integrator who collected to the default internal ConfigMap and
   then delivered to `cm://ns/name` got no artifact **and** no error, while
   the integrator guide claimed delivery writes ConfigMaps. Delivery now
   performs the write (idempotent when the Job already staged those bytes),
   making the destination set total. Parameters moved to a `SnapshotDelivery`
   struct to carry the kubeconfig that requires. The old
   `rewriteSnapshotConfigMap` became `writeSnapshotConfigMap`, shared by
   delivery and the AKS-pool merge.

3. **CLI truncated the output file before collecting** (CodeRabbit,
   outside-diff). `createSnapshotSerializer` opens the destination with
   `os.Create`, and it was built above the mode branch — so on the Job path,
   which never uses it, a failed collection left the previous capture erased.
   Construction moved into the local-collection branch that actually consumes
   it. Job-mode destinations are validated without side effects instead: the
   template by `parseSnapshotCmdOptions`, the `cm://` URI by
   `DeployAndCollect`.

A second review round surfaced three more, also fixed:

4. **Empty `Namespace` reached the cluster before failing.** The `cm://`
   branch was validated, but the default branch built `cm://<Namespace>/aicr-snapshot`
   unchecked — an empty namespace yields `cm:///aicr-snapshot`, rejected only
   when finally parsed, after RBAC and the Job. Guarded in `DeployAndCollect`
   rather than in `agentConfigMapTarget`, because `Namespace` is required in
   **both** output modes: the Job and its RBAC are created there regardless of
   whether `Output` is a `cm://` URI, so guarding only the default branch would
   still let a `cm://ns/name` caller with an empty namespace mutate the cluster.
   The CLI is insulated (both commands default the flag); this is the
   SDK-caller path.

5. **Orphaned godoc fragment on `DeployAndCollect`.** Not a typo — since Go
   1.19 `gofmt` treats `//nolint:...` as a directive and moves it to the end of
   the doc block, so rationale written as continuation lines under it got
   hoisted above and orphaned mid-sentence. Rewriting in place would just be
   re-broken by the next `gofmt`; the rationale is now a normal paragraph
   before a single-line directive, with a note so it is not reintroduced.

6. **`ToInternalAgentConfig` un-exported.** It was exported on the stated
   grounds that the CLI's local-collection path needed it — which turned out to
   be false (that path builds a `collector.Factory` and `serializer.Serializer`
   from `opts`, and *cannot* take an `AgentConfig`, since setting
   `NodeSnapshotter.AgentConfig` is what selects Job mode). That left an
   exported facade symbol with no caller outside the package: the exact drift
   this PR exists to remove. Back to unexported, stability pin dropped; the
   mirror test is an internal test, so enforcement is unaffected.

**Declined:** a suggestion to swap `context.Background()` for `context.TODO()`
in `SelectFromRecipe`. `AGENTS.md`'s canonical GOOD example for a context-less
wrapper is `context.WithTimeout(context.Background(), ...)` — this pattern
verbatim — and the repo uses it in eight places including `recipe.HydrateResult`,
the very function this wrapper calls. `context.TODO()` means "unclear which
context, fill in later"; here the absence is deliberate and permanent, which is
why `SelectFromRecipeWithContext` exists and is documented as preferred.

Also from CodeRabbit: `TestDeliverSnapshot_ConfigMapIsNoOp` asserted on a
`t.TempDir()` it never entered, so `os.ReadDir` was vacuously empty. It is
replaced by `TestDeliverSnapshot_ConfigMapRejectsMalformedURI` (real
assertions, no cluster needed) and `TestDeliverSnapshot_ConfigMapWritesNoLocalFile`
(uses `t.Chdir`, and pins that the ConfigMap branch never falls through to
file output).

### Behavior changes (2, both intentional)

1. **`CollectSnapshot` timeout.** Bounded by `AgentConfig.Timeout +
   defaults.SnapshotOperationGrace` (new, 1m). `AgentConfig.Timeout` budgets
   Job *completion* only — deploy, `--aks-gpu-pools` projection, and ConfigMap
   retrieval sit outside it — so a bare cap would have silently shrunk the
   completion budget by however long deployment took, failing Jobs on slow
   clusters that previously succeeded.
2. **Unparseable snapshot on `aicr snapshot`.** Previously this path parsed
   best-effort (skipping only the GPU-placement warning) and delivered the
   bytes anyway; the SDK path already failed. Converged on strict: a document
   `aicr snapshot` cannot parse is one `aicr validate` and
   `aicr recipe --snapshot` would reject too, so writing it out and exiting 0
   reports a success the artifact cannot back.

### Not included

An unrelated missing license header on
`tools/registry-inventory/registry-allowlist.yaml` (added by `make lint`'s
`license` fixer during qualification) was reverted to keep this PR scoped —
`make license-check` passes without it.

## Testing

```bash
make qualify
```

Full `make qualify` passes. Two stages fail **only** under the agent sandbox
and were re-run without it to confirm:

- `check-agents-sync` — its `diff` uses process substitution (`/dev/fd/63`),
  which the sandbox blocks; fails identically on `main`. Unsandboxed:
  `OK: AGENTS.md is in sync with .claude/CLAUDE.md`.
- `./tools/e2e` — chainsaw fixtures write to `/tmp/chainsaw-*`, outside the
  sandbox write allowlist. Unsandboxed: **24 passed, 0 failed, 0 skipped**.

Other stages: `test-coverage` 82.3% (threshold 80%), `golangci-lint ./pkg/...`
0 issues, `go test -race ./pkg/... ./cmd/...` clean, `make scan` clean.

**New tests**

- `TestSelectFromRecipeWithContextCancellation` — a canceled context aborts
  hydration, and the failure is classified as hydration (never `NotFound`).
- `TestSelectFromRecipeNotFoundIsOutermostCode` — pins the code contract the
  handler maps on.
- `TestWrapResolvedIsQueryable` — selector parity with the resolved result;
  rejected by the bundle path.
- `TestAgentConfigMirrorsInternal` — shape + value mirror invariant.
- `TestBundleComponents_ResolvesValuesOnce` — a provider whose document
  changes on every read proves one resolution feeds both gate and emission.
  **Verified to fail pre-fix** (`values file read 2 times, want exactly 1`).
- `TestBundleComponents_PinnedValuesSurviveGateMutation` — the pin hands out
  deep copies, so a gate's `--set` layering cannot leak into the bundle.
- `TestWithResolvedValues` — pin semantics (nil receiver, empty snapshot,
  pinned vs unpinned components, deep copies, cancellation, `DeepCopy` drops
  the pin).
- `TestDeliverSnapshot_*` — file delivery is byte-identical including a field
  the local `Snapshot` type does not model; `cm://` rejects malformed URIs and
  never falls through to file output; template rendering; template mode
  rejects an unparseable document.
- `TestAgentConfigMapTargetRejectsMalformedURI`,
  `TestDeployAndCollectRejectsBeforeClusterAccess`,
  `TestCollectSnapshot_RejectsBeforeClusterAccess` — fail-before-mutate for a
  malformed `cm://` URI, an empty/whitespace `Namespace`, and a Job-mode
  `ClusterConfigPath`. Each passes an unusable kubeconfig so the assertion
  proves the *ordering* relative to building the Kubernetes client, not just
  the rejection.
- `TestSnapshotUnwrapRoundTrips` — `WrapSnapshot`/`Unwrap` returns the same
  pointer; facade-constructed snapshots rebuild minimally; `Raw` stays empty
  outside `CollectSnapshot`.
- `TestAgentOutputURILogic` was converted from a *simulation* of
  `measureWithAgent`'s logic into a real call to `agentConfigMapTarget`, and
  now also asserts the `deliverViaConfigMap` flag.

**Coverage deltas** (per-package, branch vs `origin/main`)

| Package | Before | After | Δ |
|---|---|---|---|
| `pkg/client/v1` | 81.8% | 81.9% | +0.1% |
| `pkg/snapshotter` | 54.2% | 55.9% | +1.7% |
| `pkg/cli` | 74.9% | 74.8% | -0.1% |
| `pkg/server` | 82.6% | 82.6% | — |
| `pkg/recipe` | 100.0% | 100.0% | — |

No new exported function is left at 0% coverage.

## Risk Assessment

- [x] **Medium** — Touches multiple components or has broader impact

Spans the snapshot collection path (`pkg/snapshotter`), the SDK facade, both
CLI commands that capture snapshots, and the REST query handler. Mitigations:
`measureWithAgent` is now a composition of the same two functions the facade
calls, so byte-identity holds by construction rather than by assertion; the
full 24-test e2e suite passes; and the mirror invariant is verified to fail
against injected drift.

**Rollout notes:** No migration. `ToInternalAgentConfig` was exported earlier in
this PR and is now unexported again — it never shipped. `snapshotter.DeliverSnapshot` changed shape
during review (positional `templatePath, output` → a `SnapshotDelivery`
struct); it was introduced in this same PR, so nothing external depends on the
earlier form. Both facade signature changes are additive —
`SelectFromRecipe` is retained as a wrapper, and `CollectSnapshot` keeps its
signature. `snapshotter.DeployAndGetSnapshot` is replaced by
`DeployAndCollect`; `pkg/snapshotter` is not covered by the facade's semver
guarantee (see `docs/integrator/public-api.md`), and it had no external
consumers in tree.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
