### PR TITLE
test: parallelize releasepolicy subtests

### DIFF
--- a/tests/releasepolicy/release_reverify_test.go
+++ b/tests/releasepolicy/release_reverify_test.go
@@ -248,6 +248,7 @@ func TestReleaseReverifyWorkflowShape(t *testing.T) {
 // network trouble must be operational and must never look like a missing entry.
 // Every case here is one side of that line.
 func TestReleaseReverifyClassification(t *testing.T) {
+	t.Parallel()
 	script := reverifyClassifierScript(t)
 
 	// Every fixture derives from the floor constant. Hardcoding a version here
@@ -668,6 +669,7 @@ func TestReleaseReverifyClassification(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, code, output := runReverifyClassifier(t, script, tc.opts)
 			if got != tc.want || code != tc.code {
 				t.Fatalf("classification = %q (exit %d), want %q (exit %d)\n%s", got, code, tc.want, tc.code, output)
@@ -693,6 +695,7 @@ func TestReleaseReverifyClassification(t *testing.T) {
 // misclassifies as a security finding — which is the failure mode this workflow
 // exists to prevent, so the tests must not pass without the guards.
 func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
+	t.Parallel()
 	script := reverifyClassifierScript(t)
 
 	tests := []struct {
@@ -827,6 +830,7 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			opts := tc.opts
 			opts.tag = reverifySBOMFloor
 			if !opts.missingAssetsFile {
@@ -881,6 +885,7 @@ func TestReleaseReverifyGuardsAreLoadBearing(t *testing.T) {
 // set unambiguous, and the assertions name the exact subjects rather than
 // counting them.
 func TestReleaseReverifySBOMLoopIsolatesChildStdin(t *testing.T) {
+	t.Parallel()
 	script := reverifyClassifierScript(t)
 
 	// Pin the redirect count so a change in form (a different redirection, or a
@@ -926,6 +931,7 @@ func TestReleaseReverifySBOMLoopIsolatesChildStdin(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			opts := reverifyOptions{
 				tag:                  "v" + version,
 				assets:               assets,
@@ -990,6 +996,7 @@ func verifiedSBOMs(output string) []string {
 // did so deliberately. A release that is genuinely missing an SBOM bundle would
 // come back clean.
 func TestReleaseReverifySBOMFloorOrderingIsGuarded(t *testing.T) {
+	t.Parallel()
 	script := reverifyClassifierScript(t)
 
 	const from = `newest=""
@@ -1059,6 +1066,7 @@ if [ "${TAG}" = "${SBOM_SIGNING_FLOOR}" ] || [ "${newest}" != "${TAG}" ]; then`
 // same derive-from-the-artifact-under-test flaw that shipped the allowlist bug
 // in NVIDIA/aicr#1982.
 func TestReleaseReverifyMandatorySBOMSetIsDerivedFromTheTag(t *testing.T) {
+	t.Parallel()
 	script := reverifyClassifierScript(t)
 
 	derivation := "  read -r -a sbom_binaries <<< \"${EXPECTED_SBOM_BINARIES}\"\n" +
@@ -1133,6 +1141,7 @@ func TestReleaseReverifyMandatorySBOMSetIsDerivedFromTheTag(t *testing.T) {
 // is the deliberate divergence from rekor-monitor, whose alert tracks the
 // release-agnostic log and so genuinely clears on any clean run.
 func TestReleaseReverifyAlertCloseIsTagScoped(t *testing.T) {
+	t.Parallel()
 	doc := loadYAML(t, reverifyWorkflow)
 	env := mapValue(t, doc, "env")
 	alertTitle := fmt.Sprint(env["ALERT_TITLE"])
@@ -1184,6 +1193,7 @@ func TestReleaseReverifyAlertCloseIsTagScoped(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			closed, output, err := runReverifyCloseStep(t, script, tc.tag, tc.issues)
 			if err != nil {
 				t.Fatalf("close step failed: %v\n%s", err, output)
@@ -1195,6 +1205,7 @@ func TestReleaseReverifyAlertCloseIsTagScoped(t *testing.T) {
 	}
 
 	t.Run("an unscoped close reopens the bug", func(t *testing.T) {
+		t.Parallel()
 		// The pre-fix shape: one global alert title, closed by any clean run.
 		// Staged with the unscoped title on both sides, which is what the
 		// workflow used to create.

--- a/tests/releasepolicy/release_scripts_test.go
+++ b/tests/releasepolicy/release_scripts_test.go
@@ -67,6 +67,7 @@ func TestReleaseScriptsStructure(t *testing.T) {
 // mutated registry aliases. Deriving the expected names from the stanza's own
 // `signature:` template keeps the two from drifting apart.
 func TestReleaseSbomSignaturesAreAllowlisted(t *testing.T) {
+	t.Parallel()
 	config := loadYAML(t, ".goreleaser.yaml")
 
 	sboms, ok := config["sboms"].([]any)
@@ -201,6 +202,7 @@ func shellReleaseAssetNames(t *testing.T, tag string) []string {
 // path as a release artifact whether or not the script writes it, so every
 // path that cannot produce a bundle has to exit non-zero.
 func TestReleaseSignSbomBehavior(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		failures     int
@@ -225,6 +227,7 @@ func TestReleaseSignSbomBehavior(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			bin := filepath.Join(dir, "bin")
 			if err := os.Mkdir(bin, 0o700); err != nil {
@@ -349,6 +352,7 @@ func TestReleaseHomebrewScriptIsMutationLimited(t *testing.T) {
 }
 
 func TestReleaseResolverBehavior(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		badLabelRef string
@@ -362,6 +366,7 @@ func TestReleaseResolverBehavior(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixture := newReleaseFixture(t)
 			output := filepath.Join(fixture.dir, "digests.json")
 			env := fixture.environment()
@@ -390,6 +395,7 @@ func TestReleaseResolverBehavior(t *testing.T) {
 }
 
 func TestReleaseRejectsNonCanonicalReleaseTags(t *testing.T) {
+	t.Parallel()
 	for _, tag := range []string{
 		"v01.2.3",
 		"v1.02.3",
@@ -400,6 +406,7 @@ func TestReleaseRejectsNonCanonicalReleaseTags(t *testing.T) {
 		"v1.2.3+build.1",
 	} {
 		t.Run(tag, func(t *testing.T) {
+			t.Parallel()
 			fixture := newReleaseFixture(t)
 			environment := append(fixture.environment(), "RELEASE_TAG="+tag)
 			result := runScript(t, environment, ".github/scripts/release-images.sh", "verify-source")
@@ -411,6 +418,7 @@ func TestReleaseRejectsNonCanonicalReleaseTags(t *testing.T) {
 }
 
 func TestReleaseTargetRerunPolicy(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		releases   [][]map[string]any
@@ -541,6 +549,7 @@ func TestReleaseTargetRerunPolicy(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixture := newReleaseFixture(t)
 			writeJSON(t, fixture.releases, tc.releases)
 			if tc.assets != nil {
@@ -561,6 +570,7 @@ func TestReleaseTargetRerunPolicy(t *testing.T) {
 }
 
 func TestReleasePublishRequiresExactDraftAssetsAndID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		modifyRelease func(map[string]any)
@@ -635,6 +645,7 @@ func TestReleasePublishRequiresExactDraftAssetsAndID(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixture := newReleaseFixture(t)
 			release := map[string]any{
 				"id":         42,
@@ -684,6 +695,7 @@ func TestReleasePublishRequiresExactDraftAssetsAndID(t *testing.T) {
 }
 
 func TestReleasePreflightRejectsConflictingVersionWithoutMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newReleaseFixture(t)
 	mapPath := filepath.Join(fixture.dir, "digests.json")
 	writeDigestMap(t, mapPath, fixture.digests)
@@ -702,6 +714,7 @@ func TestReleasePreflightRejectsConflictingVersionWithoutMutation(t *testing.T) 
 }
 
 func TestReleasePreflightRejectsDuplicateDigestKeysWithoutMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newReleaseFixture(t)
 	encoded, err := json.Marshal(fixture.digests)
 	if err != nil {
@@ -727,6 +740,7 @@ func TestReleasePreflightRejectsDuplicateDigestKeysWithoutMutation(t *testing.T)
 }
 
 func TestReleasePreflightRejectsReleaseKindMismatchWithoutMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newStableReleaseFixture(t)
 	mapPath := filepath.Join(fixture.dir, "digests.json")
 	writeDigestMap(t, mapPath, fixture.digests)
@@ -742,6 +756,7 @@ func TestReleasePreflightRejectsReleaseKindMismatchWithoutMutation(t *testing.T)
 }
 
 func TestReleasePreflightFailureModesHaveNoMutations(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		setup func(*testing.T, releaseFixture, map[string]string) []string
@@ -810,6 +825,7 @@ func TestReleasePreflightFailureModesHaveNoMutations(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixture := newReleaseFixture(t)
 			digests := make(map[string]string, len(fixture.digests))
 			for key, digest := range fixture.digests {
@@ -835,6 +851,7 @@ func TestReleasePreflightFailureModesHaveNoMutations(t *testing.T) {
 }
 
 func TestReleaseStablePreflightFailureModesHaveNoMutations(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		setup func(*testing.T, releaseFixture)
@@ -922,6 +939,7 @@ func TestReleaseStablePreflightFailureModesHaveNoMutations(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixture := newStableReleaseFixture(t)
 			tc.setup(t, fixture)
 			mapPath := filepath.Join(fixture.dir, "digests.json")
@@ -942,6 +960,7 @@ func TestReleaseStablePreflightFailureModesHaveNoMutations(t *testing.T) {
 }
 
 func TestReleasePriorSelectionIgnoresNonStableNames(t *testing.T) {
+	t.Parallel()
 	fixture := newStableReleaseFixture(t)
 	writeJSON(t, fixture.releases, [][]map[string]any{{
 		{"tag_name": "v1.2.2", "draft": false, "prerelease": false},
@@ -958,6 +977,7 @@ func TestReleasePriorSelectionIgnoresNonStableNames(t *testing.T) {
 }
 
 func TestReleasePreflightRejectsMovedCurrentTag(t *testing.T) {
+	t.Parallel()
 	fixture := newReleaseFixture(t)
 	mapPath := filepath.Join(fixture.dir, "digests.json")
 	writeDigestMap(t, mapPath, fixture.digests)
@@ -973,6 +993,7 @@ func TestReleasePreflightRejectsMovedCurrentTag(t *testing.T) {
 }
 
 func TestReleasePromotionRejectsPostPreflightAliasMutationWithoutWrites(t *testing.T) {
+	t.Parallel()
 	fixture := newStableReleaseFixture(t)
 	mapPath := filepath.Join(fixture.dir, "digests.json")
 	writeDigestMap(t, mapPath, fixture.digests)
@@ -993,6 +1014,7 @@ func TestReleasePromotionRejectsPostPreflightAliasMutationWithoutWrites(t *testi
 }
 
 func TestReleasePreflightPaginatesAndPeelsAnnotatedTags(t *testing.T) {
+	t.Parallel()
 	fixture := newStableReleaseFixture(t)
 	mapPath := filepath.Join(fixture.dir, "digests.json")
 	writeDigestMap(t, mapPath, fixture.digests)
@@ -1008,7 +1030,9 @@ func TestReleasePreflightPaginatesAndPeelsAnnotatedTags(t *testing.T) {
 }
 
 func TestReleaseV0170UnlabeledBootstrapIsExact(t *testing.T) {
+	t.Parallel()
 	t.Run("pinned core digests accepted", func(t *testing.T) {
+		t.Parallel()
 		fixture := newV0170BootstrapFixture(t)
 		mapPath := filepath.Join(fixture.dir, "digests.json")
 		writeDigestMap(t, mapPath, fixture.digests)
@@ -1020,6 +1044,7 @@ func TestReleaseV0170UnlabeledBootstrapIsExact(t *testing.T) {
 	})
 
 	t.Run("other unlabeled core digest rejected", func(t *testing.T) {
+		t.Parallel()
 		fixture := newV0170BootstrapFixture(t)
 		wrong := "sha256:" + strings.Repeat("f", 64)
 		appendFile(t, fixture.digestState, releaseImages["aicr"]+":v0.17.0\t"+wrong+"\n")
@@ -1038,6 +1063,7 @@ func TestReleaseV0170UnlabeledBootstrapIsExact(t *testing.T) {
 }
 
 func TestReleaseStablePromotionConvergesAndRerunsWithoutMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newStableReleaseFixture(t)
 	mapPath := filepath.Join(fixture.dir, "digests.json")
 	writeDigestMap(t, mapPath, fixture.digests)
@@ -1070,6 +1096,7 @@ func TestReleaseStablePromotionConvergesAndRerunsWithoutMutation(t *testing.T) {
 }
 
 func TestReleasePromotionDefersLatestUntilEveryVersionIsVerified(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		extraEnv func(releaseFixture) string
@@ -1090,6 +1117,7 @@ func TestReleasePromotionDefersLatestUntilEveryVersionIsVerified(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixture := newStableReleaseFixture(t)
 			mapPath := filepath.Join(fixture.dir, "digests.json")
 			writeDigestMap(t, mapPath, fixture.digests)
@@ -1123,6 +1151,7 @@ func TestReleasePromotionHasExplicitVersionThenLatestPhases(t *testing.T) {
 }
 
 func TestReleaseStablePromotionConvergesMixedAliasStates(t *testing.T) {
+	t.Parallel()
 	fixture := newStableReleaseFixture(t)
 	keys := make([]string, 0, len(releaseImages))
 	for key := range releaseImages {
@@ -1163,6 +1192,7 @@ func TestReleaseStablePromotionConvergesMixedAliasStates(t *testing.T) {
 }
 
 func TestReleasePromotionRejectsTagMovementAfterPreflightWithoutWrites(t *testing.T) {
+	t.Parallel()
 	fixture := newStableReleaseFixture(t)
 	mapPath := filepath.Join(fixture.dir, "digests.json")
 	writeDigestMap(t, mapPath, fixture.digests)
@@ -1182,6 +1212,7 @@ func TestReleasePromotionRejectsTagMovementAfterPreflightWithoutWrites(t *testin
 }
 
 func TestReleasePromotionPrereleaseWritesOnlyVersionAliases(t *testing.T) {
+	t.Parallel()
 	fixture := newReleaseFixture(t)
 	validated := map[string]any{
 		"candidate_tag": fixture.candidateTag,
@@ -1224,6 +1255,7 @@ func TestReleasePromotionPrereleaseWritesOnlyVersionAliases(t *testing.T) {
 }
 
 func TestReleaseHomebrewBehavior(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		existingTag     string
@@ -1271,6 +1303,7 @@ func TestReleaseHomebrewBehavior(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			bin := filepath.Join(dir, "bin")
 			tap := filepath.Join(dir, "tap")
@@ -1334,7 +1367,9 @@ func TestReleaseHomebrewBehavior(t *testing.T) {
 }
 
 func TestReleaseNetworkBoundsTerminateBlockedCommands(t *testing.T) {
+	t.Parallel()
 	t.Run("candidate resolver", func(t *testing.T) {
+		t.Parallel()
 		fixture := newReleaseFixture(t)
 		writeExecutable(t, filepath.Join(fixture.bin, "timeout"), fakeTimeout)
 		writeExecutable(t, filepath.Join(fixture.bin, "crane"), blockingCommand)
@@ -1357,6 +1392,7 @@ func TestReleaseNetworkBoundsTerminateBlockedCommands(t *testing.T) {
 	})
 
 	t.Run("Homebrew checksum fetch", func(t *testing.T) {
+		t.Parallel()
 		dir := t.TempDir()
 		bin := filepath.Join(dir, "bin")
 		formulaDir := filepath.Join(dir, "tap", "Formula")

--- a/tests/releasepolicy/release_workflow_test.go
+++ b/tests/releasepolicy/release_workflow_test.go
@@ -277,6 +277,7 @@ func TestReleaseCosignAttestationsAreBounded(t *testing.T) {
 // a release that lost an architecture, or a resolution that yielded the index
 // digest, must stop the job rather than ship two SBOMs on one subject.
 func TestReleasePlatformDigestResolution(t *testing.T) {
+	t.Parallel()
 	doc := loadYAML(t, ".github/actions/attest-image-from-tag/action.yml")
 	steps := sliceValue(t, mapValue(t, doc, "runs"), "steps")
 
@@ -325,6 +326,7 @@ func TestReleasePlatformDigestResolution(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			bin := filepath.Join(dir, "bin")
 			if err := os.Mkdir(bin, 0o700); err != nil {
@@ -370,6 +372,7 @@ func TestReleasePlatformDigestResolution(t *testing.T) {
 // through as a platform digest has to be rejected here rather than silently
 // attaching a per-platform SBOM to the multi-platform index.
 func TestReleaseSbomAttestInputValidation(t *testing.T) {
+	t.Parallel()
 	doc := loadYAML(t, ".github/actions/sbom-and-attest/action.yml")
 	steps := sliceValue(t, mapValue(t, doc, "runs"), "steps")
 	index := stepIndex(steps, "Validate inputs")
@@ -400,6 +403,7 @@ func TestReleaseSbomAttestInputValidation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			output := filepath.Join(t.TempDir(), "outputs")
 			command := exec.Command("bash", "-c", script)
 			command.Env = append(os.Environ(),
@@ -448,6 +452,7 @@ const openVEXContext = "https://openvex.dev/ns/v0.2.0"
 // `{}` statement, a `not_affected` statement with no reason) are exactly the
 // ones that look healthy until a downstream consumer tries to use them.
 func TestReleaseOpenVEXValidation(t *testing.T) {
+	t.Parallel()
 	doc := loadYAML(t, ".github/actions/sbom-and-attest/action.yml")
 	steps := sliceValue(t, mapValue(t, doc, "runs"), "steps")
 	index := stepIndex(steps, "Verify OpenVEX document")
@@ -547,6 +552,7 @@ func TestReleaseOpenVEXValidation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			workspace := t.TempDir()
 			vex := filepath.Join(workspace, ".openvex.json")
 			if err := os.WriteFile(vex, []byte(tc.document), 0o600); err != nil {
@@ -571,6 +577,7 @@ func TestReleaseOpenVEXValidation(t *testing.T) {
 	// The shipped document has to survive the guard it is published through.
 	// A release cannot be the first place this is discovered.
 	t.Run("the committed .openvex.json is valid", func(t *testing.T) {
+		t.Parallel()
 		workspace := t.TempDir()
 		committed := readFile(t, ".openvex.json")
 		if err := os.WriteFile(filepath.Join(workspace, ".openvex.json"), committed, 0o600); err != nil {
@@ -641,6 +648,7 @@ exec "$@"
 `
 
 func TestReleaseAttestationInputValidationEmitsCanonicalDigestMap(t *testing.T) {
+	t.Parallel()
 	doc := loadYAML(t, ".github/workflows/attest-images.yaml")
 	job := mapValue(t, mapValue(t, doc, "jobs"), "validate-inputs")
 	steps := sliceValue(t, job, "steps")
@@ -669,6 +677,7 @@ func TestReleaseAttestationInputValidationEmitsCanonicalDigestMap(t *testing.T) 
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			output := filepath.Join(t.TempDir(), "outputs")
 			command := exec.Command("bash", "-c", script)
 			command.Env = append(os.Environ(),
@@ -727,6 +736,7 @@ func TestReleaseCompositeValidationUsesSharedLibrary(t *testing.T) {
 }
 
 func TestReleaseInputValidationLibrary(t *testing.T) {
+	t.Parallel()
 	helper := filepath.Join(repositoryRoot(t), ".github/actions/release-input-validation.sh")
 	type validationTest struct {
 		name    string
@@ -747,6 +757,7 @@ func TestReleaseInputValidationLibrary(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			args := make([]string, 0, 4+len(tc.args))
 			args = append(args, "-c", `source "$1"; shift; "$@"`, "release-input-validation", helper)
 			args = append(args, tc.args...)
@@ -958,6 +969,7 @@ func TestReleaseBuildCompositeInputs(t *testing.T) {
 }
 
 func TestReleaseCompositeValidationRejectsUnsafeInputsBeforeIO(t *testing.T) {
+	t.Parallel()
 	goBuildValid := map[string]string{
 		"INPUT_REGISTRY":            "ghcr.io",
 		"INPUT_KO_VERSION":          "v0.19.1",
@@ -996,6 +1008,7 @@ func TestReleaseCompositeValidationRejectsUnsafeInputsBeforeIO(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			doc := loadYAML(t, tc.path)
 			steps := sliceValue(t, mapValue(t, doc, "runs"), "steps")
 			validation := steps[0].(map[string]any)
@@ -1067,6 +1080,7 @@ func TestReleasePackagingConfig(t *testing.T) {
 }
 
 func TestReleaseArtifactNamesAreRerunSafe(t *testing.T) {
+	t.Parallel()
 	doc := loadYAML(t, ".github/workflows/on-tag.yaml")
 	jobs := mapValue(t, doc, "jobs")
 	build := mapValue(t, jobs, "build-ko")


### PR DESCRIPTION
## Summary

Adds `t.Parallel()` across the `tests/releasepolicy` package so its ~110 isolated bash-spawning subtests run concurrently instead of sequentially, cutting the package's wall-clock in the `tests / Test` CI job.

## Motivation / Context

The package had zero `t.Parallel()` calls, so ~110 sequential bash processes (~1s each) cost ~107–186s per CI run even though every subtest is fully self-contained.

Fixes: #2146
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tests/releasepolicy`

## Implementation Notes

**Isolation verified before parallelizing:** the package contains no `t.Setenv` or `t.Chdir` (all environment passes through `exec.Cmd.Env`), every subtest stages its own `t.TempDir()` and fake binaries, and the shared values (`script` strings extracted from workflow YAML, the `releaseImages` map, fixture helpers) are read-only or freshly allocated per subtest. No `tc := tc` copies are needed on Go 1.26 per-iteration loop variables.

**Where `t.Parallel()` was added** (61 insertions, no other changes):

- Inner `t.Run` callbacks of every table-driven / multi-subtest test the issue lists: `TestReleaseReverifyClassification`, `TestReleaseReverifyGuardsAreLoadBearing`, `TestReleaseReverifySBOMLoopIsolatesChildStdin`, `TestReleaseReverifyAlertCloseIsTagScoped`, `TestReleaseSignSbomBehavior`, `TestReleaseResolverBehavior`, `TestReleaseRejectsNonCanonicalReleaseTags`, `TestReleaseTargetRerunPolicy`, `TestReleasePublishRequiresExactDraftAssetsAndID`, `TestReleasePreflightFailureModesHaveNoMutations`, `TestReleaseStablePreflightFailureModesHaveNoMutations`, `TestReleaseV0170UnlabeledBootstrapIsExact`, `TestReleasePromotionDefersLatestUntilEveryVersionIsVerified`, `TestReleaseHomebrewBehavior`, `TestReleaseNetworkBoundsTerminateBlockedCommands`, `TestReleasePlatformDigestResolution`, `TestReleaseSbomAttestInputValidation`, `TestReleaseOpenVEXValidation`, `TestReleaseAttestationInputValidationEmitsCanonicalDigestMap`, `TestReleaseCompositeValidationRejectsUnsafeInputsBeforeIO`, `TestReleaseInputValidationLibrary`.
- Their parent test functions, as the `tparallel` linter requires when subtests are parallel.
- Top-level `t.Parallel()` on the isolated single-body bash-invoking tests (`TestReleaseSbomSignaturesAreAllowlisted`, the preflight/promotion no-mutation tests, `TestReleaseReverifySBOMFloorOrderingIsGuarded`, `TestReleaseReverifyMandatorySBOMSetIsDerivedFromTheTag`, `TestReleaseArtifactNamesAreRerunSafe`), so they overlap with the parallel phase instead of running serially before/after it.

**Left sequential:** the pure text/YAML-inspection tests (`TestReleaseReverifyWorkflowShape`, `TestReleaseScriptsStructure`, `TestScriptBudgetFor`, `TestReleasePromotionPolicy`, etc., and `image_cache_policy_test.go`) — they take milliseconds and spawn no processes, so parallelizing them buys nothing.

**Remaining floor:** the stable-promotion tests (`TestReleaseStablePromotionConvergesAndRerunsWithoutMutation` and siblings) each run 2–4 sequential full-script invocations against a single fixture and are inherently sequential internally; they now run in parallel with everything else and set the residual wall-clock.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race -count=1 ./tests/releasepolicy/...
GOLANGCI_LINT_CACHE=... golangci-lint run -c .golangci.yaml ./tests/releasepolicy/...
GOFLAGS="-mod=vendor" go test -coverprofile=... ./tests/releasepolicy/...
```

- Wall-clock with `-race` (local Apple Silicon, sandboxed): **180.7s before → 56.3s after** (~3.2×); re-verified green after rebasing onto current `main` (59.2s).
- `golangci-lint`: 0 issues (includes the `tparallel` check).
- Coverage: `[no statements]` — test-only package, no shipped-code coverage impact; `make test-coverage`'s floor is unaffected.
- Full `make qualify` was not run for this test-only change; the scoped `-race` test run and package lint above cover everything this diff can regress.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — test-only; no shipped code or workflow changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
