### PR TITLE
ci(docs): block merges on parser-level MDX validation

### DIFF
--- a/.github/workflows/fern-docs-ci.yaml
+++ b/.github/workflows/fern-docs-ci.yaml
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 # Validates Fern docs configuration on pull requests that touch docs or fern/.
+#
+# NOTE: `fern check` validates docs.yml/nav configuration — it does NOT parse
+# MDX, so it cannot catch a construct that aborts `fern generate --docs` at
+# publish time. Parser-level MDX validation is the `docs-mdx` job in
+# merge-gate.yaml, which is the blocking check (see docs/contributor/tests.md
+# "Docs MDX Gate"). This workflow is advisory nav/link validation.
 
 name: Fern Docs CI
 

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -150,16 +150,22 @@ jobs:
               # construct that parses as CommonMark but aborts
               # `fern generate --docs`.
               #
+              # docs/index.yml is Fern's navigation manifest AND the source the
+              # checkers derive their file list from, so it is both an input and
+              # a trigger: adding a page there must run the gate over it.
+              # docs/README.md is the published landing page — the earlier
+              # per-subdirectory globs missed it entirely.
+              #
               # Everything the gate is MADE of is listed too, so a change to the
-              # gate cannot skip its own verification: the two checkers, the
-              # locked parser toolchain, this workflow, and the Makefile — whose
-              # `check-docs-mdx-parse` target is what the job actually invokes,
-              # matching why the `renovate` and `notices` filters watch it.
-              - 'docs/user/**'
-              - 'docs/integrator/**'
-              - 'docs/contributor/**'
+              # gate cannot skip its own verification: the two checkers, the page
+              # enumerator, the locked parser toolchain, this workflow, and the
+              # Makefile — whose `check-docs-mdx-parse` target is what the job
+              # actually invokes, matching why the `renovate` and `notices`
+              # filters watch it.
+              - 'docs/**'
               - 'tools/check-docs-mdx'
               - 'tools/check-docs-mdx-parse'
+              - 'tools/docs-published-files'
               - 'tools/mdx/**'
               - 'Makefile'
               - '.github/workflows/merge-gate.yaml'

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -148,16 +148,20 @@ jobs:
               # Inputs to the parser-level MDX gate. Only the Fern-published
               # trees matter — a change anywhere under them can introduce a
               # construct that parses as CommonMark but aborts
-              # `fern generate --docs`. The checker, its parser, and the
-              # .settings.yaml pin are included so a change to the gate itself
-              # cannot skip its own verification.
+              # `fern generate --docs`.
+              #
+              # Everything the gate is MADE of is listed too, so a change to the
+              # gate cannot skip its own verification: the two checkers, the
+              # locked parser toolchain, this workflow, and the Makefile — whose
+              # `check-docs-mdx-parse` target is what the job actually invokes,
+              # matching why the `renovate` and `notices` filters watch it.
               - 'docs/user/**'
               - 'docs/integrator/**'
               - 'docs/contributor/**'
               - 'tools/check-docs-mdx'
               - 'tools/check-docs-mdx-parse'
-              - 'tools/check-docs-mdx-parse.mjs'
-              - '.settings.yaml'
+              - 'tools/mdx/**'
+              - 'Makefile'
               - '.github/workflows/merge-gate.yaml'
 
       # code = true iff at least one changed file is NOT docs/markdown/LICENSE.

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -56,6 +56,7 @@ jobs:
       bom: ${{ steps.changes.outputs.bom }}
       tuning: ${{ steps.changes.outputs.tuning }}
       notices: ${{ steps.changes.outputs.notices }}
