### PR TITLE
ci: exclude Markdown from GPU test path filters

### DIFF
--- a/.github/workflows/gpu-h100-inference-test.yaml
+++ b/.github/workflows/gpu-h100-inference-test.yaml
@@ -50,6 +50,7 @@ jobs:
         id: filter
         with:
           base: main
+          predicate-quantifier: 'some-with-excludes'
           filters: |
             matched:
               - '.github/workflows/gpu-h100-inference-test.yaml'
@@ -110,6 +111,10 @@ jobs:
               - 'pkg/collector/**'
               - 'pkg/snapshotter/**'
               - '.github/actions/gpu-snapshot-validate/**'
+              # Markdown/MDX under the runtime globs is documentation — never a
+              # reason to launch a GPU job (#2149). Requires some-with-excludes.
+              - '!**/*.[mM][dD]'
+              - '!**/*.[mM][dD][xX]'
 
   # NVIDIA self-hosted GPU runners reject pull_request event jobs before
   # checkout. PR GPU coverage runs through the pull-request/<number> push

--- a/.github/workflows/gpu-h100-training-test.yaml
+++ b/.github/workflows/gpu-h100-training-test.yaml
@@ -50,6 +50,7 @@ jobs:
         id: filter
         with:
           base: main
+          predicate-quantifier: 'some-with-excludes'
           filters: |
             matched:
               - '.github/workflows/gpu-h100-training-test.yaml'
@@ -106,6 +107,10 @@ jobs:
               - 'pkg/collector/**'
               - 'pkg/snapshotter/**'
               - '.github/actions/gpu-snapshot-validate/**'
+              # Markdown/MDX under the runtime globs is documentation — never a
+              # reason to launch a GPU job (#2149). Requires some-with-excludes.
+              - '!**/*.[mM][dD]'
+              - '!**/*.[mM][dD][xX]'
 
   # NVIDIA self-hosted GPU runners reject pull_request event jobs before
   # checkout. PR GPU coverage runs through the pull-request/<number> push

--- a/.github/workflows/gpu-smoke-test.yaml
+++ b/.github/workflows/gpu-smoke-test.yaml
@@ -44,6 +44,7 @@ jobs:
         id: filter
         with:
           base: main
+          predicate-quantifier: 'some-with-excludes'
           filters: |
             matched:
               - '.github/workflows/gpu-smoke-test.yaml'
@@ -73,6 +74,10 @@ jobs:
               - 'vendor/**'
               - 'pkg/defaults/timeouts.go'
               - 'validators/conformance/**'
+              # Markdown/MDX under the runtime globs is documentation — never a
+              # reason to launch a GPU job (#2149). Requires some-with-excludes.
+              - '!**/*.[mM][dD]'
+              - '!**/*.[mM][dD][xX]'
 
   gpu-smoke-test:
     needs: [check-paths]


### PR DESCRIPTION
## Summary

Markdown/MDX files under the GPU workflows' broad runtime path globs no longer trigger the NVKind GPU test lanes: the three `check-paths` filters now use `predicate-quantifier: 'some-with-excludes'` with trailing case-insensitive `!**/*.[mM][dD]` / `!**/*.[mM][dD][xX]` exclusions.

## Motivation / Context

A docs-only PR touching `pkg/validator/v1/README.md` (#2148) queued all three NVKind GPU jobs on every mirror push — the single Markdown file matched the `pkg/validator/**` glob and flipped `matched=true` (verified in the check-paths logs). The broad globs from #1511 are legitimate for code; they just should not fire on documentation.

Fixes: #2149
Related: #1511, #2148

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/gpu-smoke-test.yaml`, `gpu-h100-inference-test.yaml`, `gpu-h100-training-test.yaml`

## Implementation Notes

Exactly the fix proposed in #2149:

- `predicate-quantifier: 'some-with-excludes'` added to each `dorny/paths-filter` step (supported by the pinned v4.0.3).
- `!**/*.[mM][dD]` and `!**/*.[mM][dD][xX]` appended to each `matched:` list. The character classes make the exclusion case-insensitive — the tree tracks one uppercase Markdown file (`vendor/.../azidentity/TOKEN_CACHING.MD`) under the `vendor/**` positive glob, which a plain `!**/*.md` would miss. (`.mdx` is prophylactic — none currently live under the runtime globs.)
- The positive globs are untouched, and the filtering deliberately stays in the `check-paths` job (which diffs `main...pull-request/<n>`) rather than moving to `on.push.paths-ignore`, which would evaluate the mirror-push diff and reintroduce the rebase false-triggers the current design avoids.

Against #2149's acceptance criteria: a Markdown-only change under `pkg/validator/**` leaves the GPU jobs skipped; runtime changes and mixed md+code changes still trigger; workflow-file changes still trigger (the workflow's own path remains a positive, non-md glob); the lightweight `check-paths` jobs still run.

## Testing

Workflow-only change; full `make qualify` skipped (Go tests/e2e/lint cannot regress from workflow YAML edits). Scoped checks run instead:

```bash
actionlint .github/workflows/gpu-smoke-test.yaml \
  .github/workflows/gpu-h100-inference-test.yaml \
  .github/workflows/gpu-h100-training-test.yaml   # OK
make lint-yaml                                    # OK
```

The `actionlint` merge-gate job covers the same check in CI. Behavioral proof lands with the first docs-only PR after merge (GPU lanes should stay skipped).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — worst case a doc-only PR skips a GPU run that would have been a no-op; any code change still matches a positive glob.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, workflow-only; scoped checks above
- [x] Linter passes (`make lint`) — actionlint + yamllint run locally
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — N/A (no user-visible behavior)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
