### PR TITLE
fix(aicr-cross-review skill): visible Codex dispatch in progress view

### DIFF
--- a/.agents/skills/aicr-cross-review/SKILL.md
+++ b/.agents/skills/aicr-cross-review/SKILL.md
@@ -16,7 +16,7 @@ user-invocable: true
 # automatic path that removing the explicit nested call did not.
 disallowed-tools: Skill
 argument-hint: "<PR-number-or-URL>"
-version: 0.3.19
+version: 0.3.20
 ---
 
 # AICR Cross-Review: Multi-Agent PR Review with Consensus
@@ -226,7 +226,10 @@ the consensus mechanics):
 
 - **Review** — Claude Code (reviews the pinned diff directly; it deliberately does
   *not* delegate to the `code-review` command, whose step 8 instructs its agent to
-  `gh pr comment` the result back to the PR), Codex (background dispatch, a 9-min
+  `gh pr comment` the result back to the PR), Codex (two chained agents: a dispatch
+  agent starts the remote background job and hands back its id, which the workflow
+  immediately writes to the progress log — `Codex job <id> dispatched — review running
+  remotely` — then a wait agent runs a 9-min
   bounded wait plus up to four continuation waits when the job is still running — about 45 min
   for a live job), CodeRabbit (CLI against a detached worktree at `HEAD_SHA`, explicit
   600000 ms timeout — the Bash tool caps any single call at 10 minutes, which is why
@@ -356,8 +359,21 @@ the consensus mechanics):
 - If it dies mid-run, **resume, don't restart**:
   `Workflow({scriptPath: ..., resumeFromRunId: "<wf_...>"})` — completed lanes replay
   from cache. Empty or odd result → read `<transcriptDir>/journal.jsonl` first.
-- The Codex lane fails in three distinct ways, and the dispatch protocol treats them
-  differently:
+- **The Codex round-1 lane is two agents, deliberately.** A dispatch agent composes the
+  lean Codex task, starts the background job (and owns the fast-transient retry-once
+  rule, decided inside a brief ~90-second launch watch that exactly covers the
+  under-60s retry window), and returns `{jobId, dispatchNote}`; the workflow then logs
+  `Codex job <id> dispatched — review running remotely` and hands the id to a wait
+  agent that runs the continuation-wait protocol unchanged and translates the result.
+  The split exists for progress visibility: a single opaque agent call shows "running"
+  from spawn, which cannot distinguish "remote job dispatched and working" from
+  "dispatch never happened" — a real run sat silent for 19 minutes with no way to tell
+  which. The logged job id is the visible "started" signal, and it doubles as the
+  recovery handle when everything after dispatch dies: a dispatch-agent failure or a
+  wait-agent loss surfaces exactly like any Codex-lane unavailability (`incomplete`,
+  with `codexJobId` whenever a live job id exists). The wait agent never dispatches.
+- The Codex lane fails in three distinct ways, and the dispatch and wait protocols
+  treat them differently:
   - **Lookup miss** — the status call exits 1 with empty stdout and `No job found` on
     stderr. Companion state is keyed by workspace root and each Bash call is a fresh
     shell, so an unpinned lookup resolves to a different workspace and reports a live job
@@ -373,7 +389,8 @@ the consensus mechanics):
     a pinned recheck has also missed, return `unavailable` saying the job could not be
     located — never re-dispatch (the original may still be running) and never record it as
     exhausted budget.
-  - **Fast transient failure** — retried **once**, and only when all three hold:
+  - **Fast transient failure** — retried **once**, in the dispatch agent's launch
+    watch (the wait agent never dispatches), and only when all three hold:
     `.job.status` is `failed` (never `cancelled`), the job died in **under 60 seconds**
     by its own timestamps, and the error names a known-retryable cause such as an upstream
     capacity rejection (`Selected model is at capacity`) or a transient dispatch fault.
@@ -416,15 +433,26 @@ the consensus mechanics):
   it was waiting on (`jobId`), so even that kill stays resumable.
 - Codex is required, so a lane that is still unavailable after its retry makes the run
   report `incomplete`; re-run rather than interpreting a partial result.
-- **`incomplete` with a `codexJobId` means the review is NOT lost.** That field is the
-  live Codex job that outlasted the wait budget, surfaced top-level (alongside
-  `reviewerStatus`) precisely so recovery is mechanical, not improvised. Poll the job
+- **`incomplete` with a `codexJobId` usually means the review is NOT lost.** That field
+  is the Codex job the run was waiting on, surfaced top-level (alongside
+  `reviewerStatus`) precisely so recovery is mechanical, not improvised. The lane
+  attaches it to every unavailable wait result deliberately — losing a live id costs a
+  whole review, a wasted resume costs minutes — so it can also reference a job that
+  already failed or was cancelled: a poll that shows a terminal non-completed state, or
+  a resume that comes back unavailable again, confirms the job is dead and the review
+  must be re-run rather than resumed. For a live job: poll it
   with the companion status command until it is terminal (a background 60-second loop is
   fine — polling is cheap once the workflow is no longer holding a lane open for it),
   then resume: `Workflow({scriptPath, resumeFromRunId: "<wf_...>", args: {...prevArgs,
   codexResumeJobId: "<job id>"}})` — `prevArgs` is the previous run's args object, unchanged. The three completed lanes replay from cache, the