+      docs: ${{ steps.changes.outputs.docs }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -143,6 +144,21 @@ jobs:
               - 'validators/performance/requirements.txt'
               - 'validators/performance/licenses/**'
               - 'THIRD_PARTY_NOTICES.md'
+            docs:
+              # Inputs to the parser-level MDX gate. Only the Fern-published
+              # trees matter — a change anywhere under them can introduce a
+              # construct that parses as CommonMark but aborts
+              # `fern generate --docs`. The checker, its parser, and the
+              # .settings.yaml pin are included so a change to the gate itself
+              # cannot skip its own verification.
+              - 'docs/user/**'
+              - 'docs/integrator/**'
+              - 'docs/contributor/**'
+              - 'tools/check-docs-mdx'
+              - 'tools/check-docs-mdx-parse'
+              - 'tools/check-docs-mdx-parse.mjs'
+              - '.settings.yaml'
+              - '.github/workflows/merge-gate.yaml'
 
       # code = true iff at least one changed file is NOT docs/markdown/LICENSE.
       #
@@ -386,6 +402,47 @@ jobs:
       - run: echo "No Renovate config changes — validation not required"
 
   # ---------------------------------------------------------------------------
+  # MDX docs gate — parses every Fern-published doc with the real MDX parser.
+  #
+  # `fern check` (Fern Docs CI) does not parse MDX, and the job that does
+  # (`fern generate --docs --preview`) runs in a workflow_run companion whose
+  # status never lands on the PR head SHA, so it can never be required. That
+  # gap let a bare `<=` merge green and then fail every docs publish, including
+  # a release tag (#2050). This job is the blocking replacement: hermetic, no
+  # DOCS_FERN_TOKEN, no dependency on Fern's SaaS being up at merge time.
+  # ---------------------------------------------------------------------------
+
+  docs-mdx:
+    needs: [check-paths]
+    if: needs.check-paths.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '20'
+      # The bash approximation runs first: it is instant and its messages name
+      # the specific hazard, so the common cases fail fast with better output.
+      # The parser then decides — it is the authoritative check, and GITHUB_ACTIONS
+      # makes a missing Node or a failed dependency install a hard error rather
+      # than the local warn-and-skip.
+      - name: Check MDX safety (pattern approximation)
+        run: make check-docs-mdx
+      - name: Validate docs with the real MDX parser
+        run: make check-docs-mdx-parse
+
+  docs-mdx-skip:
+    needs: [check-paths]
+    if: needs.check-paths.outputs.docs != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "No published-docs changes — MDX parse gate not required"
+
+  # ---------------------------------------------------------------------------
   # BOM version freshness — ensures the committed container-images.md matches
   # the registry pins even on docs-only PRs (which skip the full `tests` job).
   # ---------------------------------------------------------------------------
@@ -534,6 +591,8 @@ jobs:
       - verify-licenses-skip
       - verify-renovate
       - verify-renovate-skip
+      - docs-mdx
+      - docs-mdx-skip
       - bom-freshness
       - bom-freshness-skip
       - tuning-freshness

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,6 @@ aicr-e2e.xml
 # so this only guards an accidental local build; the source stays tracked.
 /tlsproxy
 
-# MDX parser toolchain cache for tools/check-docs-mdx-parse (pinned via
-# .settings.yaml, reinstalled on pin change). Never committed.
-.mdx-cache/
+# Resolved MDX toolchain for tools/check-docs-mdx-parse. The manifest and
+# lockfile in tools/mdx/ ARE committed; only the installed tree is not.
+tools/mdx/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ aicr-e2e.xml
 # the repo root. The private-Sigstore e2e's run.sh builds the proxy to $TMPDIR,
 # so this only guards an accidental local build; the source stays tracked.
 /tlsproxy
+
+# MDX parser toolchain cache for tools/check-docs-mdx-parse (pinned via
+# .settings.yaml, reinstalled on pin change). Never committed.
+.mdx-cache/

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -39,13 +39,12 @@ linting:
   addlicense: 'v1.2.0'
   # renovate: datasource=github-releases depName=google/go-licenses depType=linting
   go_licenses: 'v2.0.1'
-  # MDX toolchain for tools/check-docs-mdx-parse — the parser-level docs gate.
-  # Must track what Fern's publish pipeline uses: this pin IS the contract that
-  # keeps the merge gate from disagreeing with `fern generate --docs`.
-  # renovate: datasource=npm depName=@mdx-js/mdx depType=linting
-  mdx: '3.1.1'
-  # renovate: datasource=npm depName=remark-gfm depType=linting
-  remark_gfm: '4.0.1'
+  # MDX toolchain for tools/check-docs-mdx-parse (the parser-level docs gate) is
+  # owned by tools/mdx/package.json + package-lock.json, not listed here. The
+  # lockfile freezes the full transitive tree, which a version string cannot;
+  # this gate decides which docs merge, so its verdict must be reproducible.
+  # Renovate updates it natively via the npm manager. Same single-source-of-truth
+  # split as the Go toolchain living in .go-version.
 
 # Security Tools
 security_tools:

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -39,6 +39,13 @@ linting:
   addlicense: 'v1.2.0'
   # renovate: datasource=github-releases depName=google/go-licenses depType=linting
   go_licenses: 'v2.0.1'
+  # MDX toolchain for tools/check-docs-mdx-parse — the parser-level docs gate.
+  # Must track what Fern's publish pipeline uses: this pin IS the contract that
+  # keeps the merge gate from disagreeing with `fern generate --docs`.
+  # renovate: datasource=npm depName=@mdx-js/mdx depType=linting
+  mdx: '3.1.1'
+  # renovate: datasource=npm depName=remark-gfm depType=linting
+  remark_gfm: '4.0.1'
 
 # Security Tools
 security_tools:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -222,7 +222,15 @@ make lint
 make lint-go      # Go linting only
 make lint-yaml    # YAML linting only
 make license      # License header check
+
+# Docs published to Fern are parsed as MDX; both checks gate the merge
+make check-docs-mdx        # fast pattern approximation (no dependencies)
+make check-docs-mdx-parse  # real MDX parser, authoritative (needs Node 20+)
 ```
+
+`check-docs-mdx-parse` warns and skips when Node is unavailable locally, but
+hard-fails in CI. See
+[Docs MDX Gate](docs/contributor/tests.md#docs-mdx-gate).
 
 ### 5. Run E2E Tests
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifeq ($(IMAGE_REGISTRY),)
 IMAGE_REGISTRY     := ghcr.io/nvidia
 endif
 IMAGE_TAG          ?= latest
-YAML_FILES         := $(shell find . -type f \( -iname "*.yml" -o -iname "*.yaml" \) ! -path "./examples/*" ! -path "./bundle/*" ! -path "./bundles/*" ! -path "*/testdata/*")
+YAML_FILES         := $(shell find . -type f \( -iname "*.yml" -o -iname "*.yaml" \) ! -path "./examples/*" ! -path "./bundle/*" ! -path "./bundles/*" ! -path "*/testdata/*" ! -path "*/node_modules/*")
 COMMIT             := $(shell git rev-parse HEAD)
 BRANCH             := $(shell git rev-parse --abbrev-ref HEAD)
 GO_VERSION         := $(shell cat .go-version 2>/dev/null)
@@ -148,8 +148,8 @@ check-docs-mdx: ## Checks docs/ markdown for MDX compatibility (void elements, b
 # strict subset of it.
 #
 # Part of `make lint` (and therefore `make qualify`) so the "if qualify passes
-# locally, CI will pass" contract still holds. It needs Node 20+ and one npm
-# install of the pins in .settings.yaml; without Node it warns and skips
+# locally, CI will pass" contract still holds. It needs Node 20+ and one
+# `npm ci` of the locked tree in tools/mdx; without Node it warns and skips
 # locally, but HARD-FAILS under CI, where the merge-gate `docs-mdx` job blocks
 # on it.
 .PHONY: check-docs-mdx-parse
@@ -195,7 +195,7 @@ LICENSE_IGNORES = \
 	-ignore 'THIRD_PARTY_NOTICES.md' \
 	-ignore 'validators/performance/licenses/**' \
 	-ignore '.licenses-cache/**' \
-	-ignore '.mdx-cache/**'
+	-ignore 'tools/mdx/node_modules/**'
 
 # The two recipes/evidence patterns in LICENSE_IGNORES match exactly the
 # generated, header-less pointer shapes MarshalPointer emits — the transient

--- a/Makefile
+++ b/Makefile
@@ -147,11 +147,11 @@ check-docs-mdx: ## Checks docs/ markdown for MDX compatibility (void elements, b
 # check-docs-mdx above is a fast, dependency-free approximation kept as a
 # strict subset of it.
 #
-# Part of `make lint` (and therefore `make qualify`) so the "if qualify passes
-# locally, CI will pass" contract still holds. It needs Node 20+ and one
-# `npm ci` of the locked tree in tools/mdx; without Node it warns and skips
-# locally, but HARD-FAILS under CI, where the merge-gate `docs-mdx` job blocks
-# on it.
+# Part of `make lint` (and therefore `make qualify`). It needs Node 20+ and one
+# `npm ci` of the locked tree in tools/mdx. With Node installed, a local
+# `make qualify` predicts CI as usual; WITHOUT it this check warns and skips, so
+# a local pass no longer implies a CI pass and invalid MDX can still be rejected
+# by the merge-gate `docs-mdx` job, where a missing Node is a HARD FAILURE.
 .PHONY: check-docs-mdx-parse
 check-docs-mdx-parse: ## Validates docs/ with the real MDX parser (requires Node; CI-blocking)
 	@./tools/check-docs-mdx-parse

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ generate: ## Runs go generate for code generation
 	@echo "Code generation completed"
 
 .PHONY: lint
-lint: lint-go lint-yaml license check-agents-sync check-docs-filenames check-docs-mdx bom-pinning-check ## Lints the entire project (Go, YAML, license headers, and chart-version pins)
+lint: lint-go lint-yaml license check-agents-sync check-docs-filenames check-docs-mdx check-docs-mdx-parse bom-pinning-check ## Lints the entire project (Go, YAML, license headers, and chart-version pins)
 	@echo "Completed Go and YAML lints and ensured license headers"
 
 # Standalone target — NOT part of `make lint` because it requires Docker
@@ -140,6 +140,21 @@ check-docs-filenames: ## Enforces lowercase kebab-case filenames in docs/
 .PHONY: check-docs-mdx
 check-docs-mdx: ## Checks docs/ markdown for MDX compatibility (void elements, bare braces, HTML comments, autolinks, bare <tags>)
 	@./tools/check-docs-mdx
+
+# Parser-level docs gate — runs the SAME MDX parser Fern does over every
+# published doc, so a construct that would abort `fern generate --docs` at
+# publish time fails here instead. This is the authoritative check;
+# check-docs-mdx above is a fast, dependency-free approximation kept as a
+# strict subset of it.
+#
+# Part of `make lint` (and therefore `make qualify`) so the "if qualify passes
+# locally, CI will pass" contract still holds. It needs Node 20+ and one npm
+# install of the pins in .settings.yaml; without Node it warns and skips
+# locally, but HARD-FAILS under CI, where the merge-gate `docs-mdx` job blocks
+# on it.
+.PHONY: check-docs-mdx-parse
+check-docs-mdx-parse: ## Validates docs/ with the real MDX parser (requires Node; CI-blocking)
+	@./tools/check-docs-mdx-parse
 
 .PHONY: lint-go
 lint-go: ## Lints Go files with golangci-lint and go vet
@@ -179,7 +194,8 @@ LICENSE_IGNORES = \
 	-ignore 'recipes/evidence/*/*/*.yaml' \
 	-ignore 'THIRD_PARTY_NOTICES.md' \
 	-ignore 'validators/performance/licenses/**' \
-	-ignore '.licenses-cache/**'
+	-ignore '.licenses-cache/**' \
+	-ignore '.mdx-cache/**'
 
 # The two recipes/evidence patterns in LICENSE_IGNORES match exactly the
 # generated, header-less pointer shapes MarshalPointer emits — the transient

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -515,7 +515,7 @@ Two checks cover this, both run by `make lint`:
 | Check | What it is | Speed |
 |-------|-----------|-------|
 | `make check-docs-mdx` | Pattern-based bash approximation. Names the specific hazard, needs no dependencies. | Instant |
-| `make check-docs-mdx-parse` | The real MDX parser (`@mdx-js/mdx`, pinned in `.settings.yaml`). Authoritative. | ~2 s + one npm install |
+| `make check-docs-mdx-parse` | The real MDX parser (`@mdx-js/mdx`, locked in `tools/mdx/package-lock.json`). Authoritative. | ~2 s + one `npm ci` |
 
 The parser is the source of truth. The bash rules are deliberately kept as a
 strict **subset** of what it rejects: a miss is caught by the parse gate, but a

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -504,11 +504,19 @@ the pre-push gate is local.
 
 ## Docs MDX Gate
 
-Fern renders `docs/user/`, `docs/integrator/`, and `docs/contributor/` through
-an MDX parser, so a construct that is valid CommonMark can still abort
-`fern generate --docs` at publish time. A bare `<=` in prose is the classic
-case — MDX reads the `<` as the start of a JSX tag and fails with
-`Unexpected character = (U+003D) before name`.
+Fern renders published docs through an MDX parser, so a construct that is valid
+CommonMark can still abort `fern generate --docs` at publish time. A bare `<=`
+in prose is the classic case — MDX reads the `<` as the start of a JSX tag and
+fails with `Unexpected character = (U+003D) before name`.
+
+**Which files are checked.** Both checks derive their file list from
+`docs/index.yml` via `tools/docs-published-files` — Fern's navigation manifest
+is the authoritative statement of what gets parsed. Globbing
+`docs/user`/`docs/integrator`/`docs/contributor` instead was a denylist in
+disguise: it missed `docs/README.md`, the published landing page, so a hazard
+there passed both gates and still broke the publish. Add a page to
+`docs/index.yml` and it is gated that day; a file that is not published is not
+gated at all.
 
 Two checks cover this, both run by `make lint`:
 
@@ -525,13 +533,19 @@ when a name-ish character follows `<` immediately) while `<= 2,000` and `<30 s`
 are not.
 
 Hazards only the parser sees: a stray closing tag (`</div>`), an unclosed
-fragment (`<>`), unbalanced expression braces spanning lines, and any
-acorn-level syntax error.
+fragment (`<>`), a placeholder sharing a line with well-formed JSX, unbalanced
+expression braces spanning lines, and any acorn-level syntax error.
+
+Well-formed JSX is fine in both — `<Component />` and `<span>text</span>` parse,
+and the Fern component set is authored that way. So is YAML frontmatter: Fern
+strips it before MDX, so a `title: gate <= 2,000` is valid, and both checks skip
+it by line number so later diagnostics still cite the true line.
 
 `check-docs-mdx-parse` needs Node 20+. Without it the script prints a warning
 and exits 0 locally, but **hard-fails under CI** — the `docs-mdx` job in
 `merge-gate.yaml` blocks on it, and the merge gate is the only required status
-check.
+check. This is the one place where a green local `make qualify` does not
+guarantee a green CI: if you have no Node, the MDX gate did not actually run.
 
 Fixing a violation is usually one of:
 

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -479,7 +479,8 @@ half of the pipeline and skips deploy-side assertions.
 `make qualify` is the canonical pre-push command. It runs:
 
 - `test-coverage` — `go test -race ./...` plus the 80% coverage floor.
-- `lint` — golangci-lint with `.golangci.yaml` plus yamllint.
+- `lint` — golangci-lint with `.golangci.yaml`, yamllint, and the docs checks
+  (filenames, MDX patterns, MDX parse — see [Docs MDX Gate](#docs-mdx-gate)).
 - `e2e` — the end-to-end pipeline runner.
 - `scan` — Grype vulnerability scan.
 - `license-check` — license header / dependency-license sweep.
@@ -500,6 +501,52 @@ golangci-lint run -c .golangci.yaml ./...           # full sweep
 This applies even to PRs labeled `documentation` when they include
 incidental Go changes. Do not rely on CI to surface lint failures —
 the pre-push gate is local.
+
+## Docs MDX Gate
+
+Fern renders `docs/user/`, `docs/integrator/`, and `docs/contributor/` through
+an MDX parser, so a construct that is valid CommonMark can still abort
+`fern generate --docs` at publish time. A bare `<=` in prose is the classic
+case — MDX reads the `<` as the start of a JSX tag and fails with
+`Unexpected character = (U+003D) before name`.
+
+Two checks cover this, both run by `make lint`:
+
+| Check | What it is | Speed |
+|-------|-----------|-------|
+| `make check-docs-mdx` | Pattern-based bash approximation. Names the specific hazard, needs no dependencies. | Instant |
+| `make check-docs-mdx-parse` | The real MDX parser (`@mdx-js/mdx`, pinned in `.settings.yaml`). Authoritative. | ~2 s + one npm install |
+
+The parser is the source of truth. The bash rules are deliberately kept as a
+strict **subset** of what it rejects: a miss is caught by the parse gate, but a
+false positive would force you to mangle prose the publish step would have
+accepted. That is why `< 500` and `< 10 s` are fine (MDX only enters tag mode
+when a name-ish character follows `<` immediately) while `<= 2,000` and `<30 s`
+are not.
+
+Hazards only the parser sees: a stray closing tag (`</div>`), an unclosed
+fragment (`<>`), unbalanced expression braces spanning lines, and any
+acorn-level syntax error.
+
+`check-docs-mdx-parse` needs Node 20+. Without it the script prints a warning
+and exits 0 locally, but **hard-fails under CI** — the `docs-mdx` job in
+`merge-gate.yaml` blocks on it, and the merge gate is the only required status
+check.
+
+Fixing a violation is usually one of:
+
+```markdown
+gate <= 2,000   →  gate `<= 2,000`
+<30 s           →  `<30 s`        or  &lt;30 s
+<br>            →  <br />
+{template}      →  \{template\}
+```
+
+Note that `fern check` (the Fern Docs CI job) does **not** parse MDX, and the
+job that does — `fern generate --docs --preview` — runs as a `workflow_run`
+companion whose status never lands on the PR head SHA, so it cannot be a
+required check. `make check-docs-mdx-parse` exists to close that gap without a
+token or a dependency on Fern's service at merge time.
 
 ## Common Gotchas
 

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -62,11 +62,13 @@
 set -euo pipefail
 
 ERRORS=0
-SEARCH_DIRS=("docs/user/" "docs/integrator/" "docs/contributor/")
-# Docs excluded from the MDX scan: container-images.md carries auto-generated
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Docs excluded from a directory scan: container-images.md carries auto-generated
 # HTML-comment splice markers that VitePress still needs and is not published
 # to Fern. (recipe-health.md is intentionally NOT excluded — it is Fern-
-# published and uses MDX-safe {/* ... */} markers.)
+# published and uses MDX-safe {/* ... */} markers.) The nav-derived list below
+# needs no exclusions: a file Fern does not publish is simply not in it.
 EXCLUDE_NAMES=("container-images.md")
 EXCLUDE_ARGS=()
 for name in "${EXCLUDE_NAMES[@]}"; do
@@ -74,21 +76,56 @@ for name in "${EXCLUDE_NAMES[@]}"; do
 done
 
 # Allow overriding the search path (e.g., for frozen version content)
+SEARCH_DIRS=()
 if [[ $# -gt 0 ]]; then
   SEARCH_DIRS=("$@")
 fi
 
+# Build the file list once; both check passes below iterate it.
+FILES=()
+if [[ ${#SEARCH_DIRS[@]} -eq 0 ]]; then
+  while IFS= read -r f; do
+    [[ -z "${f}" ]] && continue
+    FILES+=("${f}")
+  done < <("${REPO_ROOT}/tools/docs-published-files")
+else
+  for dir in "${SEARCH_DIRS[@]}"; do
+    while IFS= read -r f; do
+      [[ -z "${f}" ]] && continue
+      FILES+=("${f}")
+    done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) "${EXCLUDE_ARGS[@]}" 2>/dev/null | sort)
+  done
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "ERROR: no doc files found (scan roots: ${SEARCH_DIRS[*]:-docs/index.yml})" >&2
+  exit 1
+fi
+
+# frontmatter_end <file>: last line number of a leading YAML frontmatter block,
+# or 0 when there is none. Fern strips frontmatter before MDX parsing, so its
+# contents must not be scanned — a title like `gate <= 2,000` is valid there.
+# Reported line numbers stay correct because the awk passes skip by NR rather
+# than rewriting the file.
+frontmatter_end() {
+  local file="$1"
+  [[ "$(head -1 "${file}" 2>/dev/null)" == "---" ]] || { echo 0; return; }
+  local end
+  end="$(awk 'NR > 1 && $0 == "---" { print NR; exit }' "${file}")"
+  echo "${end:-0}"
+}
+
 # --- Check 1: non-self-closing void HTML elements (outside fenced code blocks) ---
 # These must use <tag /> in MDX, not <tag> or <tag attr>.
 VOID_ELEMENTS='img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr'
-for dir in "${SEARCH_DIRS[@]}"; do
-  while IFS= read -r file; do
-    [[ -z "${file}" ]] && continue
+for file in "${FILES[@]}"; do
+    FM_END="$(frontmatter_end "${file}")"
     while IFS= read -r match; do
       [[ -z "${match}" ]] && continue
       echo "MDX: non-self-closing void element: ${file}:${match}"
       ERRORS=$((ERRORS + 1))
-    done < <(awk '
+    done < <(awk -v fm_end="${FM_END}" '
+      NR <= fm_end { next }
       match($0, /^(`{3,}|~{3,})/) {
         m = substr($0, RSTART, RLENGTH); ch = substr(m, 1, 1); len = length(m)
         if (!in_fence) { in_fence = 1; fch = ch; flen = len; next }
@@ -99,20 +136,19 @@ for dir in "${SEARCH_DIRS[@]}"; do
       in_fence { next }
       { print NR": "$0 }
     ' "$file" | grep -E "<(${VOID_ELEMENTS})([[:space:]][^>]*)?" | grep -Ev "<(${VOID_ELEMENTS})([[:space:]][^>]*)?[[:space:]]*/>" || true)
-  done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) "${EXCLUDE_ARGS[@]}" 2>/dev/null)
 done
 
 # --- Checks 2, 3, 4, 5, 6: bare braces, HTML comments, autolinks, bare tags,
 #     and bare '<' not starting a valid tag ---
 # All evaluated outside fenced code blocks; inline code spans are stripped
 # before the line is scanned so legitimate uses inside backticks don't trip.
