### PR TITLE
fix(aiperf-bench): drop pip from the runtime image

### DIFF
--- a/validators/performance/aiperf-bench.Dockerfile
+++ b/validators/performance/aiperf-bench.Dockerfile
@@ -65,8 +65,12 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Self-contained venv so the entire dependency closure copies to the final
-# stage as a single directory. Upgrade pip first so the install uses a pip
-# with current CVE fixes (the base image ships an older pinned pip).
+# stage as a single directory.
+#
+# pip is deliberately not upgraded first: it no longer ships (see the uninstall
+# below), so a build tool has no runtime CVE surface, and `--upgrade pip` is an
+# unpinned fetch on every build. The bundled ensurepip wheel resolves the same
+# closure -- verified byte-identical -- without the download.
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
@@ -83,8 +87,13 @@ COPY validators/performance/requirements.txt /tmp/requirements.txt
 RUN grep -qE "^aiperf==${AIPERF_VERSION}([[:space:]]|$)" /tmp/requirements.txt \
  || { echo "ARG AIPERF_VERSION=${AIPERF_VERSION} does not match requirements.txt" >&2; exit 1; }
 
-RUN pip install --no-cache-dir --upgrade pip \
- && pip install --no-cache-dir -r /tmp/requirements.txt
+# pip uninstalls itself: `python -m venv` bootstraps it and the venv is copied
+# wholesale, so it would otherwise ship. Two reasons to drop it -- a distroless
+# runtime needs no package installer, and pip is third-party software added on
+# top of the approved base (which carries no Python distributions), so shipping
+# it obliges us to publish its source. Nothing in the closure depends on it.
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+ && pip uninstall --yes pip
 
 # Syntax-gate the framing wrapper here, where a shell and a compiler still
 # exist. The runtime stage has neither, and the repo runs no Python test

--- a/validators/performance/aiperf_entrypoint_test.go
+++ b/validators/performance/aiperf_entrypoint_test.go
@@ -414,3 +414,154 @@ func TestAIPerfEntrypointPathsMatchDockerfile(t *testing.T) {
 			aiperfBenchDockerfile, aiperfEntrypointScript)
 	}
 }
+
+// TestAIPerfBenchShipsNoPackageInstaller pins that the runtime image carries no
+// pip. `python -m venv` bootstraps pip into the venv, and the final stage copies
+// that venv wholesale, so pip ships unless the builder removes it again.
+//
+// Two things regress if it comes back. A distroless runtime image gains a
+// package installer no legitimate caller needs, and pip becomes third-party
+// software this layer adds on top of an approved base that carries no Python
+// distributions of its own — which obliges us to publish pip's source. That
+// source is also the awkward kind to publish: pip is not in requirements.txt,
+// so its version is whatever CPython's bundled ensurepip wheel provides and
+// moves with the builder base image rather than with anything we declare.
+//
+// Nothing in the installed closure declares pip as a dependency, so removing it
+// cannot break a runtime import.
+//
+// Asserted against the Dockerfile rather than a built image because the test
+// suite has no container runtime. The behavioral check — that `aiperf` and
+// aiperf_entrypoint.py are unaffected — was done by building both ways.
+// TestAIPerfBenchShipsNoPackageInstaller asserts the builder removes pip after
+// installing the closure. The Dockerfile documents why; this pins that it holds.
+//
+// Checks ordering and same-RUN placement, not mere presence: `pip uninstall &&
+// pip install -r requirements.txt`, and `pip uninstall && python -m ensurepip`,
+// both ship pip while containing every expected substring.
+func TestAIPerfBenchShipsNoPackageInstaller(t *testing.T) {
+	raw, err := os.ReadFile(aiperfBenchDockerfile)
+	if err != nil {
+		t.Fatalf("read %s: %v", aiperfBenchDockerfile, err)
+	}
+
+	cmds := dockerfileRunCommands(string(raw))
+	if len(cmds) == 0 {
+		t.Fatalf("parsed no RUN commands from %s", aiperfBenchDockerfile)
+	}
+
+	install, uninstall := -1, -1
+	for i, c := range cmds {
+		isInstall := strings.Contains(c.text, "pip install") &&
+			strings.Contains(c.text, "requirements.txt")
+
+		if install < 0 && isInstall {
+			install = i
+			continue
+		}
+		if install >= 0 && uninstall < 0 && strings.Contains(c.text, "pip uninstall") {
+			uninstall = i
+		}
+	}
+
+	if install < 0 {
+		t.Fatal("no RUN command installs the requirements")
+	}
+	if uninstall < 0 {
+		t.Fatal("pip is never uninstalled after the requirements install; it would " +
+			"ship in the runtime image")
+	}
+	if cmds[install].run != cmds[uninstall].run {
+		t.Errorf("pip uninstalled in RUN %d but installed in RUN %d; keep them in "+
+			"one layer so no intermediate layer retains pip",
+			cmds[uninstall].run, cmds[install].run)
+	}
+
+	// `ensurepip` reinstalls pip without "install" appearing as a subcommand.
+	for _, marker := range []string{"ensurepip", "install pip", "upgrade pip"} {
+		for i := uninstall + 1; i < len(cmds); i++ {
+			if strings.Contains(cmds[i].text, marker) {
+				t.Errorf("command after the uninstall reinstates pip (%q): %q",
+					marker, cmds[i].text)
+			}
+		}
+	}
+}
+
+type runCommand struct {
+	run  int // index of the RUN instruction this came from
+	text string
+}
+
+// dockerfileRunCommands flattens RUN instructions into their individual shell
+// commands, in order, with comments stripped and continuations joined.
+//
+// Substring searching the raw file cannot do this: a comment mentioning pip
+// satisfies the assertion, and command order within one RUN is invisible.
+func dockerfileRunCommands(raw string) []runCommand {
+	var (
+		out        []runCommand
+		current    strings.Builder
+		continuing bool
+		runIndex   int
+	)
+
+	flush := func() {
+		joined := strings.ReplaceAll(current.String(), "\\", " ")
+		for _, part := range splitShellCommands(joined) {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, runCommand{run: runIndex, text: part})
+			}
+		}
+		runIndex++
+	}
+
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(stripShellComment(line))
+		if trimmed == "" {
+			continue
+		}
+
+		if !continuing {
+			if !strings.HasPrefix(trimmed, "RUN ") {
+				continue
+			}
+			current.Reset()
+			current.WriteString(strings.TrimPrefix(trimmed, "RUN "))
+		} else {
+			current.WriteString(" ")
+			current.WriteString(trimmed)
+		}
+
+		if strings.HasSuffix(trimmed, "\\") {
+			continuing = true
+			continue
+		}
+		continuing = false
+		flush()
+	}
+	if continuing {
+		flush()
+	}
+	return out
+}
+
+// stripShellComment drops whole-line comments and truncates trailing ones.
+// Quoting is not modeled: over-trimming a command this test ignores is safe,
+// mistaking a comment for a command is not.
+func stripShellComment(line string) string {
+	if strings.HasPrefix(strings.TrimSpace(line), "#") {
+		return ""
+	}
+	if i := strings.Index(line, " #"); i >= 0 {
+		return line[:i]
+	}
+	return line
+}
+
+func splitShellCommands(s string) []string {
+	for _, sep := range []string{"&&", "||", ";"} {
+		s = strings.ReplaceAll(s, sep, "\x00")
+	}
+	return strings.Split(s, "\x00")
+}


