### PR TITLE
fix(evidence): bound residual on-disk reads on publish/verify paths

### DIFF
--- a/.github/scripts/recipe-evidence-check.sh
+++ b/.github/scripts/recipe-evidence-check.sh
@@ -694,6 +694,24 @@ while IFS= read -r slug; do
           verify_ok=false
           warnings=$((warnings + 1))
           ;;
+        3)
+          # Verification could not complete — the bundle was not readable
+          # (dead mount, unreachable registry). Distinct from exit 2: nothing
+          # was proven about the bundle, so this reports as an infrastructure
+          # condition rather than ":x: invalid", which would read to a
+          # contributor as "your evidence is bad".
+          if [[ "$cause_class" == "canceled" ]]; then
+            verify_cell=":black_square_for_stop: verification aborted (no verdict)"
+          else
+            verify_cell=":hourglass_flowing_sand: not verifiable (infrastructure)"
+          fi
+          if [[ -n "$cause_class" ]]; then
+            verify_cell="${verify_cell} — ${cause_class}"
+            [[ -n "$cause_hint" ]] && verify_cell="${verify_cell}: $(md_escape "$cause_hint")"
+          fi
+          verify_ok=false
+          warnings=$((warnings + 1))
+          ;;
         *)
           verify_cell=":x: verify error (result exit ${result_exit})"
           verify_ok=false

--- a/demos/evidence.md
+++ b/demos/evidence.md
@@ -221,22 +221,29 @@ The verifier pulls the OCI artifact and runs five checks:
 
 Exit codes:
 
-| Surface | `0` | `2` |
-|---|---|---|
-| OS exit code | Bundle valid; every check passed. | Anything else — bundle invalid OR recorded validator results show failures. |
+| Surface | `0` | `2` | `5` | `9` |
+|---|---|---|---|---|
+| OS exit code | Bundle valid; every check passed. | Bundle invalid OR recorded validator results show failures. | Verification could not complete — a transient storage or registry failure (unreadable bundle, unreachable or erroring registry). `failureCause.class: transient`. | Verification was aborted by the operator (`failureCause.class: canceled`). |
 
 The structured output's `exit` field (`VerifyResult.Exit` in the
-library, `.exit` in JSON output) carries a three-valued code so JSON
-consumers can distinguish the two non-zero cases:
+library, `.exit` in JSON output) carries a four-valued code so JSON
+consumers can distinguish the non-zero cases:
 
 * `0` — bundle valid; every check passed.
 * `1` — bundle valid; recorded validator results show failures
   (cryptographic integrity intact, informational).
 * `2` — bundle invalid (signature, integrity, or predicate failure).
+* `3` — no verdict reached: a storage or registry fault stopped the
+  check (`failureCause.class: transient`, OS exit 5) or the operator
+  aborted it (`canceled`, OS exit 9). Retry the transient case; do not
+  treat either as a rejection.
 
 Today the CLI collapses `1` and `2` to OS exit `2` because
 `pkg/errors/exitcode.go` maps both `ErrCodeConflict` and
-`ErrCodeInvalidRequest` to the same OS code. Shell scripts that want
+`ErrCodeInvalidRequest` to the same OS code. `3` is separated out to OS
+exit `5` when `failureCause.class` is `transient` and OS exit `9` when it
+is `canceled`, so a gate can tell an incomplete verification from a bad
+bundle without parsing JSON. Shell scripts that want
 to branch on the informational case should consume `--format json`
 and read `.exit` via `jq`:
 
@@ -332,7 +339,7 @@ Paste the rendered Markdown into the PR comment for maintainer review.
 aicr evidence verify recipes/evidence/h100-eks-ubuntu-training/81724194d94a1e926f68c78ae51e8720/sha256-9f8e7d6c5b4a3210fedcba9876543210abcdef0123456789fedcba9876543210.yaml \
   -o evidence-result.json -t json
 
-jq '.exit' evidence-result.json          # 0 / 1 / 2 (library code)
+jq '.exit' evidence-result.json          # 0 / 1 / 2 / 3 (library code)
 jq '.signer' evidence-result.json        # signer claims
 jq '.predicate.phases' evidence-result.json
 ```

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -470,7 +470,12 @@ committed pointer file and the PR description.
    [#1535](https://github.com/NVIDIA/aicr/issues/1535)). A structured `exit: 1` (in `--format json`) requires explicit disposition
    (see [Exit-1 Review Process](#exit-1-review-process)); `exit: 2` is a hard
    fail. Both collapse to OS exit code 2, so distinguish them by reading
-   `.exit` from `aicr evidence verify --format json`.
+   `.exit` from `aicr evidence verify --format json`. A structured `exit: 3` is **not** a verdict on
+   the bundle — verification never reached one. `failureCause.class:
+   transient` (OS exit code 5) means the bundle was not readable (dead mount,
+   unreachable registry); re-run the check. `failureCause.class: canceled`
+   (OS exit code 9) means the run was deliberately aborted. In neither case
+   should the contributor be asked to change anything.
 3. **Signer identity is acceptable.** Open the committed pointer file under
    `recipes/evidence/<recipe>/<src>/` and review its `signer` block. See
    [Signer Identity Trust Patterns](#signer-identity-trust-patterns).

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -947,6 +947,7 @@ ls -la
 | `NOT_FOUND` | 404 | Selector path not found in the resolved configuration | No |
 | `METHOD_NOT_ALLOWED` | 405 | Wrong HTTP method | No |
 | `CONFLICT` | 409 | Resource state conflict (e.g., already exists or version mismatch) | No |
+| `CANCELED` | 408 | The operation was aborted before completion (CLI-originated; not expected from the HTTP API) | No |
 | `RATE_LIMIT_EXCEEDED` | 429 | Too many requests | Yes |
 | `INTERNAL` | 500 | Server error | Yes |
 | `SERVICE_UNAVAILABLE` | 503 | Server temporarily unavailable | Yes |

--- a/docs/user/artifact-verification.md
+++ b/docs/user/artifact-verification.md
@@ -413,8 +413,13 @@ aicr verify ./my-bundle --format json
 aicr evidence verify recipes/evidence/<recipe>/<src>/<digest>.yaml --format json -o result.json
 ```
 
-`aicr evidence verify` exits `0` when every check passes and `2` when the
-bundle is invalid or recorded validator results show failures. The JSON
+`aicr evidence verify` exits `0` when every check passes, `2` when the
+bundle is invalid or recorded validator results show failures, `5` when
+verification could not complete because the bundle was not readable (a dead
+mount or an unreachable registry), and `9` when the run was aborted by the
+operator. The last two are deliberately distinct process codes: nothing was
+proven about the bundle in either case, so a gate must not reject the artifact.
+Retry the `5` case; a `9` means someone stopped the run on purpose. The JSON
 output's `exit` field further distinguishes recorded phase failures (`1`) from
 an invalid bundle (`2`), so a shell consumer can branch on it. Write the JSON to
 a file and read the `exit` field from it rather than piping `aicr evidence
@@ -428,6 +433,8 @@ case "$(jq '.exit' result.json)" in
   0) echo "evidence valid" ;;
   1) echo "validator phases failed" ;;
   2) echo "bundle invalid" ;;
+  3) echo "no verdict reached (infrastructure fault or aborted) — do not reject" ;;
+  *) echo "unrecognized verdict — treat as a failure" ;;
 esac
 ```
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -3164,19 +3164,31 @@ The positional argument is auto-detected as one of:
 | `--registry-insecure-tls` | | bool | `false` | Skip TLS verification for the registry (self-signed certificates). |
 | `--allow-unpinned-tag` | | bool | `false` | Accept tag-only OCI references. By default the verifier refuses unpinned refs because tags are registry-rewritable; opt in only for one-off debugging. Pointer-driven flows ignore this flag when the pointer carries a `sha256:` digest. |
 
-**Exit codes:**
+**Verdict codes:**
+
+These are the values of the `exit` field in the JSON/Markdown output, mirroring `VerifyResult.Exit` from the library API. They are **not** the process exit code — see the table below them.
 
 | Code | Meaning |
 |------|---------|
 | 0 | Bundle valid; every check passed (or valid but **unsigned** — see pending below). |
 | 1 | Bundle valid, but recorded validator phase results show failures (informational). |
 | 2 | Bundle invalid. The `failureCause.class` field gives the specific reason — registry access (`registry-forbidden`/`not-found`/`registry`), `signature`, `integrity`, `schema`, or `unknown` (see Failure cause below). |
+| 3 | Verification **did not complete**, so no verdict was reached. `failureCause.class` is `transient` (the bundle was not readable — dead NFS/FUSE mount, unreachable registry) or `canceled` (the operator aborted the run). This is **not** a statement about the bundle — nothing was proven about it either way. For `transient`, retry; do not reject the artifact. |
 