-for dir in "${SEARCH_DIRS[@]}"; do
-  while IFS= read -r file; do
-    [[ -z "${file}" ]] && continue
+for file in "${FILES[@]}"; do
+    FM_END="$(frontmatter_end "${file}")"
     # awk exits 1 when it finds a hazard; keep it inside the `if` condition so
     # `set -e` does not abort the whole scan at the first offending file
     # (otherwise violations in later files are silently skipped).
-    if ! awk '
+    if ! awk -v fm_end="${FM_END}" '
+      NR <= fm_end { next }
       match($0, /^(`{3,}|~{3,})/) {
         m = substr($0, RSTART, RLENGTH); ch = substr(m, 1, 1); len = length(m)
         if (!in_fence) { in_fence = 1; fch = ch; flen = len; next }
@@ -246,7 +282,6 @@ for dir in "${SEARCH_DIRS[@]}"; do
     ' "$file" 2>/dev/null; then
       ERRORS=$((ERRORS + 1))
     fi
-  done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) "${EXCLUDE_ARGS[@]}" 2>/dev/null)
 done
 
 if [[ ${ERRORS} -gt 0 ]]; then

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -24,14 +24,15 @@
 #   5. Bare angle-bracket placeholders (<word>) outside fenced and inline code
 #      — MDX interprets them as JSX component tags and fails on unexpected
 #      content that follows.
-#   6. Bare '<' NOT followed by a valid JSX name-start (fail-closed allowlist)
-#      — a '<' before anything other than a letter, '/', '!', or '>' (e.g.
-#      '<=', '< 5', '<3', '<-', or a trailing '<') is a parse error. Unlike
-#      checks 4 and 5, which match a '<' that IS followed by a name-start,
-#      this rule fails closed on every other '<'-follow, so future hazards in
-#      that family are caught by default rather than needing a new pattern.
+#   6. Bare '<' immediately followed by a character that cannot start a JSX
+#      name — '<=', '<3', '<-', or a trailing '<' at end of line. MDX reports
+#      "Unexpected character X before name" for these.
+#      NOT flagged: '<' followed by whitespace ('< 500', '< 10 s'). MDX accepts
+#      those as literal text, verified against @mdx-js/mdx; flagging them made
+#      this script reject content the publish step is happy with.
 #
-# Code handling (applies to all checks): fenced code blocks in BOTH backtick
+# Code handling (applies to checks 2-6; check 1 greps the fence-stripped line
+# WITHOUT inline-span stripping): fenced code blocks in BOTH backtick
 # (```) and tilde (~~~) styles are skipped, following CommonMark fence rules —
 # a fence opens on a run of >= 3 of either character and closes only on a later
 # line whose leading run is the SAME character and at least as long. Inline
@@ -39,12 +40,23 @@
 # and closes at the next run of exactly N backticks, so spans of any
 # backtick-run length are honored (not just single-backtick spans).
 #
-# NOTE: this checker remains an APPROXIMATION of the MDX parser, not a
-# reimplementation of it. It can still drift on hazard classes outside the
-# '<'-follow family covered above (e.g. malformed JSX attributes, unbalanced
-# expression braces spanning lines, or acorn-level syntax errors). A green run
-# is NOT parser-level validation — it means none of the known hazard patterns
-# matched, not that Fern's MDX parser will accept the file.
+# NOTE: this checker is a fast, dependency-free APPROXIMATION of the MDX
+# parser, not a reimplementation of it. tools/check-docs-mdx-parse runs the
+# real parser (@mdx-js/mdx, pinned in .settings.yaml) and is the authoritative
+# gate — it is what the merge-gate 'docs-mdx' job blocks on. A green run HERE
+# is not parser-level validation; it means no known hazard pattern matched.
+#
+# The rules above are deliberately a strict SUBSET of what the parser rejects.
+# Erring toward under-reporting is the correct direction: a miss is caught by
+# the blocking parse gate, whereas a false positive would force contributors to
+# mangle prose the publish step would have accepted. Known misses left to the
+# parser: a stray closing tag ('</div>'), an unclosed fragment ('<>'), unbalanced
+# expression braces spanning lines, and acorn-level syntax errors.
+#
+# Known code-handling limits (tracked in #2144): a fence opener indented by up
+# to three spaces is not recognized as a fence, and a code span is matched
+# within one line even though CommonMark lets spans cross lines. Both can
+# surface as a false positive here; the parse gate is the arbiter.
 
 set -euo pipefail
 
@@ -188,25 +200,34 @@ for dir in "${SEARCH_DIRS[@]}"; do
         printf "MDX: autolink outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }
-      # Bare angle-bracket placeholders: <word> or <digit> (e.g. <30 s,
-      # <13%) that are not void HTML elements (check 1) or autolinks
-      # (check 4). MDX interprets a `<` followed by a name-start character
-      # as a JSX tag and chokes on what follows.
-      line ~ /<[0-9a-zA-Z]/ && line !~ /<(img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr)([ \t>\/])/ && line !~ /<https?:\/\// {
+      # Bare angle-bracket placeholders: <word> (e.g. <name>, <path>) that are
+      # not void HTML elements (check 1) or autolinks (check 4). MDX interprets
+      # a `<` followed by a name-start character as a JSX tag and chokes on
+      # what follows.
+      #
+      # Letters only. Digit-prefixed sequences (`<30 s`) are owned by check 6 —
+      # matching them here too made one source token emit two diagnostics and
+      # increment the error count twice.
+      line ~ /<[a-zA-Z]/ && line !~ /<(img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr)([ \t>\/])/ && line !~ /<https?:\/\// {
         printf "MDX: bare <word> tag outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }
-      # Check 6 (fail-closed allowlist): a bare `<` that is NOT followed by a
-      # valid JSX name-start. MDX only accepts `<` before a letter (element),
-      # `/` (closing tag), `!` (declaration/comment, caught by check 3), or `>`
-      # (fragment); anything else — `<=`, `< 5`, `<3`, `<-`, or a trailing `<`
-      # at end of line — is a parse error (e.g. `(gate <= 2,000)` yields
-      # "Unexpected character = (U+003D) before name"). This complements
-      # checks 4 and 5 rather than replacing them: they cover the cases where
-      # `<` IS followed by a name-start (autolinks, placeholders), while this
-      # covers the cases where it is not. Inverting to an allowlist means any
-      # future `<`-follow hazard fails closed by default.
-      line ~ /<([^A-Za-z!\/>]|$)/ {
+      # Check 6: a bare `<` IMMEDIATELY followed by a character that cannot
+      # start a JSX name — `<=`, `<3`, `<-`, or a trailing `<` at end of line.
+      # MDX reports "Unexpected character X (U+00XX) before name" for these;
+      # `(gate <= 2,000)` is the case that broke the docs publish in #2050.
+      #
+      # Whitespace after `<` is EXCLUDED. `< 500`, `< 1.15`, and `< 10 s` all
+      # parse cleanly through @mdx-js/mdx — micromark only enters JSX-tag mode
+      # when a name-ish character follows immediately, so `<` + space stays
+      # literal text. Flagging them forced contributors to backtick prose the
+      # publish step accepts, which is the false-positive direction this script
+      # must avoid (see the strict-subset note in the header).
+      #
+      # `</div>` and `<>` are NOT covered here: both are real MDX errors, but
+      # deciding whether a tag is balanced needs parser state. They are caught
+      # by tools/check-docs-mdx-parse, the blocking gate.
+      line ~ /<([^A-Za-z!\/>[:space:]]|$)/ {
         printf "MDX: bare < not starting a valid tag: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -42,7 +42,7 @@
 #
 # NOTE: this checker is a fast, dependency-free APPROXIMATION of the MDX
 # parser, not a reimplementation of it. tools/check-docs-mdx-parse runs the
-# real parser (@mdx-js/mdx, pinned in .settings.yaml) and is the authoritative
+# real parser (@mdx-js/mdx, locked in tools/mdx/) and is the authoritative
 # gate — it is what the merge-gate 'docs-mdx' job blocks on. A green run HERE
 # is not parser-level validation; it means no known hazard pattern matched.
 #
@@ -50,8 +50,9 @@
 # Erring toward under-reporting is the correct direction: a miss is caught by
 # the blocking parse gate, whereas a false positive would force contributors to
 # mangle prose the publish step would have accepted. Known misses left to the
-# parser: a stray closing tag ('</div>'), an unclosed fragment ('<>'), unbalanced
-# expression braces spanning lines, and acorn-level syntax errors.
+# parser: a stray closing tag ('</div>'), an unclosed fragment ('<>'), a
+# placeholder sharing a line with well-formed JSX, unbalanced expression braces
+# spanning lines, and acorn-level syntax errors.
 #
 # Known code-handling limits (tracked in #2144): a fence opener indented by up
 # to three spaces is not recognized as a fence, and a code span is matched
@@ -208,7 +209,17 @@ for dir in "${SEARCH_DIRS[@]}"; do
       # Letters only. Digit-prefixed sequences (`<30 s`) are owned by check 6 —
       # matching them here too made one source token emit two diagnostics and
       # increment the error count twice.
-      line ~ /<[a-zA-Z]/ && line !~ /<(img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr)([ \t>\/])/ && line !~ /<https?:\/\// {
+      #
+      # Lines showing evidence of well-formed JSX — a self-closing `/>` or a
+      # closing `</` — are left to the parse gate. MDX accepts `<Component />`
+      # and `<span>text</span>`, and the Fern component set (Cards, Tabs,
+      # Accordions) is written that way, so flagging them here would reject
+      # valid content. Deciding whether tags actually balance needs parser
+      # state, which this script does not have; the trade is that a placeholder
+      # sharing a line with real JSX is caught by tools/check-docs-mdx-parse
+      # instead of here. That is the safe direction — see the strict-subset
+      # note in the header.
+      line ~ /<[a-zA-Z]/ && line !~ /\/>/ && line !~ /<\// && line !~ /<(img|br|hr|input|source|meta|link|area|base|col|embed|param|track|wbr)([ \t>\/])/ && line !~ /<https?:\/\// {
         printf "MDX: bare <word> tag outside code fence: %s:%d: %s\n", FILENAME, NR, $0
         errors++
       }

--- a/tools/check-docs-mdx-parse
+++ b/tools/check-docs-mdx-parse
@@ -38,7 +38,11 @@ PARSER="${MDX_DIR}/check-docs-mdx-parse.mjs"
 LOCKFILE="${MDX_DIR}/package-lock.json"
 STAMP="${MDX_DIR}/node_modules/.aicr-lock-digest"
 
-SEARCH_DIRS=("docs/user/" "docs/integrator/" "docs/contributor/")
+# With no arguments the file list comes from docs/index.yml via
+# tools/docs-published-files — Fern's nav is the authoritative statement of what
+# gets parsed at publish time. Positional args switch to a directory scan, which
+# the tests and frozen version content use.
+SEARCH_DIRS=()
 EXCLUDE_NAMES=("container-images.md")
 
 if [[ $# -gt 0 ]]; then
@@ -92,23 +96,29 @@ if [[ ! -f "${STAMP}" ]] || [[ "$(cat "${STAMP}")" != "${LOCK_DIGEST}" ]]; then
   echo "${LOCK_DIGEST}" >"${STAMP}"
 fi
 
-# Collect files. Paths are reported exactly as `find` yields them, so the
-# default (relative) scan roots produce repo-relative, copy-pasteable
-# file:line:column output matching tools/check-docs-mdx.
+# Collect files. Paths are repo-relative in both modes, so the file:line:column
+# output stays copy-pasteable and matches tools/check-docs-mdx.
 FILES=()
-for dir in "${SEARCH_DIRS[@]}"; do
-  exclude_args=()
-  for name in "${EXCLUDE_NAMES[@]}"; do
-    exclude_args+=(! -name "${name}")
-  done
+if [[ ${#SEARCH_DIRS[@]} -eq 0 ]]; then
   while IFS= read -r file; do
     [[ -z "${file}" ]] && continue
     FILES+=("${file}")
-  done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) "${exclude_args[@]}" 2>/dev/null | sort)
-done
+  done < <("${REPO_ROOT}/tools/docs-published-files")
+else
+  for dir in "${SEARCH_DIRS[@]}"; do
+    exclude_args=()
+    for name in "${EXCLUDE_NAMES[@]}"; do
+      exclude_args+=(! -name "${name}")
+    done
+    while IFS= read -r file; do
+      [[ -z "${file}" ]] && continue
+      FILES+=("${file}")
+    done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) "${exclude_args[@]}" 2>/dev/null | sort)
+  done
+fi
 
 if [[ ${#FILES[@]} -eq 0 ]]; then
-  echo "ERROR: no doc files found under: ${SEARCH_DIRS[*]}" >&2
+  echo "ERROR: no doc files found (scan roots: ${SEARCH_DIRS[*]:-docs/index.yml})" >&2
   exit 1
 fi
 

--- a/tools/check-docs-mdx-parse
+++ b/tools/check-docs-mdx-parse
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Parser-level MDX validation for docs/ — resolves the pinned MDX toolchain and
-# runs tools/check-docs-mdx-parse.mjs over every published doc.
+# runs tools/mdx/check-docs-mdx-parse.mjs over every published doc.
 #
 # Why this exists: `fern check` (the Fern Docs CI job) does NOT parse MDX, and
 # `fern generate --docs --preview` (which does) runs in a workflow_run companion
@@ -12,6 +12,12 @@
 # and then fail every publish, including a release tag (issue #2050). This script
 # closes it with a hermetic, token-free parse that CI can block on.
 #
+# Reproducibility: the toolchain is installed with `npm ci` from the committed
+# tools/mdx/package-lock.json, which freezes the FULL transitive tree — not just
+# the two direct dependencies. That matters because this gate decides which docs
+# merge: a floating transitive dependency could change the verdict between two
+# runs of the same commit, with no repository change to point at.
+#
 # Scope mirrors tools/check-docs-mdx: docs/user/, docs/integrator/, and
 # docs/contributor/ (everything published to Fern). container-images.md carries
 # auto-generated HTML comment splice markers, is not published to Fern, and is
@@ -19,16 +25,18 @@
 # for frozen version content).
 #
 # Node availability:
-#   - In CI (CI or GITHUB_ACTIONS set): missing node/npm, or a failed dependency
-#     install, is a HARD FAILURE. The gate must never silently pass.
+#   - In CI (CI or GITHUB_ACTIONS set): missing node/npm, or a failed install,
+#     is a HARD FAILURE. The gate must never silently pass.
 #   - Locally: the same conditions print a loud warning and exit 0, so a Go-only
 #     development environment can still run `make lint`. CI is authoritative.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PARSER="${REPO_ROOT}/tools/check-docs-mdx-parse.mjs"
-CACHE_DIR="${REPO_ROOT}/.mdx-cache"
+MDX_DIR="${REPO_ROOT}/tools/mdx"
+PARSER="${MDX_DIR}/check-docs-mdx-parse.mjs"
+LOCKFILE="${MDX_DIR}/package-lock.json"
+STAMP="${MDX_DIR}/node_modules/.aicr-lock-digest"
 
 SEARCH_DIRS=("docs/user/" "docs/integrator/" "docs/contributor/")
 EXCLUDE_NAMES=("container-images.md")
@@ -57,52 +65,32 @@ unavailable() {
 command -v node >/dev/null 2>&1 || unavailable "node not found in PATH"
 command -v npm >/dev/null 2>&1 || unavailable "npm not found in PATH"
 
-# Versions come from .settings.yaml so local and CI resolve the same parser —
-# a drifting MDX version would make this gate disagree with the publish step.
-SETTINGS="${REPO_ROOT}/.settings.yaml"
-if command -v yq >/dev/null 2>&1; then
-  MDX_VERSION="$(yq eval '.linting.mdx' "${SETTINGS}")"
-  GFM_VERSION="$(yq eval '.linting.remark_gfm' "${SETTINGS}")"
+if [[ ! -f "${LOCKFILE}" ]]; then
+  echo "ERROR: ${LOCKFILE} is missing — the pinned MDX toolchain cannot be resolved" >&2
+  exit 1
+fi
+
+# Reinstall only when the lockfile changes. Digesting the lockfile (rather than
+# trusting node_modules to exist) means a Renovate bump, a rebase, or a branch
+# switch all re-resolve, while repeat runs on an unchanged tree cost nothing.
+if command -v shasum >/dev/null 2>&1; then
+  LOCK_DIGEST="$(shasum -a 256 "${LOCKFILE}" | awk '{print $1}')"
 else
-  # yq is a documented prerequisite (make tools-setup), but fall back to a
-  # narrow grep so a missing yq degrades to a warning rather than a wrong pin.
-  MDX_VERSION="$(awk '/^  mdx:/ {gsub(/['"'"' ]/, "", $2); print $2}' "${SETTINGS}")"
-  GFM_VERSION="$(awk '/^  remark_gfm:/ {gsub(/['"'"' ]/, "", $2); print $2}' "${SETTINGS}")"
+  LOCK_DIGEST="$(sha256sum "${LOCKFILE}" | awk '{print $1}')"
 fi
 
-if [[ -z "${MDX_VERSION}" || "${MDX_VERSION}" == "null" ]]; then
-  echo "ERROR: .linting.mdx is not set in ${SETTINGS}" >&2
-  exit 1
-fi
-if [[ -z "${GFM_VERSION}" || "${GFM_VERSION}" == "null" ]]; then
-  echo "ERROR: .linting.remark_gfm is not set in ${SETTINGS}" >&2
-  exit 1
-fi
-
-# The parser is copied into CACHE_DIR before running. Node's ESM resolver walks
-# up from the IMPORTING MODULE's directory (NODE_PATH is ignored for ESM), so
-# running the copy from CACHE_DIR is what lets it resolve CACHE_DIR/node_modules
-# without installing into the repo root.
-STAMP="${CACHE_DIR}/.installed"
-WANT="mdx=${MDX_VERSION} gfm=${GFM_VERSION}"
-
-if [[ ! -f "${STAMP}" ]] || [[ "$(cat "${STAMP}")" != "${WANT}" ]]; then
-  mkdir -p "${CACHE_DIR}"
-  echo "Installing pinned MDX toolchain (${WANT})..."
+if [[ ! -f "${STAMP}" ]] || [[ "$(cat "${STAMP}")" != "${LOCK_DIGEST}" ]]; then
+  echo "Installing pinned MDX toolchain from tools/mdx/package-lock.json..."
   # --ignore-scripts: this tree is a lint dependency, not a build artifact, and
   # nothing in it needs a native build step. Declining lifecycle scripts removes
-  # the arbitrary-code-execution path that an unlocked transitive npm tree would
-  # otherwise open on every CI run.
-  if ! npm install \
-    --prefix "${CACHE_DIR}" \
-    --no-save --no-audit --no-fund --no-package-lock --ignore-scripts \
-    "@mdx-js/mdx@${MDX_VERSION}" "remark-gfm@${GFM_VERSION}" >/dev/null 2>&1; then
-    unavailable "npm install of @mdx-js/mdx@${MDX_VERSION} failed (offline?)"
+  # the arbitrary-code-execution path an npm tree would otherwise open on every
+  # CI run. `npm ci` installs the locked tree exactly and fails if package.json
+  # and the lockfile have drifted apart.
+  if ! (cd "${MDX_DIR}" && npm ci --ignore-scripts --no-audit --no-fund >/dev/null 2>&1); then
+    unavailable "npm ci in tools/mdx failed (offline, or package.json and package-lock.json have drifted)"
   fi
-  echo "${WANT}" >"${STAMP}"
+  echo "${LOCK_DIGEST}" >"${STAMP}"
 fi
-
-cp "${PARSER}" "${CACHE_DIR}/check-docs-mdx-parse.mjs"
 
 # Collect files. Paths are reported exactly as `find` yields them, so the
 # default (relative) scan roots produce repo-relative, copy-pasteable
@@ -124,4 +112,7 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
   exit 1
 fi
 
-node "${CACHE_DIR}/check-docs-mdx-parse.mjs" "${FILES[@]}"
+# The parser lives in tools/mdx/ so Node's ESM resolver — which walks up from
+# the IMPORTING MODULE's directory and ignores NODE_PATH — finds
+# tools/mdx/node_modules without any copying or path juggling.
+node "${PARSER}" "${FILES[@]}"

--- a/tools/check-docs-mdx-parse
+++ b/tools/check-docs-mdx-parse
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Parser-level MDX validation for docs/ — resolves the pinned MDX toolchain and
+# runs tools/check-docs-mdx-parse.mjs over every published doc.
+#
+# Why this exists: `fern check` (the Fern Docs CI job) does NOT parse MDX, and
+# `fern generate --docs --preview` (which does) runs in a workflow_run companion
+# whose status never lands on the PR's head SHA — so it can never be a required
+# check. That gap let a bare `<=` in docs/integrator/aks-gpu-setup.md merge green
+# and then fail every publish, including a release tag (issue #2050). This script
+# closes it with a hermetic, token-free parse that CI can block on.
+#
+# Scope mirrors tools/check-docs-mdx: docs/user/, docs/integrator/, and
+# docs/contributor/ (everything published to Fern). container-images.md carries
+# auto-generated HTML comment splice markers, is not published to Fern, and is
+# excluded. Override the scan roots with positional args (used by the tests and
+# for frozen version content).
+#
+# Node availability:
+#   - In CI (CI or GITHUB_ACTIONS set): missing node/npm, or a failed dependency
+#     install, is a HARD FAILURE. The gate must never silently pass.
+#   - Locally: the same conditions print a loud warning and exit 0, so a Go-only
+#     development environment can still run `make lint`. CI is authoritative.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PARSER="${REPO_ROOT}/tools/check-docs-mdx-parse.mjs"
+CACHE_DIR="${REPO_ROOT}/.mdx-cache"
+
+SEARCH_DIRS=("docs/user/" "docs/integrator/" "docs/contributor/")
+EXCLUDE_NAMES=("container-images.md")
+
+if [[ $# -gt 0 ]]; then
+  SEARCH_DIRS=("$@")
+fi
+
+if [[ -n "${CI:-}" || -n "${GITHUB_ACTIONS:-}" ]]; then
+  IN_CI=1
+else
+  IN_CI=0
+fi
+
+# unavailable <reason>: hard-fail under CI, warn-and-skip locally.
+unavailable() {
+  if [[ "${IN_CI}" == "1" ]]; then
+    echo "::error::MDX parse gate cannot run: $1"
+    exit 1
+  fi
+  echo "WARN: skipping MDX parse check — $1"
+  echo "WARN: this check is enforced in CI (merge-gate 'docs-mdx'); install Node 20+ to run it locally."
+  exit 0
+}
+
+command -v node >/dev/null 2>&1 || unavailable "node not found in PATH"
+command -v npm >/dev/null 2>&1 || unavailable "npm not found in PATH"
+
+# Versions come from .settings.yaml so local and CI resolve the same parser —
+# a drifting MDX version would make this gate disagree with the publish step.
+SETTINGS="${REPO_ROOT}/.settings.yaml"
+if command -v yq >/dev/null 2>&1; then
+  MDX_VERSION="$(yq eval '.linting.mdx' "${SETTINGS}")"
+  GFM_VERSION="$(yq eval '.linting.remark_gfm' "${SETTINGS}")"
+else
+  # yq is a documented prerequisite (make tools-setup), but fall back to a
+  # narrow grep so a missing yq degrades to a warning rather than a wrong pin.
+  MDX_VERSION="$(awk '/^  mdx:/ {gsub(/['"'"' ]/, "", $2); print $2}' "${SETTINGS}")"
+  GFM_VERSION="$(awk '/^  remark_gfm:/ {gsub(/['"'"' ]/, "", $2); print $2}' "${SETTINGS}")"
+fi
+
+if [[ -z "${MDX_VERSION}" || "${MDX_VERSION}" == "null" ]]; then
+  echo "ERROR: .linting.mdx is not set in ${SETTINGS}" >&2
+  exit 1
+fi
+if [[ -z "${GFM_VERSION}" || "${GFM_VERSION}" == "null" ]]; then
+  echo "ERROR: .linting.remark_gfm is not set in ${SETTINGS}" >&2
+  exit 1
+fi
+
+# The parser is copied into CACHE_DIR before running. Node's ESM resolver walks
+# up from the IMPORTING MODULE's directory (NODE_PATH is ignored for ESM), so
+# running the copy from CACHE_DIR is what lets it resolve CACHE_DIR/node_modules
+# without installing into the repo root.
+STAMP="${CACHE_DIR}/.installed"
+WANT="mdx=${MDX_VERSION} gfm=${GFM_VERSION}"
+
+if [[ ! -f "${STAMP}" ]] || [[ "$(cat "${STAMP}")" != "${WANT}" ]]; then
+  mkdir -p "${CACHE_DIR}"
+  echo "Installing pinned MDX toolchain (${WANT})..."
+  # --ignore-scripts: this tree is a lint dependency, not a build artifact, and
+  # nothing in it needs a native build step. Declining lifecycle scripts removes
+  # the arbitrary-code-execution path that an unlocked transitive npm tree would
+  # otherwise open on every CI run.
+  if ! npm install \
+    --prefix "${CACHE_DIR}" \
+    --no-save --no-audit --no-fund --no-package-lock --ignore-scripts \
+    "@mdx-js/mdx@${MDX_VERSION}" "remark-gfm@${GFM_VERSION}" >/dev/null 2>&1; then
+    unavailable "npm install of @mdx-js/mdx@${MDX_VERSION} failed (offline?)"
+  fi
+  echo "${WANT}" >"${STAMP}"
+fi
+
+cp "${PARSER}" "${CACHE_DIR}/check-docs-mdx-parse.mjs"
+
+# Collect files. Paths are reported exactly as `find` yields them, so the
+# default (relative) scan roots produce repo-relative, copy-pasteable
+# file:line:column output matching tools/check-docs-mdx.
+FILES=()
+for dir in "${SEARCH_DIRS[@]}"; do
+  exclude_args=()
+  for name in "${EXCLUDE_NAMES[@]}"; do
+    exclude_args+=(! -name "${name}")
+  done
+  while IFS= read -r file; do
+    [[ -z "${file}" ]] && continue
+    FILES+=("${file}")
+  done < <(find "${dir}" -type f \( -name '*.md' -o -name '*.mdx' \) "${exclude_args[@]}" 2>/dev/null | sort)
+done
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "ERROR: no doc files found under: ${SEARCH_DIRS[*]}" >&2
+  exit 1
+fi
+
+node "${CACHE_DIR}/check-docs-mdx-parse.mjs" "${FILES[@]}"