-  Codex lane fetches the existing job's result without dispatching a second one, and the
-  run proceeds to cross-review and verification normally. Proven live on PR 2097: a
+  Codex dispatch agent is skipped entirely (the workflow logs
+  `Codex resume: waiting on existing job <id>`), the wait agent collects the existing
+  job without dispatching a second one, and the
+  run proceeds to cross-review and verification normally. A run interrupted *between*
+  dispatch and result needs no `codexResumeJobId` at all: on `resumeFromRunId` the
+  dispatch agent's cached `{jobId}` replays instantly, so the wait prompt is
+  byte-identical to the original run's and the resume lands in the same wait with no
+  re-dispatch. Proven live on PR 2097: a
   ~53-minute job outlasted the then-three-wait budget, and the resumed run recovered it
   with zero re-dispatched work.
 - **Execute the CodeRabbit lane's STEP blocks verbatim** — same commands and paths, no
@@ -690,7 +718,7 @@ a shell variable, so substitute the literal path here.
 - **The tool shell is zsh, and every prompt that hands out a shell command says so.**
   `scripts/workflow.mjs` defines a single `SHELL_CONTRACT` constant, interpolated in
   **exactly one place** — `NO_EXECUTION`, which every prompt builder composes exactly
-  once. So all six assembled prompts carry it exactly once. Do not add a second
+  once. So all seven assembled prompts carry it exactly once. Do not add a second
   interpolation: `NO_EXECUTION` already embeds `PINNED_READS`, so putting it in
   `PINNED_READS` or `CODEX_LEAN` as well silently doubles it in every lane. That is how
   the first attempt got it wrong, and no block-level check can see it — the duplication

--- a/.agents/skills/aicr-cross-review/scripts/workflow.mjs
+++ b/.agents/skills/aicr-cross-review/scripts/workflow.mjs
@@ -88,6 +88,20 @@ const FINDINGS_SCHEMA = {
   },
 }
 