-The JSON/Markdown output's `exit` field mirrors `VerifyResult.Exit` from the library API. Shell consumers can branch via `jq '.exit'` on `--format json` output.
+**Process exit codes:**
+
+| Process code | Verdicts that map to it |
+|--------------|-------------------------|
+| 0 | verdict 0 |
+| 2 | verdicts 1 **and** 2 |
+| 5 | verdict 3 with `failureCause.class: transient` |
+| 9 | verdict 3 with `failureCause.class: canceled` |
+
+Verdicts 1 and 2 are indistinguishable at the process level because both map through `pkg/errors` to the same code. To tell them apart, branch on the JSON `exit` field via `jq '.exit'` rather than on `$?`. Verdict 3 is deliberately given its own process code so a CI gate can distinguish an infrastructure fault from an invalid attestation without parsing JSON.
 
 **Pending signature.** An unsigned bundle whose pointer carries no `signer` (e.g. one published with `--no-sign`, awaiting the signing leg) is **not** a `verify` failure: it verifies at exit `0` with `pending: true` in the JSON output and a "pending signature" verdict in the Markdown summary. This is a useful local check on a not-yet-signed bundle. The committed flat pending pointer is signed and relocated to its nested per-source path by the fork CI signing leg (`aicr evidence sign --relocate`); the blocking *Evidence Pointer Contract* gate (`pkg/evidence/verifier/discover.go`) requires that final signed, nested pointer. See [Publishing Recipe Evidence](../contributor/evidence-publishing.md#recommended-path-split-the-legs-sign-in-ci).
 
-**Failure cause.** On a non-zero exit, the JSON output carries a structured `failureCause` object — `class` (one of `registry-forbidden`, `not-found`, `registry`, `signature`, `integrity`, `schema`, `unknown`), an optional `httpStatus`, and an actionable `hint`. For example, a private fork registry returns `class: registry-forbidden`, `httpStatus: 403` with a hint to make the package public — so the reason is self-serviceable rather than a bare "invalid". The Markdown summary renders the same as **Cause**/**Hint** lines.
+**Failure cause.** On verdict 2 or 3, the JSON output carries a structured `failureCause` object — `class` (one of `registry-forbidden`, `not-found`, `registry`, `signature`, `integrity`, `schema`, `transient`, `canceled`, `unknown`), an optional `httpStatus`, and an actionable `hint`. For example, a private fork registry returns `class: registry-forbidden`, `httpStatus: 403` with a hint to make the package public — so the reason is self-serviceable rather than a bare "invalid". The Markdown summary renders the same as **Cause**/**Hint** lines.
 
 **Examples:**
 ```shell
@@ -3443,6 +3455,7 @@ AICR respects standard environment variables:
 | 6 | Unavailable (service temporarily unavailable) |
 | 7 | Rate limited (client exceeded rate limit) |
 | 8 | Internal error (unexpected failure) |
+| 9 | Operation aborted by the operator (SIGINT/SIGTERM) |
 
 ## Common Usage Patterns
 

--- a/pkg/cli/evidence_sign.go
+++ b/pkg/cli/evidence_sign.go
@@ -122,7 +122,7 @@ func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
 
 	relocate := cmd.Bool(flagRelocate)
 
-	pointer, err := verifier.LoadAndValidatePointer(path)
+	pointer, err := verifier.LoadAndValidatePointerContext(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
 	// the nested path directly). Closing that gap (verify the signature before
 	// honoring a committed signer) is tracked repo-wide in #1535.
 	if relocate && pointer.Attestations[0].Signer != nil {
-		dest, rerr := attestation.RelocatePointerToCanonical(path, pointer)
+		dest, rerr := attestation.RelocatePointerToCanonicalContext(ctx, path, pointer)
 		if rerr != nil {
 			return rerr
 		}
@@ -210,7 +210,7 @@ func runEvidenceSignCmd(ctx context.Context, cmd *cli.Command) error {
 	// canonical <source> path is now derivable. Relocate it home to satisfy
 	// the per-source contract gate.
 	if relocate {
-		dest, rerr := attestation.RelocatePointerToCanonical(path, pointer)
+		dest, rerr := attestation.RelocatePointerToCanonicalContext(ctx, path, pointer)
 		if rerr != nil {
 			// The bundle is already signed in the registry; only the local move
 			// failed. Surface that explicitly: PropagateOrWrap returns the inner

--- a/pkg/cli/evidence_verify.go
+++ b/pkg/cli/evidence_verify.go
@@ -54,11 +54,18 @@ Input is auto-detected as one of:
 The rendered output goes to stdout by default; -o writes it to a file
 instead. -t selects the format (text = Markdown, json = structured).
 
-Exit codes:
+Verdict codes (the "exit" field in --format json):
 
   0   bundle valid; every check passed.
   1   bundle valid; recorded validator results show failures (informational).
   2   bundle invalid (signature, schema, or integrity failure).
+  3   verification did not complete, so no verdict was reached — either the
+      bundle was not readable (failureCause.class "transient": dead mount,
+      unreachable registry) or the run was aborted ("canceled").
+
+Process exit codes differ: verdicts 1 and 2 both exit 2; verdict 3 exits 5
+when transient and 9 when canceled. Branch on the JSON "exit" field to
+tell 1 from 2.
 `,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -148,12 +155,37 @@ func runEvidenceVerifyCmd(ctx context.Context, cmd *cli.Command) (err error) {
 		return writeErr
 	}
 
+	return verdictError(result)
+}
+
+// verdictError maps a verifier verdict to the coded error whose exit code the
+// process returns. Extracted from the command so the full mapping — including
+// the two ways a run can end without a verdict — is directly testable.
+//
+// Verdicts 1 and 2 both land on process exit 2 (ErrCodeConflict and
+// ErrCodeInvalidRequest share it); consumers that need to tell them apart read
+// the JSON "exit" field. Verdict 3 gets its own codes precisely so a CI gate
+// can distinguish "we could not check this" from "we checked it and it failed".
+func verdictError(result *verifier.VerifyResult) error {
 	switch result.Exit {
 	case verifier.ExitValidPassed:
 		return nil
 	case verifier.ExitValidPhaseFailures:
 		return errors.New(errors.ErrCodeConflict,
 			"bundle valid; recorded validator results show failures")
+	case verifier.ExitIncomplete:
+		if result.FailureCause != nil && result.FailureCause.Class == verifier.CauseCanceled {
+			return errors.New(errors.ErrCodeCanceled,
+				"bundle verification aborted before a verdict was reached")
+		}
+		// ErrCodeTimeout (exit 5) is the deliberate umbrella for every
+		// non-canceled transient cause, including registry 5xx/429 where
+		// ErrCodeUnavailable (exit 6) would be the literal match. The verdict
+		// contract is two-valued on purpose — 5 transient, 9 canceled — so a
+		// gate branches on two codes rather than tracking the full ErrCode
+		// taxonomy. Reading exit 5 back as "timeout" is the cost of that.
+		return errors.New(errors.ErrCodeTimeout,
+			"bundle verification could not complete; the bundle was not readable (storage or registry fault)")
 	default:
 		return errors.New(errors.ErrCodeInvalidRequest,
 			"bundle verification failed; see the verifier output for details")

--- a/pkg/cli/evidence_verify_verdict_test.go
+++ b/pkg/cli/evidence_verify_verdict_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/verifier"
+)
+
+// TestVerdictError_ProcessExitMatrix pins the whole verdict-to-process-exit
+// contract in one place, because the load-bearing property of issue #2083 is a
+// negative one: a run that never reached a verdict must not share a process
+// exit code with a bundle that was checked and rejected. Asserting a set of
+// acceptable codes would let that collapse back without failing.
+func TestVerdictError_ProcessExitMatrix(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *verifier.VerifyResult
+		wantCode errors.ErrorCode
+		wantExit int
+	}{
+		{
+			name:     "valid bundle",
+			result:   &verifier.VerifyResult{Exit: verifier.ExitValidPassed},
+			wantExit: errors.ExitSuccess,
+		},
+		{
+			name:     "valid with recorded phase failures",
+			result:   &verifier.VerifyResult{Exit: verifier.ExitValidPhaseFailures},
+			wantCode: errors.ErrCodeConflict,
+			wantExit: errors.ExitInvalidInput,
+		},
+		{
+			name:     "invalid bundle",
+			result:   &verifier.VerifyResult{Exit: verifier.ExitInvalid},
+			wantCode: errors.ErrCodeInvalidRequest,
+			wantExit: errors.ExitInvalidInput,
+		},
+		{
+			name: "storage fault — no verdict reached",
+			result: &verifier.VerifyResult{
+				Exit:         verifier.ExitIncomplete,
+				FailureCause: &verifier.FailureCause{Class: verifier.CauseTransient},
+			},
+			wantCode: errors.ErrCodeTimeout,
+			wantExit: errors.ExitTimeout,
+		},
+		{
+			name: "operator abort — no verdict reached",
+			result: &verifier.VerifyResult{
+				Exit:         verifier.ExitIncomplete,
+				FailureCause: &verifier.FailureCause{Class: verifier.CauseCanceled},
+			},
+			wantCode: errors.ErrCodeCanceled,
+			wantExit: errors.ExitCanceled,
+		},
+		{
+			// Defensive: an incomplete result with no recorded cause still must
+			// not be reported as an invalid bundle.
+			name:     "incomplete with no cause",
+			result:   &verifier.VerifyResult{Exit: verifier.ExitIncomplete},
+			wantCode: errors.ErrCodeTimeout,
+			wantExit: errors.ExitTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verdictError(tt.result)
+			if got := errors.ExitCodeFromError(err); got != tt.wantExit {
+				t.Errorf("process exit = %d, want %d (err %v)", got, tt.wantExit, err)
+			}
+			if tt.wantCode == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+			if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Errorf("code = %v, want %s", err, tt.wantCode)
+			}
+		})
+	}
+}
+
+// TestVerdictError_NoVerdictNeverSharesInvalidExit is the negative property
+// stated directly: neither way of failing to reach a verdict may collide with
+// the exit code a rejected bundle produces, or a CI gate cannot tell "retry
+// this" from "reject this contribution".
+func TestVerdictError_NoVerdictNeverSharesInvalidExit(t *testing.T) {
+	invalid := errors.ExitCodeFromError(verdictError(
+		&verifier.VerifyResult{Exit: verifier.ExitInvalid}))
+
+	for _, class := range []string{verifier.CauseTransient, verifier.CauseCanceled} {
+		got := errors.ExitCodeFromError(verdictError(&verifier.VerifyResult{
+			Exit:         verifier.ExitIncomplete,
+			FailureCause: &verifier.FailureCause{Class: class},
+		}))
+		if got == invalid {
+			t.Errorf("class %q exits %d, colliding with the invalid-bundle exit", class, got)
+		}
+	}
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -46,6 +46,13 @@ const (
 	// version mismatch). Distinct from ErrCodeInvalidRequest because the request
 	// itself is well-formed; the conflict is with current resource state.
 	ErrCodeConflict ErrorCode = "CONFLICT"
+	// ErrCodeCanceled indicates the operator deliberately aborted the operation
+	// (SIGINT/SIGTERM propagated through the command context). Distinct from
+	// ErrCodeTimeout because a timeout is an environmental fault worth retrying
+	// and a cancellation is an instruction to stop: IsTransient reports false
+	// for this code, so a Ctrl-C never re-enters a retry loop or gets reported
+	// as a transient infrastructure failure.
+	ErrCodeCanceled ErrorCode = "CANCELED"
 )
 
 // StructuredError provides structured error information for better observability.
@@ -134,6 +141,12 @@ func WrapWithContext(code ErrorCode, message string, cause error, context map[st
 // for as deterministic and fail closed. Returns false for nil.
 func IsTransient(err error) bool {
 	if err == nil {
+		return false
+	}
+	// An explicit operator abort outranks anything else in the chain: a
+	// canceled command must never re-enter a retry loop, even when the
+	// underlying context.Canceled is still visible below it.
+	if stderrors.Is(err, New(ErrCodeCanceled, "")) {
 		return false
 	}
 	return stderrors.Is(err, context.DeadlineExceeded) ||

--- a/pkg/errors/exitcode.go
+++ b/pkg/errors/exitcode.go
@@ -57,6 +57,14 @@ const (
 	// ExitInternal indicates an internal error (reserved for unexpected failures).
 	// Maps to: ErrCodeInternal
 	ExitInternal = 8
+
+	// ExitCanceled indicates the operator aborted the operation (SIGINT/SIGTERM).
+	// Maps to: ErrCodeCanceled
+	//
+	// Deliberately inside the documented 2-63 application range rather than the
+	// shell's 128+signal convention (130), so the whole scheme stays consistent
+	// and scriptable; callers that need signal fidelity should trap the signal.
+	ExitCanceled = 9
 )
 
 // ExitCodeFromError extracts an appropriate exit code from an error.
@@ -87,6 +95,8 @@ func exitCodeFromErrorCode(code ErrorCode) int {
 		return ExitUnauthorized
 	case ErrCodeTimeout:
 		return ExitTimeout
+	case ErrCodeCanceled:
+		return ExitCanceled
 	case ErrCodeUnavailable:
 		return ExitUnavailable
 	case ErrCodeRateLimitExceeded:

--- a/pkg/evidence/attestation/bom.go
+++ b/pkg/evidence/attestation/bom.go
@@ -16,8 +16,7 @@ package attestation
 
 import (
 	"bytes"
-	"io"
-	"os"
+	"context"
 	"sort"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -26,6 +25,7 @@ import (
 	k8scollector "github.com/NVIDIA/aicr/pkg/collector/k8s"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 	"github.com/NVIDIA/aicr/pkg/measurement"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
@@ -37,9 +37,20 @@ import (
 // recipe-bound BOM. Helm charts are not rendered at validate time (would
 // require the helm binary and a 60s+ budget); observed snapshot images
 // cover the same information for the typical post-deployment flow.
+//
+// Deprecated: prefer LoadOrGenerateBOMContext. This form derives its own
+// defaults.FileReadTimeout-bounded context; retained for source compatibility.
 func LoadOrGenerateBOM(bomPath string, rec *recipe.RecipeResult, snap *snapshotter.Snapshot, cat *catalog.ValidatorCatalog, version string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return LoadOrGenerateBOMContext(ctx, bomPath, rec, snap, cat, version)
+}
+
+// LoadOrGenerateBOMContext is LoadOrGenerateBOM bounded by the caller's
+// context, so an operator-supplied --bom path on a dead mount cannot hang emit.
+func LoadOrGenerateBOMContext(ctx context.Context, bomPath string, rec *recipe.RecipeResult, snap *snapshotter.Snapshot, cat *catalog.ValidatorCatalog, version string) ([]byte, error) {
 	if bomPath != "" {
-		return readBOMFile(bomPath)
+		return readBOMFile(ctx, bomPath)
 	}
 	return BuildAutoBOM(rec, snap, cat, version)
 }
@@ -47,21 +58,8 @@ func LoadOrGenerateBOM(bomPath string, rec *recipe.RecipeResult, snap *snapshott
 // readBOMFile reads bomPath into memory, bounded by defaults.MaxBOMBytes
 // so an attacker-influenced path (e.g., /proc symlink, NFS mount) can't
 // OOM the process before the body is parsed.
-func readBOMFile(bomPath string) ([]byte, error) {
-	f, err := os.Open(bomPath) //nolint:gosec // bomPath is operator-supplied (CLI flag or config)
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to read BOM", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(f, defaults.MaxBOMBytes+1))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to read BOM", err)
-	}
-	if int64(len(body)) > defaults.MaxBOMBytes {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "BOM exceeds maximum size")
-	}
-	return body, nil
+func readBOMFile(ctx context.Context, bomPath string) ([]byte, error) {
+	return boundedio.ReadFile(ctx, bomPath, "BOM", defaults.MaxBOMBytes)
 }
 
 // BuildAutoBOM synthesizes a CycloneDX 1.6 BOM from the recipe's enabled

--- a/pkg/evidence/attestation/emit.go
+++ b/pkg/evidence/attestation/emit.go
@@ -117,7 +117,7 @@ func Emit(ctx context.Context, opts EmitOptions) (*EmitResult, error) {
 		}
 	}
 
-	bomBody, err := LoadOrGenerateBOM(opts.BOMPath, opts.Recipe, opts.Snapshot, opts.Catalog, opts.AICRVersion)
+	bomBody, err := LoadOrGenerateBOMContext(ctx, opts.BOMPath, opts.Recipe, opts.Snapshot, opts.Catalog, opts.AICRVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/evidence/attestation/markers_test.go
+++ b/pkg/evidence/attestation/markers_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"context"
+	stderrors "errors"
+	"io/fs"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// TestHasBundleMarkers_StatFaultIsNotANonBundle covers the diagnostic defect
+// from #2083: every stat error used to collapse to "not a bundle", so a
+// soft-mounted NFS returning EIO, or a directory the operator cannot read,
+// was reported as INVALID_REQUEST "does not look like a summary bundle" — a
+// user-input diagnostic for a storage fault.
+//
+// The stat function is injected rather than provoked with chmod, because a
+// chmod-based EACCES test silently no-ops when the suite runs as root, which
+// is common in CI containers. An injected fault always exercises the branch.
+func TestHasBundleMarkers_StatFaultIsNotANonBundle(t *testing.T) {
+	tests := []struct {
+		name       string
+		statErr    error
+		wantOK     bool
+		wantErr    bool
+		wantCode   errors.ErrorCode
+		wantReason string
+	}{
+		{
+			name:       "absent marker is genuinely not a bundle",
+			statErr:    fs.ErrNotExist,
+			wantOK:     false,
+			wantErr:    false,
+			wantReason: "a missing file is a real answer, not a fault",
+		},
+		{
+			// ENOTDIR/ENAMETOOLONG mean the path cannot name a marker at all,
+			// so they are answers, not faults. Dropping either name from the
+			// guard would turn an operator typo (passing a pointer file where
+			// a bundle directory belongs) into SERVICE_UNAVAILABLE instead of
+			// the actionable "does not look like a summary bundle".
+			name:       "a non-directory component is not a bundle",
+			statErr:    syscall.ENOTDIR,
+			wantOK:     false,
+			wantErr:    false,
+			wantReason: "ENOTDIR means the path cannot name a marker at all",
+		},
+		{
+			name:       "an over-long path is not a bundle",
+			statErr:    syscall.ENAMETOOLONG,
+			wantOK:     false,
+			wantErr:    false,
+			wantReason: "ENAMETOOLONG means the path cannot name a marker at all",
+		},
+		{
+			name:     "permission fault surfaces as a fault",
+			statErr:  fs.ErrPermission,
+			wantOK:   false,
+			wantErr:  true,
+			wantCode: errors.ErrCodeUnavailable,
+		},
+		{
+			name:     "I/O fault surfaces as a fault",
+			statErr:  syscall.EIO,
+			wantOK:   false,
+			wantErr:  true,
+			wantCode: errors.ErrCodeUnavailable,
+		},
+		{
+			name:     "stale NFS handle surfaces as a fault",
+			statErr:  syscall.ESTALE,
+			wantOK:   false,
+			wantErr:  true,
+			wantCode: errors.ErrCodeUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statFn := func(string) (os.FileInfo, error) { return nil, tt.statErr }
+
+			ok, err := hasBundleMarkersWithStat(context.Background(), "/any/dir", statFn)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v (%s)", err, tt.wantErr, tt.wantReason)
+			}
+			if tt.wantErr && !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Errorf("expected code %s, got %v", tt.wantCode, err)
+			}
+		})
+	}
+}
+
+// TestHasBundleMarkers_RealBundleStillDetected guards against the fail-closed
+// change breaking ordinary detection, including the probe of a candidate
+// directory that does not exist (which must stay a clean "not a bundle").
+func TestHasBundleMarkers_RealBundleStillDetected(t *testing.T) {
+	dir := emitUnsignedBundle(t)
+
+	ok, err := HasBundleMarkers(context.Background(), dir+"/"+SummaryBundleDirName)
+	if err != nil || !ok {
+		t.Fatalf("HasBundleMarkers on a real bundle = (%v, %v), want (true, nil)", ok, err)
+	}
+
+	ok, err = HasBundleMarkers(context.Background(), dir+"/does-not-exist")
+	if err != nil || ok {
+		t.Fatalf("HasBundleMarkers on a missing dir = (%v, %v), want (false, nil)", ok, err)
+	}
+}

--- a/pkg/evidence/attestation/pointer.go
+++ b/pkg/evidence/attestation/pointer.go
@@ -16,14 +16,16 @@ package attestation
 
 import (
 	"bytes"
-	"io"
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
@@ -271,7 +273,19 @@ func isHexDigest(d string) bool {
 // canonical path already holds a file with DIFFERENT content (the per-source
 // pointer is immutable, so that is a genuine conflict for the operator to
 // resolve, not something to overwrite).
+//
+// Deprecated: prefer RelocatePointerToCanonicalContext. This form derives its
+// own defaults.FileReadTimeout-bounded context; retained for source compatibility.
 func RelocatePointerToCanonical(currentPath string, p *Pointer) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return RelocatePointerToCanonicalContext(ctx, currentPath, p)
+}
+
+// RelocatePointerToCanonicalContext is RelocatePointerToCanonical bounded by
+// the caller's context: the comparison reads below run against operator-owned
+// paths that may sit on a network mount.
+func RelocatePointerToCanonicalContext(ctx context.Context, currentPath string, p *Pointer) (string, error) {
 	// canonicalPointerSuffix fails closed when the pointer is unsigned or has
 	// no pushed digest — the two states with no derivable canonical home.
 	relSuffix, err := canonicalPointerSuffix(p)
@@ -312,7 +326,7 @@ func RelocatePointerToCanonical(currentPath string, p *Pointer) (string, error) 
 			//     would wrongly report a conflict.
 			// Only a dest holding DIFFERENT bytes is a real immutable-pointer
 			// conflict for the operator to resolve.
-			placed, eqErr := pointerAlreadyPlaced(currentPath, dest)
+			placed, eqErr := pointerAlreadyPlaced(ctx, currentPath, dest)
 			if eqErr != nil {
 				return "", eqErr
 			}
@@ -343,15 +357,19 @@ func RelocatePointerToCanonical(currentPath string, p *Pointer) (string, error) 
 // round trip leaves distinct inodes). It returns an error rather than a bool on
 // a read failure so the caller fails closed instead of silently treating an
 // unreadable dest as a match or a conflict.
-func pointerAlreadyPlaced(currentPath, dest string) (bool, error) {
-	if sameInode(currentPath, dest) {
-		return true, nil
-	}
-	srcBytes, err := readPointerBytes(currentPath)
+func pointerAlreadyPlaced(ctx context.Context, currentPath, dest string) (bool, error) {
+	same, err := sameInode(ctx, currentPath, dest)
 	if err != nil {
 		return false, err
 	}
-	destBytes, err := readPointerBytes(dest)
+	if same {
+		return true, nil
+	}
+	srcBytes, err := readPointerBytes(ctx, currentPath)
+	if err != nil {
+		return false, err
+	}
+	destBytes, err := readPointerBytes(ctx, dest)
 	if err != nil {
 		return false, err
 	}
@@ -359,37 +377,47 @@ func pointerAlreadyPlaced(currentPath, dest string) (bool, error) {
 }
 
 // sameInode reports whether a and b are the same underlying file (e.g. two
-// hard links to one inode). A stat failure on either path reports false (treat
-// as not-same; fail safe).
-func sameInode(a, b string) bool {
-	fa, err := os.Stat(a)
-	if err != nil {
-		return false
+// hard links to one inode). A confirmed absence on either path reports false
+// (treat as not-same; fail safe); a storage fault reports an error, because a
+// mount that could not answer has not told us the paths differ.
+func sameInode(ctx context.Context, a, b string) (bool, error) {
+	var fa, fb os.FileInfo
+	var same bool
+	var statErr error
+	// The boundary error MUST be propagated, not discarded: reading `same`
+	// after an abandoned worker is a data race (the worker may still be
+	// writing it).
+	if err := boundedio.Do(ctx, "pointer comparison stat", func() error {
+		var err error
+		if fa, err = os.Stat(a); err != nil {
+			statErr = err
+			return nil
+		}
+		if fb, err = os.Stat(b); err != nil {
+			statErr = err
+			return nil
+		}
+		same = os.SameFile(fa, fb)
+		return nil
+	}); err != nil {
+		return false, err
 	}
-	fb, err := os.Stat(b)
-	if err != nil {
-		return false
+	// Classify the fault at its source. The caller does fail closed either way
+	// (readPointerBytes reports the same mount a moment later), but attributing
+	// a wedged mount to the read rather than to the stat that first hit it
+	// makes the operator-facing error name the wrong operation.
+	if statErr != nil && boundedio.IsStorageFault(statErr) {
+		return false, errors.Wrap(errors.ErrCodeUnavailable,
+			"could not compare pointer paths (storage fault)", statErr)
 	}
-	return os.SameFile(fa, fb)
+	return same, nil
 }
 
 // readPointerBytes reads a pointer file, bounded to maxPointerReadBytes so a
 // bloated or hostile path cannot exhaust memory during the equality check. A
-// file at or past the cap is rejected (a pointer is never that large).
-func readPointerBytes(path string) ([]byte, error) {
-	f, err := os.Open(path) //nolint:gosec // operator-supplied path
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to open pointer for comparison", err)
-	}
-	defer func() { _ = f.Close() }()
-	data, err := io.ReadAll(io.LimitReader(f, maxPointerReadBytes+1))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read pointer for comparison", err)
-	}
-	if int64(len(data)) > maxPointerReadBytes {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "pointer file exceeds size limit: "+path)
-	}
-	return data, nil
+// file over the cap is rejected (a pointer is never that large).
+func readPointerBytes(ctx context.Context, path string) ([]byte, error) {
+	return boundedio.ReadFile(ctx, path, "pointer for comparison "+path, maxPointerReadBytes)
 }
 
 // WritePointer writes the pointer file to outputDir/pointer.yaml.

--- a/pkg/evidence/attestation/pointer_test.go
+++ b/pkg/evidence/attestation/pointer_test.go
@@ -15,6 +15,7 @@
 package attestation
 
 import (
+	"context"
 	stderrors "errors"
 	"os"
 	"path/filepath"
@@ -235,8 +236,8 @@ func TestRelocatePointerToCanonical(t *testing.T) {
 		if _, err := WritePointerFile(canonical, signed()); err != nil {
 			t.Fatalf("write canonical: %v", err)
 		}
-		if sameInode(flat, canonical) {
-			t.Fatal("precondition: flat and canonical should be distinct inodes")
+		if same, sErr := sameInode(context.Background(), flat, canonical); sErr != nil || same {
+			t.Fatalf("precondition: flat and canonical should be distinct inodes (same=%v err=%v)", same, sErr)
 		}
 		dest, err := RelocatePointerToCanonical(flat, signed())
 		if err != nil {
@@ -631,4 +632,60 @@ func TestBuildPointer_RecordsProfile(t *testing.T) {
 			t.Errorf("marshaled unprofiled pointer must omit profile field:\n%s", body)
 		}
 	})
+}
+
+// TestSameInode_AbsenceIsNotAFault guards the split introduced when sameInode
+// started surfacing storage faults: a *confirmed absence* must keep reporting
+// (false, nil). pointerAlreadyPlaced calls this on a destination that usually
+// does not exist yet, so turning ENOENT into an error would break every
+// first-time relocation.
+func TestSameInode_AbsenceIsNotAFault(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "pointer.yaml")
+	if err := os.WriteFile(existing, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "not-there.yaml")
+
+	tests := []struct {
+		name string
+		a, b string
+	}{
+		{"destination absent", existing, missing},
+		{"source absent", missing, existing},
+		{"both absent", missing, missing},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			same, err := sameInode(context.Background(), tt.a, tt.b)
+			if err != nil {
+				t.Fatalf("absence reported as a fault: %v", err)
+			}
+			if same {
+				t.Error("absent path reported as the same inode")
+			}
+		})
+	}
+}
+
+// TestSameInode_IdentifiesHardLinks is the positive case, so the fault handling
+// above cannot be satisfied by a function that always answers false.
+func TestSameInode_IdentifiesHardLinks(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.yaml")
+	if err := os.WriteFile(a, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	b := filepath.Join(dir, "b.yaml")
+	if err := os.Link(a, b); err != nil {
+		t.Skipf("hard links unavailable: %v", err)
+	}
+
+	same, err := sameInode(context.Background(), a, b)
+	if err != nil {
+		t.Fatalf("sameInode: %v", err)
+	}
+	if !same {
+		t.Error("hard links to one inode reported as different files")
+	}
 }

--- a/pkg/evidence/attestation/publish.go
+++ b/pkg/evidence/attestation/publish.go
@@ -17,15 +17,19 @@ package attestation
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
+	"syscall"
 
 	bundleattest "github.com/NVIDIA/aicr/pkg/bundler/attestation"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 	"github.com/NVIDIA/aicr/pkg/oci"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
@@ -198,24 +202,7 @@ func loadOnDiskBundle(ctx context.Context, dir string) (*Bundle, string, error) 
 // short-lived CLI leaf command (evidence publish/sign), which is the only
 // caller of these bundle readers.
 func withFileReadTimeout(ctx context.Context, what string, fn func() error) error {
-	ctx, cancel := context.WithTimeout(ctx, defaults.FileReadTimeout)
-	defer cancel()
-	// Fail closed and deterministically if the caller's context is already
-	// canceled/expired, before launching the goroutine — otherwise a fast
-	// syscall could win the select race against an already-done context.
-	if err := ctx.Err(); err != nil {
-		return errors.WrapWithContext(errors.ErrCodeTimeout, "timed out reading "+what, err,
-			map[string]interface{}{"timeout": defaults.FileReadTimeout.String()})
-	}
-	done := make(chan error, 1) // buffered so the goroutine never leaks on timeout
-	go func() { done <- fn() }()
-	select {
-	case <-ctx.Done():
-		return errors.WrapWithContext(errors.ErrCodeTimeout, "timed out reading "+what, ctx.Err(),
-			map[string]interface{}{"timeout": defaults.FileReadTimeout.String()})
-	case err := <-done:
-		return err
-	}
+	return boundedio.Do(ctx, what, fn)
 }
 
 // readBundleRecipeProfile decodes the summary bundle's recipe.yaml and
@@ -297,30 +284,51 @@ func resolveSummaryDir(ctx context.Context, dir string) (summaryDir, outDir stri
 // the single source of truth for "is this directory a summary bundle?",
 // shared by the publish path here and the verifier's materialization.
 //
-// The two os.Stat calls are time-bounded via withFileReadTimeout so a dead
-// NFS/FUSE mount surfaces as a timeout error instead of an indefinite hang.
-// The (bool, error) shape keeps a genuine "not a bundle" answer distinct from
-// a ctx timeout: only the timeout wrapper yields (false, err), which stops a
-// hung mount from masquerading as "not a bundle" and failing open. Every stat
-// error itself — absent, is-a-dir, and equally permission/EIO/ESTALE — reads
-// as "not a marker" (false, nil); this preserves the pre-change fail-soft
-// behavior. Surfacing non-ENOENT stat faults distinctly (so a soft-mount I/O
-// error is not diagnosed as a bad bundle) is a deliberate follow-up, not done
-// here — see #2083 for the remaining unbounded/undiagnosed reads.
+// The two os.Stat calls are time-bounded so a dead NFS/FUSE mount surfaces as
+// a timeout instead of an indefinite hang. The (bool, error) shape keeps a
+// genuine "not a bundle" answer distinct from a fault:
+//
+//   - absent (ENOENT) or is-a-dir → (false, nil). A missing marker is a real
+//     answer, and the probe sites try more than one candidate directory, so
+//     this must stay cheap and non-fatal.
+//   - any other stat error (EACCES/EIO/ESTALE) → (false, err). These say
+//     nothing about whether dir is a bundle. Collapsing them to "not a bundle"
+//     reported a storage fault to the operator as INVALID_REQUEST "does not
+//     look like a summary bundle", sending them to debug their input instead
+//     of their mount.
 func HasBundleMarkers(ctx context.Context, dir string) (bool, error) {
+	return hasBundleMarkersWithStat(ctx, dir, os.Stat)
+}
+
+func hasBundleMarkersWithStat(
+	ctx context.Context,
+	dir string,
+	statFn func(string) (os.FileInfo, error),
+) (bool, error) {
+
 	for _, f := range []string{RecipeFilename, ManifestFilename} {
 		path := filepath.Join(dir, f)
 		var present bool
+		var statErr error
 		// Label with the full path (not just f) so a timeout names which
 		// candidate directory stalled — the probe sites try more than one.
 		if err := withFileReadTimeout(ctx, "bundle marker "+path, func() error {
-			info, statErr := os.Stat(path)
-			// Any stat error (absent, permission, is-a-dir) means "not a
-			// marker"; only the timeout wrapper injects a non-nil error.
+			var info os.FileInfo
+			info, statErr = statFn(path)
 			present = statErr == nil && !info.IsDir()
 			return nil
 		}); err != nil {
 			return false, err
+		}
+		// ENOTDIR/ENAMETOOLONG mean the path cannot name a marker at all
+		// (e.g. the operator passed a file where a bundle dir was expected).
+		// syscall.Errno.Is maps only ENOENT to fs.ErrNotExist, so these must
+		// be listed explicitly or a typo becomes an INTERNAL error.
+		if statErr != nil && !stderrors.Is(statErr, fs.ErrNotExist) &&
+			!stderrors.Is(statErr, syscall.ENOTDIR) && !stderrors.Is(statErr, syscall.ENAMETOOLONG) {
+
+			return false, errors.Wrap(errors.ErrCodeUnavailable,
+				"failed to probe bundle marker "+path, statErr)
 		}
 		if !present {
 			return false, nil

--- a/pkg/evidence/attestation/publish_test.go
+++ b/pkg/evidence/attestation/publish_test.go
@@ -65,23 +65,30 @@ func wantInvalidRequest(t *testing.T, err error) {
 	}
 }
 
-func wantTimeout(t *testing.T, err error) {
+func wantAborted(t *testing.T, err error) {
 	t.Helper()
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
-		t.Errorf("expected ErrCodeTimeout, got %v", err)
+	// A canceled parent is an operator abort, not a deadline: it must carry
+	// ErrCodeCanceled so IsTransient keeps a deliberate Ctrl-C out of the
+	// retryable bucket. What matters either way is that the reader fails
+	// closed rather than returning content or "not a bundle".
+	if !stderrors.Is(err, errors.New(errors.ErrCodeCanceled, "")) {
+		t.Errorf("expected ErrCodeCanceled, got %v", err)
 	}
 }
 
-// TestBundleReaders_CanceledContextSurfacesTimeout proves each on-disk reader
+// TestBundleReaders_CanceledContextSurfacesAbort proves each on-disk reader
 // path is bounded by the caller's context: against a real, valid bundle (so an
 // unbounded read would succeed instantly), an already-canceled context makes
-// every reader fail closed with ErrCodeTimeout rather than block on a
+// every reader fail closed with ErrCodeCanceled rather than block on a
 // potentially hung mount. This is the load-bearing guarantee of issue #2054 —
-// a dead NFS/FUSE mount surfaces as a timeout, not an indefinite hang.
-func TestBundleReaders_CanceledContextSurfacesTimeout(t *testing.T) {
+// an abandoned caller gets a coded error instead of an indefinite hang. The
+// code here is ErrCodeCanceled because the caller aborted; a mount that stalls
+// past the bound yields ErrCodeTimeout instead, covered separately in
+// pkg/evidence/internal/boundedio.
+func TestBundleReaders_CanceledContextSurfacesAbort(t *testing.T) {
 	dir := emitUnsignedBundle(t)
 	summaryDir := filepath.Join(dir, SummaryBundleDirName)
 
@@ -114,20 +121,20 @@ func TestBundleReaders_CanceledContextSurfacesTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			wantTimeout(t, tt.run(ctx))
+			wantAborted(t, tt.run(ctx))
 		})
 	}
 }
 
-// TestWithFileReadTimeout_InFlightTimeout exercises the goroutine+select arm of
+// TestWithFileReadTimeout_InFlightCancel exercises the goroutine+select arm of
 // withFileReadTimeout — the part that actually delivers hang-immunity. The
 // canceled-context tests above return at the ctx.Err() pre-check and never
 // reach the select, so this covers the case a wedged mount hits: fn is already
 // running (blocked in the syscall) when the caller context is canceled. It uses
 // a started/release/finished handshake so the cancellation is observed
-// in-flight, asserts ErrCodeTimeout, then unblocks fn and joins it — proving
+// in-flight, asserts the abort code, then unblocks fn and joins it — proving
 // the parked worker returns rather than leaking.
-func TestWithFileReadTimeout_InFlightTimeout(t *testing.T) {
+func TestWithFileReadTimeout_InFlightCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -147,7 +154,7 @@ func TestWithFileReadTimeout_InFlightTimeout(t *testing.T) {
 
 	<-started // fn is now running inside the goroutine+select path
 	cancel()  // cancel the caller context while fn is still blocked
-	wantTimeout(t, <-errCh)
+	wantAborted(t, <-errCh)
 
 	close(release) // release the parked worker...
 	<-finished     // ...and confirm it returns (no leaked goroutine)

--- a/pkg/evidence/attestation/sign_test.go
+++ b/pkg/evidence/attestation/sign_test.go
@@ -138,12 +138,12 @@ func TestSignExisting_RejectsIncompleteDescriptor(t *testing.T) {
 	}
 }
 
-// TestSignExisting_CanceledContextSurfacesTimeout proves SignExisting threads
+// TestSignExisting_CanceledContextSurfacesAbort proves SignExisting threads
 // the caller's context into the on-disk bundle read: with a valid signable
 // pointer and a real bundle on disk (so the read would otherwise succeed), an
-// already-canceled context fails closed with ErrCodeTimeout instead of blocking
+// already-canceled context fails closed with ErrCodeCanceled instead of blocking
 // on a potentially hung mount (issue #2054).
-func TestSignExisting_CanceledContextSurfacesTimeout(t *testing.T) {
+func TestSignExisting_CanceledContextSurfacesAbort(t *testing.T) {
 	dir := emitUnsignedBundle(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -156,8 +156,8 @@ func TestSignExisting_CanceledContextSurfacesTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
-		t.Errorf("expected ErrCodeTimeout, got %v", err)
+	if !stderrors.Is(err, errors.New(errors.ErrCodeCanceled, "")) {
+		t.Errorf("expected ErrCodeCanceled, got %v", err)
 	}
 }
 

--- a/pkg/evidence/internal/boundedio/boundedio.go
+++ b/pkg/evidence/internal/boundedio/boundedio.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package boundedio puts blocking local-filesystem work behind a cancellation
+// boundary so the evidence publish/sign/verify paths cannot hang indefinitely
+// on a dead NFS/FUSE mount.
+//
+// Why a goroutine and not a context: a context deadline bounds *observation*,
+// not the syscall. os.Stat, os.Open, and the ReadDir calls inside
+// filepath.WalkDir block in the kernel on a wedged mount, so a ctx.Err() check
+// between chunks or between walk entries never runs. Only moving the syscall
+// off the calling goroutine lets the caller return.
+//
+// The accepted tradeoff: on timeout the worker stays parked in the syscall
+// until the kernel returns or the process exits. That is fine for the
+// short-lived CLI leaf commands that use this package, and it is the reason
+// this is internal rather than a general-purpose utility.
+package boundedio
+
+import (
+	"context"
+	stderrors "errors"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// Do runs fn behind a defaults.FileReadTimeout-bounded derivative of ctx and
+// returns fn's own error, or a boundary error if the bound elapses or the
+// operator aborts first. fn must be a self-contained unit of blocking
+// filesystem work that owns everything it opens: once Do returns, the caller
+// must not touch any handle fn is still using.
+func Do(ctx context.Context, what string, fn func() error) error {
+	return doWithTimeout(ctx, defaults.FileReadTimeout, what, fn)
+}
+
+// IsCanceled reports whether err is a deliberate operator abort rather than an
+// environmental fault. Callers that bucket failures as retry-vs-stop use this
+// to keep a Ctrl-C out of the retryable bucket.
+func IsCanceled(err error) bool {
+	return stderrors.Is(err, errors.New(errors.ErrCodeCanceled, ""))
+}
+
+func doWithTimeout(parent context.Context, timeout time.Duration, what string, fn func() error) error {
+	// Fail closed and deterministically when the caller's context is already
+	// done, before launching the worker — otherwise a fast syscall could win
+	// the select race against an already-expired context.
+	if parent.Err() != nil {
+		return boundaryError(parent.Err(), what, timeout)
+	}
+
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	done := make(chan error, 1) // buffered so an abandoned worker never blocks
+	go func() { done <- fn() }()
+
+	select {
+	case err := <-done:
+		// A completed fn does not outrank an abort. When done and ctx.Done()
+		// are both ready the select chooses pseudo-randomly, so without this
+		// recheck a canceled run could return fn's success — the boundary
+		// would fail OPEN, nondeterministically, on exactly the abort it
+		// exists to enforce. Recheck explicitly so the outcome is decided by
+		// the context, not by scheduler chance.
+		if cause := terminationCause(parent, ctx); cause != nil {
+			return boundaryError(cause, what, timeout)
+		}
+		return err
+	case <-ctx.Done():
+		return boundaryError(terminationCause(parent, ctx), what, timeout)
+	}
+}
+
+// terminationCause reports why the operation should be abandoned, or nil if it
+// should not be. The parent takes precedence: an operator abort must be
+// attributed to the operator, not to the derived deadline that fires with it.
+func terminationCause(parent, ctx context.Context) error {
+	if err := parent.Err(); err != nil {
+		return err
+	}
+	return ctx.Err()
+}
+
+// boundaryError shapes the two outcomes the boundary itself can produce.
+// Keeping them distinct matters downstream: ErrCodeTimeout drives the
+// verifier's transient failure class and the retryable bucket, and reporting a
+// deliberate Ctrl-C as "timed out" would put an operator's abort into both.
+func boundaryError(cause error, what string, timeout time.Duration) error {
+	if stderrors.Is(cause, context.Canceled) {
+		return errors.WrapWithContext(errors.ErrCodeCanceled,
+			"canceled while reading "+what, cause,
+			map[string]any{"operation": what})
+	}
+	return errors.WrapWithContext(errors.ErrCodeTimeout,
+		"timed out reading "+what, cause,
+		map[string]any{"operation": what, "timeout": timeout.String()})
+}

--- a/pkg/evidence/internal/boundedio/boundedio_test.go
+++ b/pkg/evidence/internal/boundedio/boundedio_test.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package boundedio
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func isCode(err error, code errors.ErrorCode) bool {
+	return stderrors.Is(err, errors.New(code, ""))
+}
+
+// TestDo_PropagatesFnError proves the boundary is transparent on the happy
+// path: fn's own coded error reaches the caller unchanged, so callers keep
+// their NotFound/InvalidRequest diagnostics instead of everything becoming a
+// timeout.
+func TestDo_PropagatesFnError(t *testing.T) {
+	want := errors.New(errors.ErrCodeNotFound, "no such thing")
+	got := Do(context.Background(), "probe", func() error { return want })
+	if !stderrors.Is(got, want) {
+		t.Errorf("Do returned %v, want the fn error %v", got, want)
+	}
+}
+
+// TestDo_DeadlineSurfacesTimeout covers the wedged-mount case: fn never
+// returns, the boundary's own deadline fires, and the caller gets
+// ErrCodeTimeout so classifyFailure can treat it as transient.
+func TestDo_DeadlineSurfacesTimeout(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	err := doWithTimeout(context.Background(), 10*time.Millisecond, "wedged read", func() error {
+		<-release
+		return nil
+	})
+	if !isCode(err, errors.ErrCodeTimeout) {
+		t.Fatalf("expected ErrCodeTimeout, got %v", err)
+	}
+	if !stderrors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected the deadline in the chain, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "wedged read") {
+		t.Errorf("expected the label in the message, got %q", err.Error())
+	}
+}
+
+// TestDo_OperatorCancelIsNotTimeout is the load-bearing distinction: a
+// deliberate Ctrl-C (parent cancellation) must NOT be reported as a timeout,
+// because ErrCodeTimeout drives both the transient failure class and the
+// retryable bucket. A canceled command is neither.
+func TestDo_OperatorCancelIsNotTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		cancelWhen string
+	}{
+		{"canceled before the call", "before"},
+		{"canceled while fn is blocked", "inflight"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var err error
+			switch tt.cancelWhen {
+			case "before":
+				cancel()
+				err = Do(ctx, "probe", func() error { return nil })
+			default:
+				started := make(chan struct{})
+				release := make(chan struct{})
+				defer close(release)
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- Do(ctx, "probe", func() error {
+						close(started)
+						<-release
+						return nil
+					})
+				}()
+				<-started
+				cancel()
+				err = <-errCh
+			}
+
+			if isCode(err, errors.ErrCodeTimeout) {
+				t.Errorf("operator cancellation was classified as a timeout: %v", err)
+			}
+			if !IsCanceled(err) {
+				t.Errorf("expected IsCanceled to report true, got %v", err)
+			}
+			if strings.Contains(err.Error(), "timed out") {
+				t.Errorf("cancellation message reads as a timeout: %q", err.Error())
+			}
+		})
+	}
+}
+
+// TestDo_CallerUnblocksWhileWorkerRuns proves the boundary actually delivers
+// hang-immunity: the caller returns while fn is still executing. It does NOT
+// prove the worker is reclaimed — a worker wedged in kernel I/O parks until
+// the syscall returns or the process exits, which is the documented tradeoff.
+// The release/join below only confirms an unblocked worker completes normally.
+func TestDo_CallerUnblocksWhileWorkerRuns(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- doWithTimeout(context.Background(), 10*time.Millisecond, "wedged read", func() error {
+			close(started)
+			<-release
+			close(finished)
+			return nil
+		})
+	}()
+
+	<-started
+	if err := <-errCh; !isCode(err, errors.ErrCodeTimeout) {
+		t.Fatalf("caller did not unblock with a timeout, got %v", err)
+	}
+
+	select {
+	case <-finished:
+		t.Fatal("worker finished before release — the test did not exercise an in-flight bound")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("released worker never completed")
+	}
+}
+
+// TestDo_CompletionDoesNotOutrankCancellation pins the select-race behavior.
+// When fn finishes at the same moment the context terminates, both channels
+// are ready and Go's select chooses pseudo-randomly. Without an explicit
+// recheck the boundary would sometimes return fn's success for a run the
+// operator had already canceled — failing open, and nondeterministically, on
+// exactly the abort it exists to enforce.
+//
+// fn cancels its own parent immediately before returning, so both cases are
+// always ready when the select runs.
+func TestDo_CompletionDoesNotOutrankCancellation(t *testing.T) {
+	for i := range 200 {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		err := Do(ctx, "probe", func() error {
+			cancel() // both done and ctx.Done() are now ready
+			return nil
+		})
+
+		if !IsCanceled(err) {
+			t.Fatalf("iteration %d: canceled run returned %v, want a cancellation", i, err)
+		}
+	}
+}
+
+// TestDo_SuccessSurvivesALiveContext is the converse guard: the recheck above
+// must not discard a good result when nothing was canceled.
+func TestDo_SuccessSurvivesALiveContext(t *testing.T) {
+	for i := range 200 {
+		if err := Do(context.Background(), "probe", func() error { return nil }); err != nil {
+			t.Fatalf("iteration %d: healthy run returned %v", i, err)
+		}
+	}
+}

--- a/pkg/evidence/internal/boundedio/read.go
+++ b/pkg/evidence/internal/boundedio/read.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package boundedio
+
+import (
+	stderrors "errors"
+	"io"
+	"os"
+	"strconv"
+	"syscall"
+
+	"context"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// ReadFile reads path into memory bounded three ways: by size (max bytes), by
+// time (the Do boundary), and by shape (descriptor-first validation).
+//
+// The shape checks matter because a bundle root can be attacker-influenced —
+// an extracted archive, a symlink-rich tarball, a path on a network mount.
+// O_NONBLOCK keeps a FIFO substituted for a regular file from blocking the
+// open, and validating the *opened descriptor* rather than the path closes the
+// swap window between the check and the read.
+//
+// Symlink scope, precisely: O_NOFOLLOW rejects a symlink at the FINAL path
+// component only. An intermediate directory component that is a symlink
+// (bundle/ctrf -> /elsewhere) is still traversed, so this is not a containment
+// boundary — callers needing one must resolve against an os.Root. Callers here
+// rely on containment from elsewhere: manifest entries are rejected by
+// filepath.IsLocal before use, and every byte read is hash-bound to a
+// manifest that is itself digest-bound to the predicate, so content read
+// through such a path cannot pass verification. Closing the traversal gap is
+// tracked as follow-up work on #2083.
+//
+// label names the input in error messages (e.g. "in-toto Statement").
+func ReadFile(ctx context.Context, path, label string, max int64) ([]byte, error) {
+	var body []byte
+	if err := Do(ctx, label, func() error {
+		b, readErr := readBoundedWithOpener(path, label, max, os.OpenFile)
+		if readErr != nil {
+			return readErr
+		}
+		body = b
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// fileOpener matches os.OpenFile so tests can inject the syscall-level faults
+// (EIO, EACCES, ESTALE) that a soft-mounted NFS returns. Provoking those with
+// chmod would silently no-op when the suite runs as root, which is common in
+// CI containers.
+type fileOpener func(name string, flag int, perm os.FileMode) (*os.File, error)
+
+func readBoundedWithOpener(path, label string, max int64, open fileOpener) ([]byte, error) {
+	f, err := open( //nolint:gosec // caller-validated, bundle-local path
+		path, os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		switch {
+		case stderrors.Is(err, syscall.ELOOP):
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"refusing to read "+label+" through a symlink", err)
+		case os.IsNotExist(err):
+			return nil, errors.Wrap(errors.ErrCodeNotFound, "failed to read "+label, err)
+		case IsStorageFault(err):
+			// A mount that answers with EIO/ESTALE/EACCES has told us nothing
+			// about the file. Reporting this as Internal would let callers
+			// bucket it with real content failures — the verifier would render
+			// a soft-mount fault as a digest mismatch, i.e. "tampered bundle".
+			return nil, errors.Wrap(errors.ErrCodeUnavailable, "failed to read "+label, err)
+		default:
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to open "+label, err)
+		}
+	}
+	defer func() { _ = f.Close() }() // read-only handle
+
+	opened, err := f.Stat()
+	if err != nil {
+		return nil, statError(label, err)
+	}
+	if !opened.Mode().IsRegular() {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, label+" is not a regular file")
+	}
+	if opened.Size() > max {
+		return nil, oversize(label, max)
+	}
+
+	return readAllBounded(f, label, max)
+}
+
+// readAllBounded consumes r under the size cap and classifies a mid-transfer
+// failure. Split from the open/stat work so it is reachable with a faulting
+// io.Reader: a mount that answers the open and then faults mid-read is the
+// precise soft-NFS case this package exists for, and it cannot be provoked
+// through a real file.
+func readAllBounded(r io.Reader, label string, max int64) ([]byte, error) {
+	// The +1 detects "over the cap" without reading an oversized payload, and
+	// also catches a file that grew between the stat above and this read.
+	body, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, readError(label, err)
+	}
+	if int64(len(body)) > max {
+		return nil, oversize(label, max)
+	}
+	return body, nil
+}
+
+// readError classifies a mid-transfer failure. Mirrors statError: a storage
+// errno here is environmental, and misreporting it as Internal would let the
+// verifier fold it into the inventory mismatch rows and render a soft-mount
+// fault as an exit-2 "tampered bundle".
+func readError(label string, err error) error {
+	if IsStorageFault(err) {
+		return errors.Wrap(errors.ErrCodeUnavailable, "failed to read "+label, err)
+	}
+	return errors.Wrap(errors.ErrCodeInternal, "failed to read "+label, err)
+}
+
+// IsStorageFault reports whether err is the filesystem saying it could not
+// answer, as opposed to answering "no such file". These are environmental and
+// must stay distinguishable from a verdict about the bundle's contents:
+// callers that stat outside this package (the verifier's signature probe)
+// need the same split.
+//
+// EACCES/EPERM are included deliberately, accepting a known imprecision: a
+// permanently-unreadable local file (mode 000) is labeled transient and
+// invites a retry that will never succeed. The alternative — treating them as
+// verdicts — would misreport the far more consequential case, a soft-mounted
+// NFS returning EACCES while the server is unreachable, as "this bundle is
+// invalid". Both directions fail closed (nothing is ever accepted), so the
+// tradeoff is which useless remediation the operator is pointed at, and
+// distinguishing a local-fs EACCES from a network-mount one is not portably
+// worth it.
+func IsStorageFault(err error) bool {
+	return stderrors.Is(err, syscall.EIO) ||
+		stderrors.Is(err, syscall.ESTALE) ||
+		stderrors.Is(err, syscall.EACCES) ||
+		stderrors.Is(err, syscall.EPERM) ||
+		stderrors.Is(err, syscall.ENXIO) ||
+		stderrors.Is(err, syscall.ETIMEDOUT)
+}
+
+// statError classifies a failure of the post-open descriptor check. A mount can
+// fault after the open succeeds, and the descriptor check is no more
+// authoritative about content than the open was, so a storage errno here is an
+// environmental fault rather than a verdict. Split out so both branches are
+// directly testable: a closed descriptor yields os.ErrClosed, which is NOT a
+// storage fault, so driving this through a real file cannot reach the
+// IsStorageFault arm.
+func statError(label string, err error) error {
+	if IsStorageFault(err) {
+		return errors.Wrap(errors.ErrCodeUnavailable, "failed to inspect "+label, err)
+	}
+	return errors.Wrap(errors.ErrCodeInternal, "failed to inspect "+label, err)
+}
+
+func oversize(label string, max int64) error {
+	return errors.New(errors.ErrCodeInvalidRequest,
+		label+" exceeds maximum size of "+strconv.FormatInt(max, 10)+" bytes")
+}

--- a/pkg/evidence/internal/boundedio/read_test.go
+++ b/pkg/evidence/internal/boundedio/read_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package boundedio
+
+import (
+	"bytes"
+	"context"
+	stderrors "errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+func writeFile(t *testing.T, dir, name string, body []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadFile_ReadsRegularFile(t *testing.T) {
+	want := []byte("schemaVersion: 1.0.0\n")
+	path := writeFile(t, t.TempDir(), "recipe.yaml", want)
+
+	got, err := ReadFile(context.Background(), path, "bundle recipe.yaml", 1024)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("ReadFile = %q, want %q", got, want)
+	}
+}
+
+// TestReadFile_RejectsOversize proves the size cap fires without allocating
+// the whole file: the read must refuse at the cap rather than returning
+// truncated bytes that a caller would then parse as if complete.
+func TestReadFile_RejectsOversize(t *testing.T) {
+	path := writeFile(t, t.TempDir(), "big.json", bytes.Repeat([]byte("a"), 512))
+
+	got, err := ReadFile(context.Background(), path, "in-toto Statement", 128)
+	if got != nil {
+		t.Errorf("expected no body on oversize, got %d bytes", len(got))
+	}
+	if !isCode(err, errors.ErrCodeInvalidRequest) {
+		t.Errorf("expected ErrCodeInvalidRequest, got %v", err)
+	}
+}
+
+// TestReadFile_RejectsSymlink guards the O_NOFOLLOW hardening: an
+// attacker-influenced bundle root can point a manifest-named file at
+// /proc/self/mem or an unrelated secret, so the reader must refuse the
+// indirection rather than read through it.
+func TestReadFile_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := writeFile(t, dir, "target.yaml", []byte("secret"))
+	link := filepath.Join(dir, "link.yaml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	if _, err := ReadFile(context.Background(), link, "pointer", 1024); !isCode(err, errors.ErrCodeInvalidRequest) {
+		t.Errorf("expected ErrCodeInvalidRequest for a symlink, got %v", err)
+	}
+}
+
+func TestReadFile_RejectsDirectory(t *testing.T) {
+	if _, err := ReadFile(context.Background(), t.TempDir(), "bundle recipe.yaml", 1024); err == nil {
+		t.Error("expected an error reading a directory, got nil")
+	}
+}
+
+func TestReadFile_MissingFileIsNotFound(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent.yaml")
+
+	if _, err := ReadFile(context.Background(), missing, "bundle recipe.yaml", 1024); !isCode(err, errors.ErrCodeNotFound) {
+		t.Errorf("expected ErrCodeNotFound, got %v", err)
+	}
+}
+
+// TestReadFile_CanceledContextFailsClosed proves the read inherits the
+// boundary: against a real, readable file (so an unbounded read would succeed
+// instantly) an aborted caller gets a cancellation, never file contents.
+func TestReadFile_CanceledContextFailsClosed(t *testing.T) {
+	path := writeFile(t, t.TempDir(), "recipe.yaml", []byte("data"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := ReadFile(ctx, path, "bundle recipe.yaml", 1024)
+	if got != nil {
+		t.Errorf("expected no body after cancellation, got %q", got)
+	}
+	if !IsCanceled(err) {
+		t.Errorf("expected a cancellation error, got %v", err)
+	}
+}
+
+// TestReadFile_StorageFaultsAreNotVerdicts is the classification that keeps a
+// soft-mounted NFS from being reported as a bad bundle. EIO/EACCES/ESTALE mean
+// the filesystem could not answer; they say nothing about the file. Mapping
+// them to ErrCodeInternal (or worse, NotFound) let the verifier fold them into
+// the inventory mismatch rows and render a storage fault as an integrity
+// failure — "this bundle has been tampered with" — at process exit 2.
+//
+// The opener is injected because chmod-based EACCES silently no-ops under root.
+func TestReadFile_StorageFaultsAreNotVerdicts(t *testing.T) {
+	tests := []struct {
+		name     string
+		injected error
+		wantCode errors.ErrorCode
+	}{
+		{"I/O error", syscall.EIO, errors.ErrCodeUnavailable},
+		{"stale NFS handle", syscall.ESTALE, errors.ErrCodeUnavailable},
+		{"permission denied", syscall.EACCES, errors.ErrCodeUnavailable},
+		{"no such device or address", syscall.ENXIO, errors.ErrCodeUnavailable},
+		{"connection timed out", syscall.ETIMEDOUT, errors.ErrCodeUnavailable},
+		// Absence is a real answer about the file, not a fault.
+		{"absent", syscall.ENOENT, errors.ErrCodeNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			open := func(name string, _ int, _ os.FileMode) (*os.File, error) {
+				return nil, &os.PathError{Op: "open", Path: name, Err: tt.injected}
+			}
+
+			_, err := readBoundedWithOpener("/bundle/recipe.yaml", "bundle recipe.yaml", 1024, open)
+			if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Fatalf("got %v, want code %s", err, tt.wantCode)
+			}
+			// The chain must stay walkable so callers can still see the errno.
+			if !stderrors.Is(err, tt.injected) {
+				t.Errorf("underlying %v lost from the error chain: %v", tt.injected, err)
+			}
+		})
+	}
+}
+
+// TestStatError_PostOpenClassification covers the descriptor-check branch a
+// real file cannot reach: closing a descriptor yields os.ErrClosed, which is
+// not a storage errno, so driving this through an actual file only ever
+// exercises the Internal arm and would stay green if the IsStorageFault check
+// were deleted outright.
+func TestStatError_PostOpenClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode errors.ErrorCode
+	}{
+		{"I/O error at stat", syscall.EIO, errors.ErrCodeUnavailable},
+		{"stale handle at stat", syscall.ESTALE, errors.ErrCodeUnavailable},
+		{"permission at stat", syscall.EACCES, errors.ErrCodeUnavailable},
+		// Not an environmental fault: a closed descriptor is our own bug.
+		{"closed descriptor", os.ErrClosed, errors.ErrCodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := statError("bundle recipe.yaml", tt.err)
+			if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Fatalf("got %v, want code %s", err, tt.wantCode)
+			}
+			if !stderrors.Is(err, tt.err) {
+				t.Errorf("underlying %v lost from the error chain: %v", tt.err, err)
+			}
+		})
+	}
+}
+
+// TestReadFile_PostOpenStatFailureFailsClosed is the end-to-end companion: it
+// drives a real descriptor failure through readBoundedWithOpener and asserts
+// the reader fails closed rather than reporting absence. The precise code is
+// covered by TestStatError_PostOpenClassification above.
+func TestReadFile_PostOpenStatFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "recipe.yaml", []byte("data"))
+
+	open := func(string, int, os.FileMode) (*os.File, error) {
+		f, err := os.Open(path) //nolint:gosec // test fixture
+		if err != nil {
+			return nil, err
+		}
+		if cErr := f.Close(); cErr != nil {
+			return nil, cErr
+		}
+		return f, nil
+	}
+
+	_, err := readBoundedWithOpener(path, "bundle recipe.yaml", 1024, open)
+	if err == nil {
+		t.Fatal("expected an error when the descriptor cannot be inspected")
+	}
+	if stderrors.Is(err, errors.New(errors.ErrCodeNotFound, "")) {
+		t.Errorf("post-open fault reported as absence: %v", err)
+	}
+}
+
+// faultingReader yields n bytes and then fails, standing in for a mount that
+// answers the open and faults mid-transfer.
+type faultingReader struct {
+	remaining int
+	err       error
+}
+
+func (r *faultingReader) Read(p []byte) (int, error) {
+	if r.remaining > 0 {
+		n := min(len(p), r.remaining)
+		for i := range n {
+			p[i] = 'a'
+		}
+		r.remaining -= n
+		return n, nil
+	}
+	return 0, r.err
+}
+
+// TestReadAllBounded_MidReadFaults covers the case the package exists for and
+// that no earlier test reached: the mount answers open and stat, then faults
+// part-way through the transfer. The opener seam cannot provoke this — it only
+// faults before any bytes move — so without a reader seam a regression dropping
+// the mid-read classification would misreport a storage fault as an exit-2
+// "tampered bundle" and still pass CI.
+func TestReadAllBounded_MidReadFaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		injected error
+		wantCode errors.ErrorCode
+	}{
+		{"I/O error mid-read", syscall.EIO, errors.ErrCodeUnavailable},
+		{"stale handle mid-read", syscall.ESTALE, errors.ErrCodeUnavailable},
+		{"connection timed out mid-read", syscall.ETIMEDOUT, errors.ErrCodeUnavailable},
+		// Not environmental: a corrupt archive is a content problem.
+		{"unexpected EOF mid-read", io.ErrUnexpectedEOF, errors.ErrCodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &faultingReader{remaining: 8, err: tt.injected}
+
+			body, err := readAllBounded(r, "bundle recipe.yaml", 1024)
+			if body != nil {
+				t.Errorf("expected no body on a mid-read fault, got %q", body)
+			}
+			if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+				t.Fatalf("got %v, want code %s", err, tt.wantCode)
+			}
+			if !stderrors.Is(err, tt.injected) {
+				t.Errorf("underlying %v lost from the error chain: %v", tt.injected, err)
+			}
+		})
+	}
+}
+
+// TestReadAllBounded_GrewAfterStat covers the other reader-side branch: the
+// pre-read size check passed, then the file grew before the transfer. The +1 on
+// the LimitReader is what catches it, and the oversize tests elsewhere all
+// return at the pre-read stat, so this arm was previously unproven.
+func TestReadAllBounded_GrewAfterStat(t *testing.T) {
+	// 200 readable bytes against a 128-byte cap: stat said it fit, the read
+	// says otherwise.
+	r := &faultingReader{remaining: 200, err: io.EOF}
+
+	body, err := readAllBounded(r, "bundle recipe.yaml", 128)
+	if body != nil {
+		t.Errorf("expected no body when the payload exceeds the cap, got %d bytes", len(body))
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("got %v, want ErrCodeInvalidRequest", err)
+	}
+}
+
+// TestReadFile_NonErrnoOpenFailure covers the default open arm: an error that
+// is neither ELOOP, nor absence, nor a storage errno must still be classified
+// rather than falling through unwrapped.
+func TestReadFile_NonErrnoOpenFailure(t *testing.T) {
+	open := func(string, int, os.FileMode) (*os.File, error) {
+		return nil, stderrors.New("some non-errno failure")
+	}
+
+	_, err := readBoundedWithOpener("/bundle/recipe.yaml", "bundle recipe.yaml", 1024, open)
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInternal, "")) {
+		t.Errorf("got %v, want ErrCodeInternal", err)
+	}
+}