--- a/tools/check-docs-mdx-parse.mjs
+++ b/tools/check-docs-mdx-parse.mjs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parser-level MDX validation for docs/ — the authoritative gate.
+//
+// Fern renders our markdown through MDX, so a construct that is valid
+// CommonMark can still abort `fern generate --docs` at publish time. This
+// script runs the SAME parser Fern does (@mdx-js/mdx, pinned in
+// .settings.yaml) over every published doc and reports the first parse error
+// per file with file:line:column and the parser's own message.
+//
+// Do not invoke directly — `tools/check-docs-mdx-parse` resolves the pinned
+// dependencies and sets NODE_PATH before calling this. It expects the files to
+// check as argv, already filtered by the driver.
+//
+// Relationship to tools/check-docs-mdx: that script is a fast, dependency-free
+// bash approximation kept for the `make lint` fast path. THIS script is the
+// ground truth. Where they disagree, this one is right — and the bash rules
+// are deliberately kept to a strict subset so they never reject content MDX
+// accepts.
+
+import { readFileSync } from 'node:fs'
+import { compile } from '@mdx-js/mdx'
+import remarkGfm from 'remark-gfm'
+
+const files = process.argv.slice(2)
+
+if (files.length === 0) {
+  console.error('usage: check-docs-mdx-parse.mjs <file>...')
+  process.exit(2)
+}
+
+// format: 'mdx' is what makes this faithful. MDX's 'md' format disables JSX
+// and expression parsing entirely, which would silently accept every hazard
+// this gate exists to catch. Fern parses .md as MDX, so we must too.
+//
+// remark-gfm matches Fern's GFM rendering (tables, autolink literals,
+// strikethrough). GFM changes tokenization, so a '<' inside a table cell or
+// adjacent to an autolink can parse differently with and without it — running
+// the same plugin set keeps this gate from drifting from the publish step.
+const options = { format: 'mdx', remarkPlugins: [remarkGfm] }
+
+let failed = 0
+
+for (const file of files) {
+  let source
+  try {
+    source = readFileSync(file, 'utf8')
+  } catch (err) {
+    console.log(`MDX-PARSE: ${file}: cannot read: ${err.message}`)
+    failed++
+    continue
+  }
+
+  try {
+    await compile(source, options)
+  } catch (err) {
+    // VFileMessage carries line/column and a `reason` free of the file prefix;
+    // fall back to message for anything that is not a parse diagnostic.
+    const where = err.line ? `${file}:${err.line}:${err.column}` : file
+    console.log(`MDX-PARSE: ${where}: ${err.reason || err.message}`)
+    failed++
+  }
+}
+
+if (failed > 0) {
+  console.log('')
+  console.log(`ERROR: ${failed} of ${files.length} doc file(s) fail MDX parsing.`)
+  console.log('')
+  console.log('These WILL break `fern generate --docs` at publish time.')
+  console.log('Common fixes:')
+  console.log('  gate <= 2,000        → gate `<= 2,000`   (wrap in a code span)')
+  console.log('  <30 s                → `<30 s`           or &lt;30 s')
+  console.log('  a stray </div> or <> → remove it, or wrap in a code span')
+  console.log('  <br>                 → <br />            (self-close void elements)')
+  console.log('  {template}           → \\{template\\}')
+  process.exit(1)
+}
+
+console.log(`OK: ${files.length} doc file(s) parse as MDX`)