+// Result contract for the dispatch half of the Codex lane. Tiny by design: the
+// orchestrator needs the job id (to log it and to build the wait prompt) and one line
+// of context — everything else about the job belongs to the wait agent.
+const CODEX_DISPATCH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['status', 'dispatchNote'],
+  properties: {
+    status: { type: 'string', enum: ['ok', 'unavailable'] },
+    jobId: { type: 'string', description: 'the dispatched background job id (the replacement job\'s id when the retry-once rule fired) — REQUIRED when status is "ok"' },
+    dispatchNote: { type: 'string', description: 'one short line for the progress log (dispatch time, whether the retry fired); on unavailable, the broker error text' },
+  },
+}
+
 const EVAL_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -192,14 +206,40 @@ Context rules (IMPORTANT — the Codex broker reproducibly crashes mid-generatio
 - Do NOT read CLAUDE.md.
 - Before reporting a missing path/key/field/API, confirm absence at the pinned commit with a targeted check, not a full-file read.`
 
+// The Codex round-1 lane is deliberately TWO agents — dispatch, then wait — with an
+// orchestrator log() between them (see codexLane below). A single opaque agent call
+// showed "running" from spawn, which cannot distinguish "remote job dispatched and
+// working" from "dispatch never happened"; a real run sat silent for 19 minutes with no
+// way to tell which. The old single protocol is split between two constants: dispatch-
+// side rules (the dispatch command and the fast-transient retry-once rule) live in
+// CODEX_DISPATCH; wait-side rules (status/result commands, continuation waits, the
+// classification ladder) live in CODEX_WAIT. Each rule lives in exactly one constant —
+// the cross-review round still dispatches and waits in ONE agent, so crossPrompt
+// composes both constants to recover the full protocol.
 const CODEX_DISPATCH = `
 Codex dispatch protocol (mandatory):
-1. comp=$(ls -t ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | head -1)
-2. Dispatch the review as a BACKGROUND job (pass --background to codex-companion task) so it returns a job id immediately. NEVER run foreground: a foreground call hangs forever if the broker dies mid-turn.
+D1. comp=$(ls -t ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | head -1)
+D2. Dispatch the review as a BACKGROUND job (pass --background to codex-companion task) so it returns a job id immediately. NEVER run foreground: a foreground call hangs forever if the broker dies mid-turn.
    Pass --cwd "${repoPath}" on this call and on EVERY later status/result call. Companion state is keyed by the workspace root derived from the working directory, and each Bash call is a fresh shell that may start somewhere else — an unpinned lookup silently resolves to a different workspace and reports the job as unknown.
-3. Wait for it with the companion's own bounded wait — do NOT hand-roll a poll loop:
+D3. Watch the just-dispatched job BRIEFLY — only to catch a fast transient failure while a retry is still cheap, NOT to wait for the review, which takes many minutes and belongs to the wait protocol:
+     node "$comp" status <job-id> --cwd "${repoPath}" --wait --timeout-ms 90000 --poll-interval-ms 15000 --json
+   Run that Bash call with a timeout of 150000 ms. Read the JSON yourself: the job state is at .job.status (NOT a top-level "status" field). .waitTimedOut true with the job still "queued" or "running" is the HEALTHY outcome here — the job survived its launch window; stop watching. A "No job found" lookup miss on this call is NOT evidence the job died either: treat the job as live and stop watching (the pinned-recheck rule belongs to the wait protocol; do not run it here). When this prompt also carries the wait protocol, proceed to it after the watch; when it does not, dispatch is your whole job — report the job id and stop.
+D4. Retry ONLY a failure that is demonstrably both fast and transient. All three conditions must hold:
+   a. .job.status is "failed" — NOT "cancelled". The companion emits "cancelled" only for explicit cancellation, so retrying it restarts work something or someone deliberately stopped.
+   b. .waitTimedOut is false AND the job died in UNDER 60 SECONDS — compute elapsed from the job's own timestamps, not from the absence of a timeout. Use the number, not a judgment call: the two observed cases sit far apart (an upstream capacity rejection landed at ~10s, a genuine timeout at 10m19s), and leaving "quickly" undefined is how a one-retry budget turns into retry-whenever-it-feels-right. A job that fails at 8:59 also satisfies .waitTimedOut == false while having consumed nearly the whole window; that is not a transient blip and retrying it costs another full window.
+   c. The error text names a known-retryable cause: an upstream capacity rejection ("Selected model is at capacity"), a broker startup error, or a transient dispatch fault. An unrecognised error is not assumed retryable.
+   All three true → dispatch ONE new background job per step D2 and watch it once per step D3; the new job id supersedes the original everywhere a job id is used from here on. If the second attempt also fails inside its watch window, the dispatch is unavailable — report BOTH observed .job.status values and the broker error text.
+   Anything else — "cancelled", a late failure, or an unrecognised error — is a deliberate stop or an unexplained failure. Do NOT retry; report the dispatch unavailable with what you observed.
+   Retry budget is exactly one, and only when a, b and c all hold. Never loop. Every retry decision is made HERE, inside the dispatch watch window, and the wait protocol never dispatches regardless. (A launch-window lookup miss can defer first observation of an under-60s death into the wait; that rare retry opportunity is deliberately forfeited rather than giving the wait dispatch authority.)
+Every Codex task you dispatch must carry the execution rules verbatim in its own prompt — Codex runs in its own shell and does not inherit this one's constraints. That includes the shell contract stated elsewhere in this prompt: it arrives via NO_EXECUTION, which every prompt builder composes exactly once, so it is deliberately not repeated here.
+Sandbox: the review itself runs sandboxed. The one known exception is the companion's own job log under ~/.claude/plugins/data, which is sandbox-denied — if dispatch fails on that write, bypass for that call only. Never bypass for anything else, and never for a call that performs a Git operation, mutates the working copy, or writes to GitHub. Reading a path is not the boundary; acting on it is.`
+
+const CODEX_WAIT = `
+Codex wait protocol (mandatory). The job this protocol waits on is ALREADY dispatched; waiting, classification and translation are all that happens here — dispatching, and the one permitted retry, belong to the dispatch protocol, never to this one.
+W1. comp=$(ls -t ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | head -1)
+W2. Wait for it with the companion's own bounded wait — do NOT hand-roll a poll loop:
      node "$comp" status <job-id> --cwd "${repoPath}" --wait --timeout-ms 540000 --poll-interval-ms 30000 --json
-   Run that Bash call with a timeout of 600000 ms. The inner wait is deliberately 60s SHORTER than the outer cap: the two must not be equal, or Bash can kill the command before it prints its JSON, leaving you with no .waitTimedOut to classify on — and an unclassifiable kill is the one case step 5 must never guess at, since retrying a genuine timeout doubles the wall clock for nothing.
+   Run that Bash call with a timeout of 600000 ms. The inner wait is deliberately 60s SHORTER than the outer cap: the two must not be equal, or Bash can kill the command before it prints its JSON, leaving you with no .waitTimedOut to classify on — and an unclassifiable kill is the one case the classification below must never guess at, since retrying a genuine timeout doubles the wall clock for nothing.
    Read the returned JSON yourself. The job state is at .job.status (NOT a top-level "status" field), and .waitTimedOut is true if the inner deadline expired while the job was still queued/running.
    Absent JSON has TWO causes and they are not interchangeable — distinguish them before classifying:
      - Exit status 1 with EMPTY stdout and "No job found" on stderr (measured on companion v1.0.2; the message goes to stderr even with --json, so capture both streams before deciding): this is a LOOKUP MISS. It is NOT evidence the job died — it may still be running. Never classify a lookup miss as exhausted budget; doing so abandons a live required lane. Note the exit status is a reliable discriminator here, so read it directly rather than inferring from output — and do not read it through a pipe, where $? is the last stage's status, not the companion's.
@@ -208,22 +248,14 @@ Codex dispatch protocol (mandatory):
          - A pinned lookup can miss TRANSIENTLY. In companion v1.0.2, saveState writes state.json with a plain fs.writeFileSync (truncate-then-write, no temp-file-and-rename), and loadState wraps JSON.parse in a bare catch that returns the DEFAULT state — whose jobs list is empty. A read landing inside that write window therefore yields a well-formed "No job found" rather than an error, and the background worker is updating that file precisely while the status call runs. So an identical repeat is NOT guaranteed to return an identical answer; a brief pause before the recheck makes it likelier to clear.
        Once a pinned recheck has also missed, return status:"unavailable" saying the job could not be located, and stop. Do NOT re-dispatch the task: the original may still be running, and a second dispatch doubles the work while the first result becomes unreachable. Do NOT call it exhausted budget either; the distinction belongs in statusNote.
      - No output at all because your Bash call hit its 600000 ms timeout: that IS exhausted budget. Do not retry; say so in statusNote — and still set the structured jobId field to the job id you were waiting on (you know it before the call is killed; without it the orchestrator cannot resume the still-running job).
-4. .job.status == "completed" → fetch the payload with: node "$comp" result <job-id> --cwd "${repoPath}" --json  (NOT status, which returns only a job summary).
-5. Otherwise classify, and retry ONLY a failure that is demonstrably both fast and transient. All three conditions must hold:
-   a. .job.status is "failed" — NOT "cancelled". The companion emits "cancelled" only for explicit cancellation, so retrying it restarts work something or someone deliberately stopped.
-   b. .waitTimedOut is false AND the job died in UNDER 60 SECONDS — compute elapsed from the job's own timestamps, not from the absence of a timeout. Use the number, not a judgment call: the two observed cases sit far apart (an upstream capacity rejection landed at ~10s, a genuine timeout at 10m19s), and leaving "quickly" undefined is how a one-retry budget turns into retry-whenever-it-feels-right. A job that fails at 8:59 also satisfies .waitTimedOut == false while having consumed nearly the whole window; that is not a transient blip and retrying it costs another full window.
-   c. The error text names a known-retryable cause: an upstream capacity rejection ("Selected model is at capacity"), a broker startup error, or a transient dispatch fault. An unrecognised error is not assumed retryable.
-   All three true → dispatch ONE new background job per step 2 and wait once more per step 3. If the second attempt also fails, return status:"unavailable" with BOTH observed .job.status values and the broker error text in statusNote.
-   Anything else — "cancelled", a late failure, or an unrecognised error — is a deliberate stop or an unexplained failure. Do NOT retry. Return status:"unavailable" with .job.status, .waitTimedOut, elapsed time, and whether the job log showed active progress.
-   Retry budget is exactly one, and only when a, b and c all hold. Never loop.
-6. .waitTimedOut true is DIFFERENT from all of the above, and is NOT the end of the lane. It means only that the inner wait elapsed — it says nothing about the job, which is dispatched in the background and outlives the Bash call that was waiting on it. Re-read .job.status:
-   - Still "queued" or "running" → the job is ALIVE and needs more TIME, not another attempt. Wait once more on the SAME job id, in a NEW Bash call, exactly as in step 3 (same 540000 ms inner wait, same 600000 ms outer timeout). This is a CONTINUATION, not a retry: no second job is dispatched, no work is duplicated, and the first job's result stays the one you collect. The budget is not discretionary: a live job gets ALL five waits before the lane may return unavailable — returning early discards a required lane over a job that merely has not finished (observed live: a lane quit after two of its granted waits and the abandoned job completed successfully soon after). Then classify each further wait's outcome by these same rules — except that this continuation is granted FOUR times (five waits total), so a FIFTH .waitTimedOut IS exhausted budget: return status:"unavailable" saying the job was still running after all five waits, set the structured jobId field to the job id (REQUIRED — prose alone is not machine-recoverable; the orchestrator resumes the run from that field), and mention the job's last observed state in statusNote. The result stays fetchable later with: node "$comp" result <job-id> --cwd "${repoPath}" --json
-   - Any terminal state ("completed", "failed", "cancelled") → it finished while you were between calls. Handle it under step 4 or step 5; do not treat the earlier timeout as the verdict.
+W3. .job.status == "completed" → fetch the payload with: node "$comp" result <job-id> --cwd "${repoPath}" --json  (NOT status, which returns only a job summary).
+W4. .job.status "failed" or "cancelled" → the lane ends without a payload. NEVER dispatch a replacement from this protocol: retry authority lives with the dispatch protocol's brief launch watch, where the one permitted fast-transient retry already fired or was ruled out — a failure that only becomes visible during this wait is not fast. Return status:"unavailable" with .job.status, .waitTimedOut, elapsed time computed from the job's own timestamps, and whether the job log showed active progress.
+W5. .waitTimedOut true is DIFFERENT from all of the above, and is NOT the end of the lane. It means only that the inner wait elapsed — it says nothing about the job, which is dispatched in the background and outlives the Bash call that was waiting on it. Re-read .job.status:
+   - Still "queued" or "running" → the job is ALIVE and needs more TIME, not another attempt. Wait once more on the SAME job id, in a NEW Bash call, exactly as in step W2 (same 540000 ms inner wait, same 600000 ms outer timeout). This is a CONTINUATION, not a retry: no second job is dispatched, no work is duplicated, and the first job's result stays the one you collect. The budget is not discretionary: a live job gets ALL five waits before the lane may return unavailable — returning early discards a required lane over a job that merely has not finished (observed live: a lane quit after two of its granted waits and the abandoned job completed successfully soon after). Then classify each further wait's outcome by these same rules — except that this continuation is granted FOUR times (five waits total), so a FIFTH .waitTimedOut IS exhausted budget: return status:"unavailable" saying the job was still running after all five waits, set the structured jobId field to the job id (REQUIRED — prose alone is not machine-recoverable; the orchestrator resumes the run from that field), and mention the job's last observed state in statusNote. The result stays fetchable later with: node "$comp" result <job-id> --cwd "${repoPath}" --json
+   - Any terminal state ("completed", "failed", "cancelled") → it finished while you were between calls. Handle it under step W3 or W4; do not treat the earlier timeout as the verdict.
    Why this exists: measured on a real run, the lane hit .waitTimedOut at the full 540000 ms while the job was demonstrably mid-work (its log showed pinned git greps completing, exit 0), the job was STILL "running" long after the review was abandoned, and its result remained retrievable. Reporting "exhausted budget" there discarded a required lane, and with it the whole review, over a job that simply had not finished yet. Re-dispatching would have been wrong — waiting again was not.
    Never substitute your own review for an unavailable Codex lane in either case — an unavailable lane is an expected outcome the workflow handles.
-   The 600000 ms outer ceiling is not tunable: the wait runs inside a Bash call, and the Bash tool silently kills any foreground command at that point. The inner wait is 540000 ms precisely so it finishes and prints its JSON before that happens — do not raise it to match. Step 6 is how a job legitimately exceeds ten minutes: not a longer wait, but a second one across a fresh call, which is the "polling across several calls" the ceiling leaves open. Total budget for a live job is therefore five waits, about forty-five minutes. It was three waits (about twenty-seven minutes), sized above the then-measured maximum of recent review jobs (~19 min) — until a real review job on a +1951/−153 PR ran ~53 minutes and outlasted even that, so a healthy long job was misclassified as exhausted budget. Five waits covers most such jobs, and exhaustion now hands back a resumable job id (the structured jobId field above) instead of losing the work, so even a job that outlasts all five waits stays recoverable.
-Every Codex task you dispatch must carry the execution rules verbatim in its own prompt — Codex runs in its own shell and does not inherit this one's constraints. That includes the shell contract stated elsewhere in this prompt: it arrives via NO_EXECUTION, which every prompt builder composes exactly once, so it is deliberately not repeated here.
-Sandbox: the review itself runs sandboxed. The one known exception is the companion's own job log under ~/.claude/plugins/data, which is sandbox-denied — if dispatch fails on that write, bypass for that call only. Never bypass for anything else, and never for a call that performs a Git operation, mutates the working copy, or writes to GitHub. Reading a path is not the boundary; acting on it is.`
+   The 600000 ms outer ceiling is not tunable: the wait runs inside a Bash call, and the Bash tool silently kills any foreground command at that point. The inner wait is 540000 ms precisely so it finishes and prints its JSON before that happens — do not raise it to match. Step W5 is how a job legitimately exceeds ten minutes: not a longer wait, but a second one across a fresh call, which is the "polling across several calls" the ceiling leaves open. Total budget for a live job is therefore five waits, about forty-five minutes. It was three waits (about twenty-seven minutes), sized above the then-measured maximum of recent review jobs (~19 min) — until a real review job on a +1951/−153 PR ran ~53 minutes and outlasted even that, so a healthy long job was misclassified as exhausted budget. Five waits covers most such jobs, and exhaustion now hands back a resumable job id (the structured jobId field above) instead of losing the work, so even a job that outlasts all five waits stays recoverable.`
 
 const REVIEW_FOCUS = {
   'code-change': `Review for bugs, regressions, broken consumers, security issues, and instruction/config compliance.
@@ -277,20 +309,14 @@ ${NO_EXECUTION}
 ${OUTPUT_RULES}`
 }
 
-function codexReviewPrompt() {
-  // Resume path: a previous run of this exact review already dispatched a Codex job and
-  // exhausted its wait budget; the orchestrator passes that job id back so this lane
-  // collects it instead of dispatching a duplicate. ONLY this prompt may vary with
-  // codexResumeJobId — resume caching is keyed on (prompt, opts), so the claude,
-  // coderabbit and integration prompts must stay byte-identical for their cached
-  // round-1 results to replay.
-  const resumeNote = typeof codexResumeJobId === 'string' && codexResumeJobId.trim()
-    ? `RESUME NOTE (read before the dispatch protocol below): a Codex job for this exact review was already dispatched on a previous run and MUST NOT be dispatched again. The job id is ${codexResumeJobId} (workspace ${repoPath}). Skip dispatch (step 2) entirely. First check the job's state: node "$comp" status "${codexResumeJobId}" --cwd "${repoPath}" --json. If it is terminal ("completed"), fetch the payload with the result command (step 4); if "failed"/"cancelled", classify under step 5. If it is still queued or running, wait on THIS job id per the continuation-wait protocol (steps 3 and 6). All other rules — classification, the lookup-miss recheck, no re-dispatch, output translation — apply unchanged.
-`
-    : ''
-  return `You drive the Codex reviewer in a multi-reviewer cross-review.
+// Round 1 Codex lane, part 1 of 2: dispatch only. Small prompt, small structured
+// result — its whole job is to compose the lean Codex task and start the background
+// job, so the orchestrator can log the job id the moment dispatch succeeds instead of
+// the lane staying opaque until the review finishes.
+function codexDispatchPrompt() {
+  return `You dispatch the Codex reviewer's background job in a multi-reviewer cross-review. Dispatch is your WHOLE job: a separate wait agent collects and translates the result. Do NOT wait for the review to finish and do NOT fetch its result — after the brief launch watch in the dispatch protocol, report the job id and stop.
 ${header}
-${resumeNote}${CODEX_DISPATCH}
+${CODEX_DISPATCH}
 
 ${NO_EXECUTION}
 
@@ -298,7 +324,73 @@ Compose a LEAN Codex task prompt containing the saved-diff path, these review in
 ${REVIEW_FOCUS[prType] || REVIEW_FOCUS['code-change']}
 ${CODEX_LEAN}
 ${OUTPUT_RULES}
-Translate Codex's raw output into the structured result yourself.`
+
+Return status:"ok" with jobId — the background job id you dispatched (the second job's id if the retry-once rule fired) — and a one-line dispatchNote (dispatch time, whether the retry fired). If dispatch failed and the retry rule does not permit another attempt, return status:"unavailable" with the broker error text in dispatchNote and no jobId.`
+}
+
+// Round 1 Codex lane, part 2 of 2: wait and translate. A pure function of the job id
+// (plus the run's fixed args): a resumed run building this prompt for codexResumeJobId
+// produces byte-identical text to a fresh run that dispatched the same id, so
+// agent-result caching and resumeFromRunId behave identically on either path.
+function codexWaitPrompt(jobId) {
+  return `You collect the Codex reviewer's result in a multi-reviewer cross-review. A background Codex job carrying the full review instructions was already dispatched for this exact review; NEVER dispatch a job yourself — your job is to wait for it, classify the outcome, and translate its result.
+${header}
+The job id is ${jobId} (workspace ${repoPath}). Every companion status/result command below runs against this job id.
+${CODEX_WAIT}
+
+${NO_EXECUTION}
+
+Translate Codex's raw output into the structured result yourself.
+${OUTPUT_RULES}`
+}
+
+// The Codex round-1 lane as a two-step pipeline inside the parallel round:
+// dispatch agent → log() → wait agent. The log line between the two is the point of
+// the split — it appears in the workflow progress view the moment the remote job
+// exists, so a watcher can tell "dispatched and working" from "dispatch never
+// happened" instead of staring at one opaque "running" lane.
+// Resume-cache property: agent results replay from a cache keyed on (prompt, opts)
+// under resumeFromRunId. The dispatch prompt is a pure function of this run's args, so
+// a resumed run replays the cached {jobId} instantly — no second dispatch — which
+// makes the wait prompt (a pure function of that job id) byte-identical to the
+// original run's: an interrupted run resumes into the SAME wait. The claude,
+// coderabbit and integration prompts must likewise stay byte-identical for their
+// cached round-1 results to replay.
+// With codexResumeJobId set (a previous RUN's wait budget was exhausted and the
+// orchestrator passed the live job id back), the dispatch agent is skipped entirely
+// and only the wait agent runs, on the id passed in.
+async function codexLane() {
+  let jobId = typeof codexResumeJobId === 'string' && codexResumeJobId.trim() ? codexResumeJobId.trim() : null
+  if (jobId) {
+    log(`Codex resume: waiting on existing job ${jobId}`)
+  } else {
+    const d = await agent(codexDispatchPrompt(), { label: 'review:codex-dispatch', phase: 'Review', schema: CODEX_DISPATCH_SCHEMA, agentType: AGENT_TYPE.codex })
+    if (!d || d.status !== 'ok') {
+      return { status: 'unavailable', statusNote: `Codex dispatch failed — ${d ? (d.dispatchNote || 'no dispatchNote returned') : 'dispatch agent returned no result'}`, findings: [], openQuestions: [], filesChecked: [] }
+    }
+    const jid = typeof d.jobId === 'string' ? d.jobId.trim() : ''
+    // Same fail-closed rule as the codexResumeJobId intake check, for the same reason:
+    // this id is interpolated into the wait prompt and pasted into shell commands.
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(jid)) {
+      return { status: 'unavailable', statusNote: `Codex dispatch returned ok without a usable job id (got ${JSON.stringify(d.jobId)}) — cannot hand the job to the wait agent`, findings: [], openQuestions: [], filesChecked: [] }
+    }
+    jobId = jid
+    const note = (d.dispatchNote || '').trim()
+    log(`Codex job ${jobId} dispatched — review running remotely${note ? ` (${note})` : ''}`)
+  }
+  const w = await agent(codexWaitPrompt(jobId), { label: 'review:codex', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: AGENT_TYPE.codex })
+  // A dead or unavailable wait agent must not lose the live job id: attach it so
+  // incomplete() surfaces codexJobId and the run stays mechanically resumable.
+  // Deliberately unconditional — a W4 terminal classification gets a codexJobId too,
+  // even though that job is dead (a resume then just reconfirms unavailability).
+  // Losing a live id costs a whole review; a wasted resume costs minutes. SKILL.md's
+  // recovery bullet documents this asymmetry.
+  if (!w) return { status: 'unavailable', statusNote: `Codex wait agent returned no result for job ${jobId} — the job may still be live`, jobId, findings: [], openQuestions: [], filesChecked: [] }
+  // The orchestrator's jobId is the trusted recovery handle — override whatever the
+  // wait agent returned rather than keep it: a malformed or wrong agent-returned id
+  // would replace the handle and lose the live job on the next resume.
+  if (w.status !== 'ok') return { ...w, jobId }
+  return w
 }
 
 // The CodeRabbit CLI runs exactly once, in round 1; the cross-review round replays
@@ -645,7 +737,7 @@ function crossPrompt(k, items) {
   const list = items.map(findingBlock).join('\n\n')
   const perReviewer =
     k === 'codex'
-      ? `${CODEX_DISPATCH}\n${CODEX_LEAN}\nFor each candidate, have Codex read just the cited lines at the pinned commit (git -C "${repoPath}" show '${headSha}:<path>' | sed -n) before returning a verdict.${prType === 'code-change' ? '\nDuring the independent re-review apply the behavioral correctness checks: trace inputs through happy/error/edge paths; verify the scope of fallback/reset/retry logic; verify diagnostic metadata derives from real context; check multi-branch state consistency.' : ''}`
+      ? `${CODEX_DISPATCH}\n${CODEX_WAIT}\n${CODEX_LEAN}\nFor each candidate, have Codex read just the cited lines at the pinned commit (git -C "${repoPath}" show '${headSha}:<path>' | sed -n) before returning a verdict.${prType === 'code-change' ? '\nDuring the independent re-review apply the behavioral correctness checks: trace inputs through happy/error/edge paths; verify the scope of fallback/reset/retry logic; verify diagnostic metadata derives from real context; check multi-branch state consistency.' : ''}`
       : `Re-read the saved diff at ${diffPath} and search/read the repo at the pinned commit (not the mutable working copy):
 ${PINNED_READS}
 For "missing X" candidates, read the full existing file at the pinned commit to confirm absence.`
@@ -674,7 +766,9 @@ Evaluation rules:
 log(`Round 1: launching Claude Code, Codex, CodeRabbit + integration analysis for PR #${pr} (${prType})`)
 const [claudeR, codexR, rabbitR, integR] = await parallel([
   () => agent(claudeReviewPrompt(), { label: 'review:claude', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: AGENT_TYPE.claude }),
-  () => agent(codexReviewPrompt(), { label: 'review:codex', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: AGENT_TYPE.codex }),
+  // Two chained agents with a progress log between them, not one opaque call —
+  // the log line is the visible "started" signal. See codexLane above.
+  () => codexLane(),
   () => agent(coderabbitReviewPrompt(), { label: 'review:coderabbit', phase: 'Review', schema: FINDINGS_SCHEMA, agentType: AGENT_TYPE.coderabbit }),
   // general-purpose, not Explore: Explore reads excerpts to locate code and is
   // explicitly not a review/audit agent, which is exactly what this lane does.


### PR DESCRIPTION
## Summary

Splits the aicr-cross-review skill's Codex round-1 lane into a dispatch agent and a wait agent with an orchestrator `log()` between them, so the workflow progress view shows the moment the remote Codex job actually starts.

## Motivation / Context

The Codex lane was one opaque `agent()` call: the progress view showed "running" from agent spawn, which cannot distinguish "remote job dispatched and working" from "dispatch never happened". On a real run the lane sat silent for 19 minutes with no way to tell which. The workflow script has no shell access, so dispatch must stay inside a subagent — the fix is splitting the lane, not surfacing shell output.

Fixes: N/A
Related: #2102 (the aicr-cross-review skill this builds on)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: reviewer tooling (`.agents/skills/aicr-cross-review/`)

## Implementation Notes

- **Two agents, one log line.** A small dispatch agent composes the lean Codex task, starts the background job, and returns `{jobId, dispatchNote}` (new `CODEX_DISPATCH_SCHEMA`). The orchestrator then logs `Codex job <id> dispatched — review running remotely` — the visible "started" signal — and hands the id to a wait agent that runs the continuation-wait protocol unchanged (540000 ms inner waits, 600000 ms outer timeout, five waits total, lookup-miss pinned recheck exactly once, structured `jobId` on exhausted budget).
- **Rule split without loss or duplication.** The old `CODEX_DISPATCH` constant is split: dispatch-side rules (dispatch command, fast-transient retry-once conditions, now decided inside a brief ~90 s launch watch that exactly covers the under-60s retry window) stay in `CODEX_DISPATCH`; wait-side rules (status/result commands, continuation waits, classification ladder) move to a new `CODEX_WAIT`. The cross-review round still dispatches and waits in one agent by composing both constants.
- **Resume simplified.** `codexResumeJobId` now skips the dispatch agent entirely (logged as `Codex resume: waiting on existing job <id>`) instead of injecting a resume note into a combined prompt; the wait prompt is a pure function of the job id, so a resumed job's prompt is byte-identical to a fresh run's. On `resumeFromRunId`, the dispatch agent's cached `{jobId}` replays instantly, so an interrupted run resumes into the same wait with no re-dispatch.
- **Failure semantics unchanged.** Dispatch-agent failure or wait-agent loss surfaces exactly like today's Codex-lane unavailability: `status: incomplete` with `codexJobId` whenever a live job id exists. The dispatched job id is validated with the same fail-closed regex as the existing `codexResumeJobId` intake check before it reaches a shell.
- `SKILL.md` documents the two-step lane, the visible dispatch log line, and the (unchanged) recovery path; frontmatter version bumped to 0.3.20; the prompt-composition invariant count updated (seven assembled prompts, each carrying `NO_EXECUTION` exactly once).

## Testing

```bash
# Harness-style syntax check (plain `node --check` false-positives on top-level return):
# wrapped workflow.mjs body in an async function → node --check → WRAPPED-SYNTAX-OK
```

- Grep invariants verified: `SHELL_CONTRACT` interpolated exactly once (inside `NO_EXECUTION`); `NO_EXECUTION` composed exactly once per prompt builder (7 total); the five-wait budget text lives only in `CODEX_WAIT`; the retry-once text lives only in `CODEX_DISPATCH`; `codexResumeJobId` handled only in `codexLane()` (plus the existing intake validation); `jobId` present in both result schemas.
- `make qualify` skipped: skill-only change (two files under `.agents/skills/aicr-cross-review/`), no Go, YAML-lint-covered, or docs-site files touched, so tests/lint/e2e cannot regress; the scoped checks above match the change.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — takes effect on the next skill invocation; no migration. A prior run's `codexJobId` still resumes via the same `resumeFromRunId` + `codexResumeJobId` contract.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes; scoped syntax/grep checks above
- [x] Linter passes (`make lint`) — N/A for this change set (no Go/YAML files touched)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