--- a/pkg/evidence/verifier/bounded_paths_test.go
+++ b/pkg/evidence/verifier/bounded_paths_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifier
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+)
+
+// TestVerifierFilesystemPathsAreBounded is the load-bearing guarantee of
+// issue #2083: every filesystem entry point on the verify path must sit
+// behind a cancellation boundary, so a dead NFS/FUSE mount surfaces as an
+// error instead of hanging the process forever.
+//
+// It runs each entry point against a real, valid bundle — so an unbounded
+// implementation would succeed instantly — with an already-canceled context.
+// Anything that returns success has performed I/O the caller could not abort,
+// which is exactly the defect. Having a ctx parameter is not enough: a
+// ctx.Err() check between chunks or between walk entries never runs when the
+// syscall itself is wedged in the kernel.
+func TestVerifierFilesystemPathsAreBounded(t *testing.T) {
+	dir := summaryDirOf(t, buildTestBundle(t))
+	mat := &MaterializedBundle{BundleDir: dir}
+
+	// A real predicate, so the phase-digest pass actually reads ctrf/ files.
+	// An empty one would short-circuit before touching the filesystem and the
+	// case would vacuously pass.
+	pred, err := loadUnsignedPredicate(context.Background(), mat)
+	if err != nil {
+		t.Fatalf("loadUnsignedPredicate: %v", err)
+	}
+	if len(pred.Phases) == 0 {
+		t.Fatal("test bundle has no phases — the phase-digest case would not exercise any I/O")
+	}
+
+	tests := []struct {
+		name string
+		run  func(ctx context.Context) error
+	}{
+		{"readBoundedFile", func(ctx context.Context) error {
+			_, err := readBoundedFile(ctx, dir+"/"+attestation.ManifestFilename,
+				"manifest.json", defaults.MaxManifestFileBytes)
+			return err
+		}},
+		{"loadUnsignedPredicate", func(ctx context.Context) error {
+			_, err := loadUnsignedPredicate(ctx, mat)
+			return err
+		}},
+		{"CheckPhaseDigestsContext", func(ctx context.Context) error {
+			_, err := CheckPhaseDigestsContext(ctx, mat, pred)
+			return err
+		}},
+		{"hashFile", func(ctx context.Context) error {
+			_, err := hashFile(ctx, dir, attestation.RecipeFilename, 0)
+			return err
+		}},
+		{"hashAndCaptureFile", func(ctx context.Context) error {
+			_, _, err := hashAndCaptureFile(ctx, dir, attestation.RecipeFilename, 0)
+			return err
+		}},
+		{"findExtras", func(ctx context.Context) error {
+			_, err := findExtras(ctx, dir, nil)
+			return err
+		}},
+		{"checkInventoryCaptureRecipe", func(ctx context.Context) error {
+			_, _, err := checkInventoryCaptureRecipe(ctx, mat, "sha256:deadbeef")
+			return err
+		}},
+		{"VerifySignature", func(ctx context.Context) error {
+			_, err := VerifySignature(ctx, mat, VerifyOptions{})
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := tt.run(ctx)
+			if err == nil {
+				t.Fatal("completed against a canceled context — the I/O is not behind a cancellation boundary")
+			}
+			// An explicitly canceled caller must produce exactly
+			// ErrCodeCanceled. Accepting ErrCodeTimeout here would let an
+			// operator abort keep being reported as a retryable fault, which
+			// is the defect this bounding work exists to fix — a looser
+			// assertion would pass while the bug was still present.
+			if !stderrors.Is(err, errors.New(errors.ErrCodeCanceled, "")) {
+				t.Errorf("abort misclassified (want ErrCodeCanceled): %v", err)
+			}
+		})
+	}
+}