--- a/tools/check-docs-mdx-parse_test.sh
+++ b/tools/check-docs-mdx-parse_test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit harness for tools/check-docs-mdx-parse — the parser-level docs gate.
+# Run directly: bash tools/check-docs-mdx-parse_test.sh
+# Wired into CI via `make test` (test-shell target, runs tools/*_test.sh).
+#
+# Hermetic with respect to docs/: every assertion runs against fixture .md
+# files in a temp dir. It is NOT hermetic with respect to the network — the
+# first run resolves the pinned MDX toolchain via npm. Under CI that is
+# required; locally a missing node/npm is a skip, matching the driver.
+#
+# What this pins:
+#   1. The #2050 regression — '(gate <= 2,000)' must fail, with the parser's
+#      own "Unexpected character `=`" message that Fern emits verbatim.
+#   2. The two hazard classes tools/check-docs-mdx cannot see: a stray closing
+#      tag and an unclosed fragment. These are why the parse gate exists.
+#   3. The false-positive direction — '< 500' style prose must PASS, so the
+#      gate never rejects content `fern generate --docs` accepts.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="${SCRIPT_DIR}/check-docs-mdx-parse"
+
+if [[ -z "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
+    if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+        echo "SKIP: node/npm not available — check-docs-mdx-parse tests are CI-enforced"
+        exit 0
+    fi
+fi
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_TEST}"' EXIT
+
+fails=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1 — $2"; fails=$((fails + 1)); }
+
+OUT=""
+RC=0
+run() {
+    OUT="$("${CHECK}" "$1" 2>&1)"
+    RC=$?
+}
+
+check_rc_nonzero() { # <name>
+    if [[ "${RC}" != "0" ]]; then pass "$1"; else fail "$1" "want nonzero rc, got 0"; fi
+}
+check_rc_zero() { # <name>
+    if [[ "${RC}" == "0" ]]; then pass "$1"; else fail "$1" "want rc=0, got ${RC}: ${OUT}"; fi
+}
+check_contains() { # <name> <needle>
+    if [[ "${OUT}" == *"$2"* ]]; then pass "$1"; else fail "$1" "expected to contain: $2"; fi
+}
+check_absent() { # <name> <needle>
+    if [[ "${OUT}" != *"$2"* ]]; then pass "$1"; else fail "$1" "expected NOT to contain: $2"; fi
+}
+
+# --- Fixture 1: the #2050 regression that broke the docs publish. ---
+DIR_BREAKER="${TMPDIR_TEST}/breaker"
+mkdir -p "${DIR_BREAKER}"
+cat >"${DIR_BREAKER}/bare-lt.md" <<'MD'
+# Bare less-than-or-equal breaks MDX
+
+The Dynamo inference counterpart passes with 579.70 ms TTFT p99 (gate <= 2,000).
+MD
+
+run "${DIR_BREAKER}"
+check_rc_nonzero "breaker-exits-nonzero"
+check_contains   "breaker-cites-file-line-col" "bare-lt.md:3:"
+# Fern emits this exact string; asserting on it is what proves the local gate
+# and the publish step are running the same parser.
+check_contains   "breaker-parser-message" 'Unexpected character `=` (U+003D) before name'
+
+# --- Fixture 2: hazards tools/check-docs-mdx cannot detect. ---
+# A stray closing tag and an unclosed fragment both need parser state to
+# recognize. The bash checker allowlists '/' and '>' after '<' and passes both;
+# this gate must not.
+DIR_TAGS="${TMPDIR_TEST}/tags"
+mkdir -p "${DIR_TAGS}"
+cat >"${DIR_TAGS}/stray-close.md" <<'MD'
+# Stray closing tag
+
+The renderer emits a </div> with no opening tag.
+MD
+cat >"${DIR_TAGS}/open-fragment.md" <<'MD'
+# Unclosed fragment
+
+An empty fragment <> left open in prose.
+MD
+
+run "${DIR_TAGS}"
+check_rc_nonzero "tags-exits-nonzero"
+check_contains   "stray-close-reported" "stray-close.md:"
+check_contains   "open-fragment-reported" "open-fragment.md:"
+
+# --- Fixture 3: MDX-safe prose must PASS (no false positives). ---
+# '<' followed by whitespace stays literal text in MDX. If this fixture ever
+# fails, the gate has become stricter than the publish step and will reject
+# content Fern would have rendered.
+DIR_SAFE="${TMPDIR_TEST}/safe"
+mkdir -p "${DIR_SAFE}"
+cat >"${DIR_SAFE}/safe-prose.md" <<'MD'
+# MDX-safe prose
+
+Embed the cause only when status < 500, since 4xx carries client feedback.
+
+Recipes targeting Kubernetes < 1.15 must enable the feature gate explicitly.
+
+Guards fire before any cluster mutation, so skips are cheap (typically < 10 s).
+
+The wrapped form `<= 2,000` and a self-closed <br /> are both fine.
+
+| Gate | Bound |
+| ---- | ----- |
+| TTFT | `<= 2,000` ms |
+MD
+
+run "${DIR_SAFE}"
+check_rc_zero "safe-exits-zero"
+check_absent  "safe-no-violation" "MDX-PARSE:"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All check-docs-mdx-parse tests passed"

--- a/tools/check-docs-mdx-parse_test.sh
+++ b/tools/check-docs-mdx-parse_test.sh
@@ -134,6 +134,47 @@ run "${DIR_SAFE}"
 check_rc_zero "safe-exits-zero"
 check_absent  "safe-no-violation" "MDX-PARSE:"
 
+# --- Fixture 4: YAML frontmatter is stripped before parsing. ---
+# Fern removes frontmatter before MDX sees it, so a title containing '<=' is
+# valid. Without remark-frontmatter the delimiters parse as a thematic break and
+# the body as prose, and this file was rejected while Fern published it — a
+# false positive on content that ships.
+DIR_FM="${TMPDIR_TEST}/frontmatter"
+mkdir -p "${DIR_FM}"
+cat >"${DIR_FM}/with-frontmatter.md" <<'MD'
+---
+title: Latency gate <= 2,000 ms
+description: TTFT p99 under <= 2,000 ms at 256 concurrency
+---
+
+# Page with frontmatter
+
+Body text with a wrapped `<= 2,000` gate.
+MD
+
+run "${DIR_FM}"
+check_rc_zero "frontmatter-exits-zero"
+check_absent  "frontmatter-no-violation" "MDX-PARSE:"
+
+# --- Fixture 5: a hazard AFTER frontmatter is still caught, at the true line. ---
+# Stripping must not shift reported line numbers, or every diagnostic in a
+# frontmatter file points at the wrong place.
+DIR_FMH="${TMPDIR_TEST}/frontmatter-hazard"
+mkdir -p "${DIR_FMH}"
+cat >"${DIR_FMH}/fm-hazard.md" <<'MD'
+---
+title: Safe here <= 1
+---
+
+# Page
+
+Body hazard gate <= 5 sits on line 7.
+MD
+
+run "${DIR_FMH}"
+check_rc_nonzero "frontmatter-hazard-exits-nonzero"
+check_contains   "frontmatter-hazard-true-line" "fm-hazard.md:7:"
+
 if (( fails > 0 )); then
     echo "${fails} test(s) failed"
     exit 1

--- a/tools/check-docs-mdx-parse_test.sh
+++ b/tools/check-docs-mdx-parse_test.sh
@@ -123,6 +123,8 @@ Guards fire before any cluster mutation, so skips are cheap (typically < 10 s).
 
 The wrapped form `<= 2,000` and a self-closed <br /> are both fine.
 
+So is a <span>styled</span> word and a <Component /> with <Foo bar="baz" />.
+
 | Gate | Bound |
 | ---- | ----- |
 | TTFT | `<= 2,000` ms |

--- a/tools/check-docs-mdx_test.sh
+++ b/tools/check-docs-mdx_test.sh
@@ -57,6 +57,17 @@ check_absent() { # <name> <needle>
     if [[ "${OUT}" != *"$2"* ]]; then pass "$1"; else fail "$1" "expected NOT to contain: $2"; fi
 }
 
+# --- Fixture 0: the script must parse. ---
+# The awk programs live inside single-quoted bash strings, so one apostrophe in
+# a comment ("Fern's") silently terminates the quote and turns the rest of the
+# program into shell tokens. `bash -n` catches that before any behavioral
+# assertion has to.
+if bash -n "${CHECK}" 2>/dev/null; then
+    pass "script-parses"
+else
+    fail "script-parses" "bash -n reported a syntax error (an apostrophe inside the awk block?)"
+fi
+
 # --- Fixture 1: the #2050 regression — a bare '<= ' outside any code span. ---
 # The checker MUST fail closed here. If check 6 is removed, this token is not
 # a void element (check 1), autolink (check 4), or <name-start> tag (check 5),
@@ -118,6 +129,47 @@ run "${DIR_WS}"
 check_rc_zero "lt-space-exits-zero"
 check_absent  "lt-space-no-violation" "bare < not starting a valid tag"
 check_absent  "lt-space-no-word-tag"  "bare <word> tag"
+
+# --- Fixture 2d: well-formed JSX must NOT be reported. ---
+# MDX accepts self-closing components and balanced elements, and Fern's own
+# component set (Cards, Tabs, Accordions) is authored that way. Check 5 used to
+# flag every '<' followed by a letter, so it rejected all of these. A line
+# showing evidence of well-formed JSX ('/>' or '</') is now left to the parse
+# gate, which can actually tell whether the tags balance.
+DIR_JSX="${TMPDIR_TEST}/jsx"
+mkdir -p "${DIR_JSX}"
+cat >"${DIR_JSX}/valid-jsx.md" <<'MD'
+# Well-formed JSX is valid MDX
+
+A <span>styled</span> word renders fine.
+
+A self-closing <Component /> renders fine.
+
+So does <Foo bar="baz" /> with attributes.
+
+And a void element like <br /> stays clean.
+MD
+
+run "${DIR_JSX}"
+check_rc_zero "valid-jsx-exits-zero"
+check_absent  "valid-jsx-no-word-tag"  "bare <word> tag"
+check_absent  "valid-jsx-no-void"      "non-self-closing void element"
+check_absent  "valid-jsx-no-bare-lt"   "bare < not starting a valid tag"
+
+# --- Fixture 2e: an unbalanced placeholder is still caught. ---
+# Narrowing check 5 must not blind it to the case it exists for: a bare
+# '<word>' placeholder on a line with no JSX evidence.
+DIR_PLACEHOLDER="${TMPDIR_TEST}/placeholder"
+mkdir -p "${DIR_PLACEHOLDER}"
+cat >"${DIR_PLACEHOLDER}/placeholder.md" <<'MD'
+# Bare placeholder
+
+Pass <name> to select the component you want to bundle.
+MD
+
+run "${DIR_PLACEHOLDER}"
+check_rc_nonzero "placeholder-exits-nonzero"
+check_contains   "placeholder-reported" "MDX: bare <word> tag outside code fence"
 
 # --- Fixture 2c: '<30' must produce exactly ONE diagnostic, not two. ---
 # Check 5 owns letter-prefixed names and check 6 owns everything that cannot

--- a/tools/check-docs-mdx_test.sh
+++ b/tools/check-docs-mdx_test.sh
@@ -171,6 +171,37 @@ run "${DIR_PLACEHOLDER}"
 check_rc_nonzero "placeholder-exits-nonzero"
 check_contains   "placeholder-reported" "MDX: bare <word> tag outside code fence"
 
+# --- Fixture 2f: YAML frontmatter is not scanned; content after it still is. ---
+# Fern strips frontmatter before MDX, so '<=' in a title is valid. Skipping it
+# by line number (rather than rewriting the file) keeps later diagnostics
+# pointing at the true line.
+DIR_FM="${TMPDIR_TEST}/frontmatter"
+mkdir -p "${DIR_FM}"
+cat >"${DIR_FM}/fm-safe.md" <<'MD'
+---
+title: Latency gate <= 2,000 ms
+description: TTFT p99 under <= 2,000 ms
+---
+
+# Page
+
+Body text with a wrapped `<= 2,000` gate.
+MD
+cat >"${DIR_FM}/fm-hazard.md" <<'MD'
+---
+title: Safe here <= 1
+---
+
+# Page
+
+Body hazard gate <= 5 sits on line 7.
+MD
+
+run "${DIR_FM}"
+check_rc_nonzero "frontmatter-hazard-exits-nonzero"
+check_absent     "frontmatter-title-not-flagged" "fm-safe.md"
+check_contains   "frontmatter-hazard-true-line"  "fm-hazard.md:7:"
+
 # --- Fixture 2c: '<30' must produce exactly ONE diagnostic, not two. ---
 # Check 5 owns letter-prefixed names and check 6 owns everything that cannot
 # start a name, so a digit-prefixed sequence belongs to check 6 alone. When

--- a/tools/check-docs-mdx_test.sh
+++ b/tools/check-docs-mdx_test.sh
@@ -89,12 +89,58 @@ The TTFT p99 stays low (gate `<= 2,000`) under the calibrated inference gate.
 inference-perf TTFT p99 gate <= 2,000 ms
 ```
 
-A valid element like <br /> and a closing </div> must also stay clean.
+A valid element like <br /> stays clean.
 MD
 
 run "${DIR_SAFE}"
 check_rc_zero  "wrapped-lt-exits-zero"
 check_absent   "wrapped-lt-no-violation" "bare < not starting a valid tag"
+
+# --- Fixture 2b: '<' followed by WHITESPACE. Must NOT be reported. ---
+# Verified against @mdx-js/mdx: micromark only enters JSX-tag mode when a
+# name-ish character follows '<' immediately, so '< 500' and friends stay
+# literal text and parse cleanly. This checker is a strict subset of the real
+# parser, so reporting them here would be a false positive — it would force
+# contributors to backtick prose that `fern generate --docs` accepts.
+DIR_WS="${TMPDIR_TEST}/whitespace"
+mkdir -p "${DIR_WS}"
+cat >"${DIR_WS}/lt-space.md" <<'MD'
+# Less-than followed by whitespace is literal text
+
+Embed the cause only when status < 500, since 4xx carries client feedback.
+
+Recipes targeting Kubernetes < 1.15 must enable the feature gate explicitly.
+
+Guards fire before any cluster mutation, so skips are cheap (typically < 10 s).
+MD
+
+run "${DIR_WS}"
+check_rc_zero "lt-space-exits-zero"
+check_absent  "lt-space-no-violation" "bare < not starting a valid tag"
+check_absent  "lt-space-no-word-tag"  "bare <word> tag"
+
+# --- Fixture 2c: '<30' must produce exactly ONE diagnostic, not two. ---
+# Check 5 owns letter-prefixed names and check 6 owns everything that cannot
+# start a name, so a digit-prefixed sequence belongs to check 6 alone. When
+# check 5 also matched digits, one source token emitted two lines and
+# double-incremented the error count.
+DIR_DIGIT="${TMPDIR_TEST}/digit"
+mkdir -p "${DIR_DIGIT}"
+cat >"${DIR_DIGIT}/digit-tag.md" <<'MD'
+# Digit-prefixed angle bracket
+
+Cold start completes in <30 s on a warm cache.
+MD
+
+run "${DIR_DIGIT}"
+check_rc_nonzero "digit-tag-exits-nonzero"
+check_contains   "digit-tag-reported" "MDX: bare < not starting a valid tag"
+check_absent     "digit-tag-not-double-reported" "MDX: bare <word> tag"
+if [[ "$(grep -c 'digit-tag.md:3:' <<<"${OUT}")" == "1" ]]; then
+    pass "digit-tag-single-diagnostic"
+else
+    fail "digit-tag-single-diagnostic" "want exactly 1 diagnostic for line 3, got $(grep -c 'digit-tag.md:3:' <<<"${OUT}")"
+fi
 
 # --- Fixture 3: '<= ' inside a tilde (~~~) fenced code block. No false pos. ---
 # CommonMark honors ~~~ fences as code; the checker must skip their contents

--- a/tools/docs-published-files
+++ b/tools/docs-published-files
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Emits the repo-relative path of every page Fern publishes, one per line,
+# derived from docs/index.yml — Fern's navigation manifest and therefore the
+# authoritative list of what `fern generate --docs` will parse.
+#
+# Both MDX checkers consume this instead of globbing docs/user, docs/integrator
+# and docs/contributor. That glob was a denylist in disguise: it missed
+# docs/README.md, the published Introduction page, so a bare `<=` there passed
+# both gates and still broke the publish. Deriving from the nav closes the class
+# — a page added to index.yml is gated the day it is added, and a file that is
+# not published is not gated at all.
+#
+# Requires yq, which the Makefile already depends on at parse time.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NAV="${REPO_ROOT}/docs/index.yml"
+
+if [[ ! -f "${NAV}" ]]; then
+  echo "ERROR: ${NAV} not found — cannot determine which docs Fern publishes" >&2
+  exit 1
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: yq is required to read ${NAV} (run: make tools-setup)" >&2
+  exit 1
+fi
+
+# Recursive: pages nest under `section:` entries (e.g. Components), so a
+# top-level query would silently drop them.
+PATHS="$(yq eval '.. | select(has("path")) | .path' "${NAV}")"
+
+if [[ -z "${PATHS}" ]]; then
+  echo "ERROR: no page paths found in ${NAV}" >&2
+  exit 1
+fi
+
+# Collect into an array rather than piping the loop straight into `sort`: a
+# piped loop runs in a subshell, so the `missing` counter would be discarded
+# and the exit below could never fire.
+files=()
+missing=0
+while IFS= read -r rel; do
+  [[ -z "${rel}" || "${rel}" == "null" ]] && continue
+  # A nav entry pointing at a file that does not exist breaks the publish just
+  # as surely as a parse error, so surface it here rather than at release time.
+  if [[ ! -f "${REPO_ROOT}/docs/${rel}" ]]; then
+    echo "ERROR: docs/index.yml references docs/${rel}, which does not exist" >&2
+    missing=$((missing + 1))
+    continue
+  fi
+  files+=("docs/${rel}")
+done <<<"${PATHS}"
+
+if [[ ${missing} -gt 0 ]]; then
+  exit 1
+fi
+
+printf '%s\n' "${files[@]}" | sort -u

--- a/tools/mdx/check-docs-mdx-parse.mjs
+++ b/tools/mdx/check-docs-mdx-parse.mjs
@@ -16,13 +16,13 @@
 //
 // Fern renders our markdown through MDX, so a construct that is valid
 // CommonMark can still abort `fern generate --docs` at publish time. This
-// script runs the SAME parser Fern does (@mdx-js/mdx, pinned in
-// .settings.yaml) over every published doc and reports the first parse error
-// per file with file:line:column and the parser's own message.
+// script runs the SAME parser Fern does (@mdx-js/mdx, locked in
+// ./package-lock.json) over every published doc and reports the first parse
+// error per file with file:line:column and the parser's own message.
 //
-// Do not invoke directly — `tools/check-docs-mdx-parse` resolves the pinned
-// dependencies and sets NODE_PATH before calling this. It expects the files to
-// check as argv, already filtered by the driver.
+// It lives beside package.json so Node's ESM resolver finds ./node_modules by
+// walking up from this file. Do not invoke directly — `tools/check-docs-mdx-parse`
+// installs the locked tree first and passes the files to check as argv.
 //
 // Relationship to tools/check-docs-mdx: that script is a fast, dependency-free
 // bash approximation kept for the `make lint` fast path. THIS script is the

--- a/tools/mdx/check-docs-mdx-parse.mjs
+++ b/tools/mdx/check-docs-mdx-parse.mjs
@@ -32,6 +32,7 @@
 
 import { readFileSync } from 'node:fs'
 import { compile } from '@mdx-js/mdx'
+import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 
 const files = process.argv.slice(2)
@@ -45,11 +46,22 @@ if (files.length === 0) {
 // and expression parsing entirely, which would silently accept every hazard
 // this gate exists to catch. Fern parses .md as MDX, so we must too.
 //
-// remark-gfm matches Fern's GFM rendering (tables, autolink literals,
-// strikethrough). GFM changes tokenization, so a '<' inside a table cell or
-// adjacent to an autolink can parse differently with and without it — running
-// the same plugin set keeps this gate from drifting from the publish step.
-const options = { format: 'mdx', remarkPlugins: [remarkGfm] }
+// The plugin set must mirror what Fern renders with, or the gate drifts from
+// the publish step in one direction or the other:
+//
+//   remark-gfm         — tables, autolink literals, strikethrough. GFM changes
+//                        tokenization, so a '<' inside a table cell or next to
+//                        an autolink can parse differently with and without it.
+//   remark-frontmatter — Fern strips YAML frontmatter before MDX sees it.
+//                        Without this plugin the delimiters parse as a thematic
+//                        break and the frontmatter body as prose, so a title
+//                        like `gate <= 2,000` was rejected here while Fern
+//                        published it happily. That is the false-positive
+//                        direction this gate must never take.
+const options = {
+  format: 'mdx',
+  remarkPlugins: [remarkFrontmatter, remarkGfm],
+}
 
 let failed = 0
 

--- a/tools/mdx/package-lock.json
+++ b/tools/mdx/package-lock.json
@@ -1,0 +1,2001 @@
+{
+  "name": "@aicr/docs-mdx-gate",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@aicr/docs-mdx-gate",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mdx-js/mdx": "3.1.1",
+        "remark-gfm": "4.0.1"
+      }
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/tools/mdx/package-lock.json
+++ b/tools/mdx/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mdx-js/mdx": "3.1.1",
+        "remark-frontmatter": "5.0.0",
         "remark-gfm": "4.0.1"
       }
     },
@@ -419,6 +420,27 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -615,6 +637,24 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -935,6 +975,22 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -1702,6 +1758,22 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/tools/mdx/package.json
+++ b/tools/mdx/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@aicr/docs-mdx-gate",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned MDX toolchain for tools/check-docs-mdx-parse — the blocking docs gate. package-lock.json freezes the FULL transitive tree so the gate's verdict is reproducible: an upstream patch release must not be able to change which docs pass without a repository change.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "dependencies": {
+    "@mdx-js/mdx": "3.1.1",
+    "remark-gfm": "4.0.1"
+  }
+}

--- a/tools/mdx/package.json
+++ b/tools/mdx/package.json
@@ -2,11 +2,12 @@
   "name": "@aicr/docs-mdx-gate",
   "version": "0.0.0",
   "private": true,
-  "description": "Pinned MDX toolchain for tools/check-docs-mdx-parse — the blocking docs gate. package-lock.json freezes the FULL transitive tree so the gate's verdict is reproducible: an upstream patch release must not be able to change which docs pass without a repository change.",
+  "description": "Pinned MDX toolchain for tools/check-docs-mdx-parse \u2014 the blocking docs gate. Plugin set mirrors what Fern renders with (GFM, YAML frontmatter) so the gate agrees with `fern generate --docs`. package-lock.json freezes the FULL transitive tree so the gate's verdict is reproducible: an upstream patch release must not be able to change which docs pass without a repository change.",
   "license": "Apache-2.0",
   "type": "module",
   "dependencies": {
     "@mdx-js/mdx": "3.1.1",
+    "remark-frontmatter": "5.0.0",
     "remark-gfm": "4.0.1"
   }
 }


### PR DESCRIPTION
## Summary

Make parser-level MDX validation a blocking merge check, and narrow the existing pattern checker to a strict subset of what the real parser rejects.

## Motivation / Context

`fern check` (the Fern Docs CI job) validates nav/config — it does **not** parse MDX. The job that does, `fern generate --docs --preview`, runs as a `workflow_run` companion whose status never lands on the PR head SHA, so it can never be a required check. That gap let a bare `<=` in `docs/integrator/aks-gpu-setup.md` merge green and then fail *every* docs publish, including the `v0.18.0` release tag (run 30029834883).

Fixes: N/A
Related: #2050, #2127, #2144

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tools/check-docs-mdx*`, `merge-gate.yaml`, `Makefile`, `.settings.yaml`

## Implementation Notes

**The gate.** `tools/check-docs-mdx-parse` runs `@mdx-js/mdx` (locked in `tools/mdx/package-lock.json`) over every published doc. It is the same parser Fern uses — the error text is byte-identical:

```
Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`
```

Wired as the `docs-mdx` / `docs-mdx-skip` job pair in `merge-gate.yaml`, following the idiom documented in that file's header, so it rolls into the single required `gate` check with no ruleset change.

Chose a hermetic local parse over making `Preview Fern Docs: Comment` blocking. The preview route would put `DOCS_FERN_TOKEN` and Fern's SaaS availability in the merge path, and would require the Build workflow to lose its paths filter so non-docs PRs don't hang on a status that never arrives.

**Why the pattern checker was narrowed.** I probed the real parser against every `<`-follow form. `tools/check-docs-mdx` was wrong in *both* directions:

| Form | `check-docs-mdx` (before) | Real MDX |
|---|---|---|
| `gate <= 2,000` | flags | rejects — agree |
| `status < 500`, `< 1.15`, `< 10 s` | flags | **accepts** — false positive |
| stray `</div>` | passes (allowlisted `/`) | **rejects** — false negative |
| `<>` fragment | passes (allowlisted `>`) | **rejects** — false negative |

MDX only enters JSX-tag mode when a name-ish character follows `<` immediately, so `<` + whitespace stays literal text. Only `aks-gpu-setup.md:312` was ever the publish breaker; three of the four doc edits in #2127 weren't required.

The rules are now a deliberate strict **subset** of the parser. A miss costs a caught failure at the blocking gate; a false positive costs contributors mangling prose the publish step accepts — so under-reporting is the correct direction. `</div>` and `<>` need parser state and are left to the gate.

Also fixes two items from #2144: check 5 matches letters only (a digit-prefixed sequence emitted two diagnostics and double-incremented the error count), and the header no longer claims inline-span stripping applies to check 1. Fence-indent and multi-line-span handling stay open there, now noted in the script.

**Reproducibility.** The toolchain lives in `tools/mdx/` with a committed `package.json` + `package-lock.json` (131 packages, all exact + integrity-hashed), installed via `npm ci --ignore-scripts`. A version string alone cannot freeze the transitive tree, and a gate that decides which docs merge must not change its verdict between two runs of the same commit. `.settings.yaml` carries a pointer rather than a duplicate pin — the same split Go has with `.go-version` — and Renovate updates the lockfile natively.

**Node dependency.** `make lint` gains the parse check, so the "if `make qualify` passes locally, CI will pass" contract holds. Without Node the script warns and exits 0 locally, but **hard-fails** when `CI`/`GITHUB_ACTIONS` is set. The installed tree is gitignored and excluded from `addlicense` (it was otherwise stamping NVIDIA copyright headers onto third-party files) and from `YAML_FILES`.

**Review follow-ups (9caaacd5).** Three Major findings from CodeRabbit, all verified against the parser before fixing:

1. *Full tree not frozen* — `--no-package-lock` left transitives on registry ranges. Now `npm ci` from a committed lockfile (above).
2. *Check 5 rejected valid JSX* — it flagged `<span>text</span>` and `<Component />`, which MDX accepts and Fern components are authored with. Lines showing `/>` or `</` now defer to the parse gate; an unbalanced `<name>` is still caught. Pre-existing, but the strict-subset invariant this PR adds made it a contradiction.
3. *`Makefile` missing from the `docs` filter* — the job invokes `make check-docs-mdx-parse`, so a Makefile-only change could neuter the gate while `docs=false` ran `docs-mdx-skip`. Matches why `renovate` and `notices` already watch it.

## Testing

```bash
./tools/check-docs-mdx           # OK: all doc files are MDX-safe
./tools/check-docs-mdx-parse     # OK: 53 doc file(s) parse as MDX
make test-shell                  # both suites pass
make lint-go                     # 0 issues
make lint-yaml                   # PASS
make license                     # PASS (no longer walks .mdx-cache)
```

New `tools/check-docs-mdx-parse_test.sh` (8 assertions, wired into `make test-shell`) pins:

- the #2050 regression, asserting on the parser's verbatim message — that assertion is what proves this gate and the publish step run the same parser;
- the two classes the bash checker cannot see (stray closing tag, unclosed fragment);
- the false-positive direction — `< 500` style prose must pass.

`tools/check-docs-mdx_test.sh` gains fixtures for whitespace-after-`<` and single-diagnostic-per-token.

Behavior verified directly:

```
$ env -i PATH=/usr/bin:/bin bash tools/check-docs-mdx-parse
WARN: skipping MDX parse check — node not found in PATH     (rc=0)

$ env -i PATH=/usr/bin:/bin CI=true bash tools/check-docs-mdx-parse
::error::MDX parse gate cannot run: node not found in PATH  (rc=1)
```

No Go source changed, so the coverage gate does not apply. `make qualify` was not run end-to-end locally: `check-agents-sync` fails in my sandbox because it uses process substitution (`/dev/fd/63: Operation not permitted`) — `AGENTS.md` and `.claude/CLAUDE.md` are byte-identical, and neither was touched.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Medium because it adds a job to the required merge gate and a Node dependency to `make lint`. Both are contained: the job is one more real/skip pair in an established pattern, and the lint step degrades to a warning without Node. Reverting is a clean revert of this commit.

**Rollout notes:** First PR touching `docs/user|integrator|contributor/**` after merge will run `docs-mdx` (~40 s, most of it `npm install`). Contributors without Node see a warning, not a failure.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