### PR DESCRIPTION
## Summary

Removes `pip` from the `aiperf-bench` runtime image. It was shipping unintentionally: `python -m venv` bootstraps pip into the venv, and the final stage copies that venv wholesale.

## Motivation / Context

**Hardening.** The runtime stage exists to exec `aiperf` against an HTTP endpoint. A package installer inside a distroless image is reachable attack surface with no legitimate runtime caller.

**Open-source compliance.** OSRB asked us to either confirm `pip` and `wheel` are absent from the shipped image, or publish their sdists. Investigating that turned up:

- The approved base (`nvcr.io/nvidia/distroless/python`) carries **no Python distributions at all** — I verified its filesystem has zero `dist-info` entries. So pip was not inherited; it was software this layer added on top, and shipping it obliged us to publish its source.
- `pip` was also the only package whose version floats independently of `requirements.txt` (via `--upgrade pip`), so publishing "the matching source" would have meant tracking whatever pip happened to be newest at build time.

Removing it answers the obligation instead of adding one to maintain, and lets us answer OSRB with "confirmed absent" for both packages.

Fixes: N/A
Related: #2073

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`) — the `aiperf-bench` image
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

One clause: `&& pip uninstall --yes pip`, in the same `RUN` as the install so no intermediate layer retains it.

**Nothing in the installed closure declares pip as a dependency**, so removing it cannot break a runtime import. (`psutil` references `wheel`, not pip, and only in a `dev` extra we do not install.)

Also corrects a comment that credited the base image with shipping "an older pinned pip". The pip a venv receives comes from CPython's bundled `ensurepip` wheel — `pip-26.1.2-py3-none-any.whl` for 3.13, which lags PyPI's 26.2.1 — not from any base layer. The runtime base ships no Python distributions, so the old comment read as false once that was established.

## Testing

Built the image both ways and compared:

| | before | after |
|---|---|---|
| distributions in venv | 132 | **131** |
| `pip` | present (26.2.1) | **absent** |
| `wheel` | absent | absent |
| `setuptools` | present (83.0.0) | present |
| `aiperf --version` | `0.11.0` | `0.11.0` |
| `aiperf_entrypoint.py` | `AICR_AIPERF_ARTIFACT_DIR is unset` | **identical** |
| image size | 1.52 GB | 1.5 GB |

`TestAIPerfBenchShipsNoPackageInstaller` pins the removal and asserts it stays in the same layer as the install. Asserted against the Dockerfile rather than a built image because the suite has no container runtime; the behavioral check was done by building.

```bash
make lint                                # pass
go test ./validators/performance/...     # pass
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Runtime behavior is unchanged; verified identical output from both `aiperf` and the entrypoint. Anyone who was exec'ing `pip` inside a running benchmark pod would be affected, but that is not a supported path — the image has no shell, and the Job runs `aiperf_entrypoint.py` with exec-form argv.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed — N/A, no user-facing change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