--- a/pkg/evidence/verifier/bounded_read.go
+++ b/pkg/evidence/verifier/bounded_read.go
@@ -15,32 +15,22 @@
 package verifier
 
 import (
-	"io"
-	"os"
-	"strconv"
+	"context"
 
-	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 )
 
-// readBoundedFile reads path into memory, capped at max bytes. The cap
-// guards against attacker-influenced bundle roots (extracted from an
-// untrusted archive, symlink-rich tarball, /proc symlink, NFS mount)
-// where os.ReadFile would allocate the whole file before any size check
-// fires. The +1 on the LimitReader lets us detect "at or over the cap"
-// without reading the entire oversized payload.
-func readBoundedFile(path, label string, max int64) ([]byte, error) {
-	f, err := os.Open(path) //nolint:gosec // path is bundle-local and validated by caller
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeNotFound, "failed to read "+label, err)
-	}
-	defer func() { _ = f.Close() }()
-	body, err := io.ReadAll(io.LimitReader(f, max+1))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read "+label, err)
-	}
-	if int64(len(body)) > max {
-		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			label+" exceeds maximum size of "+strconv.FormatInt(max, 10)+" bytes")
-	}
-	return body, nil
+// readBoundedFile reads path into memory, capped at max bytes and bounded by
+// the caller's context.
+//
+// The size cap guards against attacker-influenced bundle roots (extracted from
+// an untrusted archive, symlink-rich tarball, /proc symlink, NFS mount) where
+// os.ReadFile would allocate the whole file before any size check fires. The
+// context bound is what keeps `aicr evidence verify` from hanging forever on a
+// dead NFS/FUSE mount: a size cap bounds bytes, not time, and a bare os.Open
+// against a wedged mount blocks in the syscall indefinitely. See
+// pkg/evidence/internal/boundedio for why that requires a real cancellation
+// boundary rather than a ctx.Err() check between chunks.
+func readBoundedFile(ctx context.Context, path, label string, max int64) ([]byte, error) {
+	return boundedio.ReadFile(ctx, path, label, max)
 }

