### PR TITLE
fix(sdk): reconcile alias and semver contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ scan: ## Scans for vulnerabilities with grype
 	grype dir:. --config .grype.yaml --fail-on high --quiet
 
 .PHONY: api-diff
-api-diff: ## Checks pkg/client/v1 compatibility against the latest stable release
+api-diff: ## Checks pkg/client/v1 and transparent-alias target compatibility against the latest stable release
 	@bash tools/api-diff
 
 .PHONY: qualify

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -40,13 +40,15 @@ reachable from `HEAD`. The gate checks out that baseline in a temporary
 detached worktree, so it leaves the current working tree unchanged but adds
 checkout and filesystem I/O cost to `make qualify`.
 
-The gate compares declarations exported by `pkg/client/v1`. For external named
-types reached through transparent aliases, `apidiff` matches the target's
-package path and type name but does not recursively compare its definition. A
-change to such a target can therefore alter the facade contract without failing
-the gate. Reviewers must manually assess changes to aliased target types as
-changes to the stable facade until
-[#2019](https://github.com/NVIDIA/aicr/issues/2019) resolves this gap.
+The gate compares declarations exported by `pkg/client/v1`. Because `apidiff`
+does not recursively compare an external named type reached through an alias,
+the gate derives the repository-local named-type closure exposed by
+`BundleConfig`, `BundleAttester`, `BundleArtifact`, `OIDCResolveOptions`, and
+`CriteriaRegistry` from both the release baseline and current source. It then
+compares only that baseline/current closure, including nested fields and method
+signatures; unrelated exports in the evolving target packages remain filtered
+out. Closure derivation and an out-of-sync transparent-alias root list both fail
+the gate closed.
 
 To acknowledge an intentional break, first run `make api-diff`. Add a
 baseline-scoped entry to `pkg/client/v1/api-diff-exceptions.yaml` containing the

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -483,8 +483,9 @@ half of the pipeline and skips deploy-side assertions.
 - `e2e` — the end-to-end pipeline runner.
 - `scan` — Grype vulnerability scan.
 - `license-check` — license header / dependency-license sweep.
-- `api-diff` — exported `pkg/client/v1` compatibility against the latest stable
-  release.
+- `api-diff` — exported `pkg/client/v1` compatibility, including the scoped
+  repository-local type closure reachable through transparent aliases, against
+  the latest stable release.
 
 CI runs the equivalent. If `make qualify` passes locally on the
 current branch, push CI will pass.

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -7,7 +7,8 @@ state can import AICR directly. This page is for those consumers.
 ## Which package to import
 
 **Import the `github.com/NVIDIA/aicr/pkg/client/v1` package.** This is the
-stable facade.
+compatibility-reviewed facade and the surface AICR intends to stabilize at
+v1.0.
 
 ```go
 import aicr "github.com/NVIDIA/aicr/pkg/client/v1"
@@ -485,15 +486,18 @@ Passing a `nil` `context.Context` returns `ErrCodeInvalidRequest`. Use
 
 ## Compatibility
 
-The facade's exported API follows [Semantic Versioning][semver]:
+Today AICR is pre-1.0. Under Go module versioning, a v0 minor release may
+contain breaking API changes. The project mechanically detects and explicitly
+records incompatible changes to the facade, but consumers must **pin a patch
+version** in `go.mod` and audit upgrades.
+
+Starting with v1.0, the facade's exported API follows [Semantic
+Versioning][semver]:
 
 - **Major** bumps may rename, remove, or change the shape of exported
   types and function signatures.
 - **Minor** bumps may add new exported types, fields, or methods.
-- **Patch** bumps are bug-fix-only.
-
-Today AICR is pre-1.0. **Pin a patch version** in your `go.mod` and
-audit diffs on upgrade.
+- **Patch** bumps contain compatible bug fixes.
 
 ## See also
 

--- a/docs/integrator/public-api.md
+++ b/docs/integrator/public-api.md
@@ -9,7 +9,7 @@ in the [Go library integration guide](./go-library.md).
 
 | Tier | Meaning |
 |------|---------|
-| **Public (stable)** | Covered by semver; breaking changes only in major bumps. |
+| **Public (stable)** | Compatibility-reviewed facade. During v0, breaks are detected and explicitly recorded; starting with v1.0, breaking changes require a major bump. |
 | **Public (evolving)** | Exported today but may change in minor bumps. Pin and audit on upgrade. |
 | **Internal** | Treated as implementation detail. May change without notice. |
 
@@ -56,12 +56,11 @@ The `github.com/NVIDIA/aicr/pkg/client/v1` package is Public (stable). Types
 reachable from this surface are either facade-owned structs or transparent
 aliases — the table below documents which.
 
-Transparent aliases extend that stable contract to their target types. The
-automated API-diff gate matches an external named target by package path and
-type name, but does not recursively compare the target's definition. Until
-[#2019](https://github.com/NVIDIA/aicr/issues/2019) resolves this limitation,
-changes to those definitions require manual compatibility review because they
-can affect facade consumers without failing the gate.
+Transparent aliases extend that contract to their target types. They are kept
+where identity and direct interoperability with an existing builder, interface,
+result, or provider-scoped state are more valuable than a duplicative facade
+wrapper. The API-diff gate scopes additional checks to the aliased definitions;
+unrelated exports in their evolving packages remain free to change.
 
 | Facade symbol | Translates to/from | Notes |
 |---|---|---|
@@ -74,6 +73,10 @@ can affect facade consumers without failing the gate.
 | `aicr.RecipeResult` | `pkg/recipe.RecipeResult` | **Facade-owned struct** exposing `Name`, `Version`, `TranslatedAt`, `SelectedProfile` (the recorded ADR-015 selection, nil for unprofiled recipes), and `Components` (enabled/deployable components only — disabled refs remain visible via `Resolved().ComponentRefs`). Call `Resolved()` for the full upstream `*pkg/recipe.RecipeResult` (constraints, deployment order, validation config, metadata). The previous `aicr.Recipe` alias was removed in #1115; `ResolveRecipeFromCriteria` and `ResolveRecipeFromSnapshot` now return `*RecipeResult`. |
 | `aicr.AllowLists` | `pkg/recipe.AllowLists` | **Facade-owned struct** with `[]string` fields (Accelerators / Services / Intents / OSTypes). Use `aicr.WrapAllowLists` to lift a `*pkg/recipe.AllowLists`. |
 | `aicr.Criteria` | `pkg/recipe.Criteria` | **Facade-owned struct** whose enum-typed fields (Service / Accelerator / Intent / OS / Platform) project to plain strings; Nodes stays an `int` per the facade's string/int contract. Use `aicr.WrapCriteria` to lift a `*pkg/recipe.Criteria`. |
+| `aicr.BundleConfig` | `pkg/bundler/config.Config` | Deliberate transparent alias. It keeps the facade compatible with `config.NewConfig` and its functional options instead of duplicating the bundler's configuration builder. |
+| `aicr.BundleAttester` | `pkg/bundler/attestation.Attester` | Deliberate transparent alias. Existing attester implementations pass directly into `BundleOptions` without an adapter. |
+| `aicr.BundleArtifact` | `*pkg/bundler/result.Output` | Deliberate transparent alias. Callers receive the complete bundler result, including `HasErrors`, without a lossy projection. |
+| `aicr.OIDCResolveOptions` | `pkg/bundler/attestation.ResolveOptions` | Deliberate transparent alias. CLI and server callers can pass the same late-bound signing inputs used by the attestation resolver. |
 | `aicr.CriteriaRegistry` | `pkg/recipe.CriteriaRegistry` | Documented transparent alias. Kept as an alias intentionally because the registry is behavior-rich (`ParseService`, `SetStrict`, `Values`, ...) and carries mutable per-`DataProvider` state — wrapping would either break the per-Client identity coupling (copy) or add no isolation win over the alias (pointer). |
 
 ## Recommended consumption pattern

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aicr is the stable, public Go library surface for external
-// consumers of the AI Cluster Runtime.
+// Package aicr is the public, compatibility-reviewed Go library surface for
+// external consumers of the AI Cluster Runtime.
 //
 // External projects should import THIS package and use the types and
 // constructors re-exported here. The underlying pkg/* packages are
-// public and will remain importable, but this facade is the contract
-// the project commits to via semver.
+// public and will remain importable, but this facade is the reviewed
+// compatibility contract the project intends to stabilize at v1.0.
 //
 // # Surface
 //
@@ -36,6 +36,14 @@
 // RecipeResult, ComponentBundle, ComponentRef, PhaseResult, AllowLists)
 // are facade-owned structs translated to and from the upstream pkg/*
 // shapes, so internal field renames don't churn external callers.
+//
+// Five types remain deliberate transparent aliases: BundleConfig,
+// BundleAttester, BundleArtifact, OIDCResolveOptions, and CriteriaRegistry.
+// They preserve direct interoperability with the configuration builders,
+// attestation implementations, bundle results, and provider-scoped criteria
+// registry used elsewhere in AICR. The API compatibility gate compares their
+// repository-local reachable type closure without freezing unrelated exports
+// in the evolving target packages.
 //
 // # Example
 //
@@ -57,10 +65,16 @@
 //
 // # Stability
 //
-// This package's exported API follows semver. The underlying pkg/*
-// packages may introduce breaking changes between minor releases; if
-// you depend on them directly, pin AICR to a patch version and audit
-// upgrades.
+// AICR is currently pre-1.0. Under Go module versioning, a v0 minor release may
+// contain breaking API changes. The project detects and explicitly records
+// incompatible changes to this facade, but v0 consumers must pin a patch
+// version and audit upgrades.
+//
+// Starting with v1.0, this package's exported API follows semantic versioning:
+// breaking changes require a major release, minor releases may add API, and
+// patch releases contain compatible fixes. The underlying pkg/* packages may
+// continue to evolve under the stability tiers documented in
+// docs/integrator/public-api.md.
 //
 // # Concurrency and Client lifecycle
 //

--- a/pkg/client/v1/bundle.go
+++ b/pkg/client/v1/bundle.go
@@ -29,14 +29,13 @@ import (
 
 // BundleConfig is the bundler configuration — deployer mode, value
 // overrides, node selectors, tolerations, vendoring, app/chart names,
-// etc. Transparent alias of pkg/bundler/config.Config (the alias is
-// tracked by #1078). Construct one with
-// config.NewConfig(config.WithDeployer(...), ...) — the same builder the
+// etc. Deliberate transparent alias of pkg/bundler/config.Config. Construct one
+// with config.NewConfig(config.WithDeployer(...), ...) — the same builder the
 // CLI bundle command and the REST /v1/bundle handler use, so MakeBundle
 // reproduces their exact output byte-for-byte.
 type BundleConfig = config.Config
 
-// BundleAttester signs bundle content. Transparent alias of
+// BundleAttester signs bundle content. Deliberate transparent alias of
 // pkg/bundler/attestation.Attester. The zero value of BundleOptions
 // leaves this nil, in which case MakeBundle uses the bundler's
 // no-op attester (the same default bundler.New applies when --attest
@@ -45,8 +44,8 @@ type BundleAttester = attestation.Attester
 
 // BundleArtifact summarizes a completed bundle generation: file count,
 // total size, duration, per-bundler results, and the output directory
-// the files were written to. Transparent alias of
-// pkg/bundler/result.Output (#1078 wraps it). Inspect HasErrors() for
+// the files were written to. Deliberate transparent alias of
+// pkg/bundler/result.Output. Inspect HasErrors() for
 // non-fatal per-bundler failures; the bundle files themselves are on
 // disk under OutputDir.
 type BundleArtifact = *result.Output

--- a/pkg/client/v1/evidence.go
+++ b/pkg/client/v1/evidence.go
@@ -25,7 +25,7 @@ import (
 )
 
 // OIDCResolveOptions configures keyless-signing OIDC token resolution for a
-// pushed evidence bundle. Transparent alias of
+// pushed evidence bundle. Deliberate transparent alias of
 // pkg/bundler/attestation.ResolveOptions, mirroring how BundleOptions exposes
 // BundleAttester: the caller (CLI/server) builds the resolution inputs and the
 // facade threads them through to attestation.Emit, which resolves the token

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -14,9 +14,10 @@
 
 // stability_test pins the public surface of pkg/client/v1 by exercising
 // every exported type and function the way an out-of-tree library consumer
-// would. The package follows semver: any change that breaks these
-// assertions (renaming, removing, or changing the signature of an
-// exported identifier) is a breaking change that requires a major bump.
+// would. Any change that breaks these assertions (renaming, removing, or
+// changing the signature of an exported identifier) is incompatible. During
+// v0 it requires explicit compatibility review and acknowledgement; starting
+// with v1.0 it requires a major bump.
 // Every new export must add a compile-time assertion here in the same PR.
 //
 // The tests do not execute network or filesystem I/O; they exist to make
@@ -226,8 +227,8 @@ func TestStability_TypesAndAliases(t *testing.T) {
 	)
 
 	// Type-alias surface — these are explicitly documented as alias passthroughs
-	// (#1078) and are exercised here so a future drop or retype is a compile
-	// error.
+	// and are exercised here so a future drop or retype is a compile error. The
+	// API-diff gate separately scopes checks to each target definition.
 	//nolint:staticcheck // QF1011: explicit types pin the aliases' target types.
 	var (
 		_ *recipe.CriteriaRegistry    = (*aicr.CriteriaRegistry)(nil)

--- a/tools/api-diff
+++ b/tools/api-diff
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# api-diff compares pkg/client/v1 with the most recent stable release. The
-# current working tree is never modified: the release source is materialized in
-# a temporary detached worktree and apidiff consumes its export data.
+# api-diff compares pkg/client/v1 and the definitions exposed through its
+# transparent aliases with the most recent stable release. The current working
+# tree is never modified: the release source is materialized in a temporary
+# detached worktree and apidiff consumes its export data.
 
 set -euo pipefail
 
@@ -38,6 +39,22 @@ has_tools apidiff git yq
 cd "${REPO_ROOT}"
 
 readonly PACKAGE='github.com/NVIDIA/aicr/pkg/client/v1'
+# apidiff treats an alias to an external named type as only the target package
+# path plus type name; it does not recursively compare the target definition.
+# These are the facade-to-target mappings. tools/api-diff-closure starts its
+# traversal at each facade alias declaration so instantiated type arguments are
+# retained, then derives every repository-local named type reachable through
+# the complete target and its public fields and method signatures. This covers
+# nested contract types without freezing unrelated exports. Format: facade
+# alias|target package|root type. Each mapping is kept explicit so the
+# syntax-aware exhaustiveness check can detect alias retargeting.
+readonly ALIAS_TARGETS=(
+    'BundleConfig|github.com/NVIDIA/aicr/pkg/bundler/config|Config'
+    'BundleAttester|github.com/NVIDIA/aicr/pkg/bundler/attestation|Attester'
+    'OIDCResolveOptions|github.com/NVIDIA/aicr/pkg/bundler/attestation|ResolveOptions'
+    'BundleArtifact|github.com/NVIDIA/aicr/pkg/bundler/result|Output'
+    'CriteriaRegistry|github.com/NVIDIA/aicr/pkg/recipe|CriteriaRegistry'
+)
 readonly VERSIONS_FILE="${REPO_ROOT}/.settings.yaml"
 readonly EXCEPTIONS_FILE="${API_DIFF_EXCEPTIONS_FILE:-${REPO_ROOT}/pkg/client/v1/api-diff-exceptions.yaml}"
 readonly EXIT_NO_BASELINE=10
@@ -48,6 +65,7 @@ readonly EXIT_STALE_ACKNOWLEDGEMENT=14
 readonly EXIT_DUPLICATE_ACKNOWLEDGEMENT=15
 readonly EXIT_INCOMPATIBLE_CHANGES=16
 readonly EXIT_APIDIFF_VERSION_MISMATCH=17
+readonly EXIT_ALIAS_CONTRACT_MISMATCH=18
 
 # These statuses are part of the decision-flow test contract. They prevent a
 # failure in an earlier branch from satisfying an assertion for a later one.
@@ -57,6 +75,154 @@ api_diff_err() {
 
     printf "${COLOR_RED}[ERR]${COLOR_RESET} %s\n" "${message}" >&2
     exit "${status}"
+}
+
+# Keep the scoped target mappings exhaustive. A newly exported transparent
+# alias is a stable SDK dependency after its first release, and retargeting an
+# existing alias must update the reachable compatibility scope even when the
+# facade-level break is explicitly acknowledged.
+if ! actual_alias_targets="$(go run ./tools/api-diff-closure -dir "${REPO_ROOT}" -aliases "${PACKAGE}")"; then
+    api_diff_err "${EXIT_ALIAS_CONTRACT_MISMATCH}" "Could not inspect exported transparent aliases in ${PACKAGE}."
+fi
+contract_alias_targets="$(printf '%s\n' "${ALIAS_TARGETS[@]}" | LC_ALL=C sort)"
+if [[ "${actual_alias_targets}" != "${contract_alias_targets}" ]]; then
+    api_diff_err "${EXIT_ALIAS_CONTRACT_MISMATCH}" "Transparent alias contract is out of sync. Actual mappings: [${actual_alias_targets//$'\n'/, }]. Scoped mappings: [${contract_alias_targets//$'\n'/, }]. Update ALIAS_TARGETS in tools/api-diff for every exported alias and target."
+fi
+
+# Filter a package-level apidiff report down to changes whose subject is one of
+# the aliased target types. apidiff names direct fields and methods as T.X (or
+# T[P].X for a generic receiver), pointer methods as (*T).X (or (*T[P]).X),
+# and promoted methods with a "method set of T" suffix. Package
+# additions/removals and changes to unrelated declarations are intentionally
+# excluded.
+filter_alias_target_report() {
+    local target_types=$1
+
+    awk -v target_types="${target_types}" '
+        BEGIN {
+            split(target_types, targets, ",")
+        }
+        function after_type_arguments(tail, closing_bracket) {
+            if (substr(tail, 1, 1) != "[") {
+                return tail
+            }
+            closing_bracket = index(tail, "]")
+            if (closing_bracket == 0) {
+                return ""
+            }
+            return substr(tail, closing_bracket + 1)
+        }
+        function is_direct_target_subject(message, target, tail) {
+            if (index(message, target) != 1) {
+                return 0
+            }
+            tail = after_type_arguments(substr(message, length(target) + 1))
+            return substr(tail, 1, 1) == ":" || substr(tail, 1, 1) == "."
+        }
+        function is_pointer_target_subject(message, target, prefix, tail) {
+            prefix = "(*" target
+            if (index(message, prefix) != 1) {
+                return 0
+            }
+            tail = after_type_arguments(substr(message, length(prefix) + 1))
+            return index(tail, ").") == 1
+        }
+        function names_target_method_set(message, target, pointer, marker, start, tail) {
+            marker = "method set of " (pointer ? "*" : "") target
+            start = index(message, marker)
+            if (start == 0) {
+                return 0
+            }
+            tail = after_type_arguments(substr(message, start + length(marker)))
+            return substr(tail, 1, 1) == ":"
+        }
+        function is_target_change(line, message, i, target) {
+            message = line
+            sub(/^- /, "", message)
+            for (i in targets) {
+                target = targets[i]
+                if (is_direct_target_subject(message, target) ||
+                    is_pointer_target_subject(message, target) ||
+                    names_target_method_set(message, target, 0) ||
+                    names_target_method_set(message, target, 1)) {
+                    return 1
+                }
+            }
+            return 0
+        }
+        $0 == "Incompatible changes:" {
+            section = "incompatible"
+            next
+        }
+        $0 == "Compatible changes:" {
+            section = "compatible"
+            next
+        }
+        /^- / && is_target_change($0) {
+            if (section == "incompatible") {
+                incompatible = incompatible $0 "\n"
+            } else if (section == "compatible") {
+                compatible = compatible $0 "\n"
+            }
+        }
+        END {
+            if (incompatible != "") {
+                printf "Incompatible changes:\n%s", incompatible
+            }
+            if (compatible != "") {
+                printf "Compatible changes:\n%s", compatible
+            }
+        }
+    '
+}
+
+# Return the baseline-reachable closure types, retaining baseline/current
+# membership per type. A current-only type is a newly exposed API contract even
+# when its package was already reachable; comparing it with the package's older
+# unrelated definition would incorrectly freeze its pre-exposure history. Its
+# direct parent remains in scope, so incompatible signature changes that expose
+# it are still reported. A baseline-only type also remains in scope so removal
+# cannot erase the evidence needed to report its own incompatibility.
+build_alias_scope() {
+    local baseline_closure=$1
+    local current_closure=$2
+
+    {
+        while IFS= read -r entry; do
+            if [[ -n "${entry}" ]]; then
+                printf 'baseline|%s\n' "${entry}"
+            fi
+        done <<< "${baseline_closure}"
+        while IFS= read -r entry; do
+            if [[ -n "${entry}" ]]; then
+                printf 'current|%s\n' "${entry}"
+            fi
+        done <<< "${current_closure}"
+    } | awk -F '|' '
+        NF == 3 { membership[$2 SUBSEP $3] = membership[$2 SUBSEP $3] $1 SUBSEP }
+        END {
+            for (key in membership) {
+                if (index(membership[key], "baseline" SUBSEP) != 0) {
+                    split(key, parts, SUBSEP)
+                    print parts[1] "|" parts[2]
+                }
+            }
+        }
+    ' | LC_ALL=C sort -u | awk -F '|' '
+        package != "" && $1 != package {
+            print package "|" names
+            names = ""
+        }
+        {
+            package = $1
+            names = names (names == "" ? "" : ",") $2
+        }
+        END {
+            if (package != "") {
+                print package "|" names
+            }
+        }
+    '
 }
 
 if ! required_apidiff_version="$(yq eval -r '.linting.apidiff' "${VERSIONS_FILE}")"; then
@@ -101,12 +267,48 @@ cleanup() {
 }
 trap cleanup EXIT
 
-msg "Comparing ${PACKAGE} against ${baseline}"
+msg "Comparing ${PACKAGE} and its transparent alias targets against ${baseline}"
 git worktree prune
 git worktree add --detach "${release_worktree}" "${baseline}" >/dev/null
+
+current_root_args=()
+for spec in "${ALIAS_TARGETS[@]}"; do
+    IFS='|' read -r alias_name _ _ <<< "${spec}"
+    current_root_args+=("-root" "${PACKAGE}=${alias_name}")
+done
+if ! current_alias_closure="$(go run ./tools/api-diff-closure -dir "${REPO_ROOT}" "${current_root_args[@]}")"; then
+    api_diff_err "${EXIT_ALIAS_CONTRACT_MISMATCH}" "Could not derive the current transparent-alias reachable type closure."
+fi
+
+if ! baseline_alias_targets="$(go run ./tools/api-diff-closure -dir "${release_worktree}" -aliases "${PACKAGE}")"; then
+    api_diff_err "${EXIT_ALIAS_CONTRACT_MISMATCH}" "Could not inspect exported transparent aliases in ${PACKAGE} at baseline ${baseline}."
+fi
+baseline_root_args=()
+while IFS='|' read -r alias_name _ _; do
+    if [[ -n "${alias_name}" ]]; then
+        baseline_root_args+=("-root" "${PACKAGE}=${alias_name}")
+    fi
+done <<< "${baseline_alias_targets}"
+
+baseline_alias_closure=""
+if (( ${#baseline_root_args[@]} > 0 )); then
+    if ! baseline_alias_closure="$(go run ./tools/api-diff-closure -dir "${release_worktree}" "${baseline_root_args[@]}")"; then
+        api_diff_err "${EXIT_ALIAS_CONTRACT_MISMATCH}" "Could not derive the transparent-alias reachable type closure at baseline ${baseline}."
+    fi
+fi
+alias_scope="$(build_alias_scope "${baseline_alias_closure}" "${current_alias_closure}")"
+
 (
     cd "${release_worktree}"
     apidiff -w "${release_export}" "${PACKAGE}"
+    alias_index=0
+    while IFS='|' read -r target_package _; do
+        if [[ -z "${target_package}" ]]; then
+            continue
+        fi
+        apidiff -w "${release_export}.alias-${alias_index}" "${target_package}"
+        alias_index=$((alias_index + 1))
+    done <<< "${alias_scope}"
 )
 
 # Additions are informational and intentionally do not fail the gate. Capture
@@ -114,6 +316,23 @@ git worktree add --detach "${release_worktree}" "${baseline}" >/dev/null
 # acknowledgement decisions. A second apidiff invocation would reload the
 # working-tree package and its dependency graph.
 report="$(apidiff "${release_export}" "${PACKAGE}")"
+alias_index=0
+while IFS='|' read -r target_package target_types; do
+    if [[ -z "${target_package}" ]]; then
+        continue
+    fi
+    target_report="$(apidiff "${release_export}.alias-${alias_index}" "${target_package}")"
+    scoped_report="$(printf '%s\n' "${target_report}" | filter_alias_target_report "${target_types}")"
+    if [[ -n "${scoped_report}" ]]; then
+        msg "Transparent alias reachable-type changes: ${target_package} (${target_types})"
+        if [[ -n "${report}" ]]; then
+            report="${report}"$'\n'"${scoped_report}"
+        else
+            report="${scoped_report}"
+        fi
+    fi
+    alias_index=$((alias_index + 1))
+done <<< "${alias_scope}"
 incompatible="$(printf '%s\n' "${report}" | awk '
     $0 == "Incompatible changes:" { in_incompatible = 1; next }
     $0 == "Compatible changes:" { in_incompatible = 0 }
@@ -153,7 +372,7 @@ fi
 # exists becomes stale the moment that tag advances the baseline. Warn instead
 # so the maintainer can prune it on a green build.
 if [[ -z "${incompatible}" ]]; then
-    msg "No incompatible ${PACKAGE} changes since ${baseline}."
+    msg "No incompatible SDK facade or transparent-alias target changes since ${baseline}."
     if [[ -n "${stale_baselines}" ]]; then
         log_warning "Prunable API-diff acknowledgement baseline(s) in ${EXCEPTIONS_FILE}: ${stale_baselines}; active baseline is ${baseline} and its diff is clean. Remove the acknowledgement(s) for non-active baselines."
     fi
@@ -180,4 +399,4 @@ if (( acknowledgement_count == 1 )); then
     log_error "Acknowledged changes: ${acknowledged_changes}"
 fi
 
-api_diff_err "${EXIT_INCOMPATIBLE_CHANGES}" "Incompatible ${PACKAGE} changes since ${baseline}. Add a baseline-scoped acknowledgement to ${EXCEPTIONS_FILE} only for an intentional breaking change."
+api_diff_err "${EXIT_INCOMPATIBLE_CHANGES}" "Incompatible SDK facade or transparent-alias target changes since ${baseline}. Add a baseline-scoped acknowledgement to ${EXCEPTIONS_FILE} only for an intentional breaking change."

--- a/tools/api-diff-closure/main.go
+++ b/tools/api-diff-closure/main.go
@@ -1,0 +1,465 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// api-diff-closure inspects repository-local types used by the public SDK. It
+// can print either the transparent aliases declared by one package or the
+// named types reachable from a set of public API roots. It is an implementation
+// detail of tools/api-diff.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"go/importer"
+	"go/token"
+	"go/types"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const goListTimeout = 2 * time.Minute
+
+type rootSpecs []string
+
+func (r *rootSpecs) String() string {
+	return strings.Join(*r, ",")
+}
+
+func (r *rootSpecs) Set(value string) error {
+	if _, _, ok := strings.Cut(value, "="); !ok {
+		return fmt.Errorf("root %q must have package=Type[,Type] form", value)
+	}
+	*r = append(*r, value)
+	return nil
+}
+
+type rootSpec struct {
+	packagePath string
+	typeNames   []string
+}
+
+type listedPackage struct {
+	ImportPath string
+	Export     string
+	Module     *struct {
+		Path string
+	}
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "api-diff-closure: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	flags := flag.NewFlagSet("api-diff-closure", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	workingDir := flags.String("dir", ".", "module working directory")
+	aliasPackage := flags.String("aliases", "", "package whose exported transparent aliases to print")
+	var rawRoots rootSpecs
+	flags.Var(&rawRoots, "root", "public API root in package=Type[,Type] form (repeatable)")
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("parse arguments: %w", err)
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if *aliasPackage == "" && len(rawRoots) == 0 {
+		return fmt.Errorf("either -aliases or at least one -root is required")
+	}
+	if *aliasPackage != "" && len(rawRoots) != 0 {
+		return fmt.Errorf("-aliases and -root are mutually exclusive")
+	}
+
+	var (
+		packagePaths []string
+		roots        []rootSpec
+		err          error
+	)
+	if *aliasPackage != "" {
+		packagePaths = []string{*aliasPackage}
+	} else {
+		roots, err = parseRoots(rawRoots)
+		if err != nil {
+			return err
+		}
+		packagePaths = packagePathsForRoots(roots)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), goListTimeout)
+	defer cancel()
+	packages, modulePath, err := loadPackages(ctx, *workingDir, packagePaths)
+	if err != nil {
+		return err
+	}
+
+	if *aliasPackage != "" {
+		aliases, mappingErr := transparentAliasMappings(packages[*aliasPackage], modulePath)
+		if mappingErr != nil {
+			return mappingErr
+		}
+		for _, alias := range aliases {
+			if _, writeErr := fmt.Fprintf(stdout, "%s|%s|%s\n", alias.aliasName, alias.packagePath, alias.typeName); writeErr != nil {
+				return fmt.Errorf("write alias mapping: %w", writeErr)
+			}
+		}
+		return nil
+	}
+
+	closure, err := reachableTypes(packages, modulePath, roots)
+	if err != nil {
+		return err
+	}
+	for _, entry := range closure {
+		if _, writeErr := fmt.Fprintf(stdout, "%s|%s\n", entry.packagePath, entry.typeName); writeErr != nil {
+			return fmt.Errorf("write closure: %w", writeErr)
+		}
+	}
+	return nil
+}
+
+func packagePathsForRoots(roots []rootSpec) []string {
+	packagePaths := make([]string, 0, len(roots))
+	for _, root := range roots {
+		packagePaths = append(packagePaths, root.packagePath)
+	}
+	return packagePaths
+}
+
+func parseRoots(rawRoots []string) ([]rootSpec, error) {
+	roots := make([]rootSpec, 0, len(rawRoots))
+	seen := make(map[string]struct{})
+	for _, raw := range rawRoots {
+		packagePath, names, _ := strings.Cut(raw, "=")
+		packagePath = strings.TrimSpace(packagePath)
+		if packagePath == "" {
+			return nil, fmt.Errorf("root %q has an empty package path", raw)
+		}
+		for _, name := range strings.Split(names, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				return nil, fmt.Errorf("root %q has an empty type name", raw)
+			}
+			key := packagePath + "=" + name
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			roots = append(roots, rootSpec{packagePath: packagePath, typeNames: []string{name}})
+		}
+	}
+	return roots, nil
+}
+
+func loadPackages(ctx context.Context, workingDir string, packagePaths []string) (map[string]*types.Package, string, error) {
+	rootPackages := make([]string, 0, len(packagePaths))
+	seen := make(map[string]struct{})
+	for _, packagePath := range packagePaths {
+		if _, ok := seen[packagePath]; ok {
+			continue
+		}
+		seen[packagePath] = struct{}{}
+		rootPackages = append(rootPackages, packagePath)
+	}
+	sort.Strings(rootPackages)
+
+	listArgs := append([]string{"list", "-json", "-export", "-deps"}, rootPackages...)
+	cmd := exec.CommandContext(ctx, "go", listArgs...)
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, "", fmt.Errorf("load packages: %w", ctx.Err())
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, "", fmt.Errorf("go list failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, "", fmt.Errorf("run go list: %w", err)
+	}
+
+	listed := make(map[string]listedPackage)
+	decoder := json.NewDecoder(strings.NewReader(string(output)))
+	for {
+		var pkg listedPackage
+		if err := decoder.Decode(&pkg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, "", fmt.Errorf("decode go list output: %w", err)
+		}
+		listed[pkg.ImportPath] = pkg
+	}
+
+	modulePath := ""
+	for _, packagePath := range rootPackages {
+		pkg, ok := listed[packagePath]
+		if !ok {
+			return nil, "", fmt.Errorf("go list omitted root package %s", packagePath)
+		}
+		if pkg.Module == nil || pkg.Module.Path == "" {
+			return nil, "", fmt.Errorf("root package %s is not in a Go module", packagePath)
+		}
+		if modulePath == "" {
+			modulePath = pkg.Module.Path
+		} else if modulePath != pkg.Module.Path {
+			return nil, "", fmt.Errorf("root packages span modules %s and %s", modulePath, pkg.Module.Path)
+		}
+	}
+
+	lookup := func(path string) (io.ReadCloser, error) {
+		pkg, ok := listed[path]
+		if !ok {
+			return nil, fmt.Errorf("package %s was not returned by go list", path)
+		}
+		if pkg.Export == "" {
+			return nil, fmt.Errorf("package %s has no export data", path)
+		}
+		file, err := os.Open(pkg.Export) //nolint:gosec // path comes from trusted go list export metadata
+		if err != nil {
+			return nil, fmt.Errorf("open export data for %s: %w", path, err)
+		}
+		return file, nil
+	}
+	packageImporter := importer.ForCompiler(token.NewFileSet(), "gc", lookup)
+	loaded := make(map[string]*types.Package, len(rootPackages))
+	for _, packagePath := range rootPackages {
+		pkg, err := packageImporter.Import(packagePath)
+		if err != nil {
+			return nil, "", fmt.Errorf("import %s: %w", packagePath, err)
+		}
+		loaded[packagePath] = pkg
+	}
+	return loaded, modulePath, nil
+}
+
+type aliasMapping struct {
+	aliasName   string
+	packagePath string
+	typeName    string
+}
+
+func transparentAliasMappings(pkg *types.Package, modulePath string) ([]aliasMapping, error) {
+	if pkg == nil {
+		return nil, fmt.Errorf("alias package was not loaded")
+	}
+
+	mappings := make([]aliasMapping, 0)
+	for _, name := range pkg.Scope().Names() {
+		object, ok := pkg.Scope().Lookup(name).(*types.TypeName)
+		if !ok || !object.Exported() || !object.IsAlias() {
+			continue
+		}
+
+		target, err := normalizedAliasTarget(object.Type())
+		if err != nil {
+			return nil, fmt.Errorf("normalize exported alias %s.%s: %w", pkg.Path(), name, err)
+		}
+		targetObject := target.Obj()
+		if targetObject.Pkg() == nil {
+			return nil, fmt.Errorf("exported alias %s.%s targets non-package type %s", pkg.Path(), name, targetObject.Name())
+		}
+		if !isWithinModule(targetObject.Pkg().Path(), modulePath) {
+			return nil, fmt.Errorf(
+				"exported alias %s.%s targets type %s.%s outside module %s",
+				pkg.Path(), name, targetObject.Pkg().Path(), targetObject.Name(), modulePath,
+			)
+		}
+		mappings = append(mappings, aliasMapping{
+			aliasName:   name,
+			packagePath: targetObject.Pkg().Path(),
+			typeName:    targetObject.Name(),
+		})
+	}
+
+	sort.Slice(mappings, func(i, j int) bool {
+		if mappings[i].aliasName == mappings[j].aliasName {
+			if mappings[i].packagePath == mappings[j].packagePath {
+				return mappings[i].typeName < mappings[j].typeName
+			}
+			return mappings[i].packagePath < mappings[j].packagePath
+		}
+		return mappings[i].aliasName < mappings[j].aliasName
+	})
+	return mappings, nil
+}
+
+func normalizedAliasTarget(typ types.Type) (*types.Named, error) {
+	switch typ := typ.(type) {
+	case *types.Alias:
+		return normalizedAliasTarget(typ.Rhs())
+	case *types.Pointer:
+		return normalizedAliasTarget(typ.Elem())
+	case *types.Named:
+		return typ, nil
+	default:
+		return nil, fmt.Errorf("target %s is not a named type or pointer to a named type", typ)
+	}
+}
+
+type closureEntry struct {
+	packagePath string
+	typeName    string
+}
+
+func reachableTypes(packages map[string]*types.Package, modulePath string, roots []rootSpec) ([]closureEntry, error) {
+	collector := typeCollector{
+		modulePath: modulePath,
+		seenTypes:  make(map[types.Type]struct{}),
+		entries:    make(map[closureEntry]struct{}),
+	}
+	for _, root := range roots {
+		pkg, ok := packages[root.packagePath]
+		if !ok {
+			return nil, fmt.Errorf("root package %s was not loaded", root.packagePath)
+		}
+		for _, name := range root.typeNames {
+			object := pkg.Scope().Lookup(name)
+			typeName, ok := object.(*types.TypeName)
+			if !ok {
+				return nil, fmt.Errorf("root %s.%s is not a type", root.packagePath, name)
+			}
+			collector.visit(typeName.Type())
+		}
+	}
+
+	entries := make([]closureEntry, 0, len(collector.entries))
+	for entry := range collector.entries {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].packagePath == entries[j].packagePath {
+			return entries[i].typeName < entries[j].typeName
+		}
+		return entries[i].packagePath < entries[j].packagePath
+	})
+	return entries, nil
+}
+
+type typeCollector struct {
+	modulePath string
+	seenTypes  map[types.Type]struct{}
+	entries    map[closureEntry]struct{}
+}
+
+func (c *typeCollector) visit(typ types.Type) {
+	if typ == nil {
+		return
+	}
+	if _, ok := c.seenTypes[typ]; ok {
+		return
+	}
+	c.seenTypes[typ] = struct{}{}
+
+	switch typ := typ.(type) {
+	case *types.Alias:
+		c.visit(types.Unalias(typ))
+		c.visitTypeParams(typ.TypeParams())
+		for i := range typ.TypeArgs().Len() {
+			c.visit(typ.TypeArgs().At(i))
+		}
+	case *types.Named:
+		for i := range typ.TypeArgs().Len() {
+			c.visit(typ.TypeArgs().At(i))
+		}
+		if !c.addTypeName(typ.Obj()) {
+			return
+		}
+		c.visitTypeParams(typ.TypeParams())
+		c.visit(typ.Underlying())
+		c.visitMethodSet(types.NewMethodSet(typ))
+		c.visitMethodSet(types.NewMethodSet(types.NewPointer(typ)))
+	case *types.Pointer:
+		c.visit(typ.Elem())
+	case *types.Array:
+		c.visit(typ.Elem())
+	case *types.Slice:
+		c.visit(typ.Elem())
+	case *types.Map:
+		c.visit(typ.Key())
+		c.visit(typ.Elem())
+	case *types.Chan:
+		c.visit(typ.Elem())
+	case *types.Struct:
+		for i := range typ.NumFields() {
+			field := typ.Field(i)
+			if field.Exported() || field.Embedded() {
+				c.visit(field.Type())
+			}
+		}
+	case *types.Signature:
+		c.visitTypeParams(typ.TypeParams())
+		c.visitTuple(typ.Params())
+		c.visitTuple(typ.Results())
+	case *types.Interface:
+		typ.Complete()
+		for i := range typ.NumMethods() {
+			method := typ.Method(i)
+			if method.Exported() {
+				c.visit(method.Type())
+			}
+		}
+		for i := range typ.NumEmbeddeds() {
+			c.visit(typ.EmbeddedType(i))
+		}
+	case *types.TypeParam:
+		c.visit(typ.Constraint())
+	case *types.Union:
+		for i := range typ.Len() {
+			c.visit(typ.Term(i).Type())
+		}
+	}
+}
+
+func (c *typeCollector) addTypeName(object *types.TypeName) bool {
+	if object == nil || object.Pkg() == nil || !isWithinModule(object.Pkg().Path(), c.modulePath) {
+		return false
+	}
+	c.entries[closureEntry{packagePath: object.Pkg().Path(), typeName: object.Name()}] = struct{}{}
+	return true
+}
+
+func (c *typeCollector) visitMethodSet(methods *types.MethodSet) {
+	for i := range methods.Len() {
+		method, ok := methods.At(i).Obj().(*types.Func)
+		if ok && method.Exported() {
+			c.visit(method.Type())
+		}
+	}
+}
+
+func (c *typeCollector) visitTypeParams(params *types.TypeParamList) {
+	for i := range params.Len() {
+		c.visit(params.At(i))
+	}
+}
+
+func (c *typeCollector) visitTuple(tuple *types.Tuple) {
+	for i := range tuple.Len() {
+		c.visit(tuple.At(i).Type())
+	}
+}
+
+func isWithinModule(packagePath, modulePath string) bool {
+	return packagePath == modulePath || strings.HasPrefix(packagePath, modulePath+"/")
+}

--- a/tools/api-diff-closure/main_test.go
+++ b/tools/api-diff-closure/main_test.go
@@ -1,0 +1,452 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestTransparentAliasMappingsIncludesGenericAndPointerAliases(t *testing.T) {
+	const modulePath = "example.com/project"
+	target := checkPackage(t, modulePath+"/target", `
+package target
+
+type Generic[T any] struct {
+	Value T
+}
+
+type Concrete struct{}
+`, nil)
+	facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import "example.com/project/target"
+
+type GenericAlias[T any] = target.Generic[T]
+type PointerAlias = *target.Concrete
+type Defined target.Concrete
+type hiddenAlias = target.Concrete
+`, packageImporter{target.Path(): target})
+
+	got, err := transparentAliasMappings(facade, modulePath)
+	if err != nil {
+		t.Fatalf("transparentAliasMappings() error = %v", err)
+	}
+	want := []aliasMapping{
+		{aliasName: "GenericAlias", packagePath: target.Path(), typeName: "Generic"},
+		{aliasName: "PointerAlias", packagePath: target.Path(), typeName: "Concrete"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("transparentAliasMappings() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizedAliasTargetPreservesConcreteTypeArguments(t *testing.T) {
+	const modulePath = "example.com/project"
+	payload := checkPackage(t, modulePath+"/payload", `
+package payload
+
+type Contract struct{}
+`, nil)
+	target := checkPackage(t, modulePath+"/target", `
+package target
+
+type Box[T any] struct {
+	Value T
+}
+`, nil)
+	facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import (
+	"example.com/project/payload"
+	"example.com/project/target"
+)
+
+type Public = *target.Box[map[string][]*payload.Contract]
+`, packageImporter{payload.Path(): payload, target.Path(): target})
+
+	alias := facade.Scope().Lookup("Public").(*types.TypeName)
+	got, err := normalizedAliasTarget(alias.Type())
+	if err != nil {
+		t.Fatalf("normalizedAliasTarget() error = %v", err)
+	}
+	if got.Obj().Pkg().Path() != target.Path() || got.Obj().Name() != "Box" {
+		t.Fatalf("normalizedAliasTarget() target = %s, want %s.Box", got, target.Path())
+	}
+	if got.TypeArgs().Len() != 1 {
+		t.Fatalf("normalizedAliasTarget() type argument count = %d, want 1", got.TypeArgs().Len())
+	}
+	if got.TypeArgs().At(0).String() != "map[string][]*example.com/project/payload.Contract" {
+		t.Fatalf("normalizedAliasTarget() type argument = %s, want concrete payload container", got.TypeArgs().At(0))
+	}
+}
+
+func TestTransparentAliasMappingsRejectsNonProjectTarget(t *testing.T) {
+	const modulePath = "example.com/project"
+	external := checkPackage(t, "example.com/external", `
+package external
+
+type Type struct{}
+`, nil)
+	facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import "example.com/external"
+
+type ExternalAlias = external.Type
+`, packageImporter{external.Path(): external})
+
+	_, err := transparentAliasMappings(facade, modulePath)
+	if err == nil {
+		t.Fatal("transparentAliasMappings() error = nil, want non-project-target error")
+	}
+}
+
+func TestRunReportsCurrentAliasMappings(t *testing.T) {
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err = run([]string{
+		"-dir", repositoryRoot,
+		"-aliases", "github.com/NVIDIA/aicr/pkg/client/v1",
+	}, &stdout)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	const want = "BundleArtifact|github.com/NVIDIA/aicr/pkg/bundler/result|Output\n" +
+		"BundleAttester|github.com/NVIDIA/aicr/pkg/bundler/attestation|Attester\n" +
+		"BundleConfig|github.com/NVIDIA/aicr/pkg/bundler/config|Config\n" +
+		"CriteriaRegistry|github.com/NVIDIA/aicr/pkg/recipe|CriteriaRegistry\n" +
+		"OIDCResolveOptions|github.com/NVIDIA/aicr/pkg/bundler/attestation|ResolveOptions\n"
+	if stdout.String() != want {
+		t.Fatalf("run() output = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestReachableTypes(t *testing.T) {
+	const modulePath = "example.com/project"
+	rootPackage := types.NewPackage(modulePath+"/root", "root")
+	nestedPackage := types.NewPackage(modulePath+"/nested", "nested")
+	externalPackage := types.NewPackage("example.com/external", "external")
+
+	nested := newNamed(nestedPackage, "Nested", types.NewStruct(nil, nil))
+	methodResult := newNamed(nestedPackage, "MethodResult", types.NewStruct(nil, nil))
+	hidden := newNamed(rootPackage, "hidden", types.NewStruct(nil, nil))
+	external := newNamed(externalPackage, "External", types.NewStruct(nil, nil))
+
+	rootFields := []*types.Var{
+		types.NewField(token.NoPos, rootPackage, "Nested", types.NewPointer(nested), false),
+		types.NewField(token.NoPos, rootPackage, "External", external, false),
+		types.NewField(token.NoPos, rootPackage, "private", hidden, false),
+	}
+	root := newNamed(rootPackage, "Root", types.NewStruct(rootFields, nil))
+	methodSignature := types.NewSignatureType(
+		types.NewVar(token.NoPos, rootPackage, "", types.NewPointer(root)),
+		nil,
+		nil,
+		types.NewTuple(types.NewVar(token.NoPos, rootPackage, "input", nested)),
+		types.NewTuple(types.NewVar(token.NoPos, rootPackage, "", methodResult)),
+		false,
+	)
+	root.AddMethod(types.NewFunc(token.NoPos, rootPackage, "Transform", methodSignature))
+	rootPackage.Scope().Insert(root.Obj())
+
+	got, err := reachableTypes(
+		map[string]*types.Package{rootPackage.Path(): rootPackage},
+		modulePath,
+		[]rootSpec{{packagePath: rootPackage.Path(), typeNames: []string{"Root"}}},
+	)
+	if err != nil {
+		t.Fatalf("reachableTypes() error = %v", err)
+	}
+	want := []closureEntry{
+		{packagePath: nestedPackage.Path(), typeName: "MethodResult"},
+		{packagePath: nestedPackage.Path(), typeName: "Nested"},
+		{packagePath: rootPackage.Path(), typeName: "Root"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reachableTypes() = %#v, want %#v", got, want)
+	}
+}
+
+func TestReachableTypesTraversesUnexportedEmbeddedFields(t *testing.T) {
+	const modulePath = "example.com/project"
+	nested := checkPackage(t, modulePath+"/nested", `
+package nested
+
+type PromotedField struct{}
+`, nil)
+	root := checkPackage(t, modulePath+"/root", `
+package root
+
+import "example.com/project/nested"
+
+type embedded struct {
+	Promoted nested.PromotedField
+}
+
+type Root struct {
+	embedded
+}
+`, packageImporter{nested.Path(): nested})
+
+	got, err := reachableTypes(
+		map[string]*types.Package{root.Path(): root},
+		modulePath,
+		[]rootSpec{{packagePath: root.Path(), typeNames: []string{"Root"}}},
+	)
+	if err != nil {
+		t.Fatalf("reachableTypes() error = %v", err)
+	}
+	want := []closureEntry{
+		{packagePath: nested.Path(), typeName: "PromotedField"},
+		{packagePath: root.Path(), typeName: "Root"},
+		{packagePath: root.Path(), typeName: "embedded"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reachableTypes() = %#v, want %#v", got, want)
+	}
+}
+
+func TestReachableTypesTraversesNamedTypeParameters(t *testing.T) {
+	const modulePath = "example.com/project"
+	constraint := checkPackage(t, modulePath+"/constraint", `
+package constraint
+
+type Contract interface {
+	Validate()
+}
+`, nil)
+	root := checkPackage(t, modulePath+"/root", `
+package root
+
+import "example.com/project/constraint"
+
+type Box[T constraint.Contract] struct{}
+`, packageImporter{constraint.Path(): constraint})
+
+	got, err := reachableTypes(
+		map[string]*types.Package{root.Path(): root},
+		modulePath,
+		[]rootSpec{{packagePath: root.Path(), typeNames: []string{"Box"}}},
+	)
+	if err != nil {
+		t.Fatalf("reachableTypes() error = %v", err)
+	}
+	want := []closureEntry{
+		{packagePath: constraint.Path(), typeName: "Contract"},
+		{packagePath: root.Path(), typeName: "Box"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reachableTypes() = %#v, want %#v", got, want)
+	}
+}
+
+func TestReachableTypesTraversesAliasTypeParameters(t *testing.T) {
+	const modulePath = "example.com/project"
+	constraint := checkPackage(t, modulePath+"/constraint", `
+package constraint
+
+type Contract interface {
+	Validate()
+}
+`, nil)
+	target := checkPackage(t, modulePath+"/target", `
+package target
+
+type Concrete struct{}
+`, nil)
+	facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import (
+	"example.com/project/constraint"
+	"example.com/project/target"
+)
+
+type Public[T constraint.Contract] = target.Concrete
+`, packageImporter{constraint.Path(): constraint, target.Path(): target})
+
+	got, err := reachableTypes(
+		map[string]*types.Package{facade.Path(): facade},
+		modulePath,
+		[]rootSpec{{packagePath: facade.Path(), typeNames: []string{"Public"}}},
+	)
+	if err != nil {
+		t.Fatalf("reachableTypes() error = %v", err)
+	}
+	want := []closureEntry{
+		{packagePath: constraint.Path(), typeName: "Contract"},
+		{packagePath: target.Path(), typeName: "Concrete"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reachableTypes() = %#v, want %#v", got, want)
+	}
+}
+
+func TestReachableTypesTraversesConcreteAliasArguments(t *testing.T) {
+	const modulePath = "example.com/project"
+	payload := checkPackage(t, modulePath+"/payload", `
+package payload
+
+type Contract struct {
+	Stable string
+}
+
+type Unrelated struct {
+	Legacy string
+}
+`, nil)
+	external := checkPackage(t, "example.com/external", `
+package external
+
+import "example.com/project/payload"
+
+type Wrapper[T any] struct {
+	Value T
+	Unrelated payload.Unrelated
+}
+`, packageImporter{payload.Path(): payload})
+	target := checkPackage(t, modulePath+"/target", `
+package target
+
+type Box[T any] struct {
+	Value T
+}
+`, nil)
+	facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import (
+	"example.com/external"
+	"example.com/project/payload"
+	"example.com/project/target"
+)
+
+type PointerContainers = *target.Box[map[string][]*payload.Contract]
+type ArrayChannel = target.Box[chan [2]*payload.Contract]
+type ExternalContainer = target.Box[external.Wrapper[payload.Contract]]
+`, packageImporter{external.Path(): external, payload.Path(): payload, target.Path(): target})
+
+	want := []closureEntry{
+		{packagePath: payload.Path(), typeName: "Contract"},
+		{packagePath: target.Path(), typeName: "Box"},
+	}
+	for _, rootName := range []string{"PointerContainers", "ArrayChannel", "ExternalContainer"} {
+		t.Run(rootName, func(t *testing.T) {
+			got, err := reachableTypes(
+				map[string]*types.Package{facade.Path(): facade},
+				modulePath,
+				[]rootSpec{{packagePath: facade.Path(), typeNames: []string{rootName}}},
+			)
+			if err != nil {
+				t.Fatalf("reachableTypes() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("reachableTypes() = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestReachableTypesRejectsMissingRoot(t *testing.T) {
+	pkg := types.NewPackage("example.com/project/root", "root")
+	_, err := reachableTypes(
+		map[string]*types.Package{pkg.Path(): pkg},
+		"example.com/project",
+		[]rootSpec{{packagePath: pkg.Path(), typeNames: []string{"Missing"}}},
+	)
+	if err == nil {
+		t.Fatal("reachableTypes() error = nil, want missing-root error")
+	}
+}
+
+func TestParseRoots(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    []rootSpec
+		wantErr bool
+	}{
+		{
+			name:  "splits and deduplicates types",
+			input: []string{"example.com/project/pkg=Root,Nested", "example.com/project/pkg=Root"},
+			want: []rootSpec{
+				{packagePath: "example.com/project/pkg", typeNames: []string{"Root"}},
+				{packagePath: "example.com/project/pkg", typeNames: []string{"Nested"}},
+			},
+		},
+		{name: "missing separator", input: []string{"example.com/project/pkg"}, wantErr: true},
+		{name: "empty package", input: []string{"=Root"}, wantErr: true},
+		{name: "empty type", input: []string{"example.com/project/pkg="}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRoots(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseRoots() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseRoots() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newNamed(pkg *types.Package, name string, underlying types.Type) *types.Named {
+	return types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), underlying, nil)
+}
+
+type packageImporter map[string]*types.Package
+
+func (i packageImporter) Import(path string) (*types.Package, error) {
+	pkg, ok := i[path]
+	if !ok {
+		return nil, fmt.Errorf("package %s not found", path)
+	}
+	return pkg, nil
+}
+
+func checkPackage(t *testing.T, packagePath, source string, importer types.Importer) *types.Package {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, packagePath+".go", source, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parse %s: %v", packagePath, err)
+	}
+	config := types.Config{
+		GoVersion: "go1.26",
+		Importer:  importer,
+	}
+	pkg, err := config.Check(packagePath, fileSet, []*ast.File{file}, nil)
+	if err != nil {
+		t.Fatalf("type-check %s: %v", packagePath, err)
+	}
+	return pkg
+}

--- a/tools/api-diff_test.sh
+++ b/tools/api-diff_test.sh
@@ -22,6 +22,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_DIFF="${SCRIPT_DIR}/api-diff"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+export API_DIFF_TEST_REPO_ROOT="${REPO_ROOT}"
 
 # Without yq every assertion below fails inside has_tools, which reads as dozens
 # of unrelated defects rather than one missing tool. Skip with a single clear
@@ -70,6 +71,80 @@ if [[ "$1" == "version" && "$2" == "-m" ]]; then
             exit 1
             ;;
     esac
+fi
+if [[ "$1" == "run" && "$2" == "./tools/api-diff-closure" ]]; then
+    alias_mode=false
+    closure_dir=""
+    previous_arg=""
+    for arg in "$@"; do
+        if [[ "${arg}" == "-aliases" ]]; then
+            alias_mode=true
+        elif [[ "${previous_arg}" == "-dir" ]]; then
+            closure_dir="${arg}"
+        fi
+        previous_arg="${arg}"
+    done
+    if [[ "${alias_mode}" == "true" ]]; then
+        if [[ "${ALIAS_MAPPING_SCENARIO:-correct}" == "failure" ]]; then
+            echo "mock alias mapping failure" >&2
+            exit 42
+        fi
+        cat <<'ALIASES'
+BundleArtifact|github.com/NVIDIA/aicr/pkg/bundler/result|Output
+BundleAttester|github.com/NVIDIA/aicr/pkg/bundler/attestation|Attester
+ALIASES
+        if [[ "${ALIAS_MAPPING_SCENARIO:-correct}" == "retarget" ]]; then
+            echo 'BundleConfig|github.com/NVIDIA/aicr/pkg/bundler/result|Output'
+        else
+            echo 'BundleConfig|github.com/NVIDIA/aicr/pkg/bundler/config|Config'
+        fi
+        echo 'CriteriaRegistry|github.com/NVIDIA/aicr/pkg/recipe|CriteriaRegistry'
+        if [[ "${ALIAS_MAPPING_SCENARIO:-correct}" == "extra-generic" ]]; then
+            echo 'GenericAlias|github.com/NVIDIA/aicr/pkg/bundler/result|Result'
+        fi
+        echo 'OIDCResolveOptions|github.com/NVIDIA/aicr/pkg/bundler/attestation|ResolveOptions'
+        exit 0
+    fi
+    if [[ "${ALIAS_CLOSURE_SCENARIO:-correct}" == "failure" ]]; then
+        echo "mock alias closure failure" >&2
+        exit 42
+    fi
+    cat <<'CLOSURE'
+github.com/NVIDIA/aicr/pkg/bundler/attestation|AttestSubject
+github.com/NVIDIA/aicr/pkg/bundler/attestation|Attester
+github.com/NVIDIA/aicr/pkg/bundler/attestation|Dependency
+github.com/NVIDIA/aicr/pkg/bundler/attestation|ResolveOptions
+github.com/NVIDIA/aicr/pkg/bundler/attestation|StatementMetadata
+github.com/NVIDIA/aicr/pkg/bundler/config|Config
+github.com/NVIDIA/aicr/pkg/bundler/config|DeployerType
+github.com/NVIDIA/aicr/pkg/bundler/result|Output
+github.com/NVIDIA/aicr/pkg/bundler/result|Result
+github.com/NVIDIA/aicr/pkg/bundler/types|BundleType
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaAcceleratorType
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaField
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaIntentType
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaOSType
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaOrigin
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaPlatformType
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaRegistry
+github.com/NVIDIA/aicr/pkg/recipe|CriteriaServiceType
+CLOSURE
+    if [[ "${ALIAS_CLOSURE_SCENARIO:-correct}" == "different-membership" ]]; then
+        if [[ "${closure_dir}" == "${API_DIFF_TEST_REPO_ROOT}" ]]; then
+            echo 'github.com/NVIDIA/aicr/pkg/bundler/result|DeploymentInfo'
+        else
+            echo 'github.com/NVIDIA/aicr/pkg/bundler/result|BundleError'
+        fi
+    else
+        cat <<'CLOSURE'
+github.com/NVIDIA/aicr/pkg/bundler/result|BundleError
+github.com/NVIDIA/aicr/pkg/bundler/result|DeploymentInfo
+CLOSURE
+    fi
+    if [[ "${ALIAS_CLOSURE_SCENARIO:-correct}" == "generic-argument" ]]; then
+        echo 'github.com/NVIDIA/aicr/pkg/payload|Contract'
+    fi
+    exit 0
 fi
 exit 1
 STUB
@@ -122,8 +197,11 @@ if [[ "${1:-}" == "-incompatible" ]]; then
     exit 99
 fi
 
-printf 'mode=report cwd=%s\n' "$(pwd)" >>"${APIDIFF_LOG}"
-if [[ -n "${APIDIFF_REPORT:-}" ]]; then
+package="${2:-}"
+printf 'mode=report package=%s cwd=%s\n' "${package}" "$(pwd)" >>"${APIDIFF_LOG}"
+if [[ -n "${APIDIFF_TARGET_REPORT_PACKAGE:-}" && "${package}" == "${APIDIFF_TARGET_REPORT_PACKAGE}" ]]; then
+    printf '%s' "${APIDIFF_TARGET_REPORT:-}"
+elif [[ -n "${APIDIFF_REPORT:-}" ]]; then
     printf '%s' "${APIDIFF_REPORT}"
 elif [[ -n "${APIDIFF_INCOMPATIBLE:-}" ]]; then
     printf 'Incompatible changes:\n%s' "${APIDIFF_INCOMPATIBLE}"
@@ -266,12 +344,20 @@ run() {
         OUT="$(cd "${caller_dir}" && GIT_SCENARIO="${scenario}" API_DIFF_BASELINE="${baseline}" \
             APIDIFF_INCOMPATIBLE="${incompatible}" \
             APIDIFF_REPORT="${APIDIFF_REPORT:-}" \
+            APIDIFF_TARGET_REPORT_PACKAGE="${APIDIFF_TARGET_REPORT_PACKAGE:-}" \
+            APIDIFF_TARGET_REPORT="${APIDIFF_TARGET_REPORT:-}" \
+            ALIAS_MAPPING_SCENARIO="${ALIAS_MAPPING_SCENARIO:-correct}" \
+            ALIAS_CLOSURE_SCENARIO="${ALIAS_CLOSURE_SCENARIO:-correct}" \
             API_DIFF_EXCEPTIONS_FILE="${exceptions_file}" \
             APIDIFF_VERSION_SCENARIO="${version_scenario}" \
             GOPATH_SCENARIO="${gopath_scenario}" "${API_DIFF}" 2>&1)"
     else
         OUT="$(cd "${caller_dir}" && GIT_SCENARIO="${scenario}" APIDIFF_INCOMPATIBLE="${incompatible}" \
             APIDIFF_REPORT="${APIDIFF_REPORT:-}" \
+            APIDIFF_TARGET_REPORT_PACKAGE="${APIDIFF_TARGET_REPORT_PACKAGE:-}" \
+            APIDIFF_TARGET_REPORT="${APIDIFF_TARGET_REPORT:-}" \
+            ALIAS_MAPPING_SCENARIO="${ALIAS_MAPPING_SCENARIO:-correct}" \
+            ALIAS_CLOSURE_SCENARIO="${ALIAS_CLOSURE_SCENARIO:-correct}" \
             API_DIFF_EXCEPTIONS_FILE="${exceptions_file}" \
             APIDIFF_VERSION_SCENARIO="${version_scenario}" \
             GOPATH_SCENARIO="${gopath_scenario}" "${API_DIFF}" 2>&1)"
@@ -312,6 +398,17 @@ check_occurrences() {
     if [[ "${occurrences}" == "$3" ]]; then pass "$1"; else fail "$1" "want $3 occurrence(s) of: $2 got ${occurrences}"; fi
 }
 
+expected_apidiff_log() {
+    local cwd=$1
+
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/client/v1 cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/attestation cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/config cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/result cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/types cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/recipe cwd=%s' "${cwd}"
+}
+
 run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" correct "${SCRIPT_DIR}" failure
 check_rc "gopath-lookup-failure-fails" 1
 check_contains "gopath-lookup-failure-is-diagnostic" "Could not determine GOPATH"
@@ -326,6 +423,39 @@ run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" unreadable
 check_rc "unverifiable-apidiff-version-fails" 17
 check_contains "unverifiable-apidiff-version-is-diagnostic" "Could not verify the module version of apidiff"
 check_log_absent "unverifiable-apidiff-version-stops-before-git" "prune"
+
+run alias-contract-current-map v9.8.7
+check_rc "current-transparent-alias-map-succeeds" 0
+
+ALIAS_MAPPING_SCENARIO=extra-generic
+run alias-contract-generic-mismatch v9.8.7
+unset ALIAS_MAPPING_SCENARIO
+check_rc "unscoped-generic-transparent-alias-fails" 18
+check_contains "unscoped-generic-transparent-alias-is-diagnostic" "Transparent alias contract is out of sync"
+check_contains "unscoped-generic-transparent-alias-is-named" "GenericAlias"
+check_log_absent "unscoped-generic-transparent-alias-stops-before-git" "prune"
+
+ALIAS_MAPPING_SCENARIO=retarget
+run alias-contract-retargeted v9.8.7
+unset ALIAS_MAPPING_SCENARIO
+check_rc "retargeted-transparent-alias-fails" 18
+check_contains "retargeted-transparent-alias-is-diagnostic" "Transparent alias contract is out of sync"
+check_contains "retargeted-transparent-alias-reports-actual-target" "BundleConfig|github.com/NVIDIA/aicr/pkg/bundler/result|Output"
+check_contains "retargeted-transparent-alias-reports-scoped-target" "BundleConfig|github.com/NVIDIA/aicr/pkg/bundler/config|Config"
+check_log_absent "retargeted-transparent-alias-stops-before-git" "prune"
+
+ALIAS_MAPPING_SCENARIO=failure
+run alias-mapping-failure v9.8.7
+unset ALIAS_MAPPING_SCENARIO
+check_rc "alias-mapping-failure-fails-closed" 18
+check_contains "alias-mapping-failure-is-diagnostic" "Could not inspect exported transparent aliases"
+check_log_absent "alias-mapping-failure-stops-before-git" "prune"
+
+ALIAS_CLOSURE_SCENARIO=failure
+run alias-closure-failure v9.8.7
+unset ALIAS_CLOSURE_SCENARIO
+check_rc "alias-closure-derivation-failure-fails-closed" 18
+check_contains "alias-closure-derivation-failure-is-diagnostic" "Could not derive the current transparent-alias reachable type closure"
 
 run no-tags
 check_rc "empty-tag-list-fails" 10
@@ -350,8 +480,8 @@ outside_module_dir="${STUB_DIR}/outside-module"
 mkdir -p "${outside_module_dir}"
 run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" correct "${outside_module_dir}"
 check_rc "new-side-from-outside-module-succeeds" 0
-check_apidiff_log_equals "new-side-loads-once-from-repository-root" \
-    "mode=report cwd=${REPO_ROOT}"
+check_apidiff_log_equals "facade-and-alias-targets-load-once-from-repository-root" \
+    "$(expected_apidiff_log "${REPO_ROOT}")"
 
 run decision v9.8.7 "" "${MISSING_EXCEPTIONS}"
 check_rc "missing-exceptions-file-fails" 11
@@ -369,8 +499,8 @@ check_contains "plain-report-keeps-incompatible-header" "Incompatible changes:"
 check_contains "plain-report-keeps-compatible-header" "Compatible changes:"
 check_contains "plain-report-keeps-compatible-change" "Client.New: added"
 check_occurrences "incompatible-change-is-not-printed-twice" "Client.Legacy: removed" 1
-check_apidiff_log_equals "plain-report-loads-new-side-once" \
-    "mode=report cwd=${REPO_ROOT}"
+check_apidiff_log_equals "plain-report-loads-facade-and-alias-targets-once" \
+    "$(expected_apidiff_log "${REPO_ROOT}")"
 check_contains "unacknowledged-method-removal-is-diagnostic" "Add a baseline-scoped acknowledgement"
 
 compatible_only_report=$'Compatible changes:\n- Client.New: added\n'
@@ -380,8 +510,83 @@ unset APIDIFF_REPORT
 check_rc "compatible-only-report-succeeds" 0
 check_contains "compatible-only-change-is-reported" "Client.New: added"
 check_contains "compatible-only-report-is-clean" "No incompatible"
-check_apidiff_log_equals "compatible-only-report-loads-new-side-once" \
-    "mode=report cwd=${REPO_ROOT}"
+check_apidiff_log_equals "compatible-only-report-loads-facade-and-alias-targets-once" \
+    "$(expected_apidiff_log "${REPO_ROOT}")"
+
+alias_target_cases=(
+    'bundle-config|github.com/NVIDIA/aicr/pkg/bundler/config|(*Config).Deployer: removed'
+    'bundle-attester|github.com/NVIDIA/aicr/pkg/bundler/attestation|Attester.Identity: removed'
+    'oidc-resolve-options|github.com/NVIDIA/aicr/pkg/bundler/attestation|ResolveOptions.Attest: removed'
+    'bundle-artifact|github.com/NVIDIA/aicr/pkg/bundler/result|Output.OutputDir: removed'
+    'bundle-artifact-nested-result|github.com/NVIDIA/aicr/pkg/bundler/result|Result.Checksum: removed'
+    'bundle-artifact-cross-package-type|github.com/NVIDIA/aicr/pkg/bundler/types|BundleType.String: removed'
+    'criteria-registry|github.com/NVIDIA/aicr/pkg/recipe|(*CriteriaRegistry).Values: removed'
+    'criteria-registry-signature-type|github.com/NVIDIA/aicr/pkg/recipe|CriteriaField: changed from string to int'
+)
+for case_spec in "${alias_target_cases[@]}"; do
+    IFS='|' read -r case_name target_package target_change <<< "${case_spec}"
+    APIDIFF_TARGET_REPORT_PACKAGE="${target_package}"
+    APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- '"${target_change}"$'\n- Unrelated.Legacy: removed\n'
+    run "alias-${case_name}" v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+    unset APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
+    check_rc "${case_name}-break-fails" 16
+    check_contains "${case_name}-break-is-reported" "${target_change}"
+    check_absent "${case_name}-does-not-freeze-unrelated-export" "Unrelated.Legacy: removed"
+done
+
+# These receiver spellings are copied from the pinned apidiff report for a
+# generic Target[P] with changed pointer and removed value methods. ConfigExtra
+# deliberately shares Config's prefix so the scope check cannot pass by merely
+# accepting any subject that starts with the target type name.
+APIDIFF_TARGET_REPORT_PACKAGE='github.com/NVIDIA/aicr/pkg/bundler/config'
+APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- (*Config[P]).Deployer: changed from func(P) P to func([]P) P\n- Config[P].Validate: removed\n- ConfigExtra[P].Validate: removed\n'
+run alias-generic-receivers v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
+check_rc "generic-target-receiver-breaks-fail" 16
+check_contains "generic-pointer-receiver-break-is-reported" "(*Config[P]).Deployer: changed from func(P) P to func([]P) P"
+check_contains "generic-value-receiver-break-is-reported" "Config[P].Validate: removed"
+check_absent "similarly-named-generic-type-remains-excluded" "ConfigExtra[P].Validate: removed"
+
+APIDIFF_TARGET_REPORT_PACKAGE='github.com/NVIDIA/aicr/pkg/bundler/attestation'
+APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- VerificationIdentity.Issuer: removed\n'
+run alias-unrelated-only v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
+check_rc "unrelated-target-package-break-succeeds" 0
+check_absent "unrelated-target-package-break-is-not-reported" "VerificationIdentity.Issuer: removed"
+check_contains "unrelated-target-package-break-keeps-gate-clean" "No incompatible SDK facade or transparent-alias target changes"
+
+ALIAS_CLOSURE_SCENARIO=generic-argument
+APIDIFF_TARGET_REPORT_PACKAGE='github.com/NVIDIA/aicr/pkg/payload'
+APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- Contract.Legacy: removed\n- Unrelated.Legacy: removed\n'
+run alias-generic-argument v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset ALIAS_CLOSURE_SCENARIO APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
+check_rc "generic-alias-argument-break-fails" 16
+check_contains "generic-alias-argument-break-is-reported" "Contract.Legacy: removed"
+check_absent "generic-alias-argument-does-not-freeze-unrelated-export" "Unrelated.Legacy: removed"
+
+ALIAS_CLOSURE_SCENARIO=different-membership
+APIDIFF_TARGET_REPORT_PACKAGE='github.com/NVIDIA/aicr/pkg/bundler/result'
+APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- DeploymentInfo.Legacy: removed\n'
+run alias-current-only-reachable-type v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
+check_rc "current-only-reachable-type-break-succeeds" 0
+check_absent "current-only-reachable-type-break-is-not-reported" "DeploymentInfo.Legacy: removed"
+check_contains "current-only-reachable-type-break-keeps-gate-clean" "No incompatible SDK facade or transparent-alias target changes"
+
+APIDIFF_TARGET_REPORT_PACKAGE='github.com/NVIDIA/aicr/pkg/bundler/result'
+APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- BundleError.Legacy: removed\n'
+run alias-baseline-only-reachable-type v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
+check_rc "baseline-only-reachable-type-break-fails" 16
+check_contains "baseline-only-reachable-type-break-is-reported" "BundleError.Legacy: removed"
+
+APIDIFF_TARGET_REPORT_PACKAGE='github.com/NVIDIA/aicr/pkg/bundler/result'
+APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- Output.Result: changed from Result to DeploymentInfo\n- DeploymentInfo.Legacy: removed\n'
+run alias-current-only-type-parent-break v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset ALIAS_CLOSURE_SCENARIO APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
+check_rc "current-only-type-parent-break-fails" 16
+check_contains "current-only-type-parent-break-is-reported" "Output.Result: changed from Result to DeploymentInfo"
+check_absent "current-only-nested-type-remains-unreported" "DeploymentInfo.Legacy: removed"
 
 run decision v9.8.7 "${removed_method}" "${EXACT_EXCEPTIONS}"
 check_rc "exact-baseline-acknowledgement-succeeds" 0


### PR DESCRIPTION
## Summary

Extend the SDK compatibility gate to cover the repository-local type contracts exposed through `pkg/client/v1` transparent aliases. Align the facade documentation and godoc with the deliberate alias policy and AICR's pre-v1 semantic-versioning guarantees.

## Motivation / Context

`apidiff` identifies an external alias target by package and type name but does not recursively compare that target's definition. That allowed incompatible field, method, interface, or signature changes behind the facade's five transparent aliases to pass unnoticed, while stale alias comments and stability wording disagreed with the actual v0 contract.

Fixes: #2019
Related: #2016, #1078, #2060

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK facade and API compatibility tooling

## Implementation Notes

- Add a Go export-data helper that discovers exact exported alias mappings, including generic and pointer aliases, and recursively derives the repository-local named types reachable through public fields and method signatures.
- Compare the baseline/current closure behind `BundleConfig`, `BundleAttester`, `BundleArtifact`, `OIDCResolveOptions`, and `CriteriaRegistry`, while filtering unrelated exports from their evolving target packages.
- Fail closed when alias discovery, closure derivation, or the explicit alias-root contract drifts; derive baseline roots from the baseline source so alias retargeting cannot hide the old contract.
- Record why all five aliases remain deliberate and align package/docs wording with the v0 upgrade contract and the future v1 semver promise.

## Testing

```bash
# Passed
GOFLAGS=-mod=vendor go test -race -count=1 ./pkg/client/v1/...
GOFLAGS=-mod=vendor go test -race -count=1 -coverprofile=/tmp/api-diff-closure.cover ./tools/api-diff-closure
golangci-lint run -c .golangci.yaml ./pkg/client/v1/... ./tools/api-diff-closure/...
bash tools/api-diff_test.sh
make api-diff
make lint
make tuning-check
make license-check

# Attempted in full; see result below
make qualify
```

The focused suites, API-diff decision tests, live comparison against `v0.18.0`, lints, tuning check, and license check pass. The helper reports 66.5% statement coverage. Full local qualification is blocked by this execution environment's outbound HTTP 403 responses for Sigstore TUF metadata, the Kubernetes chart registry, and Grype's vulnerability database; the remaining non-blocked e2e cases pass.

## Risk Assessment

<!-- Select one and explain -->

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No runtime rollout or migration is required. The change makes compatibility qualification stricter for definitions already exposed through the SDK facade.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
