### PR TITLE
docs: v0.19 doc sweep — fix drift, stale versions, broken commands

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,7 +38,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
 unset GITLAB_TOKEN
 
 # Development workflow
-make qualify      # Full check: test + lint + e2e + scan (run before PR)
+make qualify      # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff (run before PR)
 make test         # Unit tests with -race
 make lint         # golangci-lint + yamllint
 make scan         # Grype vulnerability scan
@@ -558,7 +558,7 @@ Process and unique findings below; the rule sections above (Error Wrapping, Cont
 
 ## Pull Request Requirements
 
-**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers tests, linting (golangci-lint + yamllint), e2e, vulnerability scan, and repo-specific checks (docs sidebar, agents sync). Do not substitute a subset of commands — if `make qualify` passes locally, CI will pass.
+**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers coverage-gated tests, linting (golangci-lint + yamllint + license headers, agents sync, docs filename/MDX gates, chart-version pins), tuning-check, e2e, vulnerability scan, license allowlist check, and API compatibility (api-diff). Do not substitute a subset of commands — `make qualify` is the closest local equivalent of the CI gate. A few checks run only in CI (e.g. the lychee docs link check on `docs/**` PRs, CodeQL, and the GPU test lanes), so a green local `qualify` does not guarantee every CI job passes.
 
 **Mandatory lint gate for Go changes:** If your PR changes any `.go` files, you MUST run `golangci-lint run -c .golangci.yaml` on each affected package path (e.g., `./pkg/recipe/...`, `./cmd/aicr/...`, `./tests/chainsaw/...`) and confirm zero issues before creating or pushing the PR. For a full module scan, use `./...`. Do not rely on CI to catch lint failures — fix them locally first. This applies even to PRs labeled as "documentation only" if they include Go code changes.
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -69,10 +69,10 @@ This action runs `tools/setup-tools --skip-go --skip-docker` in auto mode, which
 #### `load-versions/`
 **Purpose**: Load tool versions from `.settings.yaml` as workflow outputs
 **When to use**: When you need version values in workflow steps
-**Outputs**:
-- `go`, `goreleaser`, `ko`, `crane`, `golangci_lint`, `yamllint`, `addlicense`
-- `grype`, `kubectl`, `kind`, `nvkind`, `ctlptl`, `tilt`, `helm`
-- `kind_node_image`, `h100_kind_node_image`
+**Outputs**: the Go version (from `.go-version`), plus one output per exposed
+`.settings.yaml` pin (tool versions, chart versions, image references, and
+quality thresholds; not every settings key is exposed) — see
+[`load-versions/action.yml`](load-versions/action.yml) for the authoritative set.
 
 **Example**:
 ```yaml
@@ -92,7 +92,7 @@ This action runs `tools/setup-tools --skip-go --skip-docker` in auto mode, which
 - `install_ko` (optional): Install ko (default: "false")
 - `install_syft` (optional): Install syft (default: "false")
 - `install_crane` (optional): Install crane (default: "false")
-- `crane_version` (optional): crane version (default: "v0.20.6")
+- `crane_version` (optional): crane version (default: "v0.21.0")
 - `install_goreleaser` (optional): Install goreleaser (default: "false")
 - `goreleaser_version` (required when `install_goreleaser: "true"`): GoReleaser version from `load-versions`
 
@@ -102,7 +102,7 @@ This action runs `tools/setup-tools --skip-go --skip-docker` in auto mode, which
   with:
     install_ko: 'true'
     install_crane: 'true'
-    crane_version: 'v0.20.6'
+    crane_version: 'v0.21.0'
 ```
 
 #### `go-build-release/`
@@ -215,7 +215,7 @@ are explained in the action's header comment.
 - `go_version` (required): Go version to install
 - `goreleaser_version` (required): GoReleaser version from `load-versions`
 - `kind_version` (optional): Kind version (default: "0.31.0")
-- `helm_version` (optional): Helm version (default: "v4.1.0")
+- `helm_version` (optional): Helm version (default: "v4.1.1")
 - `kwok_version` (optional): KWOK version (default: "v0.7.0")
 - `kubectl_version` (optional): kubectl version (default: "v1.35.0")
 
@@ -454,7 +454,7 @@ To use these actions in other repositories:
 - uses: NVIDIA/aicr/.github/actions/go-test@main
   with:
     go_version: '1.26'
-    helm_version: 'v4.2.2'
+    helm_version: 'v4.2.3'
     coverage_report: 'true'
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
 unset GITLAB_TOKEN
 
 # Development workflow
-make qualify      # Full check: test + lint + e2e + scan (run before PR)
+make qualify      # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff (run before PR)
 make test         # Unit tests with -race
 make lint         # golangci-lint + yamllint
 make scan         # Grype vulnerability scan
@@ -558,7 +558,7 @@ Process and unique findings below; the rule sections above (Error Wrapping, Cont
 
 ## Pull Request Requirements
 
-**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers tests, linting (golangci-lint + yamllint), e2e, vulnerability scan, and repo-specific checks (docs sidebar, agents sync). Do not substitute a subset of commands — if `make qualify` passes locally, CI will pass.
+**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers coverage-gated tests, linting (golangci-lint + yamllint + license headers, agents sync, docs filename/MDX gates, chart-version pins), tuning-check, e2e, vulnerability scan, license allowlist check, and API compatibility (api-diff). Do not substitute a subset of commands — `make qualify` is the closest local equivalent of the CI gate. A few checks run only in CI (e.g. the lychee docs link check on `docs/**` PRs, CodeQL, and the GPU test lanes), so a green local `qualify` does not guarantee every CI job passes.
 
 **Mandatory lint gate for Go changes:** If your PR changes any `.go` files, you MUST run `golangci-lint run -c .golangci.yaml` on each affected package path (e.g., `./pkg/recipe/...`, `./cmd/aicr/...`, `./tests/chainsaw/...`) and confirm zero issues before creating or pushing the PR. For a full module scan, use `./...`. Do not rely on CI to catch lint failures — fix them locally first. This applies even to PRs labeled as "documentation only" if they include Go code changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions from developers of all backgrounds and experience level
 
 ## Code of Conduct
 
-This project follows NVIDIA's commitment to fostering an open and welcoming environment. Please be respectful and professional in all interactions. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for details.
+This project adopts the Contributor Covenant v2.1. Please be respectful and professional in all interactions. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for details.
 
 ## Getting Started
 
@@ -138,7 +138,7 @@ More specific recipes are never matched unless explicitly requested. Generic int
 
 Trust is established through evidence, not assertions. Every released artifact carries verifiable proof of origin and build process.
 
-**What:** All releases include SLSA build provenance (build level under review, #1536), SBOM attestations, and Sigstore signatures. Users can verify exactly which commit, workflow, and build produced any artifact.
+**What:** Releases include SLSA Build Level 3 provenance for container images (via the reusable attestation workflow, since v0.17.0) and SLSA Build Provenance v1 for CLI binaries, plus SBOM attestations and Sigstore signatures. Users can verify exactly which commit, workflow, and build produced any artifact.
 
 **Why:** This underpins supply-chain security, compliance, and confidence. "Trust us" is not a security model.
 
@@ -170,7 +170,7 @@ Trust is established through evidence, not assertions. Every released artifact c
 
 ### Review Process
 
-1. **Automated Checks** run via GitHub Actions — the same gate `make qualify` runs locally (tests with race detector, golangci-lint, YAML linting, security scan, coverage, E2E). See [Full Qualification](DEVELOPMENT.md#7-full-qualification) in the development guide.
+1. **Automated Checks** run via GitHub Actions — the same gate `make qualify` runs locally. See [Full Qualification](DEVELOPMENT.md#7-full-qualification) and the [Make Targets Reference](DEVELOPMENT.md#make-targets-reference) in the development guide.
 
 2. **Maintainer Review** covers:
    - Correctness and functionality

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ make lint           # Run linters
 make build          # Build binaries
 
 # 3. Before submitting PR
-make qualify        # Full check: test + lint + e2e + scan
+make qualify        # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff
 ```
 
 ## Prerequisites
@@ -54,6 +54,11 @@ make qualify        # Full check: test + lint + e2e + scan
 | ctlptl | Local cluster + registry management (for Tilt) |
 | tilt | Local Kubernetes dev environment with hot reload |
 | kubectl | Kubernetes CLI |
+| chainsaw | Declarative Kubernetes e2e testing |
+| cosign | Artifact signing and attestation |
+| helmfile | Declarative Helm release management |
+
+This table is a summary — run `make tools-check` for the full pinned set from `.settings.yaml`.
 
 ### Linux-Specific Setup
 
@@ -104,16 +109,13 @@ Example `make tools-check` output:
 
 Tool                 Expected        Installed       Status
 ----                 --------        ---------       ------
-go                   1.26            1.26            ✓
-golangci-lint        v2.11.3         2.11.3          ✓
-grype                v0.107.0        0.107.0         ✓
-ko                   v0.18.0         0.18.0          ✓
-goreleaser           v2              2.13.3          ✓
-helm                 v4.1.1          v4.1.1          ✓
-kind                 0.31.0          0.31.0          ✓
-yamllint             1.38.0          1.38.0          ✓
-kubectl              v1.35.0         v1.35.0         ✓
-docker               -               24.0.7          ✓
+go                   <pinned>        <installed>     ✓
+golangci-lint        <pinned>        <installed>     ✓
+grype                <pinned>        <installed>     ✓
+ko                   <pinned>        <installed>     ✓
+...
+
+(Expected versions come from `.settings.yaml` — the single source of truth.)
 
 Legend: ✓ = installed, ⚠ = version mismatch, ✗ = missing
 ```
@@ -133,7 +135,7 @@ Edit `.settings.yaml` to update versions; changes propagate everywhere automatic
 After installing tools:
 
 ```bash
-# Download Go module dependencies
+# Format, tidy, and vendor dependencies; regenerate THIRD_PARTY_NOTICES.md
 make tidy
 
 # Run full qualification to ensure setup is correct
@@ -215,13 +217,13 @@ make test-coverage
 ### 4. Lint Your Code
 
 ```bash
-# Run all linters (Go, YAML, license headers)
+# Run all linters (Go, YAML, license headers, agents sync, docs filename/MDX gates, chart-version pins)
 make lint
 
-# Or run individually
+# Or run individually for a faster loop (all of these already run as part of `make lint`)
 make lint-go      # Go linting only
 make lint-yaml    # YAML linting only
-make license      # License header check
+make license      # Add/verify license headers (may modify files)
 
 # Docs published to Fern are parsed as MDX; both checks gate the merge
 make check-docs-mdx        # fast pattern approximation (no dependencies)
@@ -260,7 +262,7 @@ Before submitting a PR, run everything:
 make qualify
 ```
 
-This runs: `test` → `lint` → `e2e` → `scan`
+This runs: `test-coverage` → `lint` → `tuning-check` → `e2e` → `scan` → `license-check` → `api-diff`
 
 ## Local Kubernetes Development
 
@@ -413,11 +415,11 @@ curl "http://localhost:8080/v1/recipe?os=ubuntu&service=eks"
 │       │         ┌─────────────────────────┘             │
 │       ▼         ▼                                       │
 │  ┌─────────────────────────────────────────────────┐    │
-│  │              Kind Cluster (kind-aicr)          │    │
+│  │              Kind Cluster (kind-aicr)           │    │
 │  │  ┌─────────────────────────────────────────┐    │    │
-│  │  │           Namespace: aicr              │    │    │
+│  │  │           Namespace: aicr               │    │    │
 │  │  │  ┌─────────────┐  ┌─────────────────┐   │    │    │
-│  │  │  │   aicrd    │  │    Service      │   │    │    │
+│  │  │  │   aicrd     │  │    Service      │   │    │    │
 │  │  │  │ Deployment  │◀─│  (ClusterIP)    │   │    │    │
 │  │  │  └─────────────┘  └─────────────────┘   │    │    │
 │  │  └─────────────────────────────────────────┘    │    │
@@ -441,19 +443,21 @@ make kwok-e2e RECIPE=gb200-eks-training # Test single recipe
 
 Recipes with `spec.criteria.service` defined are auto-discovered. KWOK validates scheduling (node selectors, tolerations, resource requests) but not runtime behavior (no container execution or GPU functionality).
 
-For the deployer matrix (argocd / argocd-helm OCI lanes), see [Deployer Matrix Testing](docs/contributor/tests.md).
+For the deployer matrix (argocd / argocd-helm OCI lanes), see [Deployer Coverage Matrix](docs/contributor/tests.md#deployer-coverage-matrix).
 
 | Command | Description |
 |---------|-------------|
 | `make kwok-test-all` | Test all recipes in shared cluster (serial) |
 | `make kwok-e2e RECIPE=<name>` | Full e2e: cluster, nodes, validate |
 | `make kwok-test-deployer RECIPE=<name> DEPLOYER=<name>` | Validate single recipe under a specific deployer (`helm`, `argocd-oci`, `argocd-helm-oci`) |
+| `make kwok-test RECIPE=<name>` | Validate bundle scheduling on an existing KWOK cluster |
 | `make kwok-cluster` | Create Kind cluster with KWOK |
+| `make kwok-nodes RECIPE=<name>` | Create KWOK nodes from a recipe overlay |
+| `make kwok-nodes-delete` | Delete all KWOK-simulated nodes |
 | `make kwok-status` | Show cluster and node status |
 | `make kwok-cluster-delete` | Delete cluster |
 
 See [kwok/README.md](kwok/README.md) for adding recipes, profiles, and troubleshooting.
-
 
 ## Make Targets Reference
 
@@ -461,10 +465,10 @@ See [kwok/README.md](kwok/README.md) for adding recipes, profiles, and troublesh
 
 | Target | Description |
 |--------|-------------|
-| `make qualify` | Full qualification (test + lint + e2e + scan) |
+| `make qualify` | Full qualification (test-coverage, lint, tuning-check, e2e, scan, license-check, api-diff) |
 | `make test` | Unit tests with race detector and coverage |
 | `make test-coverage` | Tests with coverage threshold (from `.settings.yaml` `quality.coverage_threshold`) |
-| `make lint` | Lint Go, YAML, and verify license headers |
+| `make lint` | Lint Go and YAML; verify license headers, agents sync, docs filename/MDX gates, and chart-version pins |
 | `make lint-go` | Go linting only |
 | `make lint-yaml` | YAML linting only |
 | `make e2e` | CLI end-to-end tests |
@@ -488,6 +492,8 @@ See [kwok/README.md](kwok/README.md) for adding recipes, profiles, and troublesh
 | `make bump-major` | Bump major version (1.2.3 → 2.0.0) |
 | `make bump-minor` | Bump minor version (1.2.3 → 1.3.0) |
 | `make bump-patch` | Bump patch version (1.2.3 → 1.2.4) |
+| `make bump-rc` | Tag RC pre-release (v1.2.3 → v1.3.0-rc1 → v1.3.0-rc2) |
+| `make bump-promote TAG=<rc-tag>` | Promote a pre-release to stable on the same SHA |
 
 ### Binary Attestation
 
@@ -528,11 +534,12 @@ Verify a bundle with `aicr verify <dir>`. Update the trusted root cache with
 
 | Target | Description |
 |--------|-------------|
-| `make tidy` | Format code and update dependencies |
+| `make tidy` | Format, tidy, and vendor dependencies; regenerate THIRD_PARTY_NOTICES.md |
 | `make fmt-check` | Check code formatting (CI-friendly) |
 | `make upgrade` | Upgrade all dependencies |
 | `make generate` | Run go generate |
 | `make license` | Add/verify license headers |
+| `make license-check` | Verify license allowlist compliance (verify-only, CI-friendly) |
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ See the full [Component Catalog](docs/user/component-catalog.md) for every compo
 
 | Dimension | Values |
 |-----------|--------|
-| **Services** | AKS, BCM, EKS, GKE, Kind, LKE, OCP, OKE |
-| **Accelerators** | A100, B200, GB200, H100, H200, L40, RTX PRO 6000 |
-| **Operating systems** | Amazon Linux, COS, RHEL, Talos, Ubuntu |
+| **Services** | AKS, BCM, EKS, GKE, Kind, LKE, Metal3, OCP, OKE |
+| **Accelerators** | A100, B200, GB200, GB300, H100, H200, L40, L40S, RTX PRO 6000 |
+| **Operating systems** | Amazon Linux, COS, Oracle Linux, RHEL, Talos, Ubuntu |
 | **Workload intents** | Inference, Training |
 | **Platforms** | Dynamo, Kubeflow, NIM, Run:ai, Slurm (Slinky) |
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -174,6 +174,7 @@ Published to GitHub Container Registry (`ghcr.io/nvidia/`):
 |-------|------|-------------|
 | `aicr` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Pure-Go CLI/agent (driver-free GPU discovery) |
 | `aicrd` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Minimal API server |
+| `aicr-gate` | `nvcr.io/nvidia/distroless/static:v4.0.0` | Bundle readiness-gate Job image (emitted by `aicr bundle --readiness-hooks`) |
 
 Published to GitHub Container Registry (`ghcr.io/nvidia/aicr-validators/`):
 
@@ -229,6 +230,7 @@ export TAG=$(curl -s https://api.github.com/repos/NVIDIA/aicr/releases/latest | 
 # GitHub CLI (core images)
 gh attestation verify oci://ghcr.io/nvidia/aicr:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 gh attestation verify oci://ghcr.io/nvidia/aicrd:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
+gh attestation verify oci://ghcr.io/nvidia/aicr-gate:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"
 
 # GitHub CLI (validator images)
 gh attestation verify oci://ghcr.io/nvidia/aicr-validators/deployment:${TAG} --repo NVIDIA/aicr --signer-workflow NVIDIA/aicr/.github/workflows/attest-images.yaml --source-ref "refs/tags/${TAG}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,8 +73,8 @@ should be upgraded.
 
 | Version | Supported |
 |---------|-----------|
-| `0.16.x` (latest released minor) | ✅ Receives security fixes |
-| `< 0.16` | ❌ End-of-life — upgrade to the latest release |
+| `0.19.x` (latest released minor) | ✅ Receives security fixes |
+| `< 0.19` | ❌ End-of-life — upgrade to the latest release |
 
 Security fixes ship in a new patch or minor release rather than as backports to
 end-of-life versions. When AICR reaches 1.0 this policy will be revised and a
@@ -82,7 +82,7 @@ longer support window published here.
 
 ## Product Security Resources
 
-For all security-related concerns: https://www.nvidia.com/en-us/security
+For all security-related concerns: [NVIDIA Product Security](https://www.nvidia.com/en-us/security)
 
 ## Supply Chain Security
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -8,6 +8,7 @@ Runbooks for testing and demonstrating AICR end-to-end workflows on live cluster
 |------|-------------|
 | [cuj1-training.md](cuj1-training.md) | CUJ1 (training) - EKS + GKE end-to-end, plus a config-driven GKE + signed-evidence variant |
 | [cuj1-slinky-slurm.md](cuj1-slinky-slurm.md) | CUJ1 - Slinky Slurm on EKS / GKE / Kind (recipe → bundle → validate → `srun`) |
+| [slinky-slurm-demo.html](slinky-slurm-demo.html) | CUJ1 Slinky Slurm — slide deck |
 | [cuj2-inference.md](cuj2-inference.md) | CUJ2 (inference) - EKS + GKE end-to-end with the Dynamo platform |
 | [cuj2-demo.md](cuj2-demo.md) | CUJ2 (inference) - Annotated slide-style demo walkthrough (training vs inference) |
 | [recipe-data-architecture.md](recipe-data-architecture.md) | Recipe metadata system: inheritance, criteria matching, deployment order, runtime external data |

--- a/demos/cuj1-slinky-slurm.md
+++ b/demos/cuj1-slinky-slurm.md
@@ -93,7 +93,7 @@ AICR injects placement from bundle flags using each component's registry paths:
 
 **Operator note:** slurm-operator chart v1.2.0 honors `nodeSelector`, `tolerations`, and `affinity` for both the operator and webhook. AICR's `--system-node-selector` and `--system-node-toleration` flags fan out to both deployments. Set affinity through `--set-json slurmoperator:operator.affinity=...` and `--set-json slurmoperator:webhook.affinity=...`. On EKS, include **both** `NoSchedule` and `NoExecute` for each taint key — nodes often carry both effects.
 
-**Override aliases:** `slinkyslurm`, `slurmcluster` (cluster chart); `slurm`, `slurmoperator` (operator chart). See `valueOverrideKeys` in `recipes/registry.yaml`.
+**Override aliases:** `slinkyslurm`, `slurmcluster` (cluster chart); `slurm`, `slurmoperator`, `slinkyslurmoperator` (operator chart). See `valueOverrideKeys` in `recipes/registry.yaml`.
 
 **Scalar vs structured overrides:**
 
@@ -202,7 +202,7 @@ kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="Available")].status}
   -n slurm deploy/slinky-slurm-login-slinky --timeout=10m
 ```
 
-If nodewright is already installed, skip those sections in `deploy.sh` to avoid upgrade conflicts.
+If nodewright is already installed, generate the bundle without the nodewright components (`--set nodewright:enabled=false --set nodewrightcustomizations:enabled=false`) to avoid upgrade conflicts.
 
 ## Validate Cluster
 

--- a/demos/cuj1-training.md
+++ b/demos/cuj1-training.md
@@ -137,7 +137,7 @@ aicr bundle \
 cd ./bundle && chmod +x deploy.sh && ./deploy.sh
 ```
 
-> **GKE only:** If nodewright-operator is already installed on the cluster, comment out or skip the nodewright-operator and nodewright-customizations sections in deploy.sh to avoid upgrade conflicts.
+> **GKE only:** If nodewright-operator is already installed on the cluster, generate the bundle without the nodewright components — add `--set nodewright:enabled=false --set nodewrightcustomizations:enabled=false` to the `aicr bundle` command — to avoid upgrade conflicts. Don't hand-edit the generated `deploy.sh`: it deploys the numbered component directories generically, and edits break `aicr verify` because `deploy.sh` is covered by the bundle's `checksums.txt` (whose digest the attestation signs).
 
 ## Validate Cluster
 
@@ -399,7 +399,8 @@ aicr validate --config aicr-config.yaml \
 Because `spec.validate.evidence.attestation.out` is set in the config, this run
 also writes a recipe-evidence bundle to `./evidence/` and pushes it (signed via
 cosign keyless OIDC — opens a browser, or uses ambient GitHub Actions OIDC if
-present) to `ghcr.io/<owner>/aicr-evidence`.
+present) to `ghcr.io/nvidia/aicr-evidence-cuj1-gke-demo` (the
+`spec.validate.evidence.attestation.push` value above).
 
 ```text
 ./evidence

--- a/demos/cuj2-inference.md
+++ b/demos/cuj2-inference.md
@@ -41,6 +41,7 @@ aicr snapshot \
     --namespace aicr-validation \
     --node-selector nodeGroup=gpu-worker \
     --toleration dedicated=gpu-workload:NoSchedule \
+    --toleration nvidia.com/gpu=present:NoSchedule \
     --output snapshot.yaml
 ```
 
@@ -116,6 +117,7 @@ aicr bundle \
   --recipe recipe.yaml \
   --accelerated-node-selector nodeGroup=gpu-worker \
   --accelerated-node-toleration dedicated=gpu-workload:NoSchedule \
+  --accelerated-node-toleration nvidia.com/gpu=present:NoSchedule \
   --system-node-selector nodeGroup=system-worker \
   --storage-class <storage-class> \
   --output bundle
@@ -128,6 +130,8 @@ aicr bundle \
 ```shell
 cd ./bundle && chmod +x deploy.sh && ./deploy.sh
 ```
+
+> **GKE only:** If nodewright-operator is already installed on the cluster, generate the bundle without the nodewright components — add `--set nodewright:enabled=false --set nodewrightcustomizations:enabled=false` to the `aicr bundle` command — to avoid upgrade conflicts. Don't hand-edit the generated `deploy.sh`: it deploys the numbered component directories generically, and edits break `aicr verify` because `deploy.sh` is covered by the bundle's `checksums.txt` (whose digest the attestation signs).
 
 ## Validate Cluster
 
@@ -148,6 +152,7 @@ aicr validate \
 aicr validate \
     --recipe recipe.yaml \
     --toleration dedicated=gpu-workload:NoSchedule \
+    --toleration nvidia.com/gpu=present:NoSchedule \
     --phase conformance \
     --output report.json
 ```

--- a/demos/images/e2e.md
+++ b/demos/images/e2e.md
@@ -15,14 +15,14 @@ Caption: "Config complexity: manual errors, drift, version mismatches"
 
 **Step 1 - RECIPE**  
 Icon: Mixing bowl with ingredients
-Command: `aicr recipe -a h100 -i training -p kubeflow -o recipe.yaml`
+Command: `aicr recipe --service eks --accelerator h100 --intent training --os ubuntu --platform kubeflow -o recipe.yaml`
 Visual: Cluster Snapshot + Intent toggle (Training/Inference) → glowing recipe.yaml
 Callouts: Driver 580.82.07, Device Plugin v0.17.4, CDI Enabled
 Caption: "Generate hardware-specific optimizations for workload intent"
 
 **Step 2 - BUNDLE**
 Icon: Shipping box with GitOps logo
-Command: `aicr bundle -f recipe.yaml -d argocd -o ./bundles`
+Command: `aicr bundle -r recipe.yaml -d argocd -o ./bundles --attest`
 Visual: Recipe transforms into deployment-ready artifacts:
 
 ```shell
@@ -45,7 +45,7 @@ Caption: "Use existing OSS tooling to deploy to your cluster"
 
 **Step 4 - VALIDATE**
 Icon: Inspection magnifying glass with Checkmark shield
-Command: `aicr validate -r recipe.yaml -p deployment -p conformance -p performance`
+Command: `aicr validate -r recipe.yaml --phase deployment --phase conformance --phase performance`
 Visual: Recipe compared against snapshot with green checkmarks
 Caption: "Verify recipe was correctly reconciled in your cluster"
 

--- a/demos/private-signing.md
+++ b/demos/private-signing.md
@@ -42,13 +42,13 @@ Running it end to end is exactly what validates the private-signing surface — 
 
 Prerequisites: `kind`, `kubectl`, `helm`, `mkcert`, `chainsaw`, `cosign`, `go`, `yq`, `docker`, and `gh` (to download the release binary).
 
-From the repo root, this is the whole thing — download the attested release binary, then run the store-up + sign + verify flow (substitute the release or RC tag for `v0.16.0`):
+From the repo root, this is the whole thing — download the attested release binary, then run the store-up + sign + verify flow (substitute the release or RC tag for `v0.19.0`):
 
 ```shell
 # 1. Download the attested release binary (it ships its aicr-attestation.sigstore.json sidecar)
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m); case "$ARCH" in x86_64) ARCH=amd64 ;; aarch64) ARCH=arm64 ;; esac
-gh release download v0.16.0 -R NVIDIA/aicr -p "aicr_*_${OS}_${ARCH}.tar.gz"
+gh release download v0.19.0 -R NVIDIA/aicr -p "aicr_*_${OS}_${ARCH}.tar.gz"
 tar xzf aicr_*_${OS}_${ARCH}.tar.gz          # -> ./aicr + aicr-attestation.sigstore.json
 ./aicr trust update                          # cache the public Sigstore root (needed by the binary-attestation gate)
 
@@ -112,7 +112,7 @@ Run the numbered commands with the **attested release binary** you downloaded ab
 
 ```shell
 export PATH="$PWD:$PATH"          # the ./aicr you extracted (beside aicr-attestation.sigstore.json)
-aicr version                      # expect 0.16.x, not an older system build
+aicr --version                    # expect 0.19.x, not an older system build
 ls "$(command -v aicr)"-attestation.sigstore.json
 # present -> --attest will run; absent -> use a release-archive binary
 ```
@@ -212,7 +212,7 @@ export AWS_CA_BUNDLE="$(mkcert -CAROOT)/rootCA.pem"
 
 docker run -d --rm --name aicr-kms -p 4566:4566 -e USE_SSL=1 \
   -e MINISTACK_SSL_CERT=/certs/cert.pem -e MINISTACK_SSL_KEY=/certs/key.pem \
-  -v "$CERT:/certs:ro" ministackorg/ministack:1.3.61
+  -v "$CERT:/certs:ro" ministackorg/ministack:1.4.13
 until aws kms list-keys --endpoint-url https://localhost:4566 >/dev/null 2>&1; do sleep 2; done   # wait for KMS
 
 ARN=$(aws kms create-key --endpoint-url https://localhost:4566 \

--- a/demos/validation-acceptance.md
+++ b/demos/validation-acceptance.md
@@ -56,7 +56,7 @@ aicr bundle \
   --accelerated-node-selector nodeGroup=gpu-worker \
   --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
   --accelerated-node-toleration dedicated=worker-workload:NoExecute \
-  --system-node-selector dedicated=system-workload \
+  --system-node-selector nodeGroup=system-worker \
   --system-node-toleration dedicated=system-workload:NoSchedule \
   --system-node-toleration dedicated=system-workload:NoExecute \
   --output bundle
@@ -150,7 +150,7 @@ aicr validate \
 ```
 
 Expected:
-- All 3 phases run (deployment, performance, conformance)
+- All 3 phases run (deployment, conformance, performance)
 - Only checks defined in the recipe are executed per phase
 - Phase failure does NOT block subsequent phases in the report
 - Report contains tests from all phases

--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -156,8 +156,8 @@ Criteria fields (see `pkg/recipe/criteria.go` `type Criteria`):
 
 | Field | Type | Wildcard | Static OSS values |
 |---|---|---|---|
-| `service` | `CriteriaServiceType` | `any` or empty | `eks`, `gke`, `aks`, `oke`, `ocp`, `kind`, `lke`, `bcm` |
-| `accelerator` | `CriteriaAcceleratorType` | `any` or empty | `h100`, `h200`, `gb200`, `b200`, `a100`, `l40`, `l40s`, `rtx-pro-6000` |
+| `service` | `CriteriaServiceType` | `any` or empty | `eks`, `gke`, `aks`, `oke`, `ocp`, `kind`, `lke`, `bcm`, `metal3` |
+| `accelerator` | `CriteriaAcceleratorType` | `any` or empty | `h100`, `h200`, `gb200`, `gb300`, `b200`, `a100`, `l40`, `l40s`, `rtx-pro-6000` |
 | `intent` | `CriteriaIntentType` | `any` or empty | `training`, `inference` |
 | `os` | `CriteriaOSType` | `any` or empty | `ubuntu`, `rhel`, `cos`, `amazonlinux`, `ol`, `talos` |
 | `platform` | `CriteriaPlatformType` | `any` or empty | `dynamo`, `kubeflow`, `nim`, `runai`, `slurm` |

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -22,8 +22,12 @@ navigation:
     contents:
       - page: Installation
         path: user/installation.md
+      - page: End-to-End Tutorial
+        path: user/tutorial.md
       - page: CLI Reference
         path: user/cli-reference.md
+      - page: Generating Bundles
+        path: user/bundling.md
       - page: CLI Configuration File
         path: user/cli-config.md
       - page: Artifact Verification
@@ -122,5 +126,7 @@ navigation:
         path: contributor/rekor-v2-signing.md
       - page: Publishing Recipe Evidence
         path: contributor/evidence-publishing.md
+      - page: Publishing the Evidence Dashboard
+        path: contributor/evidence-dashboard-publish.md
       - page: UAT Day/Night Cycle
         path: contributor/uat.md

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -31,7 +31,7 @@ go get github.com/NVIDIA/aicr@latest
 For reproducibility in downstream projects, pin a specific tag:
 
 ```bash
-go get github.com/NVIDIA/aicr@v0.11.1
+go get github.com/NVIDIA/aicr@v0.19.0
 ```
 
 ## Quick start

--- a/docs/integrator/index.md
+++ b/docs/integrator/index.md
@@ -30,7 +30,7 @@ This section is for integrators who:
 | [Data Extension](data-extension.md) | Extending the embedded catalog via `--data` — overlays, components, and runtime criteria values without a rebuild |
 | [Validator Extension](validator-extension.md) | Adding custom validators and overriding embedded ones via `--data` |
 | [Supply Chain Verification](supply-chain-verification.md) | Verifying SLSA provenance, SBOMs, and attestations; admission policies; offline verification |
-| [NodeWright Component](components/nodewright.md) | NodeWright component reference and configuration |
+| [Nodewright Component](components/nodewright.md) | Nodewright component reference and configuration |
 
 ## Quick Start
 

--- a/docs/integrator/kubernetes-deployment.md
+++ b/docs/integrator/kubernetes-deployment.md
@@ -243,7 +243,7 @@ duplicated here.
 | `AICR_ALLOWED_INTENTS` | (unset = all) | Comma-separated allowlist of intent types (e.g. `training,inference`) |
 | `AICR_ALLOWED_OS` | (unset = all) | Comma-separated allowlist of OS types (e.g. `ubuntu,rhel`) |
 
-**Note:** These are the only environment variables the API server reads. The four `AICR_ALLOWED_*` allowlists are parsed once at startup to restrict which criteria values the server will accept. Rate-limit, request-timeout, and body-size settings are compiled-in constants from `pkg/defaults`, not environment-tunable. The server uses structured JSON logging to stderr. The CLI supports three logging modes (CLI/Text/JSON), but the API server always uses JSON for consistent log aggregation.
+**Note:** These are the only environment variables the API server reads for criteria filtering and transport; server-side bundle signing (`POST /v1/bundle?attest=true`) reads an additional set documented in [API Reference › Server-Side Signing](../user/api-reference.md#server-side-signing). The four `AICR_ALLOWED_*` allowlists are parsed once at startup to restrict which criteria values the server will accept. Rate-limit, request-timeout, and body-size settings are compiled-in constants from `pkg/defaults`, not environment-tunable. The server uses structured JSON logging to stderr. The CLI supports three logging modes (CLI/Text/JSON), but the API server always uses JSON for consistent log aggregation.
 
 ### ConfigMap for Custom Recipe Data (Advanced)
 

--- a/docs/integrator/validator-extension.md
+++ b/docs/integrator/validator-extension.md
@@ -132,9 +132,12 @@ validation:
 Every check to run must be listed explicitly. If you omit the `checks` list (or
 set it to `[]`, which clears any inherited checks), the phase runs **zero**
 validators and is skipped — an empty phase reports as passing, so a missing entry
-is easy to overlook. A declared name that matches no catalog entry for the phase
-is likewise dropped (it logs a warning but does not fail the run), so keep names
-in sync with the `name` fields in `validators/catalog.yaml`.
+is easy to overlook. A declared name that matches no catalog entry for the phase —
+or that resolves under a different phase, or is declared twice — **fails the run
+closed**: the `aicr validate` process exits 2 (`INVALID_REQUEST` — the CLI exit
+code, distinct from the validator-container contract above where exit 2 means
+"check skipped") before any Job is deployed, reporting every offender at once,
+so keep names in sync with the `name` fields in `validators/catalog.yaml`.
 
 ### Step 5: Run Validation
 

--- a/docs/user/agent-deployment.md
+++ b/docs/user/agent-deployment.md
@@ -117,7 +117,7 @@ aicr snapshot \
 # Full customization
 aicr snapshot \
   --namespace gpu-operator \
-  --image ghcr.io/nvidia/aicr:v0.8.0 \
+  --image ghcr.io/nvidia/aicr:v0.19.0 \
   --node-selector accelerator=nvidia-h100 \
   --toleration nvidia.com/gpu:NoSchedule \
   --timeout 10m \
@@ -127,7 +127,7 @@ aicr snapshot \
 **Available flags:**
 - `--kubeconfig`: Custom kubeconfig path (default: `~/.kube/config` or `$KUBECONFIG`)
 - `--namespace`: Deployment namespace (default: `default`)
-- `--image`: Container image (default: matches the CLI version, e.g. `ghcr.io/nvidia/aicr:v0.8.0`; dev and snapshot builds use `:latest`)
+- `--image`: Container image (default: matches the CLI version, e.g. `ghcr.io/nvidia/aicr:v0.19.0`; dev and snapshot builds use `:latest`)
 - `--image-pull-secret`: Secret name for pulling the agent image from a private registry (repeatable)
 - `--job-name`: Job name (default: `aicr`)
 - `--service-account-name`: ServiceAccount name (default: `aicr`)
@@ -138,7 +138,7 @@ aicr snapshot \
 - `--privileged`: Run agent in privileged mode (default: enabled; required for GPU/SystemD collectors). Set to `false` for PSS-restricted namespaces.
 - `--require-gpu`: Fail the snapshot if no GPU is found. In agent mode also requests an `nvidia.com/gpu` resource for the pod (required in CDI environments).
 - `--runtime-class`: Set `runtimeClassName` on the agent pod for `nvidia-smi` access without consuming a GPU. Use with `--node-selector` to target GPU nodes.
-- `--os`: Node OS family (`ubuntu`, `rhel`, `cos`, `amazonlinux`, `talos`). Selects the per-OS pod configuration and service collector backend.
+- `--os`: Node OS family (`ubuntu`, `rhel`, `cos`, `amazonlinux`, `ol`, `talos`). Selects the per-OS pod configuration and service collector backend.
 - `--requests` / `--limits`: Override agent container resource requests/limits (comma-separated `name=quantity` pairs).
 - `--cluster-config`: Path to a pre-existing k8s-launch-kit cluster-config.yaml to ingest network topology (local agent mode only).
 - `--aks-gpu-pools`: Path to an `az aks nodepool list -o json` dump, projected into the `K8s.aks-gpu-pools.gpu-driver` reading. Controller-side: works in agent Job mode too — the file never enters the pod; the CLI merges the projection into the returned snapshot.
@@ -195,7 +195,7 @@ By default, the agent Job tolerates **all taints** using the universal toleratio
 Pin to a specific version:
 
 ```shell
-aicr snapshot --image ghcr.io/nvidia/aicr:v0.8.0
+aicr snapshot --image ghcr.io/nvidia/aicr:v0.19.0
 ```
 
 **Finding versions:**

--- a/docs/user/air-gap-mirror.md
+++ b/docs/user/air-gap-mirror.md
@@ -112,8 +112,8 @@ metadata:
   name: aicr-images
 spec:
   images:
-    - name: nvcr.io/nvidia/cloud-native/gpu-operator:v25.3.0
-    - name: registry.k8s.io/nfd/node-feature-discovery:v0.17.2
+    - name: nvcr.io/nvidia/gpu-operator:v26.3.3
+    - name: registry.k8s.io/nfd/node-feature-discovery:v0.19.0
     # ...
 ---
 apiVersion: content.hauler.cattle.io/v1
@@ -124,7 +124,7 @@ spec:
   charts:
     - name: gpu-operator
       repoURL: oci://ghcr.io/nvidia
-      version: v25.3.0
+      version: v26.3.3
     # ...
 ```
 
@@ -187,13 +187,13 @@ components:
   - name: aicr-images
     required: true
     images:
-      - nvcr.io/nvidia/cloud-native/gpu-operator:v25.3.0
-      - registry.k8s.io/nfd/node-feature-discovery:v0.17.2
+      - nvcr.io/nvidia/gpu-operator:v26.3.3
+      - registry.k8s.io/nfd/node-feature-discovery:v0.19.0
       # ...
     charts:
       - name: gpu-operator
         url: oci://ghcr.io/nvidia/gpu-operator
-        version: v25.3.0
+        version: v26.3.3
         namespace: gpu-operator
       # ...
 ```

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -127,8 +127,8 @@ Generate an optimized configuration recipe based on environment parameters.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `service` | string | any | K8s service: `eks`, `gke`, `aks`, `oke`, `ocp`, `kind`, `lke`, `bcm`, `any` |
-| `accelerator` | string | any | GPU type: `h100`, `h200`, `gb200`, `b200`, `a100`, `l40`, `l40s`, `rtx-pro-6000`, `any` |
+| `service` | string | any | K8s service: `eks`, `gke`, `aks`, `oke`, `ocp`, `kind`, `lke`, `bcm`, `metal3`, `any` |
+| `accelerator` | string | any | GPU type: `h100`, `h200`, `gb200`, `gb300`, `b200`, `a100`, `l40`, `l40s`, `rtx-pro-6000`, `any` |
 | `gpu` | string | any | Alias for `accelerator` |
 | `intent` | string | any | Workload: `training`, `inference`, `any` |
 | `os` | string | any | Node OS: `ubuntu`, `rhel`, `cos`, `amazonlinux`, `ol`, `talos`, `any` |
@@ -1209,7 +1209,7 @@ openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o ./ts-clien
 
 **"Invalid accelerator type" error:**
 ```shell
-# Use valid values: h100, h200, gb200, b200, a100, l40, l40s, rtx-pro-6000, any
+# Use valid values: h100, h200, gb200, gb300, b200, a100, l40, l40s, rtx-pro-6000, any
 curl "http://localhost:8080/v1/recipe?accelerator=h100"
 ```
 

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -114,6 +114,10 @@ spec:
       platform: kubeflow
       nodes: 2
     profile: ""                      # optional name=value; empty uses the declared default
+    # configuration:                 # typed desired-state inputs (not matched on)
+    #   slurm:                       # only valid when the resolved recipe platform is slurm
+    #     accounting:
+    #       mode: disabled           # disabled | customer-managed | aicr-provided
     # input:
     #   snapshot: snapshot.yaml      # derive criteria from a snapshot instead
     output:
@@ -230,6 +234,7 @@ exclusive** — query by criteria or derive from a snapshot, not both.
 | `criteria.service` / `.accelerator` / `.intent` / `.os` / `.platform` | string | Same names and values as the CLI flags |
 | `criteria.nodes` | int | Target GPU node count |
 | `profile` | string | Optional configuration profile selection in `name=value` form. Empty applies the resolved declaration's default. |
+| `configuration.slurm.accounting.mode` | string | Slurm accounting ownership: `disabled` (default) \| `customer-managed` \| `aicr-provided`; mirrors `--slurm-accounting-mode`. Only valid when the resolved recipe platform is `slurm` (whether from `criteria.platform`, a snapshot, or `--platform`) — an explicit mode (even `disabled`) on any other platform is rejected with `INVALID_REQUEST` |
 | `input.snapshot` | string | Snapshot path to derive the recipe from |
 | `output.path` | string | Recipe output path |
 | `output.format` | string | `yaml` \| `json` \| `table` |

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -160,7 +160,7 @@ aicr snapshot \
 aicr snapshot \
   --kubeconfig ~/.kube/config \
   --namespace gpu-operator \
-  --image ghcr.io/nvidia/aicr:v0.8.0 \
+  --image ghcr.io/nvidia/aicr:v0.19.0 \
   --job-name snapshot-gpu-nodes \
   --service-account-name aicr \
   --node-selector accelerator=nvidia-h100 \
@@ -1880,7 +1880,7 @@ The `--vendor-charts` flag pulls upstream Helm chart bytes into the bundle at bu
 my-bundle/
   001-gpu-operator/
     Chart.yaml                     # wrapper, declares the vendored subchart
-    charts/gpu-operator-v25.3.0.tgz # vendored upstream tarball
+    charts/gpu-operator-v26.3.3.tgz # vendored upstream tarball
     values.yaml                    # values nested under the subchart name
     cluster-values.yaml            # dynamic values, also nested
     install.sh                     # helm upgrade --install <name> ./<dir> ...
@@ -1904,10 +1904,10 @@ kind: BundleProvenance
 vendoredCharts:
   - name: gpu-operator
     chart: gpu-operator
-    version: v25.3.0
+    version: v26.3.3
     repository: https://helm.ngc.nvidia.com/nvidia
     sha256: abc123...
-    tarballName: gpu-operator-v25.3.0.tgz
+    tarballName: gpu-operator-v26.3.3.tgz
     pullerVersion: helm-cli v3.20.2
 ```
 

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -17,6 +17,7 @@ This section is for users who:
 | [Installation](installation.md) | Install the `aicr` CLI (automated script, manual, or build from source) |
 | [End-to-End Tutorial](tutorial.md) | Learning path: install → recipe → bundle → deploy → validate, start to finish |
 | [CLI Reference](cli-reference.md) | Complete command reference with examples for all CLI operations |
+| [CLI Configuration File](cli-config.md) | The complete `AICRConfig` schema for `--config` on snapshot, recipe, bundle, validate, and verify |
 | [Generating Bundles](bundling.md) | Task-oriented how-to: deployers, value overrides, node scheduling, offline/vendored charts, readiness gates |
 | [Artifact Verification](artifact-verification.md) | Verify bundles and recipe-evidence: trust levels, public-trust, KMS/PEM keys, offline, and CI gating |
 | [API Reference](api-reference.md) | REST API quick start and endpoint documentation |
@@ -27,6 +28,9 @@ This section is for users who:
 | [Slurm Shared Storage](slinky-slurm-storage.md) | Add opt-in persistent RWX home and data filesystems to Slinky Slurm |
 | [Container Images](container-images.md) | Container image inventory across all components (BOM) |
 | [Recipe Health](recipe-health.md) | Per-recipe health and validation status tracking |
+| [TestGrid](testgrid.md) | Live per-recipe validation pass/fail board and its coordinate scheme |
+| [Evidence Dashboard](evidence-dashboard.md) | Signed third-party recipe evidence, consensus model, and deep links |
+| [Coverage Matrix](coverage-matrix.md) | Which CUJs and CLI verbs are exercised, on what hardware, at what cadence (generated) |
 | [Air-Gap Mirror](air-gap-mirror.md) | Mirror images and charts for air-gapped deployment |
 
 ## Quick Start

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -26,11 +26,11 @@ aicr bundle \
   --set gpuoperator:driver.version=580.105.08 \
   --output ./bundles
 
-# Validate against snapshot (default phase: readiness)
+# Validate against snapshot (readiness constraints run first, then all phases)
 aicr snapshot --output snapshot.yaml
 aicr validate --recipe eks-gb200-ubuntu-training-with-validation.yaml --snapshot snapshot.yaml
 
-# All phases (readiness, deployment, performance, conformance)
+# All phases (deployment, conformance, performance)
 aicr validate --recipe eks-gb200-ubuntu-training-with-validation.yaml --snapshot snapshot.yaml --phase all
 ```
 

--- a/pkg/validator/v1/README.md
+++ b/pkg/validator/v1/README.md
@@ -17,7 +17,7 @@ deploy AICR validator Jobs.
 
 ## Package surface
 
-The package is intentionally narrow and exports three concerns:
+The package is intentionally narrow and exports four concerns:
 
 1. **`ValidationInput`** (`validation_input.go`) — the wire format consumed
    by a recipe's `spec.validation` block. Carries phases, checks,

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -52,7 +52,7 @@ go test -v ./pkg/recipe/... -run TestAllMetadataFilesConformToSchema
 go test -v ./pkg/recipe/... -run TestNoDuplicateCriteriaAcrossOverlays
 ```
 
-For details, see [Automated Validation](../docs/contributor/recipe.md#automated-validation).
+For details, see [Automated Tests](../docs/integrator/recipe-development.md#automated-tests).
 
 ## See Also
 

--- a/tests/chainsaw/README.md
+++ b/tests/chainsaw/README.md
@@ -21,8 +21,8 @@ make e2e
 Or manually:
 
 ```bash
-make build
-AICR_BIN=$(pwd)/dist/aicr_darwin_arm64_v8.0/aicr \
+go build -o dist/e2e/aicr ./cmd/aicr
+AICR_BIN=$(pwd)/dist/e2e/aicr \
   chainsaw test --no-cluster \
     --config tests/chainsaw/chainsaw-config.yaml \
     --test-dir tests/chainsaw/cli/
@@ -31,7 +31,7 @@ AICR_BIN=$(pwd)/dist/aicr_darwin_arm64_v8.0/aicr \
 Single test:
 
 ```bash
-AICR_BIN=$(pwd)/dist/aicr_darwin_arm64_v8.0/aicr \
+AICR_BIN=$(pwd)/dist/e2e/aicr \
   chainsaw test --no-cluster --test-dir tests/chainsaw/cli/recipe-generation
 ```
 

--- a/tests/chainsaw/ai-conformance/README.md
+++ b/tests/chainsaw/ai-conformance/README.md
@@ -25,7 +25,7 @@ aicr recipe \
   --output recipe.yaml
 ```
 
-Overlay chain: `base` → `monitoring-hpa` → `eks` → `eks-inference` → `h100-eks-inference` → `h100-eks-ubuntu-inference` → `h100-eks-ubuntu-inference-dynamo`
+Applied overlays (inheritance chain plus criteria-wildcard overlays `monitoring-hpa` and `h100-any`): `base` → `monitoring-hpa` → `h100-any` → `eks` → `eks-inference` → `h100-eks-inference` → `h100-eks-ubuntu-inference` → `h100-eks-ubuntu-inference-dynamo`
 
 Bundle generated with:
 
@@ -43,11 +43,12 @@ The Kind GPU workflows use these leaf recipes instead:
 - `h100-kind-inference-dynamo`
 - `h100-kind-training-kubeflow`
 
-## Cluster Inference Components (17)
+## Cluster Inference Components (18)
 
 | Component | Namespace | Type | What is Validated |
 |-----------|-----------|------|-------------------|
 | cert-manager | cert-manager | Helm | 3 Deployments (controller, webhook, cainjector) |
+| nfd | node-feature-discovery | Helm | In the bundle; no dedicated assertion in this suite |
 | gpu-operator | gpu-operator | Helm | Operator Deployment, ClusterPolicy ready, 6 DaemonSets (driver, device-plugin, dcgm-exporter, toolkit, gfd, validator) |
 | nvsentinel | nvsentinel | Helm | Controller Deployment, platform-connector DaemonSet |
 | nodewright-operator | skyhook | Helm | Controller-manager Deployment |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -26,7 +26,6 @@ make e2e-tilt
 | `cli/bundle/*` | Bundle generation (helm, argocd, node selectors) |
 | `cli/external-data/*` | External data directory (`--data` flag) |
 | `cli/format/*` | Output format variations (`--format json/table`) |
-| `cli/deploy-agent/*` | Snapshot `--deploy-agent` flag |
 | `api/recipe/*`, `api/bundle/*` | REST endpoints |
 | `snapshot/*` | Snapshot with deploy-agent (requires fake GPU) |
 | `recipe/from-snapshot` | Recipe from ConfigMap snapshot (`cm://...`) |

--- a/tools/bom/README.md
+++ b/tools/bom/README.md
@@ -49,6 +49,8 @@ Flags:
 | `-aicr-version` | `dev` | AICR version embedded in the BOM |
 | `-skip-helm` | `false` | Skip `helm template` rendering |
 | `-strict` | `false` | Fail on unpinned charts or render errors |
+| `-deterministic` | `false` | Suppress per-run metadata (timestamps, version churn) in Markdown for committable artifacts |
+| `-no-title` | `false` | Omit the H1 title so the body can be embedded as a section |
 
 ## Output schema
 

--- a/tools/uat-broker/README.md
+++ b/tools/uat-broker/README.md
@@ -23,7 +23,7 @@ Resolve one reservation row to `GITHUB_OUTPUT`-style `key=value` lines:
 uat-broker reservations --name aws-h100 >> "$GITHUB_OUTPUT"
 # slug=ah1
 # cloud=aws
-# reservation-id=cr-0cbe491320188dfa6
+# reservation-id=cr-0e16ad417f9a5bf69
 # accelerator=h100
 # gpu-count=8
 # cluster-config-path=tests/uat/aws/cluster-config.yaml
@@ -39,9 +39,11 @@ forwards it to the cloud pipelines as `needs.resolve.outputs.slug`.
 `nightly-intents` is the comma-separated list of intents the nightly batch runs
 on this reservation (#1276, DC3); it is emitted **resolved** (an un-annotated
 reservation reports the `training` default rather than an empty value). The
-launch set is `training,inference` on both reservations, so both CUJs run
-nightly on both clouds — the controller splits on comma and dispatches one
-serialized cell per intent per version.
+launch set is `training,inference` on every reservation, so both CUJs run
+nightly on all reservations. The emitted CSV is the leg-level enrollment
+summary and opt-out gate (an explicit empty list skips the leg); the actual
+per-cell intents come from the broker's `schedule` output, further gated per
+version by `nightly-intent-min-versions`.
 
 List every reservation name (one per line):
 


### PR DESCRIPTION
## Summary

Documentation-only sweep ahead of the v0.19.0 release: fixes verified drift against code and pinned versions, broken documented commands, stale release references, contradictions with current behavior, and navigation gaps. 35 files, no code changes.

## Motivation / Context

Pre-release doc health pass for v0.19.0 (current RC: v0.19.0-rc1). Three parallel audits covered `docs/` (user/integrator/contributor), root/governance docs, and `demos/` + package READMEs; every fix below was verified against its source of truth before applying.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: root governance docs, `demos/`, `.github/actions/README.md`, package/test READMEs, `docs/index.yml` (Fern nav)

## Implementation Notes

**Enum drift** (checked against `pkg/recipe/criteria.go`, `pkg/recipe/oskind`, `api/aicr/v1/server.yaml`): added `metal3`, `gb300`, `l40s`, and `ol` where missing from documented criteria value lists (README dimensions table, API reference, contributor recipe doc, agent-deployment).

**Broken documented commands**: `aicr version` → `aicr --version`; the `demos/images/e2e.md` commands fixed end to end (invalid short flags `-a`/`-i`/`-p`/`-f` replaced, `--service eks --os ubuntu` added so the recipe criteria actually resolve to a leaf, `--attest` added to match the attestation caption); removed the nonexistent `--deploy-agent` test-suite row; `--system-node-selector` in `demos/validation-acceptance.md` passed a taint value instead of the node label.

**Stale versions**: `SECURITY.md` supported-versions table bumped 0.16.x → 0.19.x (timed to this release — merge with/after v0.19.0 final, or I can hold it at 0.18.x); gpu-operator/nfd pins in air-gap and provenance examples (→ v26.3.3 / v0.19.0 per `recipes/registry.yaml`); `go get` pin in the Go-library guide; agent image tag examples; ministack image pin (`.settings.yaml`); two action defaults in `.github/actions/README.md`. Replaced `DEVELOPMENT.md`'s hand-pinned `tools-check` sample output with a version-free skeleton pointing at `.settings.yaml` so it can't re-drift.

**Make-target drift**: `make qualify` / `make lint` compositions corrected everywhere they are enumerated (`DEVELOPMENT.md` ×3, `CONTRIBUTING.md`, `.claude/CLAUDE.md` + `AGENTS.md` mirror resynced via `tools/check-agents-sync`); added missing `bump-rc`, `bump-promote`, `kwok-*`, and `license-check` rows; `CONTRIBUTING.md` now links the make-targets table instead of re-enumerating the gate (kills a recurring drift source).

**Contradictions with current code**: `validator-extension.md` still described the pre-#2121 warn-and-continue behavior for unknown check names (now documents the fail-closed `aicr validate` exit 2, explicitly distinguished from the validator-container exit-code contract); `kubernetes-deployment.md` claimed the allowlist vars are "the only environment variables the API server reads" (signing env vars exist); `CONTRIBUTING.md` still hedged the SLSA level on #1536 — now states image Build Level 3 via the reusable attestation workflow since v0.17.0, plus Build Provenance v1 for CLI binaries; validate phase order corrected to deployment → conformance → performance (`pkg/validator/phases.go`), and "readiness" removed as a phase in `examples/recipes/README.md`.

**Demo/tooling guidance corrected against behavior**: the "comment out sections in deploy.sh" advice for a pre-installed nodewright now points at the supported `--set nodewright:enabled=false --set nodewrightcustomizations:enabled=false` bundle-time toggles (deploy.sh deploys numbered directories generically); the uat-broker README now describes `nightly-intents` as the leg-level enrollment summary/opt-out (per-cell dispatch comes from the broker schedule with per-version gates); the ai-conformance NFD row states the suite has no dedicated NFD assertion, and its overlay list is labeled as inheritance chain plus criteria-wildcard overlays (`monitoring-hpa`, `h100-any`).

**RELEASING.md**: documented the 7th released image (`aicr-gate`) in the image table and the attestation verify block (`on-tag.yaml` publishes seven).

**Reference/nav gaps**: `spec.recipe.configuration.slurm.accounting.mode` added to `cli-config.md`; Fern nav entries added for `user/tutorial.md`, `user/bundling.md`, `contributor/evidence-dashboard-publish.md`; four missing rows in the user-guide index table; demos table now lists `slinky-slurm-demo.html`.

**Out-of-scope follow-ups (deliberately not in this PR)**:
- `fern/versions/` has no v0.18.0 entry (released docs never published; nothing in CI catches it) — needs a RELEASING.md checklist item
- `make server` sets unprefixed `LOG_LEVEL`, which `pkg/logging` ignores — Makefile (code) fix
- `make changelog-file` contradicts RELEASING.md's "changelog is not committed"
- `tests/chainsaw/README.md` file-structure listing has drifted ~45% (wants a generator or gate, not a manual patch)
- `demos/images/*.md` hand-copied statistics drift every release (wants a "snapshot as of" marker or generated numbers)
- Intra-file EKS/GKE duplication across CUJ demos; `cli-config.md` vs `cli-reference.md` schema duplication; testgrid/evidence-dashboard table duplication
- `demos/cuj2-inference.md` validates `--phase all` on EKS but `--phase conformance` on GKE with no stated reason — needs an owner decision

## Testing

Doc-only change; full `make qualify` skipped (tests/e2e/Go lint cannot regress from Markdown/nav-YAML edits). Scoped checks run instead:

```bash
make check-agents-sync     # OK — AGENTS.md in sync with .claude/CLAUDE.md
make check-docs-filenames  # OK
make check-docs-mdx        # OK (fast approximation; check-docs-mdx-parse unavailable offline, enforced by the docs-mdx merge gate)
make lint-yaml             # OK
```

All cross-doc anchors touched by this PR verified against their target headings (`#make-targets-reference`, `#deployer-coverage-matrix`, `#automated-tests`, `#server-side-signing`); all files referenced by new nav/table entries exist. The lychee link check runs in CI on `docs/**` PRs.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** The `SECURITY.md` supported-versions bump to 0.19.x assumes v0.19.0 ships; hold the merge until the release if that matters.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, doc-only; scoped checks above
- [x] Linter passes (`make lint`) — docs-relevant subset run locally; Go lint unaffected
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