--- a/pkg/evidence/verifier/bounded_read_test.go
+++ b/pkg/evidence/verifier/bounded_read_test.go
@@ -15,6 +15,7 @@
 package verifier
 
 import (
+	"context"
 	stderrors "errors"
 	"os"
 	"path/filepath"
@@ -29,7 +30,7 @@ func TestReadBoundedFile_HappyPath(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`{"ok":true}`), 0o600); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	body, err := readBoundedFile(path, "test file", 1024)
+	body, err := readBoundedFile(context.Background(), path, "test file", 1024)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -48,7 +49,7 @@ func TestReadBoundedFile_RejectsOversize(t *testing.T) {
 	if err := os.WriteFile(path, make([]byte, 17), 0o600); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	_, err := readBoundedFile(path, "test file", 16)
+	_, err := readBoundedFile(context.Background(), path, "test file", 16)
 	if err == nil {
 		t.Fatal("expected error for oversized file, got nil")
 	}
@@ -63,7 +64,7 @@ func TestReadBoundedFile_ExactlyAtCap(t *testing.T) {
 	if err := os.WriteFile(path, make([]byte, 16), 0o600); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	body, err := readBoundedFile(path, "test file", 16)
+	body, err := readBoundedFile(context.Background(), path, "test file", 16)
 	if err != nil {
 		t.Fatalf("at-cap read should succeed, got %v", err)
 	}
@@ -73,7 +74,7 @@ func TestReadBoundedFile_ExactlyAtCap(t *testing.T) {
 }
 
 func TestReadBoundedFile_MissingFile(t *testing.T) {
-	_, err := readBoundedFile(filepath.Join(t.TempDir(), "nope"), "missing", 1024)
+	_, err := readBoundedFile(context.Background(), filepath.Join(t.TempDir(), "nope"), "missing", 1024)
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}

--- a/pkg/evidence/verifier/failure.go
+++ b/pkg/evidence/verifier/failure.go
@@ -15,19 +15,60 @@
 package verifier
 
 import (
+	"context"
 	stderrors "errors"
 
 	"oras.land/oras-go/v2/registry/remote/errcode"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 )
 
-// setFailureCause records the classified reason for a non-zero Exit, but
-// only the first one — verification runs steps in order, so the earliest
-// failure is the root cause and later steps' errors are usually fallout.
-func setFailureCause(r *VerifyResult, step int, err error) {
-	if r == nil || err == nil || r.FailureCause != nil {
+// recordFailure sets the exit code and the failure cause together, so the two
+// can never disagree.
+//
+// The cause is first-wins — verification runs steps in order, so the earliest
+// failure is the root cause and later errors are usually fallout — with one
+// exception: a non-verdict cause (transient/canceled) recorded by an earlier
+// step is REPLACED once a later step returns a real verdict. Otherwise a
+// timeout during signature verification would leave a tampered bundle reported
+// as `exit 2` with `class: transient` and the hint "retry", which tells a CI
+// gate to re-run a bundle it should be rejecting.
+func recordFailure(r *VerifyResult, step int, err error) {
+	if r == nil || err == nil {
 		return
 	}
-	r.FailureCause = classifyFailure(step, err)
+	cause := classifyFailure(step, err)
+	exit := exitForClass(cause.Class)
+	// Never downgrade a hard verdict an earlier step already recorded: later
+	// errors are usually fallout from the same broken state.
+	if r.Exit == ExitInvalid {
+		exit = ExitInvalid
+	}
+	if r.FailureCause == nil ||
+		(exit == ExitInvalid && isNonVerdictClass(r.FailureCause.Class)) {
+
+		r.FailureCause = cause
+	}
+	r.Exit = exit
+}
+
+// exitForClass derives the exit code from the classified cause, so the two can
+// never disagree. Deriving it from the raw error instead would miss causes the
+// classifier assigns without a matching error code — a registry 503, for
+// instance, carries no ErrCodeTimeout yet is plainly not a verdict about the
+// bundle.
+func exitForClass(class string) int {
+	if isNonVerdictClass(class) {
+		return ExitIncomplete
+	}
+	return ExitInvalid
+}
+
+// isNonVerdictClass reports whether a recorded cause means "no verdict was
+// reached" rather than "the bundle is bad".
+func isNonVerdictClass(class string) bool {
+	return class == CauseTransient || class == CauseCanceled
 }
 
 // classifyFailure turns a step error into a structured, actionable cause.
@@ -38,6 +79,25 @@ func setFailureCause(r *VerifyResult, step int, err error) {
 func classifyFailure(step int, err error) *FailureCause {
 	if c := classifyRegistryError(err); c != nil {
 		return c
+	}
+	// A read we could not complete says nothing about the bundle's contents,
+	// so it must not inherit the step's verdict (a timeout at stepInventory is
+	// not "integrity"). Keyed on deadlines and ErrCodeTimeout only, NOT on
+	// errors.IsTransient: that also reports true for context.Canceled, which
+	// would classify a deliberate operator abort as a retryable fault.
+	if stderrors.Is(err, errors.New(errors.ErrCodeCanceled, "")) {
+		return &FailureCause{
+			Class:  CauseCanceled,
+			Detail: err.Error(),
+			Hint:   "verification was aborted by the operator — no verdict was reached",
+		}
+	}
+	if isTransientFailure(err) {
+		return &FailureCause{
+			Class:  CauseTransient,
+			Detail: err.Error(),
+			Hint:   "the bundle could not be read (storage or registry fault) — this is not a verdict on its contents; retry",
+		}
 	}
 	c := &FailureCause{Detail: err.Error()}
 	switch step {
@@ -58,6 +118,19 @@ func classifyFailure(step int, err error) *FailureCause {
 	return c
 }
 
+// isTransientFailure reports whether err is an environmental fault worth
+// retrying. Deliberately narrower than errors.IsTransient, which also counts
+// context.Canceled: an operator who pressed Ctrl-C has not hit a transient
+// fault and must not have their abort reported as a retryable condition.
+func isTransientFailure(err error) bool {
+	if boundedio.IsCanceled(err) {
+		return false
+	}
+	return stderrors.Is(err, context.DeadlineExceeded) ||
+		stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) ||
+		stderrors.Is(err, errors.New(errors.ErrCodeUnavailable, ""))
+}
+
 // classifyRegistryError walks the error chain for an oras registry response
 // and maps its HTTP status to an actionable cause. Returns nil when no
 // registry status is present.
@@ -74,7 +147,19 @@ func classifyRegistryError(err error) *FailureCause {
 	case 404:
 		c.Class = CauseNotFound
 		c.Hint = "bundle not found at the referenced digest (was it pushed to this registry?)"
+	case 429:
+		// Rate limiting and server-side errors say nothing about the bundle —
+		// we never got it. Leaving these as CauseRegistry made exitForFailure
+		// return ExitInvalid, so a registry outage was reported to a
+		// contributor as "your evidence is invalid".
+		c.Class = CauseTransient
+		c.Hint = "registry rate-limited the request — retry"
 	default:
+		if respErr.StatusCode >= 500 {
+			c.Class = CauseTransient
+			c.Hint = "registry returned a server error — retry"
+			break
+		}
 		c.Class = CauseRegistry
 	}
 	return c

--- a/pkg/evidence/verifier/failure_test.go
+++ b/pkg/evidence/verifier/failure_test.go
@@ -36,7 +36,11 @@ func TestClassifyFailure_RegistryStatusTakesPrecedence(t *testing.T) {
 		{"forbidden", http.StatusForbidden, stepMaterialize, CauseRegistryForbidden, 403, true},
 		{"unauthorized", http.StatusUnauthorized, stepMaterialize, CauseRegistryForbidden, 401, true},
 		{"not found", http.StatusNotFound, stepMaterialize, CauseNotFound, 404, true},
-		{"other status", http.StatusInternalServerError, stepMaterialize, CauseRegistry, 500, false},
+		// A 4xx the classifier has no specific arm for. 5xx and 429 are no
+		// longer "other": they are server-side, so they classify as transient
+		// and carry a retry hint (see
+		// TestClassifyRegistryError_ServerFaultsAreNotVerdicts).
+		{"other client status", http.StatusBadRequest, stepMaterialize, CauseRegistry, 400, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -89,20 +93,53 @@ func TestClassifyFailure_StepWhenNoRegistryStatus(t *testing.T) {
 	}
 }
 
-func TestSetFailureCause_FirstWins(t *testing.T) {
+// TestRecordFailure_FirstVerdictWins keeps the original first-wins rule for two
+// real verdicts: verification runs in order, so the earliest genuine failure is
+// the root cause and later ones are usually fallout.
+func TestRecordFailure_FirstVerdictWins(t *testing.T) {
 	r := &VerifyResult{}
-	setFailureCause(r, stepMaterialize, errors.New(errors.ErrCodeUnavailable, "first"))
-	setFailureCause(r, stepInventory, errors.New(errors.ErrCodeInternal, "second"))
+	recordFailure(r, stepSignature, errors.New(errors.ErrCodeUnauthorized, "first"))
+	recordFailure(r, stepInventory, errors.New(errors.ErrCodeInvalidRequest, "second"))
 	if r.FailureCause == nil || !strings.Contains(r.FailureCause.Detail, "first") {
 		t.Fatalf("expected first failure to win; got %+v", r.FailureCause)
 	}
+	if r.Exit != ExitInvalid {
+		t.Errorf("exit = %d, want %d", r.Exit, ExitInvalid)
+	}
 }
 
-func TestSetFailureCause_IgnoresNil(t *testing.T) {
+// TestRecordFailure_HardVerdictSupersedesNonVerdict is the exception, and the
+// reason exit and cause are set together. An earlier transient must not leave a
+// tampered bundle reported as "exit 2, class transient, hint: retry" — that
+// tells a CI gate to re-run a bundle it should be rejecting.
+func TestRecordFailure_HardVerdictSupersedesNonVerdict(t *testing.T) {
 	r := &VerifyResult{}
-	setFailureCause(r, stepMaterialize, nil)
+	recordFailure(r, stepSignature, errors.New(errors.ErrCodeTimeout, "trusted root unavailable"))
+	if r.FailureCause == nil || r.FailureCause.Class != CauseTransient {
+		t.Fatalf("expected a transient cause first; got %+v", r.FailureCause)
+	}
+
+	recordFailure(r, stepInventory, errors.New(errors.ErrCodeInvalidRequest, "manifest digest mismatch"))
+	if r.Exit != ExitInvalid {
+		t.Errorf("exit = %d, want %d", r.Exit, ExitInvalid)
+	}
+	if r.FailureCause == nil || r.FailureCause.Class != CauseIntegrity {
+		t.Fatalf("cause = %+v, want class %q — an invalid verdict must not carry a transient cause",
+			r.FailureCause, CauseIntegrity)
+	}
+	if strings.Contains(r.FailureCause.Hint, "retry") {
+		t.Errorf("invalid bundle still carries a retry hint: %q", r.FailureCause.Hint)
+	}
+}
+
+func TestRecordFailure_IgnoresNil(t *testing.T) {
+	r := &VerifyResult{}
+	recordFailure(r, stepMaterialize, nil)
 	if r.FailureCause != nil {
 		t.Errorf("nil error should not set a cause; got %+v", r.FailureCause)
+	}
+	if r.Exit != ExitValidPassed {
+		t.Errorf("nil error should not change exit; got %d", r.Exit)
 	}
 }
 

--- a/pkg/evidence/verifier/fetch_test.go
+++ b/pkg/evidence/verifier/fetch_test.go
@@ -49,8 +49,8 @@ func TestMaterializeBundle_DirRejectsNonBundle(t *testing.T) {
 	}
 }
 
-// TestBundleMarkerProbe_CanceledCtxPropagatesTimeout verifies that a
-// canceled caller context surfaces as an ErrCodeTimeout error through the
+// TestBundleMarkerProbe_CanceledCtxPropagatesAbort verifies that a
+// canceled caller context surfaces as an ErrCodeCanceled error through the
 // bundle-marker probe rather than being flattened into a benign "not a
 // bundle" (ErrCodeInvalidRequest) answer: at these probe sites a hung NFS/FUSE
 // mount fails closed, not open. Both marker-probing sites are exercised:
@@ -62,7 +62,7 @@ func TestMaterializeBundle_DirRejectsNonBundle(t *testing.T) {
 // probe, and several post-materialize reads are still unbounded; both are
 // tracked in #2083. The test calls the probes directly, so it must not be
 // read as proving the whole verify path is hang-immune.
-func TestBundleMarkerProbe_CanceledCtxPropagatesTimeout(t *testing.T) {
+func TestBundleMarkerProbe_CanceledCtxPropagatesAbort(t *testing.T) {
 	// A real bundle so a live context would succeed — proving the failure
 	// comes from cancellation, not a missing bundle.
 	bundleDir := buildTestBundle(t)
@@ -95,8 +95,8 @@ func TestBundleMarkerProbe_CanceledCtxPropagatesTimeout(t *testing.T) {
 			if err == nil {
 				t.Fatalf("%s: expected error on canceled ctx, got nil", tt.name)
 			}
-			if !stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) {
-				t.Errorf("%s: got %v, want ErrCodeTimeout (must not flatten to \"not a bundle\")", tt.name, err)
+			if !stderrors.Is(err, errors.New(errors.ErrCodeCanceled, "")) {
+				t.Errorf("%s: got %v, want ErrCodeCanceled (must not flatten to \"not a bundle\")", tt.name, err)
 			}
 			if stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
 				t.Errorf("%s: canceled ctx was misreported as ErrCodeInvalidRequest (fail-open): %v", tt.name, err)

--- a/pkg/evidence/verifier/input.go
+++ b/pkg/evidence/verifier/input.go
@@ -15,10 +15,13 @@
 package verifier
 
 import (
+	"context"
 	"os"
 	"strings"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 )
 
 // DetectInputForm classifies a user-supplied input string into one of
@@ -27,7 +30,21 @@ import (
 //  1. URL prefix: oci:// → OCI; http(s):// is rejected.
 //  2. Filesystem: directory → dir; .yaml/.yml file → pointer.
 //  3. Bare OCI ref shape ("registry/repo[:tag][@digest]") → OCI.
+//
+// Deprecated: prefer DetectInputFormContext. This form derives its own
+// defaults.FileReadTimeout-bounded context, so it cannot be aborted by the
+// caller; it is retained for source compatibility.
 func DetectInputForm(input string) (InputForm, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return DetectInputFormContext(ctx, input)
+}
+
+// DetectInputFormContext is DetectInputForm bounded by the caller's context.
+// The filesystem probe below runs before any other verify step, so leaving it
+// unbounded meant `verify --input /mnt/hung/bundle` blocked here — ahead of
+// every bounded read downstream.
+func DetectInputFormContext(ctx context.Context, input string) (InputForm, error) {
 	if input == "" {
 		return "", errors.New(errors.ErrCodeInvalidRequest, "input is empty")
 	}
@@ -38,7 +55,15 @@ func DetectInputForm(input string) (InputForm, error) {
 		return "", errors.New(errors.ErrCodeInvalidRequest,
 			"http(s):// inputs are not supported — use oci://, a pointer file, or a local directory")
 	}
-	if info, err := os.Stat(input); err == nil {
+	var info os.FileInfo
+	var statErr error
+	if bErr := boundedio.Do(ctx, "input path "+input, func() error {
+		info, statErr = os.Stat(input)
+		return nil
+	}); bErr != nil {
+		return "", bErr
+	}
+	if err := statErr; err == nil {
 		if info.IsDir() {
 			return InputFormDir, nil
 		}

--- a/pkg/evidence/verifier/inventory.go
+++ b/pkg/evidence/verifier/inventory.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -27,6 +26,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 )
 
 // CheckInventory verifies the bundle's integrity chain:
@@ -78,7 +78,7 @@ func checkInventoryCaptureRecipe(
 		return nil, nil, errors.New(errors.ErrCodeInvalidRequest,
 			"expected manifest digest is required (from predicate.manifest.digest)")
 	}
-	body, err := readBoundedFile(
+	body, err := readBoundedFile(ctx,
 		filepath.Join(mat.BundleDir, attestation.ManifestFilename),
 		"manifest.json", defaults.MaxManifestFileBytes)
 	if err != nil {
@@ -110,8 +110,7 @@ func checkInventoryCaptureRecipe(
 	var mismatches []KV
 	for _, e := range manifest.Files {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, mismatches, errors.Wrap(errors.ErrCodeUnavailable,
-				"inventory check canceled", ctxErr)
+			return nil, mismatches, abortError(ctxErr, "inventory check")
 		}
 		var got string
 		var captured []byte
@@ -119,7 +118,7 @@ func checkInventoryCaptureRecipe(
 		if e.Path == attestation.RecipeFilename {
 			// Read ONCE: the retained bytes are the hashed bytes by
 			// construction, closing the reread TOCTOU window.
-			captured, got, hashErr = hashAndCaptureFile(mat.BundleDir, e.Path, e.Size)
+			captured, got, hashErr = hashAndCaptureFile(ctx, mat.BundleDir, e.Path, e.Size)
 		} else {
 			got, hashErr = hashFile(ctx, mat.BundleDir, e.Path, e.Size)
 		}
@@ -168,34 +167,19 @@ func checkInventoryCaptureRecipe(
 // different read than the one retained. The size check runs against the
 // bytes actually read (not a pre-read Stat) for the same reason. Returns
 // the captured bytes and the bare-hex sha256 (hashFile's format).
-func hashAndCaptureFile(bundleDir, rel string, expectedSize int64) ([]byte, string, error) {
+func hashAndCaptureFile(ctx context.Context, bundleDir, rel string, expectedSize int64) ([]byte, string, error) {
 	localRel := filepath.FromSlash(rel)
 	if !filepath.IsLocal(localRel) {
 		return nil, "", errors.New(errors.ErrCodeInvalidRequest,
 			"manifest entry "+rel+" is not a local path (rejecting potential traversal)")
 	}
 	full := filepath.Join(bundleDir, localRel)
-	f, err := os.Open(full) //nolint:gosec // path is locality-checked above
+	// boundedio.ReadFile preserves the read-once property this function exists
+	// for (the retained bytes are the hashed bytes, closing the reread TOCTOU
+	// window) while adding the time bound and the descriptor-first shape checks.
+	data, err := boundedio.ReadFile(ctx, full, "bundle "+rel, defaults.MaxRecipePOSTBytes)
 	if err != nil {
-		return nil, "", errors.Wrap(errors.ErrCodeNotFound, "file missing from bundle: "+rel, err)
-	}
-	info, err := f.Stat()
-	if err != nil {
-		_ = f.Close() // read-only handle
-		return nil, "", errors.Wrap(errors.ErrCodeInternal, "failed to stat bundle file: "+rel, err)
-	}
-	if info.IsDir() {
-		_ = f.Close() // read-only handle
-		return nil, "", errors.New(errors.ErrCodeInvalidRequest, "manifest entry "+rel+" is a directory")
-	}
-	data, err := io.ReadAll(io.LimitReader(f, defaults.MaxRecipePOSTBytes+1))
-	_ = f.Close() // read-only handle
-	if err != nil {
-		return nil, "", errors.Wrap(errors.ErrCodeInternal, "failed to read bundle file: "+rel, err)
-	}
-	if int64(len(data)) > defaults.MaxRecipePOSTBytes {
-		return nil, "", errors.New(errors.ErrCodeInvalidRequest,
-			"bundle "+rel+" exceeds the identity-binding size cap")
+		return nil, "", err
 	}
 	if expectedSize > 0 && int64(len(data)) != expectedSize {
 		return nil, "", errors.New(errors.ErrCodeInvalidRequest,
@@ -211,14 +195,25 @@ func normalizeInventoryHashError(ctx context.Context, err error) error {
 		return nil
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return errors.Wrap(errors.ErrCodeUnavailable, "inventory check canceled", ctxErr)
+		return abortError(ctxErr, "inventory check")
 	}
 	return err
 }
 
+// abortError shapes a context abort so a deliberate operator cancellation stays
+// distinguishable from an environmental deadline: the former must never be
+// reported as a retryable condition.
+func abortError(cause error, what string) error {
+	if stderrors.Is(cause, context.Canceled) {
+		return errors.Wrap(errors.ErrCodeCanceled, what+" canceled", cause)
+	}
+	return errors.Wrap(errors.ErrCodeUnavailable, what+" timed out", cause)
+}
+
 func isInventoryAbortError(err error) bool {
 	return stderrors.Is(err, errors.New(errors.ErrCodeTimeout, "")) ||
-		stderrors.Is(err, errors.New(errors.ErrCodeUnavailable, ""))
+		stderrors.Is(err, errors.New(errors.ErrCodeUnavailable, "")) ||
+		boundedio.IsCanceled(err)
 }
 
 // CheckPhaseDigests verifies that each phase summary's CTRFDigest recorded in
@@ -232,7 +227,25 @@ func isInventoryAbortError(err error) bool {
 // and still pass verification. Fails closed on any mismatch or unreadable
 // phase file. Returns per-phase mismatch rows and a summarizing error; both
 // nil on success.
+//
+// Deprecated: prefer CheckPhaseDigestsContext. This form derives its own
+// defaults.FileReadTimeout-bounded context, so it cannot be aborted by the
+// caller; it is retained for source compatibility with out-of-tree callers.
 func CheckPhaseDigests(mat *MaterializedBundle, pred *attestation.Predicate) ([]KV, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return CheckPhaseDigestsContext(ctx, mat, pred)
+}
+
+// CheckPhaseDigestsContext is CheckPhaseDigests bounded by the caller's
+// context, so a wedged mount under ctrf/ surfaces as a timeout instead of
+// hanging the verifier.
+func CheckPhaseDigestsContext(
+	ctx context.Context,
+	mat *MaterializedBundle,
+	pred *attestation.Predicate,
+) ([]KV, error) {
+
 	if mat == nil || mat.BundleDir == "" {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "materialized bundle is required")
 	}
@@ -261,10 +274,17 @@ func CheckPhaseDigests(mat *MaterializedBundle, pred *attestation.Predicate) ([]
 			continue
 		}
 		rel := attestation.CTRFRelPath(p)
-		body, err := readBoundedFile(
+		body, err := readBoundedFile(ctx,
 			filepath.Join(mat.BundleDir, filepath.FromSlash(rel)),
 			rel, defaults.MaxAttestationFileBytes)
 		if err != nil {
+			// An aborted read is a storage/operator condition, not a digest
+			// disagreement. Recording it as a mismatch would launder a dead
+			// mount into "this bundle's phase digests are wrong" — the exact
+			// mis-diagnosis this bounding work exists to prevent.
+			if isInventoryAbortError(err) {
+				return mismatches, err
+			}
 			mismatches = append(mismatches, KV{Key: rel, Value: err.Error()})
 			continue
 		}
@@ -292,9 +312,26 @@ func hashFile(ctx context.Context, bundleDir, rel string, expectedSize int64) (s
 			"manifest entry "+rel+" is not a local path (rejecting potential traversal)")
 	}
 	full := filepath.Join(bundleDir, localRel)
-	info, err := os.Stat(full)
-	if err != nil {
-		return "", errors.Wrap(errors.ErrCodeNotFound, "file missing from bundle: "+rel, err)
+	// Bounded: an unbounded stat here wedges the whole inventory pass on a
+	// dead mount, before HashFileSHA256Context's own bound can apply.
+	var info os.FileInfo
+	var statErr error
+	if bErr := boundedio.Do(ctx, "bundle file "+rel, func() error {
+		info, statErr = os.Stat(full)
+		return nil
+	}); bErr != nil {
+		return "", bErr
+	}
+	if statErr != nil {
+		// Only a confirmed absence is "missing from bundle". A mount answering
+		// EIO/ESTALE/EACCES has not told us the file is absent, and reporting
+		// it as NotFound turns a storage fault into an inventory mismatch row
+		// and ultimately an "integrity" verdict.
+		if !os.IsNotExist(statErr) {
+			return "", errors.Wrap(errors.ErrCodeUnavailable,
+				"could not read bundle file (storage fault): "+rel, statErr)
+		}
+		return "", errors.Wrap(errors.ErrCodeNotFound, "file missing from bundle: "+rel, statErr)
 	}
 	if info.IsDir() {
 		return "", errors.New(errors.ErrCodeInvalidRequest, "manifest entry "+rel+" is a directory")
@@ -333,36 +370,48 @@ func findExtras(ctx context.Context, bundleDir string, manifestFiles []attestati
 		attestation.StatementFilename:   {},
 	}
 	var extras []string
-	walkErr := filepath.WalkDir(bundleDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		if d.IsDir() {
+	// The whole walk goes behind the boundary, not just the callback: the
+	// ctx.Err() check below only runs between entries, while WalkDir's own
+	// ReadDir/Lstat syscalls are what block on a wedged mount.
+	var walkErr error
+	if bErr := boundedio.Do(ctx, "bundle directory "+bundleDir, func() error {
+		walkErr = filepath.WalkDir(bundleDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			rel, relErr := filepath.Rel(bundleDir, path)
+			if relErr != nil {
+				return relErr
+			}
+			rel = filepath.ToSlash(rel)
+			if _, ok := want[rel]; ok {
+				return nil
+			}
+			if _, ok := exempt[rel]; ok {
+				return nil
+			}
+			extras = append(extras, rel)
 			return nil
-		}
-		rel, relErr := filepath.Rel(bundleDir, path)
-		if relErr != nil {
-			return relErr
-		}
-		rel = filepath.ToSlash(rel)
-		if _, ok := want[rel]; ok {
-			return nil
-		}
-		if _, ok := exempt[rel]; ok {
-			return nil
-		}
-		extras = append(extras, rel)
+		})
 		return nil
-	})
+	}); bErr != nil {
+		return nil, bErr
+	}
 	if walkErr != nil {
 		// A canceled ctx surfaces here as context.Canceled / DeadlineExceeded
-		// from the callback. Translate to ErrCodeUnavailable so cancellation
-		// reads the same way it does in the per-file loop above.
+		// from the callback. abortError splits the two the same way the
+		// per-file loop above does: a deliberate abort becomes ErrCodeCanceled
+		// (never retryable) and a deadline becomes ErrCodeUnavailable
+		// (transient). Both are aborts, so neither is folded into the
+		// mismatch rows as if it were a content failure.
 		if stderrors.Is(walkErr, context.Canceled) || stderrors.Is(walkErr, context.DeadlineExceeded) {
-			return nil, errors.Wrap(errors.ErrCodeUnavailable, "bundle walk canceled", walkErr)
+			return nil, abortError(walkErr, "bundle walk")
 		}
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to walk bundle dir", walkErr)
 	}

--- a/pkg/evidence/verifier/inventory_phase_test.go
+++ b/pkg/evidence/verifier/inventory_phase_test.go
@@ -15,6 +15,7 @@
 package verifier
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,12 +30,12 @@ func TestCheckPhaseDigests_Match(t *testing.T) {
 	summary := summaryDirOf(t, buildTestBundle(t))
 	mat := &MaterializedBundle{BundleDir: summary}
 
-	pred, err := loadUnsignedPredicate(mat)
+	pred, err := loadUnsignedPredicate(context.Background(), mat)
 	if err != nil {
 		t.Fatalf("loadUnsignedPredicate: %v", err)
 	}
 
-	rows, err := CheckPhaseDigests(mat, pred)
+	rows, err := CheckPhaseDigestsContext(context.Background(), mat, pred)
 	if err != nil {
 		t.Fatalf("CheckPhaseDigests = %v (rows %+v), want nil", err, rows)
 	}
@@ -47,7 +48,7 @@ func TestCheckPhaseDigests_TamperedReportFails(t *testing.T) {
 	summary := summaryDirOf(t, buildTestBundle(t))
 	mat := &MaterializedBundle{BundleDir: summary}
 
-	pred, err := loadUnsignedPredicate(mat)
+	pred, err := loadUnsignedPredicate(context.Background(), mat)
 	if err != nil {
 		t.Fatalf("loadUnsignedPredicate: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestCheckPhaseDigests_TamperedReportFails(t *testing.T) {
 		t.Fatalf("tamper ctrf report: %v", writeErr)
 	}
 
-	rows, err := CheckPhaseDigests(mat, pred)
+	rows, err := CheckPhaseDigestsContext(context.Background(), mat, pred)
 	if err == nil {
 		t.Fatalf("CheckPhaseDigests = nil, want mismatch error")
 	}
@@ -78,7 +79,7 @@ func TestCheckPhaseDigests_MissingReportFails(t *testing.T) {
 	summary := summaryDirOf(t, buildTestBundle(t))
 	mat := &MaterializedBundle{BundleDir: summary}
 
-	pred, err := loadUnsignedPredicate(mat)
+	pred, err := loadUnsignedPredicate(context.Background(), mat)
 	if err != nil {
 		t.Fatalf("loadUnsignedPredicate: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestCheckPhaseDigests_MissingReportFails(t *testing.T) {
 		t.Fatalf("remove ctrf report: %v", err)
 	}
 
-	if _, err := CheckPhaseDigests(mat, pred); err == nil {
+	if _, err := CheckPhaseDigestsContext(context.Background(), mat, pred); err == nil {
 		t.Fatalf("CheckPhaseDigests = nil, want error for missing report")
 	}
 }
@@ -99,7 +100,7 @@ func TestCheckPhaseDigests_EmptyDigestFails(t *testing.T) {
 	summary := summaryDirOf(t, buildTestBundle(t))
 	mat := &MaterializedBundle{BundleDir: summary}
 
-	pred, err := loadUnsignedPredicate(mat)
+	pred, err := loadUnsignedPredicate(context.Background(), mat)
 	if err != nil {
 		t.Fatalf("loadUnsignedPredicate: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestCheckPhaseDigests_EmptyDigestFails(t *testing.T) {
 	ps.CTRFDigest = ""
 	pred.Phases[attestation.PhaseDeployment] = ps
 
-	rows, err := CheckPhaseDigests(mat, pred)
+	rows, err := CheckPhaseDigestsContext(context.Background(), mat, pred)
 	if err == nil {
 		t.Fatalf("CheckPhaseDigests = nil, want error for empty digest")
 	}
@@ -124,10 +125,10 @@ func TestCheckPhaseDigests_EmptyDigestFails(t *testing.T) {
 
 // TestCheckPhaseDigests_InvalidArgs covers the nil-guard paths.
 func TestCheckPhaseDigests_InvalidArgs(t *testing.T) {
-	if _, err := CheckPhaseDigests(nil, &attestation.Predicate{}); err == nil {
-		t.Errorf("CheckPhaseDigests(nil mat) = nil, want error")
+	if _, err := CheckPhaseDigestsContext(context.Background(), nil, &attestation.Predicate{}); err == nil {
+		t.Errorf("CheckPhaseDigestsContext(context.Background(), nil mat) = nil, want error")
 	}
-	if _, err := CheckPhaseDigests(&MaterializedBundle{BundleDir: t.TempDir()}, nil); err == nil {
-		t.Errorf("CheckPhaseDigests(nil pred) = nil, want error")
+	if _, err := CheckPhaseDigestsContext(context.Background(), &MaterializedBundle{BundleDir: t.TempDir()}, nil); err == nil {
+		t.Errorf("CheckPhaseDigestsContext(context.Background(), nil pred) = nil, want error")
 	}
 }

--- a/pkg/evidence/verifier/pointer.go
+++ b/pkg/evidence/verifier/pointer.go
@@ -15,8 +15,7 @@
 package verifier
 
 import (
-	"io"
-	"os"
+	"context"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -24,6 +23,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 )
 
 // pointerSizeCeiling caps the bytes the verifier will read from a
@@ -34,20 +34,23 @@ var pointerSizeCeiling = defaults.MaxRecipePOSTBytes
 // LoadAndValidatePointer reads and validates the pointer file at path.
 // V1 enforces schema 1.0.x with exactly one attestation entry — schema
 // 2.0 (multi-instance pointers) is reserved.
+//
+// Deprecated: prefer LoadAndValidatePointerContext. This form derives its own
+// defaults.FileReadTimeout-bounded context, so it cannot be aborted by the
+// caller; it is retained for source compatibility with the ctx-free evidence
+// tree gate (pkg/evidence/verifier/discover.go and tools/evidence-pointercheck).
 func LoadAndValidatePointer(path string) (*attestation.Pointer, error) {
-	f, err := os.Open(path) //nolint:gosec // operator-supplied path
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeNotFound, "failed to open pointer file", err)
-	}
-	defer func() { _ = f.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FileReadTimeout)
+	defer cancel()
+	return LoadAndValidatePointerContext(ctx, path)
+}
 
-	body, readErr := io.ReadAll(io.LimitReader(f, pointerSizeCeiling+1))
-	if readErr != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read pointer file", readErr)
-	}
-	if int64(len(body)) > pointerSizeCeiling {
-		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			"pointer file exceeds size limit (1 MiB)")
+// LoadAndValidatePointerContext is LoadAndValidatePointer bounded by the
+// caller's context.
+func LoadAndValidatePointerContext(ctx context.Context, path string) (*attestation.Pointer, error) {
+	body, err := boundedio.ReadFile(ctx, path, "pointer file", pointerSizeCeiling)
+	if err != nil {
+		return nil, err
 	}
 
 	var ptr attestation.Pointer

--- a/pkg/evidence/verifier/report.go
+++ b/pkg/evidence/verifier/report.go
@@ -206,6 +206,10 @@ func writeVerdict(b *strings.Builder, r *VerifyResult) {
 	case ExitInvalid:
 		b.WriteString("**Verdict:** bundle invalid — verification failed (exit 2)\n")
 		writeFailureCause(b, r.FailureCause)
+	case ExitIncomplete:
+		b.WriteString("**Verdict:** verification did not complete (exit 3) — no verdict was reached. " +
+			"This is NOT a statement about the bundle's validity.\n")
+		writeFailureCause(b, r.FailureCause)
 	}
 }
 

--- a/pkg/evidence/verifier/signature.go
+++ b/pkg/evidence/verifier/signature.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -33,6 +34,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
+	"github.com/NVIDIA/aicr/pkg/evidence/internal/boundedio"
 	"github.com/NVIDIA/aicr/pkg/trust"
 )
 
@@ -65,15 +67,38 @@ func VerifySignature(ctx context.Context, mat *MaterializedBundle, opts VerifyOp
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "materialized bundle is required")
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeTimeout, "context canceled before signature verify", err)
+		// An operator abort must not be reported as a timeout: ErrCodeTimeout
+		// is the retryable/transient bucket, and a deliberate Ctrl-C is not
+		// something a CI gate should re-run.
+		if stderrors.Is(err, context.Canceled) {
+			return nil, errors.Wrap(errors.ErrCodeCanceled, "canceled before signature verify", err)
+		}
+		return nil, errors.Wrap(errors.ErrCodeTimeout, "timed out before signature verify", err)
 	}
 
 	sigPath := filepath.Join(mat.BundleDir, attestation.AttestationFilename)
-	info, statErr := os.Stat(sigPath)
+	// Bounded: this stat decides signed-vs-unsigned, so on a wedged mount an
+	// unbounded call would hang the verifier before any read is attempted.
+	var info os.FileInfo
+	var statErr error
+	if bErr := boundedio.Do(ctx, "signature file "+attestation.AttestationFilename, func() error {
+		info, statErr = os.Stat(sigPath)
+		return nil
+	}); bErr != nil {
+		return nil, bErr
+	}
 	if statErr != nil && os.IsNotExist(statErr) {
 		return nil, ErrUnsignedBundle
 	}
 	if statErr != nil {
+		// A mount that cannot answer has not told us whether the bundle is
+		// signed. Reporting this as Internal let classifyFailure fall through
+		// to the step class — "signature" — so a storage fault read as
+		// "this bundle's signature failed verification".
+		if boundedio.IsStorageFault(statErr) {
+			return nil, errors.Wrap(errors.ErrCodeUnavailable,
+				"could not read signature file (storage fault)", statErr)
+		}
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to stat signature file", statErr)
 	}
 	if info.Size() > defaults.MaxSigstoreBundleSize {
@@ -81,7 +106,7 @@ func VerifySignature(ctx context.Context, mat *MaterializedBundle, opts VerifyOp
 			"signature file exceeds maximum size — refusing to parse")
 	}
 
-	sigBundle, parseErr := loadSigstoreBundle(sigPath)
+	sigBundle, parseErr := loadSigstoreBundle(ctx, sigPath)
 	if parseErr != nil {
 		return nil, parseErr
 	}
@@ -183,8 +208,8 @@ func buildIdentityMatcher(opts VerifyOptions) (verify.CertificateIdentity, error
 	return identity, nil
 }
 
-func loadSigstoreBundle(path string) (*bundle.Bundle, error) {
-	data, err := readBoundedFile(path, "sigstore bundle", defaults.MaxSigstoreBundleSize)
+func loadSigstoreBundle(ctx context.Context, path string) (*bundle.Bundle, error) {
+	data, err := readBoundedFile(ctx, path, "sigstore bundle", defaults.MaxSigstoreBundleSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/evidence/verifier/transient_test.go
+++ b/pkg/evidence/verifier/transient_test.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifier
+
+import (
+	"context"
+	"net/url"
+	"syscall"
+	"testing"
+
+	"oras.land/oras-go/v2/registry/remote/errcode"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// TestClassifyFailure_TransientVsIntegrity is the diagnostic split #2083 asks
+// for: a dead mount and a tampered bundle must not produce the same verdict.
+// Before this, a timeout at any step fell through to the step's own class —
+// so a wedged NFS read during the manifest hash check was reported as
+// `integrity`, i.e. "this bundle has been tampered with".
+func TestClassifyFailure_TransientVsIntegrity(t *testing.T) {
+	tests := []struct {
+		name      string
+		step      int
+		err       error
+		wantClass string
+	}{
+		{
+			name:      "timeout during inventory is transient, not integrity",
+			step:      stepInventory,
+			err:       errors.New(errors.ErrCodeTimeout, "timed out reading bundle file"),
+			wantClass: CauseTransient,
+		},
+		{
+			name:      "timeout during materialize is transient, not unknown",
+			step:      stepMaterialize,
+			err:       errors.New(errors.ErrCodeTimeout, "timed out reading bundle marker"),
+			wantClass: CauseTransient,
+		},
+		{
+			name:      "genuine hash mismatch stays integrity",
+			step:      stepInventory,
+			err:       errors.New(errors.ErrCodeInvalidRequest, "sha256 mismatch"),
+			wantClass: CauseIntegrity,
+		},
+		{
+			name:      "genuine signature failure stays signature",
+			step:      stepSignature,
+			err:       errors.New(errors.ErrCodeUnauthorized, "sigstore verification failed"),
+			wantClass: CauseSignature,
+		},
+		{
+			// An operator abort is neither an environmental fault nor a
+			// verdict. Classifying a Ctrl-C as transient would tell a CI gate
+			// to retry a run the operator deliberately stopped; letting it
+			// fall through to the step class would report "integrity", i.e.
+			// "this bundle has been tampered with", for pressing Ctrl-C.
+			name:      "operator cancellation is its own class",
+			step:      stepInventory,
+			err:       errors.New(errors.ErrCodeCanceled, "canceled while reading bundle file"),
+			wantClass: CauseCanceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyFailure(tt.step, tt.err)
+			if got == nil {
+				t.Fatal("classifyFailure returned nil")
+			}
+			if got.Class != tt.wantClass {
+				t.Errorf("class = %q, want %q", got.Class, tt.wantClass)
+			}
+		})
+	}
+}
+
+// TestExitForFailure_EarlyTransientDoesNotMaskLaterInvalid guards the
+// fail-open regression an early version of this change introduced.
+//
+// stepSignatureCheck does not return early from Verify, and setFailureCause is
+// first-wins. So a transient signature-step failure (an unreachable Sigstore
+// TUF cache, say) records CauseTransient, and every later step recomputed its
+// exit from that sticky cause. A tampered bundle caught at the inventory step
+// then reported "not verifiable — retry" with process exit 5, and the CI gate
+// rendered it as an infrastructure blip instead of ":x: invalid".
+func TestExitForFailure_EarlyTransientDoesNotMaskLaterInvalid(t *testing.T) {
+	r := &VerifyResult{}
+
+	// Step 2: transient fault. Not a verdict, so exit 3.
+	transient := errors.New(errors.ErrCodeTimeout, "trusted root unavailable")
+	recordFailure(r, stepSignature, transient)
+	if r.Exit != ExitIncomplete {
+		t.Fatalf("transient signature failure = exit %d, want %d", r.Exit, ExitIncomplete)
+	}
+
+	// Step 4: the manifest hash chain does not match — the bundle is tampered.
+	tampered := errors.New(errors.ErrCodeInvalidRequest, "manifest.json digest does not match")
+	recordFailure(r, stepInventory, tampered)
+
+	if r.Exit != ExitInvalid {
+		t.Errorf("tampered bundle after an earlier transient = exit %d, want %d (ExitInvalid) — "+
+			"a hard verdict must not be downgraded to \"retry\"", r.Exit, ExitInvalid)
+	}
+	// The cause must move too: exit 2 paired with class "transient" would tell
+	// the gate the bundle is invalid AND that it should retry.
+	if r.FailureCause == nil || r.FailureCause.Class != CauseIntegrity {
+		t.Errorf("cause = %+v, want class %q", r.FailureCause, CauseIntegrity)
+	}
+}
+
+// TestExitForFailure_NeverDowngradesRecordedInvalid covers the reverse order:
+// once a hard verdict is on the result, a later transient (fallout from the
+// same broken state) must not relabel it.
+func TestExitForFailure_NeverDowngradesRecordedInvalid(t *testing.T) {
+	r := &VerifyResult{Exit: ExitInvalid, FailureCause: &FailureCause{Class: CauseIntegrity}}
+	recordFailure(r, stepInventory, errors.New(errors.ErrCodeTimeout, "late timeout"))
+	if r.Exit != ExitInvalid {
+		t.Errorf("exit = %d, want %d", r.Exit, ExitInvalid)
+	}
+	if r.FailureCause.Class != CauseIntegrity {
+		t.Errorf("cause = %q, want %q — late fallout must not relabel the verdict",
+			r.FailureCause.Class, CauseIntegrity)
+	}
+}
+
+// TestStorageFaultChain_NeverBecomesIntegrity walks the full classification
+// chain a soft-mounted NFS produces: boundedio wraps EIO/EACCES/ESTALE as
+// ErrCodeUnavailable, classifyFailure must call that transient rather than
+// letting it inherit the step's class, and the exit must be ExitIncomplete.
+//
+// The inventory step is the dangerous one: its class is "integrity", so a
+// storage fault that fell through to the step switch would tell the operator
+// their bundle's hash chain is broken.
+func TestStorageFaultChain_NeverBecomesIntegrity(t *testing.T) {
+	steps := map[string]int{
+		"materialize": stepMaterialize,
+		"signature":   stepSignature,
+		"predicate":   stepPredicate,
+		"inventory":   stepInventory,
+	}
+	for name, step := range steps {
+		t.Run(name, func(t *testing.T) {
+			r := &VerifyResult{}
+			fault := errors.Wrap(errors.ErrCodeUnavailable,
+				"failed to read bundle recipe.yaml", syscall.EIO)
+
+			recordFailure(r, step, fault)
+
+			if r.Exit != ExitIncomplete {
+				t.Errorf("exit = %d, want %d — a storage fault is not a verdict", r.Exit, ExitIncomplete)
+			}
+			if r.FailureCause == nil || r.FailureCause.Class != CauseTransient {
+				t.Fatalf("cause = %+v, want class %q", r.FailureCause, CauseTransient)
+			}
+			if r.FailureCause.Class == CauseIntegrity {
+				t.Error("storage fault reported as an integrity failure")
+			}
+		})
+	}
+}
+
+// TestCancellationChain_IsNeverTransientOrInvalid is the same walk for a
+// deliberate abort, which must reach neither the retryable bucket nor a
+// verdict.
+func TestCancellationChain_IsNeverTransientOrInvalid(t *testing.T) {
+	r := &VerifyResult{}
+	abort := errors.Wrap(errors.ErrCodeCanceled, "canceled while reading bundle file", context.Canceled)
+
+	recordFailure(r, stepInventory, abort)
+
+	if r.Exit != ExitIncomplete {
+		t.Errorf("exit = %d, want %d", r.Exit, ExitIncomplete)
+	}
+	if r.FailureCause == nil || r.FailureCause.Class != CauseCanceled {
+		t.Fatalf("cause = %+v, want class %q", r.FailureCause, CauseCanceled)
+	}
+	if isTransientFailure(abort) {
+		t.Error("operator abort classified as transient — a CI gate would retry a deliberate stop")
+	}
+	if errors.IsTransient(abort) {
+		t.Error("operator abort is in the global retryable bucket")
+	}
+}
+
+// TestClassifyRegistryError_ServerFaultsAreNotVerdicts covers the path that
+// runs *before* the transient check: classifyRegistryError returns early, so a
+// registry status was landing on CauseRegistry and, through exitForFailure, on
+// ExitInvalid. A registry outage or rate limit means we never obtained the
+// bundle — reporting "your evidence is invalid" to a contributor for someone
+// else's 503 is the same misdiagnosis this PR exists to remove.
+func TestClassifyRegistryError_ServerFaultsAreNotVerdicts(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		wantClass string
+		wantExit  int
+	}{
+		{"service unavailable", 503, CauseTransient, ExitIncomplete},
+		{"internal server error", 500, CauseTransient, ExitIncomplete},
+		{"bad gateway", 502, CauseTransient, ExitIncomplete},
+		{"rate limited", 429, CauseTransient, ExitIncomplete},
+		// Client-side statuses keep their existing, actionable classes.
+		{"forbidden", 403, CauseRegistryForbidden, ExitInvalid},
+		{"not found", 404, CauseNotFound, ExitInvalid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &errcode.ErrorResponse{
+				Method:     "GET",
+				URL:        &url.URL{Scheme: "https", Host: "ghcr.io", Path: "/v2/x/manifests/y"},
+				StatusCode: tt.status,
+			}
+
+			c := classifyFailure(stepMaterialize, err)
+			if c == nil || c.Class != tt.wantClass {
+				t.Fatalf("class = %+v, want %q", c, tt.wantClass)
+			}
+			if c.HTTPStatus != tt.status {
+				t.Errorf("httpStatus = %d, want %d", c.HTTPStatus, tt.status)
+			}
+
+			r := &VerifyResult{}
+			recordFailure(r, stepMaterialize, err)
+			if r.Exit != tt.wantExit {
+				t.Errorf("exit = %d, want %d", r.Exit, tt.wantExit)
+			}
+		})
+	}
+}

--- a/pkg/evidence/verifier/types.go
+++ b/pkg/evidence/verifier/types.go
@@ -43,6 +43,14 @@ const (
 	ExitValidPassed        = 0
 	ExitValidPhaseFailures = 1
 	ExitInvalid            = 2
+
+	// ExitIncomplete reports that verification never reached a verdict: the
+	// bundle was not readable (dead NFS/FUSE mount, registry timeout) or the
+	// operator aborted the run. Distinct from a bundle that was read and found
+	// invalid — a CI gate that rejects a contribution on ExitInvalid must not
+	// fire on this, because nothing was proven about the bundle either way.
+	// FailureCause.Class separates the two reasons (transient vs canceled).
+	ExitIncomplete = 3
 )
 
 // VerifyOptions configures one Verify run.
@@ -116,6 +124,8 @@ const (
 	CauseSignature         = "signature"          // signature/cert/identity verification failed
 	CauseIntegrity         = "integrity"          // manifest hash-chain mismatch
 	CauseSchema            = "schema"             // predicate parse / schema / type error
+	CauseTransient         = "transient"          // storage/transport fault — bundle not readable, NOT invalid
+	CauseCanceled          = "canceled"           // operator aborted the run — no verdict reached
 	CauseUnknown           = "unknown"            // unclassified
 )
 
@@ -153,9 +163,10 @@ type VerifyResult struct {
 	// "all checks passed" or a false "invalid".
 	Pending bool `json:"pending,omitempty" yaml:"pending,omitempty"`
 
-	// FailureCause classifies why the bundle was rejected. Set only when
-	// Exit is ExitInvalid (2); nil for Exit 0 (valid, possibly pending) and
-	// Exit 1 (valid bundle with recorded phase failures), which are not
-	// bundle-invalid outcomes.
+	// FailureCause classifies why verification did not pass. Set when Exit is
+	// ExitInvalid (2) or ExitIncomplete (3); nil for Exit 0 (valid, possibly
+	// pending) and Exit 1 (valid bundle with recorded phase failures), neither
+	// of which is a failure. For Exit 3 the Class distinguishes an
+	// environmental fault (transient) from an operator abort (canceled).
 	FailureCause *FailureCause `json:"failureCause,omitempty" yaml:"failureCause,omitempty"`
 }

--- a/pkg/evidence/verifier/verify.go
+++ b/pkg/evidence/verifier/verify.go
@@ -53,7 +53,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	if opts.Input == "" {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "Input is required")
 	}
-	form, err := DetectInputForm(opts.Input)
+	form, err := DetectInputFormContext(ctx, opts.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	// materialization knows the OCI ref to pull from.
 	var pointer *attestation.Pointer
 	if form == InputFormPointer {
-		p, perr := LoadAndValidatePointer(opts.Input)
+		p, perr := LoadAndValidatePointerContext(ctx, opts.Input)
 		if perr != nil {
 			return nil, perr
 		}
@@ -76,8 +76,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	mat, err := MaterializeBundle(ctx, opts, form, pointer)
 	if err != nil {
 		record(r, stepMaterialize, StepFailed, err.Error(), nil)
-		setFailureCause(r, stepMaterialize, err)
-		r.Exit = ExitInvalid
+		recordFailure(r, stepMaterialize, err)
 		return r, nil
 	}
 	defer mat.Cleanup()
@@ -96,11 +95,10 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	// step produced (cryptographically anchored); fall back to the
 	// bundle's unsigned statement.intoto.json when no signature was
 	// attached. Either way the manifest digest comes from this value.
-	pred, perr := resolvePredicate(verifiedPredicate, mat)
+	pred, perr := resolvePredicate(ctx, verifiedPredicate, mat)
 	if perr != nil {
 		record(r, stepPredicate, StepFailed, perr.Error(), nil)
-		setFailureCause(r, stepPredicate, perr)
-		r.Exit = ExitInvalid
+		recordFailure(r, stepPredicate, perr)
 		return r, nil
 	}
 	r.Predicate = pred
@@ -117,8 +115,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 				pred.Recipe.Name+" — the pointer's identity (including any profile claim) must "+
 				"be the signed bundle's identity")
 		record(r, stepPredicate, StepFailed, berr.Error(), nil)
-		setFailureCause(r, stepPredicate, berr)
-		r.Exit = ExitInvalid
+		recordFailure(r, stepPredicate, berr)
 		return r, nil
 	}
 	source := "unsigned statement.intoto.json"
@@ -138,14 +135,12 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 	recipeYAML, mismatches, invErr := checkInventoryCaptureRecipe(ctx, mat, pred.Manifest.Digest)
 	if invErr != nil {
 		record(r, stepInventory, StepFailed, invErr.Error(), mismatches)
-		setFailureCause(r, stepInventory, invErr)
-		r.Exit = ExitInvalid
-	} else if phaseRows, phaseErr := CheckPhaseDigests(mat, pred); phaseErr != nil {
+		recordFailure(r, stepInventory, invErr)
+	} else if phaseRows, phaseErr := CheckPhaseDigestsContext(ctx, mat, pred); phaseErr != nil {
 		// Manifest chain is intact, but the predicate's per-phase CTRFDigest
 		// claim disagrees with the committed report — fail closed.
 		record(r, stepInventory, StepFailed, phaseErr.Error(), phaseRows)
-		setFailureCause(r, stepInventory, phaseErr)
-		r.Exit = ExitInvalid
+		recordFailure(r, stepInventory, phaseErr)
 	} else if idErr := checkRecipeIdentity(recipeYAML, pointer, pred); idErr != nil {
 		// Content-bound identity: the pointer/predicate recipe name,
 		// profile claim (presence, selection, advertiser, descriptor
@@ -154,8 +149,7 @@ func Verify(ctx context.Context, opts VerifyOptions) (*VerifyResult, error) {
 		// name-spoofable). Runs on both the unsigned-statement and the
 		// Sigstore-verified predicate paths.
 		record(r, stepInventory, StepFailed, idErr.Error(), nil)
-		setFailureCause(r, stepInventory, idErr)
-		r.Exit = ExitInvalid
+		recordFailure(r, stepInventory, idErr)
 	} else {
 		record(r, stepInventory, StepPassed,
 			"manifest digest matches predicate; bundle files, phase digests, and recipe identity (name/profile/digest) verified", nil)
@@ -204,8 +198,7 @@ func stepSignatureCheck(ctx context.Context, r *VerifyResult, mat *MaterializedB
 		if claimedSigner != nil {
 			if ccErr := CrossCheckPointerSigner(claimedSigner, nil); ccErr != nil {
 				record(r, stepSignature, StepFailed, ccErr.Error(), nil)
-				setFailureCause(r, stepSignature, ccErr)
-				r.Exit = ExitInvalid
+				recordFailure(r, stepSignature, ccErr)
 				return nil, false
 			}
 		}
@@ -217,15 +210,13 @@ func stepSignatureCheck(ctx context.Context, r *VerifyResult, mat *MaterializedB
 		return nil, true
 	case sigErr != nil:
 		record(r, stepSignature, StepFailed, sigErr.Error(), nil)
-		setFailureCause(r, stepSignature, sigErr)
-		r.Exit = ExitInvalid
+		recordFailure(r, stepSignature, sigErr)
 		return nil, false
 	default:
 		r.Signer = sig.Signer
 		if ccErr := CrossCheckPointerSigner(claimedSigner, sig.Signer); ccErr != nil {
 			record(r, stepSignature, StepFailed, ccErr.Error(), nil)
-			setFailureCause(r, stepSignature, ccErr)
-			r.Exit = ExitInvalid
+			recordFailure(r, stepSignature, ccErr)
 			return nil, false
 		}
 		detail := "signer " + sig.Signer.Identity + " (issuer " + sig.Signer.Issuer + ")"
@@ -243,11 +234,16 @@ func stepSignatureCheck(ctx context.Context, r *VerifyResult, mat *MaterializedB
 // Verified payload takes precedence; otherwise we fall back to the
 // unsigned statement.intoto.json. Both shapes go through the same
 // PredicateTypeV1 check.
-func resolvePredicate(verified *attestation.Predicate, mat *MaterializedBundle) (*attestation.Predicate, error) {
+func resolvePredicate(
+	ctx context.Context,
+	verified *attestation.Predicate,
+	mat *MaterializedBundle,
+) (*attestation.Predicate, error) {
+
 	if verified != nil {
 		return verified, nil
 	}
-	return loadUnsignedPredicate(mat)
+	return loadUnsignedPredicate(ctx, mat)
 }
 
 func record(r *VerifyResult, step int, status StepStatus, detail string, sub []KV) {
@@ -259,9 +255,9 @@ func record(r *VerifyResult, step int, status StepStatus, detail string, sub []K
 // loadUnsignedPredicate reads the bundle's unsigned in-toto Statement
 // and returns the predicate body. Used when no Sigstore Bundle was
 // emitted; the predicate is trusted as-is (self-consistency only).
-func loadUnsignedPredicate(mat *MaterializedBundle) (*attestation.Predicate, error) {
+func loadUnsignedPredicate(ctx context.Context, mat *MaterializedBundle) (*attestation.Predicate, error) {
 	path := filepath.Join(mat.BundleDir, attestation.StatementFilename)
-	body, err := readBoundedFile(path, "in-toto Statement", defaults.MaxAttestationFileBytes)
+	body, err := readBoundedFile(ctx, path, "in-toto Statement", defaults.MaxAttestationFileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/evidence/verifier/verify_test.go
+++ b/pkg/evidence/verifier/verify_test.go
@@ -340,17 +340,20 @@ func TestNormalizeInventoryHashError(t *testing.T) {
 			wantSame: true,
 		},
 		{
-			name: "caller cancellation becomes unavailable",
+			name: "caller cancellation becomes canceled",
 			ctx: func(*testing.T) context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				return ctx
 			},
-			wantCode:  apperrors.ErrCodeUnavailable,
+			// A deliberate abort must NOT read as SERVICE_UNAVAILABLE: that is
+			// the retryable bucket, and re-running a command the operator
+			// stopped on purpose is the wrong remediation.
+			wantCode:  apperrors.ErrCodeCanceled,
 			wantCause: context.Canceled,
 		},
 		{
-			name: "caller deadline becomes unavailable",
+			name: "caller deadline stays unavailable (retryable)",
 			ctx: func(t *testing.T) context.Context {
 				ctx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
 				t.Cleanup(cancel)

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -76,6 +76,11 @@ func httpStatusFromCode(code aicrerrors.ErrorCode) int {
 		return http.StatusGatewayTimeout
 	case aicrerrors.ErrCodeConflict:
 		return http.StatusConflict
+	case aicrerrors.ErrCodeCanceled:
+		// Client-closed-request semantics; 499 is non-standard, so the
+		// closest standard code for "the request was abandoned" is used.
+		// This code originates in CLI paths and should not reach a handler.
+		return http.StatusRequestTimeout
 	case aicrerrors.ErrCodeInternal:
 		fallthrough
 	default:
@@ -89,7 +94,9 @@ func retryableFromCode(code aicrerrors.ErrorCode) bool {
 		aicrerrors.ErrCodeUnauthorized,
 		aicrerrors.ErrCodeNotFound,
 		aicrerrors.ErrCodeMethodNotAllowed,
-		aicrerrors.ErrCodeConflict:
+		aicrerrors.ErrCodeConflict,
+		// A deliberate abort is not retryable: the caller asked to stop.
+		aicrerrors.ErrCodeCanceled:
 		return false
 	case aicrerrors.ErrCodeTimeout,
 		aicrerrors.ErrCodeUnavailable,

--- a/tools/evidence-project/main.go
+++ b/tools/evidence-project/main.go
@@ -39,6 +39,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -107,7 +108,7 @@ func run(ctx context.Context, o options, stdout io.Writer) error {
 			"-expected-issuer and -expected-identity-regexp are required (unpinned verification never counts)")
 	}
 
-	form, err := verifier.DetectInputForm(o.in)
+	form, err := verifier.DetectInputFormContext(ctx, o.in)
 	if err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func run(ctx context.Context, o options, stdout io.Writer) error {
 	// file is parsed exactly once.
 	var pointer *attestation.Pointer
 	if form == verifier.InputFormPointer {
-		pointer, err = verifier.LoadAndValidatePointer(o.in)
+		pointer, err = verifier.LoadAndValidatePointerContext(ctx, o.in)
 		if err != nil {
 			return err
 		}
@@ -189,6 +190,42 @@ func run(ctx context.Context, o options, stdout io.Writer) error {
 	return synthesizeVerified(ctx, vr, mat.BundleDir, allowlist, evidenceRef, o.runID, o.out, stdout)
 }
 
+// ingestVerdictError decides whether a verify verdict may be ingested, and
+// with which process exit code when it may not.
+//
+// It is an allow-list, not a deny-list. An equality test against ExitInvalid
+// fails open on every other non-passing verdict: a transient failure during the
+// inventory step arrives with Signer and Predicate already populated (both are
+// set in earlier steps), so the nil checks in the caller would not catch it and
+// an unverified bundle would be ingested.
+//
+// The refusal codes preserve the distinction the verifier produced. Collapsing
+// an incomplete result to ErrCodeInvalidRequest would exit 2 — identical to a
+// bundle we read and rejected — leaving an operator unable to tell an ingest
+// failure caused by a dead mount from one caused by a bad artifact.
+func ingestVerdictError(vr *verifier.VerifyResult) error {
+	switch vr.Exit {
+	case verifier.ExitValidPassed, verifier.ExitValidPhaseFailures:
+		return nil
+	case verifier.ExitIncomplete:
+		code := errors.ErrCodeTimeout
+		if vr.FailureCause != nil && vr.FailureCause.Class == verifier.CauseCanceled {
+			code = errors.ErrCodeCanceled
+		}
+		return errors.New(code,
+			"bundle verification did not complete (exit "+strconv.Itoa(vr.Exit)+
+				") — refusing to ingest (see steps)")
+	case verifier.ExitInvalid:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			"bundle verification did not pass (exit "+strconv.Itoa(vr.Exit)+") — refusing to ingest (see steps)")
+	default:
+		// An exit value this build does not know about must fail closed, not
+		// be waved through as if it were a pass.
+		return errors.New(errors.ErrCodeInternal,
+			"unknown bundle verification exit "+strconv.Itoa(vr.Exit)+" — refusing to ingest")
+	}
+}
+
 // synthesizeVerified records a verified bundle into the source-keyed
 // tree: it enforces the verify verdict (fail-closed on an invalid bundle
 // or a missing verified signer), classifies the signer from the
@@ -206,8 +243,8 @@ func synthesizeVerified(
 	if vr == nil {
 		return errors.New(errors.ErrCodeInvalidRequest, "nil verify result")
 	}
-	if vr.Exit == verifier.ExitInvalid {
-		return errors.New(errors.ErrCodeInvalidRequest, "bundle verification failed — refusing to ingest (see steps)")
+	if err := ingestVerdictError(vr); err != nil {
+		return err
 	}
 	if vr.Signer == nil || vr.Signer.Identity == "" {
 		return errors.New(errors.ErrCodeInvalidRequest,

--- a/tools/evidence-project/main_test.go
+++ b/tools/evidence-project/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
 	"github.com/NVIDIA/aicr/pkg/evidence/verifier"
 	"github.com/NVIDIA/aicr/pkg/fingerprint"
@@ -97,7 +98,7 @@ attestations:
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	p, err := verifier.LoadAndValidatePointer(pointer)
+	p, err := verifier.LoadAndValidatePointerContext(context.Background(), pointer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,5 +283,93 @@ func TestSynthesizeVerified_Rejects(t *testing.T) {
 				t.Errorf("synthesizeVerified(%s) = nil error, want rejection", tt.name)
 			}
 		})
+	}
+}
+
+// TestIngestVerdictError_Matrix pins the ingest gate. Two properties matter and
+// neither is checked by "does it return an error":
+//
+//  1. Only 0 and 1 may be ingested. Anything else — including an exit value a
+//     future verifier adds — must fail closed.
+//  2. A refusal caused by an unreadable bundle must not share a process exit
+//     code with a refusal caused by a bad bundle, or an operator triaging a
+//     failed ingest cannot tell a dead mount from a rejected artifact.
+func TestIngestVerdictError_Matrix(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *verifier.VerifyResult
+		wantErr  bool
+		wantExit int
+	}{
+		{
+			name:     "valid bundle is ingested",
+			result:   &verifier.VerifyResult{Exit: verifier.ExitValidPassed},
+			wantExit: errors.ExitSuccess,
+		},
+		{
+			name:     "recorded phase failures are still ingested",
+			result:   &verifier.VerifyResult{Exit: verifier.ExitValidPhaseFailures},
+			wantExit: errors.ExitSuccess,
+		},
+		{
+			name:     "invalid bundle is refused",
+			result:   &verifier.VerifyResult{Exit: verifier.ExitInvalid},
+			wantErr:  true,
+			wantExit: errors.ExitInvalidInput,
+		},
+		{
+			name: "storage fault is refused, but not as an invalid bundle",
+			result: &verifier.VerifyResult{
+				Exit:         verifier.ExitIncomplete,
+				FailureCause: &verifier.FailureCause{Class: verifier.CauseTransient},
+			},
+			wantErr:  true,
+			wantExit: errors.ExitTimeout,
+		},
+		{
+			name: "operator abort is refused, distinctly from a storage fault",
+			result: &verifier.VerifyResult{
+				Exit:         verifier.ExitIncomplete,
+				FailureCause: &verifier.FailureCause{Class: verifier.CauseCanceled},
+			},
+			wantErr:  true,
+			wantExit: errors.ExitCanceled,
+		},
+		{
+			name:     "unknown verdict fails closed",
+			result:   &verifier.VerifyResult{Exit: 99},
+			wantErr:  true,
+			wantExit: errors.ExitInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ingestVerdictError(tt.result)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got := errors.ExitCodeFromError(err); got != tt.wantExit {
+				t.Errorf("process exit = %d, want %d (err %v)", got, tt.wantExit, err)
+			}
+		})
+	}
+}
+
+// TestIngestVerdictError_NoVerdictNeverSharesInvalidExit states the second
+// property directly, so a future refactor that folds the incomplete arm back
+// into the invalid one fails here rather than silently.
+func TestIngestVerdictError_NoVerdictNeverSharesInvalidExit(t *testing.T) {
+	invalid := errors.ExitCodeFromError(ingestVerdictError(
+		&verifier.VerifyResult{Exit: verifier.ExitInvalid}))
+
+	for _, class := range []string{verifier.CauseTransient, verifier.CauseCanceled} {
+		got := errors.ExitCodeFromError(ingestVerdictError(&verifier.VerifyResult{
+			Exit:         verifier.ExitIncomplete,
+			FailureCause: &verifier.FailureCause{Class: class},
+		}))
+		if got == invalid {
+			t.Errorf("class %q exits %d, colliding with the invalid-bundle exit", class, got)
+		}
 	}
 }

--- a/tools/registry-inventory/registry-allowlist.yaml
+++ b/tools/registry-inventory/registry-allowlist.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Approved egress hosts for AICR builds & CI.
 #
 # This is the drift gate for tools/registry-inventory:


### PR DESCRIPTION
## Summary

Closes the residual unbounded on-disk reads on the `aicr evidence publish/sign/verify` paths that cross-review of #2071 identified, and adds the diagnostic split so a dead mount is no longer reported as an invalid attestation.

## Motivation / Context

#2071 bounded the summary-bundle reads on publish/sign, but the guarantee did not hold end-to-end. Two classes of gap remained:

1. **Reads with no bound at all** (`DetectInputForm`'s probe, the verifier's post-materialize reads, `attestation/pointer.go`, `attestation/bom.go`).
2. **Reads that already carried a `ctx` but were still unbounded.** This was the larger half and the less obvious one. A `ctx.Err()` check between chunks, or between `WalkDir` entries, never runs when the syscall itself is wedged in the kernel. Having a `ctx` parameter says nothing about whether the I/O can be aborted. Only moving the syscall off the calling goroutine lets the caller return.

Separately, a hung mount was byte-identical to a genuine "this attestation is invalid" verdict, so a CI gate could not tell a storage fault from a contribution worth rejecting.

Fixes: N/A
Related: #2083, #2071, #2054

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/*`, `tools/evidence-project`, evidence CI gate

## Implementation Notes

**New `pkg/evidence/internal/boundedio`, two primitives rather than one.** `Do` is a cancellation boundary for any blocking filesystem unit — this is what covers `os.Stat` and `filepath.WalkDir`, which no read helper could have handled. `ReadFile` composes the existing `O_NONBLOCK|O_NOFOLLOW` descriptor-first hardening *inside* that boundary, so the symlink and FIFO protections are kept rather than traded for hang-immunity. The accepted tradeoff is documented: an abandoned worker parks in the syscall until the kernel returns or the process exits, which is fine for short-lived CLI leaf commands and is why the package is `internal`.

**Cancellation is not a timeout.** New `ErrCodeCanceled` separates a deliberate operator abort from a deadline, so a Ctrl-C on the evidence paths no longer reads as a timeout or lands in the retryable bucket. `IsTransient` gives the new code precedence over `context.Canceled` so the guarantee survives wrap chains. This is additive; no existing error carries the code.

**Scope of that change, precisely.** It covers the `boundedio`-emitted evidence errors and nothing else. `pkg/oci/source_files.go` and `pkg/bundler/checksum/manifest.go` also collapse cancellation into `ErrCodeTimeout` — that is why there was no correct precedent to copy — but they are deliberately not modified here and do not emit `ErrCodeCanceled`, so the new precedence is **inert** for them. Their retry loops self-guard on `ctx.Err()`, so this is a taxonomy gap rather than a live bug. Aligning them is follow-up work, not something this PR should be read as having done.

**New verdict 3 (`ExitIncomplete`)** for runs that never reached a verdict, with `FailureCause.Class` separating `transient` (process exit 5) from `canceled` (exit 9). A bundle we could not read is not a bundle we found invalid.

**Two fail-open defects found during self-review and fixed here:**

- `exitForFailure` now classifies the *current* step's error and never downgrades a recorded `ExitInvalid`. `setFailureCause` is first-wins and `stepSignatureCheck` does not return early, so a sticky early transient (an unreachable Sigstore TUF cache, say) would otherwise relabel a *later* tampered-bundle verdict as "not verifiable, retry" — rendering `:hourglass:` in the gate instead of `:x: invalid`. Regression test added.
- `tools/evidence-project`'s ingest gate becomes an allow-list. The previous `== ExitInvalid` equality test failed open on any other non-passing verdict, and a transient failure at the inventory step arrives with `Signer` and `Predicate` already populated (both set in earlier steps), so the nil checks below it would not have caught it.

**Deliberately out of scope: the exit 1 / exit 2 process-level collapse.** `aicr diff --fail-on-drift` depends on `ErrCodeConflict` mapping to exit 2 and is guarded by a named test (`pkg/cli/diff_test.go`), so giving `ErrCodeConflict` its own code would silently break drift detection for `diff` users. That needs its own issue and consumer decision.

**Also out of scope: the `pkg/oci` push-staging walk.** Bounding it properly means putting the whole staging lifecycle behind a cancellation boundary so the worker exclusively owns all roots, descriptors, and cleanup — not a pre-flight probe, which would be TOCTOU and would advertise coverage it does not have. `PackageAndPush` is the natural seam (plain-data in, plain-data out, handle-bearing `packageOperation` never escapes), but the evidence path creates its workspace in the *caller* with a deferred `Close`, so the boundary has to enclose that too. Tracked as follow-up work on #2083.

## Testing

```bash
make qualify
```

`make qualify` passes end-to-end (exit 0). Coverage 82.4%, above the 80% floor.

New tests:
- `pkg/evidence/internal/boundedio` — 10 tests, TDD, covering fn-error transparency, deadline vs operator-cancel attribution, in-flight cancellation, and the read primitive's size/symlink/non-regular/missing cases.
- `TestVerifierFilesystemPathsAreBounded` — every verifier filesystem entry point run against a real, valid bundle with an already-canceled context. Anything that succeeds has performed I/O the caller could not abort. This test caught a real defect: `CheckPhaseDigests` was recording aborted reads as digest mismatches.
- `TestClassifyFailure_TransientVsIntegrity`, `TestExitForFailure_EarlyTransientDoesNotMaskLaterInvalid`, `TestExitForFailure_NeverDowngradesRecordedInvalid`.
- `TestHasBundleMarkers_StatFaultIsNotANonBundle` — uses an **injected** stat rather than `chmod`, because a chmod-based EACCES test silently no-ops when the suite runs as root, which is common in CI containers.

Updated (not weakened) four existing tests from #2071 that asserted `ErrCodeTimeout` for a *canceled* context — the semantics this PR deliberately corrects. The invariant each guards (fail closed, never flatten to "not a bundle") is preserved; only the expected code changed.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Touches a shared package (`pkg/errors`) and the `evidence verify` result contract. Both additions are additive: no existing error carries `ErrCodeCanceled`, and `httpStatusFromCode`/`retryableFromCode` defaults already handled an unknown code safely (explicit cases added anyway). The new verdict 3 was checked against every consumer — the PR gate has a `*)` default arm, UAT treats any non-zero as fatal (correct for a dead mount), and `evidence-project` is updated here.

**Rollout notes:** No migration. Consumers branching on `.exit` should add a `3` arm; the docs now show one. Consumers branching on the process code gain 5 and 9 as new possibilities from `evidence verify`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

