### PR TITLE
fix(sdk): harden transparent alias API diff

### DIFF
--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -71,10 +71,6 @@ runs:
         go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
         setup-envtest use --print path >/dev/null 2>&1
 
-    - name: Run Tests with Coverage
-      shell: bash
-      run: make test
-
     - name: Install API-diff tool
       if: inputs.apidiff_version != ''
       shell: bash
@@ -83,6 +79,10 @@ runs:
       run: |
         set -euo pipefail
         GOFLAGS= go install "golang.org/x/exp/cmd/apidiff@${APIDIFF_VERSION}"
+
+    - name: Run Tests with Coverage
+      shell: bash
+      run: make test
 
     - name: Coverage Report
       if: inputs.coverage_report == 'true'

--- a/docs/contributor/maintaining.md
+++ b/docs/contributor/maintaining.md
@@ -48,7 +48,11 @@ the gate derives the repository-local named-type closure exposed by
 compares only that baseline/current closure, including nested fields and method
 signatures; unrelated exports in the evolving target packages remain filtered
 out. Closure derivation and an out-of-sync transparent-alias root list both fail
-the gate closed.
+the gate closed. Generic target aliases are supported only when they forward
+every type parameter unchanged with identical constraints. Concrete,
+transformed, and narrowed instantiations fail before `apidiff` because its
+package-level report cannot distinguish one instantiation from the generic
+origin.
 
 To acknowledge an intentional break, first run `make api-diff`. Add a
 baseline-scoped entry to `pkg/client/v1/api-diff-exceptions.yaml` containing the

--- a/tools/api-diff
+++ b/tools/api-diff
@@ -39,12 +39,16 @@ has_tools apidiff git yq
 cd "${REPO_ROOT}"
 
 readonly PACKAGE='github.com/NVIDIA/aicr/pkg/client/v1'
+readonly MODULE_PATH="${PACKAGE%/pkg/client/v1}"
 # apidiff treats an alias to an external named type as only the target package
 # path plus type name; it does not recursively compare the target definition.
 # These are the facade-to-target mappings. tools/api-diff-closure starts its
-# traversal at each facade alias declaration so instantiated type arguments are
-# retained, then derives every repository-local named type reachable through
-# the complete target and its public fields and method signatures. This covers
+# traversal at each facade alias declaration so type arguments embedded in the
+# reachable API remain available, then derives every repository-local named type
+# reachable through the complete target and its public fields and method
+# signatures. Generic aliases must forward their parameters unchanged; concrete
+# and otherwise specialized generic aliases fail closed because apidiff's
+# package-level report cannot scope changes to one instantiation. This covers
 # nested contract types without freezing unrelated exports. Format: facade
 # alias|target package|root type. Each mapping is kept explicit so the
 # syntax-aware exhaustiveness check can detect alias retargeting.
@@ -94,7 +98,9 @@ fi
 # T[P].X for a generic receiver), pointer methods as (*T).X (or (*T[P]).X),
 # and promoted methods with a "method set of T" suffix. Package
 # additions/removals and changes to unrelated declarations are intentionally
-# excluded.
+# excluded. A baseline-only target package that is absent from the current tree
+# is handled separately as a package removal because there is no current package
+# for apidiff to load or filter.
 filter_alias_target_report() {
     local target_types=$1
 
@@ -174,6 +180,42 @@ filter_alias_target_report() {
             }
         }
     '
+}
+
+# Report the one package-level incompatibility that apidiff cannot produce in
+# package mode: a baseline package that has been removed from the current tree.
+# The baseline export has already succeeded, and alias_scope proves that at
+# least one type in this package was reachable through the released facade.
+removed_alias_target_package_report() {
+    local target_package=$1
+
+    printf 'Incompatible changes:\n- package %s: removed\n' "${target_package}"
+}
+
+alias_closure_contains_package() {
+    local closure=$1
+    local target_package=$2
+
+    awk -F '|' -v target_package="${target_package}" '
+        $1 == target_package { found = 1 }
+        END { exit(found ? 0 : 1) }
+    ' <<< "${closure}"
+}
+
+# A removed Go package can leave documentation or testdata behind in its old
+# directory. In that case there is still no current package for apidiff to load.
+# Conversely, any Go source must go through apidiff so malformed or transient
+# package-load failures remain fatal instead of being mislabeled as removal.
+current_package_has_go_source() {
+    local target_directory=$1
+    local source
+
+    for source in "${target_directory}"/*.go; do
+        if [[ -f "${source}" || -L "${source}" ]]; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 # Return the baseline-reachable closure types, retaining baseline/current
@@ -306,7 +348,7 @@ alias_scope="$(build_alias_scope "${baseline_alias_closure}" "${current_alias_cl
         if [[ -z "${target_package}" ]]; then
             continue
         fi
-        apidiff -w "${release_export}.alias-${alias_index}" "${target_package}"
+        apidiff -allow-internal -w "${release_export}.alias-${alias_index}" "${target_package}"
         alias_index=$((alias_index + 1))
     done <<< "${alias_scope}"
 )
@@ -321,8 +363,19 @@ while IFS='|' read -r target_package target_types; do
     if [[ -z "${target_package}" ]]; then
         continue
     fi
-    target_report="$(apidiff "${release_export}.alias-${alias_index}" "${target_package}")"
-    scoped_report="$(printf '%s\n' "${target_report}" | filter_alias_target_report "${target_types}")"
+    if [[ "${target_package}" != "${MODULE_PATH}/"* ]]; then
+        api_diff_err "${EXIT_ALIAS_CONTRACT_MISMATCH}" "Transparent-alias closure package ${target_package} is outside current module ${MODULE_PATH}."
+    fi
+    target_relative_path="${target_package#"${MODULE_PATH}/"}"
+    target_directory="${REPO_ROOT}/${target_relative_path}"
+    if alias_closure_contains_package "${current_alias_closure}" "${target_package}" || current_package_has_go_source "${target_directory}"; then
+        target_report="$(apidiff -allow-internal "${release_export}.alias-${alias_index}" "${target_package}")"
+        scoped_report="$(printf '%s\n' "${target_report}" | filter_alias_target_report "${target_types}")"
+    elif [[ -d "${target_directory}" || ( ! -e "${target_directory}" && ! -L "${target_directory}" ) ]]; then
+        scoped_report="$(removed_alias_target_package_report "${target_package}")"
+    else
+        api_diff_err "${EXIT_ALIAS_CONTRACT_MISMATCH}" "Transparent-alias closure package path ${target_directory} exists but is not a directory."
+    fi
     if [[ -n "${scoped_report}" ]]; then
         msg "Transparent alias reachable-type changes: ${target_package} (${target_types})"
         if [[ -n "${report}" ]]; then

--- a/tools/api-diff-closure/main.go
+++ b/tools/api-diff-closure/main.go
@@ -64,6 +64,36 @@ type listedPackage struct {
 	}
 }
 
+// moduleMembership records the actual module identity that go list reported for
+// every loaded package. Import-path prefixes are insufficient because a
+// dependency may itself be a nested module whose path extends the root module
+// path.
+type moduleMembership struct {
+	modulePath         string
+	packageModulePaths map[string]string
+}
+
+func newModuleMembership(modulePath string, packageModulePaths map[string]string) moduleMembership {
+	membership := moduleMembership{
+		modulePath:         modulePath,
+		packageModulePaths: make(map[string]string, len(packageModulePaths)),
+	}
+	for packagePath, packageModulePath := range packageModulePaths {
+		membership.packageModulePaths[packagePath] = packageModulePath
+	}
+	return membership
+}
+
+func (m moduleMembership) contains(packagePath string) bool {
+	packageModulePath, ok := m.packageModulePaths[packagePath]
+	return ok && packageModulePath == m.modulePath
+}
+
+func (m moduleMembership) moduleForPackage(packagePath string) (string, bool) {
+	modulePath, ok := m.packageModulePaths[packagePath]
+	return modulePath, ok
+}
+
 func main() {
 	if err := run(os.Args[1:], os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "api-diff-closure: %v\n", err)
@@ -108,13 +138,13 @@ func run(args []string, stdout io.Writer) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), goListTimeout)
 	defer cancel()
-	packages, modulePath, err := loadPackages(ctx, *workingDir, packagePaths)
+	packages, membership, err := loadPackages(ctx, *workingDir, packagePaths)
 	if err != nil {
 		return err
 	}
 
 	if *aliasPackage != "" {
-		aliases, mappingErr := transparentAliasMappings(packages[*aliasPackage], modulePath)
+		aliases, mappingErr := transparentAliasMappings(packages[*aliasPackage], membership)
 		if mappingErr != nil {
 			return mappingErr
 		}
@@ -126,7 +156,7 @@ func run(args []string, stdout io.Writer) error {
 		return nil
 	}
 
-	closure, err := reachableTypes(packages, modulePath, roots)
+	closure, err := reachableTypes(packages, membership, roots)
 	if err != nil {
 		return err
 	}
@@ -171,7 +201,16 @@ func parseRoots(rawRoots []string) ([]rootSpec, error) {
 	return roots, nil
 }
 
-func loadPackages(ctx context.Context, workingDir string, packagePaths []string) (map[string]*types.Package, string, error) {
+func loadPackages(
+	ctx context.Context,
+	workingDir string,
+	packagePaths []string,
+) (
+	map[string]*types.Package,
+	moduleMembership,
+	error,
+) {
+
 	rootPackages := make([]string, 0, len(packagePaths))
 	seen := make(map[string]struct{})
 	for _, packagePath := range packagePaths {
@@ -189,13 +228,13 @@ func loadPackages(ctx context.Context, workingDir string, packagePaths []string)
 	output, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, "", fmt.Errorf("load packages: %w", ctx.Err())
+			return nil, moduleMembership{}, fmt.Errorf("load packages: %w", ctx.Err())
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return nil, "", fmt.Errorf("go list failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+			return nil, moduleMembership{}, fmt.Errorf("go list failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
 		}
-		return nil, "", fmt.Errorf("run go list: %w", err)
+		return nil, moduleMembership{}, fmt.Errorf("run go list: %w", err)
 	}
 
 	listed := make(map[string]listedPackage)
@@ -206,7 +245,7 @@ func loadPackages(ctx context.Context, workingDir string, packagePaths []string)
 			if err == io.EOF {
 				break
 			}
-			return nil, "", fmt.Errorf("decode go list output: %w", err)
+			return nil, moduleMembership{}, fmt.Errorf("decode go list output: %w", err)
 		}
 		listed[pkg.ImportPath] = pkg
 	}
@@ -215,17 +254,24 @@ func loadPackages(ctx context.Context, workingDir string, packagePaths []string)
 	for _, packagePath := range rootPackages {
 		pkg, ok := listed[packagePath]
 		if !ok {
-			return nil, "", fmt.Errorf("go list omitted root package %s", packagePath)
+			return nil, moduleMembership{}, fmt.Errorf("go list omitted root package %s", packagePath)
 		}
 		if pkg.Module == nil || pkg.Module.Path == "" {
-			return nil, "", fmt.Errorf("root package %s is not in a Go module", packagePath)
+			return nil, moduleMembership{}, fmt.Errorf("root package %s is not in a Go module", packagePath)
 		}
 		if modulePath == "" {
 			modulePath = pkg.Module.Path
 		} else if modulePath != pkg.Module.Path {
-			return nil, "", fmt.Errorf("root packages span modules %s and %s", modulePath, pkg.Module.Path)
+			return nil, moduleMembership{}, fmt.Errorf("root packages span modules %s and %s", modulePath, pkg.Module.Path)
 		}
 	}
+	packageModulePaths := make(map[string]string, len(listed))
+	for packagePath, pkg := range listed {
+		if pkg.Module != nil && pkg.Module.Path != "" {
+			packageModulePaths[packagePath] = pkg.Module.Path
+		}
+	}
+	membership := newModuleMembership(modulePath, packageModulePaths)
 
 	lookup := func(path string) (io.ReadCloser, error) {
 		pkg, ok := listed[path]
@@ -246,11 +292,11 @@ func loadPackages(ctx context.Context, workingDir string, packagePaths []string)
 	for _, packagePath := range rootPackages {
 		pkg, err := packageImporter.Import(packagePath)
 		if err != nil {
-			return nil, "", fmt.Errorf("import %s: %w", packagePath, err)
+			return nil, moduleMembership{}, fmt.Errorf("import %s: %w", packagePath, err)
 		}
 		loaded[packagePath] = pkg
 	}
-	return loaded, modulePath, nil
+	return loaded, membership, nil
 }
 
 type aliasMapping struct {
@@ -259,7 +305,7 @@ type aliasMapping struct {
 	typeName    string
 }
 
-func transparentAliasMappings(pkg *types.Package, modulePath string) ([]aliasMapping, error) {
+func transparentAliasMappings(pkg *types.Package, membership moduleMembership) ([]aliasMapping, error) {
 	if pkg == nil {
 		return nil, fmt.Errorf("alias package was not loaded")
 	}
@@ -275,14 +321,27 @@ func transparentAliasMappings(pkg *types.Package, modulePath string) ([]aliasMap
 		if err != nil {
 			return nil, fmt.Errorf("normalize exported alias %s.%s: %w", pkg.Path(), name, err)
 		}
+		if target.TypeArgs().Len() != 0 {
+			alias, ok := object.Type().(*types.Alias)
+			if !ok {
+				return nil, fmt.Errorf("exported alias %s.%s has unexpected type %T", pkg.Path(), name, object.Type())
+			}
+			if err := validateGenericAliasScope(alias, target); err != nil {
+				return nil, fmt.Errorf("inspect exported alias %s.%s: %w", pkg.Path(), name, err)
+			}
+		}
 		targetObject := target.Obj()
 		if targetObject.Pkg() == nil {
 			return nil, fmt.Errorf("exported alias %s.%s targets non-package type %s", pkg.Path(), name, targetObject.Name())
 		}
-		if !isWithinModule(targetObject.Pkg().Path(), modulePath) {
+		if !membership.contains(targetObject.Pkg().Path()) {
+			targetModulePath := "<no module>"
+			if listedModulePath, ok := membership.moduleForPackage(targetObject.Pkg().Path()); ok {
+				targetModulePath = listedModulePath
+			}
 			return nil, fmt.Errorf(
-				"exported alias %s.%s targets type %s.%s outside module %s",
-				pkg.Path(), name, targetObject.Pkg().Path(), targetObject.Name(), modulePath,
+				"exported alias %s.%s targets type %s.%s from module %s, not root module %s",
+				pkg.Path(), name, targetObject.Pkg().Path(), targetObject.Name(), targetModulePath, membership.modulePath,
 			)
 		}
 		mappings = append(mappings, aliasMapping{
@@ -304,6 +363,39 @@ func transparentAliasMappings(pkg *types.Package, modulePath string) ([]aliasMap
 	return mappings, nil
 }
 
+// validateGenericAliasScope rejects generic target specializations that the
+// package-level apidiff report cannot distinguish from the generic origin. A
+// direct, constraint-identical forwarding alias exposes the complete origin and
+// can safely use that report; concrete, transformed, or narrowed aliases expose
+// only a subset and require an instantiation-specific comparison surface.
+func validateGenericAliasScope(alias *types.Alias, target *types.Named) error {
+	targetArguments := target.TypeArgs()
+	if targetArguments.Len() == 0 {
+		return nil
+	}
+
+	aliasParameters := alias.TypeParams()
+	targetParameters := target.Origin().TypeParams()
+	if aliasParameters.Len() != targetArguments.Len() || targetParameters.Len() != targetArguments.Len() {
+		return unsupportedGenericAliasError(target)
+	}
+	for i := range targetArguments.Len() {
+		argumentMatches := types.Identical(targetArguments.At(i), aliasParameters.At(i))
+		constraintMatches := types.Identical(aliasParameters.At(i).Constraint(), targetParameters.At(i).Constraint())
+		if !argumentMatches || !constraintMatches {
+			return unsupportedGenericAliasError(target)
+		}
+	}
+	return nil
+}
+
+func unsupportedGenericAliasError(target *types.Named) error {
+	return fmt.Errorf(
+		"generic target alias instantiated as %s cannot be scoped safely; generic target aliases must forward every type parameter unchanged with identical constraints (concrete, transformed, and narrowed instantiations are unsupported)",
+		target,
+	)
+}
+
 func normalizedAliasTarget(typ types.Type) (*types.Named, error) {
 	switch typ := typ.(type) {
 	case *types.Alias:
@@ -322,9 +414,17 @@ type closureEntry struct {
 	typeName    string
 }
 
-func reachableTypes(packages map[string]*types.Package, modulePath string, roots []rootSpec) ([]closureEntry, error) {
+func reachableTypes(
+	packages map[string]*types.Package,
+	membership moduleMembership,
+	roots []rootSpec,
+) (
+	[]closureEntry,
+	error,
+) {
+
 	collector := typeCollector{
-		modulePath: modulePath,
+		membership: membership,
 		seenTypes:  make(map[types.Type]struct{}),
 		entries:    make(map[closureEntry]struct{}),
 	}
@@ -357,7 +457,7 @@ func reachableTypes(packages map[string]*types.Package, modulePath string, roots
 }
 
 type typeCollector struct {
-	modulePath string
+	membership moduleMembership
 	seenTypes  map[types.Type]struct{}
 	entries    map[closureEntry]struct{}
 }
@@ -432,7 +532,7 @@ func (c *typeCollector) visit(typ types.Type) {
 }
 
 func (c *typeCollector) addTypeName(object *types.TypeName) bool {
-	if object == nil || object.Pkg() == nil || !isWithinModule(object.Pkg().Path(), c.modulePath) {
+	if object == nil || object.Pkg() == nil || !c.membership.contains(object.Pkg().Path()) {
 		return false
 	}
 	c.entries[closureEntry{packagePath: object.Pkg().Path(), typeName: object.Name()}] = struct{}{}
@@ -458,8 +558,4 @@ func (c *typeCollector) visitTuple(tuple *types.Tuple) {
 	for i := range tuple.Len() {
 		c.visit(tuple.At(i).Type())
 	}
-}
-
-func isWithinModule(packagePath, modulePath string) bool {
-	return packagePath == modulePath || strings.HasPrefix(packagePath, modulePath+"/")
 }

--- a/tools/api-diff-closure/main_test.go
+++ b/tools/api-diff-closure/main_test.go
@@ -16,13 +16,16 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"go/types"
+	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -48,7 +51,7 @@ type Defined target.Concrete
 type hiddenAlias = target.Concrete
 `, packageImporter{target.Path(): target})
 
-	got, err := transparentAliasMappings(facade, modulePath)
+	got, err := transparentAliasMappings(facade, projectMembership(facade, target))
 	if err != nil {
 		t.Fatalf("transparentAliasMappings() error = %v", err)
 	}
@@ -58,6 +61,121 @@ type hiddenAlias = target.Concrete
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("transparentAliasMappings() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTransparentAliasMappingsIncludesNonMaterializedAliases(t *testing.T) {
+	t.Setenv("GODEBUG", "gotypesalias=0")
+	const modulePath = "example.com/project"
+	target := checkPackage(t, modulePath+"/target", `
+package target
+
+type Concrete struct{}
+`, nil)
+	facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import "example.com/project/target"
+
+type PlainAlias = target.Concrete
+type PointerAlias = *target.Concrete
+`, packageImporter{target.Path(): target})
+
+	got, err := transparentAliasMappings(facade, projectMembership(facade, target))
+	if err != nil {
+		t.Fatalf("transparentAliasMappings() error = %v", err)
+	}
+	want := []aliasMapping{
+		{aliasName: "PlainAlias", packagePath: target.Path(), typeName: "Concrete"},
+		{aliasName: "PointerAlias", packagePath: target.Path(), typeName: "Concrete"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("transparentAliasMappings() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTransparentAliasMappingsRejectsNonMaterializedGenericSpecialization(t *testing.T) {
+	t.Setenv("GODEBUG", "gotypesalias=0")
+	const modulePath = "example.com/project"
+	target := checkPackage(t, modulePath+"/target", `
+package target
+
+type Generic[T any] struct {
+	Value T
+}
+`, nil)
+	facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import "example.com/project/target"
+
+type Public = target.Generic[int]
+`, packageImporter{target.Path(): target})
+
+	_, err := transparentAliasMappings(facade, projectMembership(facade, target))
+	if err == nil {
+		t.Fatal("transparentAliasMappings() error = nil, want non-materialized generic specialization error")
+	}
+	const wantDiagnostic = "exported alias example.com/project/facade.Public"
+	if !strings.Contains(err.Error(), wantDiagnostic) {
+		t.Fatalf("transparentAliasMappings() error = %q, want fragment %q", err, wantDiagnostic)
+	}
+}
+
+func TestTransparentAliasMappingsRejectsUnsafeGenericSpecializations(t *testing.T) {
+	const modulePath = "example.com/project"
+	target := checkPackage(t, modulePath+"/target", `
+package target
+
+type Generic[T any] struct {
+	Value T
+}
+`, nil)
+	tests := []struct {
+		name        string
+		declaration string
+		wantTarget  string
+	}{
+		{
+			name:        "concrete argument",
+			declaration: "type Public = target.Generic[int]",
+			wantTarget:  modulePath + "/target.Generic[int]",
+		},
+		{
+			name:        "transformed parameter",
+			declaration: "type Public[T any] = target.Generic[[]T]",
+			wantTarget:  modulePath + "/target.Generic[[]T]",
+		},
+		{
+			name:        "narrowed parameter",
+			declaration: "type Public[T ~int] = target.Generic[T]",
+			wantTarget:  modulePath + "/target.Generic[T]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facade := checkPackage(t, modulePath+"/facade", `
+package facade
+
+import "example.com/project/target"
+
+`+tt.declaration, packageImporter{target.Path(): target})
+
+			_, err := transparentAliasMappings(facade, projectMembership(facade, target))
+			if err == nil {
+				t.Fatal("transparentAliasMappings() error = nil, want unsupported generic specialization error")
+			}
+			for _, fragment := range []string{
+				"inspect exported alias example.com/project/facade.Public",
+				"generic target alias instantiated as " + tt.wantTarget + " cannot be scoped safely",
+				"concrete, transformed, and narrowed instantiations are unsupported",
+			} {
+				if !strings.Contains(err.Error(), fragment) {
+					t.Fatalf("transparentAliasMappings() error = %q, want fragment %q", err, fragment)
+				}
+			}
+		})
 	}
 }
 
@@ -117,9 +235,45 @@ import "example.com/external"
 type ExternalAlias = external.Type
 `, packageImporter{external.Path(): external})
 
-	_, err := transparentAliasMappings(facade, modulePath)
+	membership := projectMembership(facade)
+	membership.packageModulePaths[external.Path()] = "example.com/external"
+	_, err := transparentAliasMappings(facade, membership)
 	if err == nil {
 		t.Fatal("transparentAliasMappings() error = nil, want non-project-target error")
+	}
+	const wantDiagnostic = "from module example.com/external, not root module example.com/project"
+	if !strings.Contains(err.Error(), wantDiagnostic) {
+		t.Fatalf("transparentAliasMappings() error = %q, want fragment %q", err, wantDiagnostic)
+	}
+}
+
+func TestModuleMembershipUsesExactModuleIdentity(t *testing.T) {
+	const modulePath = "example.com/project"
+	membership := newModuleMembership(modulePath, map[string]string{
+		modulePath:                        modulePath,
+		modulePath + "/internal/contract": modulePath,
+		modulePath + "/extension":         modulePath + "/extension",
+		modulePath + "-tools":             modulePath + "-tools",
+	})
+	tests := []struct {
+		name        string
+		packagePath string
+		want        bool
+	}{
+		{name: "module root", packagePath: modulePath, want: true},
+		{name: "same-module dependency", packagePath: modulePath + "/internal/contract", want: true},
+		{name: "nested dependency module", packagePath: modulePath + "/extension", want: false},
+		{name: "similar external module", packagePath: modulePath + "-tools", want: false},
+		{name: "standard library without module", packagePath: "time", want: false},
+		{name: "unlisted package without module", packagePath: "command-line-arguments", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := membership.contains(tt.packagePath); got != tt.want {
+				t.Fatalf("contains(%q) = %v, want %v", tt.packagePath, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -144,6 +298,82 @@ func TestRunReportsCurrentAliasMappings(t *testing.T) {
 		"OIDCResolveOptions|github.com/NVIDIA/aicr/pkg/bundler/attestation|ResolveOptions\n"
 	if stdout.String() != want {
 		t.Fatalf("run() output = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestLoadPackagesKeepsNestedModuleOutsideClosure(t *testing.T) {
+	const (
+		modulePath       = "example.com/project"
+		rootPackagePath  = modulePath + "/root"
+		localPackagePath = modulePath + "/extensions"
+	)
+	workingDir := t.TempDir()
+	writeFixtureFile(t, workingDir, "go.mod", `module example.com/project
+
+go 1.26
+
+require example.com/project/extension v0.0.0
+
+replace example.com/project/extension => ./nested-extension
+`)
+	writeFixtureFile(t, workingDir, "nested-extension/go.mod", `module example.com/project/extension
+
+go 1.26
+`)
+	writeFixtureFile(t, workingDir, "nested-extension/extension.go", `package extension
+
+type Contract struct{}
+`)
+	writeFixtureFile(t, workingDir, "extensions/contract.go", `package extensions
+
+type Contract struct{}
+`)
+	writeFixtureFile(t, workingDir, "root/root.go", `package root
+
+import (
+	"example.com/project/extension"
+	"example.com/project/extensions"
+)
+
+type Root struct {
+	Dependency extension.Contract
+	Local      extensions.Contract
+}
+`)
+
+	t.Setenv("GOFLAGS", "-mod=mod")
+	t.Setenv("GOWORK", "off")
+	ctx, cancel := context.WithTimeout(context.Background(), goListTimeout)
+	defer cancel()
+	packages, membership, err := loadPackages(ctx, workingDir, []string{rootPackagePath})
+	if err != nil {
+		t.Fatalf("loadPackages() error = %v", err)
+	}
+	const dependencyModulePath = modulePath + "/extension"
+	if membership.contains(dependencyModulePath) {
+		t.Fatal("nested dependency module package was classified as repository-local")
+	}
+	if gotModulePath, ok := membership.moduleForPackage(dependencyModulePath); !ok || gotModulePath != dependencyModulePath {
+		t.Fatalf("nested dependency module identity = %q, %v, want %q, true", gotModulePath, ok, dependencyModulePath)
+	}
+	if !membership.contains(localPackagePath) {
+		t.Fatal("same-module package with similar import path was not classified as repository-local")
+	}
+
+	got, err := reachableTypes(
+		packages,
+		membership,
+		[]rootSpec{{packagePath: rootPackagePath, typeNames: []string{"Root"}}},
+	)
+	if err != nil {
+		t.Fatalf("reachableTypes() error = %v", err)
+	}
+	want := []closureEntry{
+		{packagePath: localPackagePath, typeName: "Contract"},
+		{packagePath: rootPackagePath, typeName: "Root"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reachableTypes() = %#v, want %#v", got, want)
 	}
 }
 
@@ -177,7 +407,7 @@ func TestReachableTypes(t *testing.T) {
 
 	got, err := reachableTypes(
 		map[string]*types.Package{rootPackage.Path(): rootPackage},
-		modulePath,
+		projectMembership(rootPackage, nestedPackage),
 		[]rootSpec{{packagePath: rootPackage.Path(), typeNames: []string{"Root"}}},
 	)
 	if err != nil {
@@ -216,7 +446,7 @@ type Root struct {
 
 	got, err := reachableTypes(
 		map[string]*types.Package{root.Path(): root},
-		modulePath,
+		projectMembership(root, nested),
 		[]rootSpec{{packagePath: root.Path(), typeNames: []string{"Root"}}},
 	)
 	if err != nil {
@@ -251,7 +481,7 @@ type Box[T constraint.Contract] struct{}
 
 	got, err := reachableTypes(
 		map[string]*types.Package{root.Path(): root},
-		modulePath,
+		projectMembership(root, constraint),
 		[]rootSpec{{packagePath: root.Path(), typeNames: []string{"Box"}}},
 	)
 	if err != nil {
@@ -293,7 +523,7 @@ type Public[T constraint.Contract] = target.Concrete
 
 	got, err := reachableTypes(
 		map[string]*types.Package{facade.Path(): facade},
-		modulePath,
+		projectMembership(facade, constraint, target),
 		[]rootSpec{{packagePath: facade.Path(), typeNames: []string{"Public"}}},
 	)
 	if err != nil {
@@ -360,7 +590,7 @@ type ExternalContainer = target.Box[external.Wrapper[payload.Contract]]
 		t.Run(rootName, func(t *testing.T) {
 			got, err := reachableTypes(
 				map[string]*types.Package{facade.Path(): facade},
-				modulePath,
+				projectMembership(facade, payload, target),
 				[]rootSpec{{packagePath: facade.Path(), typeNames: []string{rootName}}},
 			)
 			if err != nil {
@@ -377,7 +607,7 @@ func TestReachableTypesRejectsMissingRoot(t *testing.T) {
 	pkg := types.NewPackage("example.com/project/root", "root")
 	_, err := reachableTypes(
 		map[string]*types.Package{pkg.Path(): pkg},
-		"example.com/project",
+		projectMembership(pkg),
 		[]rootSpec{{packagePath: pkg.Path(), typeNames: []string{"Missing"}}},
 	)
 	if err == nil {
@@ -420,6 +650,25 @@ func TestParseRoots(t *testing.T) {
 
 func newNamed(pkg *types.Package, name string, underlying types.Type) *types.Named {
 	return types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), underlying, nil)
+}
+
+func projectMembership(packages ...*types.Package) moduleMembership {
+	packageModulePaths := make(map[string]string, len(packages))
+	for _, pkg := range packages {
+		packageModulePaths[pkg.Path()] = "example.com/project"
+	}
+	return newModuleMembership("example.com/project", packageModulePaths)
+}
+
+func writeFixtureFile(t *testing.T, root, relativePath, content string) {
+	t.Helper()
+	path := filepath.Join(root, relativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("create fixture directory for %s: %v", relativePath, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture file %s: %v", relativePath, err)
+	}
 }
 
 type packageImporter map[string]*types.Package

--- a/tools/api-diff_test.sh
+++ b/tools/api-diff_test.sh
@@ -13,16 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Decision-flow tests for tools/api-diff. Git, Go, and apidiff are stubbed so no
-# worktree is created and no network access is needed. yq is intentionally not
-# stubbed: these tests exercise the real structural parser supplied by the
-# repository's pinned toolchain, so mikefarah/yq is the one required tool.
+# Decision-flow tests for tools/api-diff stub Git, Go, and apidiff so no real
+# worktree is created. A final end-to-end fixture uses the pinned apidiff against
+# a temporary local module. yq is intentionally not stubbed: these tests
+# exercise the real structural parser supplied by the repository's pinned
+# toolchain, so mikefarah/yq is required throughout.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_DIFF="${SCRIPT_DIR}/api-diff"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 export API_DIFF_TEST_REPO_ROOT="${REPO_ROOT}"
+
+if command -v go >/dev/null 2>&1; then
+    test_go_bin="$(go env GOBIN 2>/dev/null || true)"
+    if [[ -z "${test_go_bin}" ]]; then
+        test_go_path="$(go env GOPATH 2>/dev/null || true)"
+        test_go_path="${test_go_path%%:*}"
+        if [[ -n "${test_go_path}" ]]; then
+            test_go_bin="${test_go_path}/bin"
+        fi
+    fi
+    if [[ -n "${test_go_bin}" ]]; then
+        export PATH="${test_go_bin}:${PATH}"
+    fi
+fi
+REAL_PATH="${PATH}"
+REAL_APIDIFF="$(command -v apidiff 2>/dev/null || true)"
 
 # Without yq every assertion below fails inside has_tools, which reads as dozens
 # of unrelated defects rather than one missing tool. Skip with a single clear
@@ -87,6 +104,10 @@ if [[ "$1" == "run" && "$2" == "./tools/api-diff-closure" ]]; then
     if [[ "${alias_mode}" == "true" ]]; then
         if [[ "${ALIAS_MAPPING_SCENARIO:-correct}" == "failure" ]]; then
             echo "mock alias mapping failure" >&2
+            exit 42
+        fi
+        if [[ "${ALIAS_MAPPING_SCENARIO:-correct}" == "concrete-generic" ]]; then
+            echo "api-diff-closure: inspect exported alias github.com/NVIDIA/aicr/pkg/client/v1.BundleConfig: generic target alias instantiated as github.com/NVIDIA/aicr/pkg/bundler/config.Config[int] cannot be scoped safely; generic target aliases must forward every type parameter unchanged with identical constraints (concrete, transformed, and narrowed instantiations are unsupported)" >&2
             exit 42
         fi
         cat <<'ALIASES'
@@ -188,17 +209,42 @@ STUB
 
 cat >"${STUB_DIR}/apidiff" <<'STUB'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "-w" ]]; then
-    : >"$2"
+allow_internal=false
+export_path=""
+positional=()
+while (( $# > 0 )); do
+    case "$1" in
+        -allow-internal)
+            allow_internal=true
+            shift
+            ;;
+        -w)
+            export_path=$2
+            shift 2
+            ;;
+        -incompatible)
+            echo "unexpected redundant apidiff -incompatible invocation" >&2
+            exit 99
+            ;;
+        *)
+            positional+=("$1")
+            shift
+            ;;
+    esac
+done
+
+package="${positional[${#positional[@]}-1]:-}"
+if [[ -n "${export_path}" ]]; then
+    printf 'mode=export package=%s allow_internal=%s\n' "${package}" "${allow_internal}" >>"${APIDIFF_LOG}"
+    : >"${export_path}"
     exit 0
 fi
-if [[ "${1:-}" == "-incompatible" ]]; then
-    echo "unexpected redundant apidiff -incompatible invocation" >&2
-    exit 99
-fi
 
-package="${2:-}"
-printf 'mode=report package=%s cwd=%s\n' "${package}" "$(pwd)" >>"${APIDIFF_LOG}"
+printf 'mode=report package=%s allow_internal=%s cwd=%s\n' "${package}" "${allow_internal}" "$(pwd)" >>"${APIDIFF_LOG}"
+if [[ -n "${APIDIFF_FAILURE_PACKAGE:-}" && "${package}" == "${APIDIFF_FAILURE_PACKAGE}" ]]; then
+    echo "mock current package load failure for ${package}" >&2
+    exit 42
+fi
 if [[ -n "${APIDIFF_TARGET_REPORT_PACKAGE:-}" && "${package}" == "${APIDIFF_TARGET_REPORT_PACKAGE}" ]]; then
     printf '%s' "${APIDIFF_TARGET_REPORT:-}"
 elif [[ -n "${APIDIFF_REPORT:-}" ]]; then
@@ -346,6 +392,7 @@ run() {
             APIDIFF_REPORT="${APIDIFF_REPORT:-}" \
             APIDIFF_TARGET_REPORT_PACKAGE="${APIDIFF_TARGET_REPORT_PACKAGE:-}" \
             APIDIFF_TARGET_REPORT="${APIDIFF_TARGET_REPORT:-}" \
+            APIDIFF_FAILURE_PACKAGE="${APIDIFF_FAILURE_PACKAGE:-}" \
             ALIAS_MAPPING_SCENARIO="${ALIAS_MAPPING_SCENARIO:-correct}" \
             ALIAS_CLOSURE_SCENARIO="${ALIAS_CLOSURE_SCENARIO:-correct}" \
             API_DIFF_EXCEPTIONS_FILE="${exceptions_file}" \
@@ -356,6 +403,7 @@ run() {
             APIDIFF_REPORT="${APIDIFF_REPORT:-}" \
             APIDIFF_TARGET_REPORT_PACKAGE="${APIDIFF_TARGET_REPORT_PACKAGE:-}" \
             APIDIFF_TARGET_REPORT="${APIDIFF_TARGET_REPORT:-}" \
+            APIDIFF_FAILURE_PACKAGE="${APIDIFF_FAILURE_PACKAGE:-}" \
             ALIAS_MAPPING_SCENARIO="${ALIAS_MAPPING_SCENARIO:-correct}" \
             ALIAS_CLOSURE_SCENARIO="${ALIAS_CLOSURE_SCENARIO:-correct}" \
             API_DIFF_EXCEPTIONS_FILE="${exceptions_file}" \
@@ -401,12 +449,18 @@ check_occurrences() {
 expected_apidiff_log() {
     local cwd=$1
 
-    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/client/v1 cwd=%s\n' "${cwd}"
-    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/attestation cwd=%s\n' "${cwd}"
-    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/config cwd=%s\n' "${cwd}"
-    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/result cwd=%s\n' "${cwd}"
-    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/types cwd=%s\n' "${cwd}"
-    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/recipe cwd=%s' "${cwd}"
+    printf 'mode=export package=github.com/NVIDIA/aicr/pkg/client/v1 allow_internal=false\n'
+    printf 'mode=export package=github.com/NVIDIA/aicr/pkg/bundler/attestation allow_internal=true\n'
+    printf 'mode=export package=github.com/NVIDIA/aicr/pkg/bundler/config allow_internal=true\n'
+    printf 'mode=export package=github.com/NVIDIA/aicr/pkg/bundler/result allow_internal=true\n'
+    printf 'mode=export package=github.com/NVIDIA/aicr/pkg/bundler/types allow_internal=true\n'
+    printf 'mode=export package=github.com/NVIDIA/aicr/pkg/recipe allow_internal=true\n'
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/client/v1 allow_internal=false cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/attestation allow_internal=true cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/config allow_internal=true cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/result allow_internal=true cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/bundler/types allow_internal=true cwd=%s\n' "${cwd}"
+    printf 'mode=report package=github.com/NVIDIA/aicr/pkg/recipe allow_internal=true cwd=%s' "${cwd}"
 }
 
 run failure v9.8.7 "" "${EMPTY_EXCEPTIONS}" correct "${SCRIPT_DIR}" failure
@@ -434,6 +488,17 @@ check_rc "unscoped-generic-transparent-alias-fails" 18
 check_contains "unscoped-generic-transparent-alias-is-diagnostic" "Transparent alias contract is out of sync"
 check_contains "unscoped-generic-transparent-alias-is-named" "GenericAlias"
 check_log_absent "unscoped-generic-transparent-alias-stops-before-git" "prune"
+
+ALIAS_MAPPING_SCENARIO=concrete-generic
+run alias-contract-concrete-generic v9.8.7
+unset ALIAS_MAPPING_SCENARIO
+check_rc "concrete-generic-transparent-alias-fails-closed" 18
+check_contains "concrete-generic-transparent-alias-is-diagnostic" \
+    "generic target alias instantiated as github.com/NVIDIA/aicr/pkg/bundler/config.Config[int] cannot be scoped safely"
+check_contains "concrete-generic-transparent-alias-explains-supported-form" \
+    "generic target aliases must forward every type parameter unchanged with identical constraints"
+check_log_absent "concrete-generic-transparent-alias-stops-before-git" "prune"
+check_apidiff_log_equals "concrete-generic-transparent-alias-stops-before-apidiff" ""
 
 ALIAS_MAPPING_SCENARIO=retarget
 run alias-contract-retargeted v9.8.7
@@ -580,6 +645,15 @@ unset APIDIFF_TARGET_REPORT_PACKAGE APIDIFF_TARGET_REPORT
 check_rc "baseline-only-reachable-type-break-fails" 16
 check_contains "baseline-only-reachable-type-break-is-reported" "BundleError.Legacy: removed"
 
+APIDIFF_FAILURE_PACKAGE='github.com/NVIDIA/aicr/pkg/bundler/config'
+run alias-existing-target-load-failure v9.8.7 "" "${EMPTY_EXCEPTIONS}"
+unset APIDIFF_FAILURE_PACKAGE
+check_rc "existing-target-load-failure-is-not-treated-as-removal" 42
+check_contains "existing-target-load-failure-remains-diagnostic" \
+    "mock current package load failure for github.com/NVIDIA/aicr/pkg/bundler/config"
+check_absent "existing-target-load-failure-does-not-invent-package-removal" \
+    "package github.com/NVIDIA/aicr/pkg/bundler/config: removed"
+
 APIDIFF_TARGET_REPORT_PACKAGE='github.com/NVIDIA/aicr/pkg/bundler/result'
 APIDIFF_TARGET_REPORT=$'Incompatible changes:\n- Output.Result: changed from Result to DeploymentInfo\n- DeploymentInfo.Legacy: removed\n'
 run alias-current-only-type-parent-break v9.8.7 "" "${EMPTY_EXCEPTIONS}"
@@ -634,8 +708,270 @@ run decision v9.8.7 "${removed_method}" "${REINDENTED_EXCEPTIONS}"
 check_rc "reindented-valid-yaml-succeeds" 0
 check_contains "reindented-valid-yaml-is-diagnostic" "Allowing acknowledged incompatible API change(s) for v9.8.7: #1234"
 
+# Exercise the complete gate with the pinned apidiff against a real temporary
+# module. Config exposes an internal named type through its public field, so the
+# internal type is part of the transparent-alias closure even though apidiff
+# ignores that package by default.
+if [[ -z "${REAL_APIDIFF}" ]]; then
+    if [[ -n "${CI:-}" ]]; then
+        fail "reachable-internal-target-regression-runs" "apidiff is not installed"
+    else
+        echo "SKIP: reachable internal target regression; run 'make tools-setup' to install apidiff"
+    fi
+else
+    internal_fixture="${STUB_DIR}/internal-target-fixture"
+    if ! (
+        set -e
+        export PATH="${REAL_PATH}"
+        mkdir -p \
+            "${internal_fixture}/tools/api-diff-closure" \
+            "${internal_fixture}/pkg/client/v1" \
+            "${internal_fixture}/pkg/bundler/attestation" \
+            "${internal_fixture}/pkg/bundler/config" \
+            "${internal_fixture}/pkg/bundler/result" \
+            "${internal_fixture}/pkg/recipe" \
+            "${internal_fixture}/internal/sdkcontract"
+        cp "${API_DIFF}" "${internal_fixture}/tools/api-diff"
+        cp "${SCRIPT_DIR}/common" "${internal_fixture}/tools/common"
+        cp "${SCRIPT_DIR}/api-diff-closure/main.go" "${internal_fixture}/tools/api-diff-closure/main.go"
+
+        cat >"${internal_fixture}/go.mod" <<'EOF'
+module github.com/NVIDIA/aicr
+
+go 1.26
+EOF
+        cat >"${internal_fixture}/.settings.yaml" <<EOF
+linting:
+  apidiff: '${PINNED_APIDIFF_VERSION}'
+EOF
+        cat >"${internal_fixture}/pkg/client/v1/api-diff-exceptions.yaml" <<'EOF'
+acknowledgements: []
+EOF
+        cat >"${internal_fixture}/pkg/client/v1/client.go" <<'EOF'
+package v1
+
+import (
+	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/bundler/result"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+type BundleConfig = config.Config
+type BundleAttester = attestation.Attester
+type OIDCResolveOptions = attestation.ResolveOptions
+type BundleArtifact = result.Output
+type CriteriaRegistry = recipe.CriteriaRegistry
+EOF
+        cat >"${internal_fixture}/pkg/bundler/attestation/attestation.go" <<'EOF'
+package attestation
+
+type Attester struct{}
+type ResolveOptions struct{}
+EOF
+        cat >"${internal_fixture}/pkg/bundler/config/config.go" <<'EOF'
+package config
+
+import "github.com/NVIDIA/aicr/internal/sdkcontract"
+
+type Config struct {
+	Contract sdkcontract.Contract
+}
+EOF
+        cat >"${internal_fixture}/pkg/bundler/result/result.go" <<'EOF'
+package result
+
+type Output struct{}
+EOF
+        cat >"${internal_fixture}/pkg/recipe/recipe.go" <<'EOF'
+package recipe
+
+type CriteriaRegistry struct{}
+EOF
+        cat >"${internal_fixture}/internal/sdkcontract/contract.go" <<'EOF'
+package sdkcontract
+
+type Contract struct {
+	Legacy string
+}
+EOF
+
+        git -C "${internal_fixture}" init -q -b main
+        git -C "${internal_fixture}" add .
+        git -C "${internal_fixture}" \
+            -c user.name='API Diff Test' \
+            -c user.email='api-diff-test@example.com' \
+            commit --no-gpg-sign -q -m 'test: establish API baseline'
+
+        cat >"${internal_fixture}/internal/sdkcontract/contract.go" <<'EOF'
+package sdkcontract
+
+type Contract struct {
+	Legacy int
+}
+EOF
+        git -C "${internal_fixture}" rev-parse --verify HEAD >/dev/null
+    ); then
+        fail "reachable-internal-target-fixture-setup" "could not create the temporary Git fixture"
+    else
+        OUT="$(cd "${internal_fixture}" && PATH="${REAL_PATH}" API_DIFF_BASELINE=HEAD ./tools/api-diff 2>&1)"
+        RC=$?
+        check_rc "reachable-internal-target-incompatibility-fails-closed" 16
+        check_contains "reachable-internal-target-incompatibility-is-scoped" \
+            "Transparent alias reachable-type changes: github.com/NVIDIA/aicr/internal/sdkcontract (Contract)"
+        check_contains "reachable-internal-target-incompatibility-is-reported" \
+            "Contract.Legacy: changed from string to int"
+        check_absent "reachable-internal-target-is-not-silently-ignored" \
+            "Ignoring internal package github.com/NVIDIA/aicr/internal/sdkcontract"
+    fi
+fi
+
+# Exercise a baseline alias retarget whose old reachable target package is
+# deleted from the current tree while its documentation directory remains.
+# apidiff cannot load that current package, so the gate must report the package
+# removal and still adjudicate it through the exact-baseline acknowledgement
+# workflow.
+if [[ -z "${REAL_APIDIFF}" ]]; then
+    if [[ -n "${CI:-}" ]]; then
+        fail "deleted-alias-target-regression-runs" "apidiff is not installed"
+    else
+        echo "SKIP: deleted alias target regression; run 'make tools-setup' to install apidiff"
+    fi
+else
+    deleted_target_fixture="${STUB_DIR}/deleted-alias-target-fixture"
+    if ! (
+        set -e
+        export PATH="${REAL_PATH}"
+        mkdir -p \
+            "${deleted_target_fixture}/tools/api-diff-closure" \
+            "${deleted_target_fixture}/pkg/client/v1" \
+            "${deleted_target_fixture}/pkg/bundler/attestation" \
+            "${deleted_target_fixture}/pkg/bundler/config" \
+            "${deleted_target_fixture}/pkg/bundler/result" \
+            "${deleted_target_fixture}/pkg/legacyconfig" \
+            "${deleted_target_fixture}/pkg/recipe"
+        cp "${API_DIFF}" "${deleted_target_fixture}/tools/api-diff"
+        cp "${SCRIPT_DIR}/common" "${deleted_target_fixture}/tools/common"
+        cp "${SCRIPT_DIR}/api-diff-closure/main.go" \
+            "${deleted_target_fixture}/tools/api-diff-closure/main.go"
+
+        cat >"${deleted_target_fixture}/go.mod" <<'EOF'
+module github.com/NVIDIA/aicr
+
+go 1.26
+EOF
+        cat >"${deleted_target_fixture}/.settings.yaml" <<EOF
+linting:
+  apidiff: '${PINNED_APIDIFF_VERSION}'
+EOF
+        cat >"${deleted_target_fixture}/pkg/client/v1/api-diff-exceptions.yaml" <<'EOF'
+acknowledgements: []
+EOF
+        cat >"${deleted_target_fixture}/pkg/client/v1/client.go" <<'EOF'
+package v1
+
+import (
+	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/bundler/result"
+	"github.com/NVIDIA/aicr/pkg/legacyconfig"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+type BundleConfig = legacyconfig.Config
+type BundleAttester = attestation.Attester
+type OIDCResolveOptions = attestation.ResolveOptions
+type BundleArtifact = result.Output
+type CriteriaRegistry = recipe.CriteriaRegistry
+EOF
+        cat >"${deleted_target_fixture}/pkg/bundler/attestation/attestation.go" <<'EOF'
+package attestation
+
+type Attester struct{}
+type ResolveOptions struct{}
+EOF
+        cat >"${deleted_target_fixture}/pkg/bundler/config/config.go" <<'EOF'
+package config
+
+type Config struct{}
+EOF
+        cat >"${deleted_target_fixture}/pkg/bundler/result/result.go" <<'EOF'
+package result
+
+type Output struct{}
+EOF
+        cat >"${deleted_target_fixture}/pkg/legacyconfig/config.go" <<'EOF'
+package legacyconfig
+
+type Config struct{}
+EOF
+        cat >"${deleted_target_fixture}/pkg/legacyconfig/README.md" <<'EOF'
+# Legacy configuration
+EOF
+        cat >"${deleted_target_fixture}/pkg/recipe/recipe.go" <<'EOF'
+package recipe
+
+type CriteriaRegistry struct{}
+EOF
+
+        git -C "${deleted_target_fixture}" init -q -b main
+        git -C "${deleted_target_fixture}" add .
+        git -C "${deleted_target_fixture}" \
+            -c user.name='API Diff Test' \
+            -c user.email='api-diff-test@example.com' \
+            commit --no-gpg-sign -q -m 'test: establish retarget baseline'
+
+        cat >"${deleted_target_fixture}/pkg/client/v1/client.go" <<'EOF'
+package v1
+
+import (
+	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
+	"github.com/NVIDIA/aicr/pkg/bundler/config"
+	"github.com/NVIDIA/aicr/pkg/bundler/result"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+type BundleConfig = config.Config
+type BundleAttester = attestation.Attester
+type OIDCResolveOptions = attestation.ResolveOptions
+type BundleArtifact = result.Output
+type CriteriaRegistry = recipe.CriteriaRegistry
+EOF
+        rm "${deleted_target_fixture}/pkg/legacyconfig/config.go"
+    ); then
+        fail "deleted-alias-target-fixture-setup" "could not create the temporary Git fixture"
+    else
+        OUT="$(cd "${deleted_target_fixture}" && PATH="${REAL_PATH}" API_DIFF_BASELINE=HEAD ./tools/api-diff 2>&1)"
+        RC=$?
+        check_rc "deleted-alias-target-unacknowledged-break-fails" 16
+        check_contains "deleted-alias-target-retarget-is-reported" \
+            "BundleConfig: changed from github.com/NVIDIA/aicr/pkg/legacyconfig.Config to github.com/NVIDIA/aicr/pkg/bundler/config.Config"
+        check_contains "deleted-alias-target-package-removal-is-scoped" \
+            "Transparent alias reachable-type changes: github.com/NVIDIA/aicr/pkg/legacyconfig (Config)"
+        check_contains "deleted-alias-target-package-removal-is-reported" \
+            "package github.com/NVIDIA/aicr/pkg/legacyconfig: removed"
+        check_absent "deleted-alias-target-does-not-abort-during-package-load" \
+            "loading github.com/NVIDIA/aicr/pkg/legacyconfig"
+
+        cat >"${deleted_target_fixture}/pkg/client/v1/api-diff-exceptions.yaml" <<'EOF'
+acknowledgements:
+  - baseline: HEAD
+    issue: '#1234'
+    summary: Retarget the bundle configuration alias.
+    rationale: The old package was intentionally retired with its facade alias target.
+    incompatible_changes:
+      - 'BundleConfig: changed from github.com/NVIDIA/aicr/pkg/legacyconfig.Config to github.com/NVIDIA/aicr/pkg/bundler/config.Config'
+      - 'package github.com/NVIDIA/aicr/pkg/legacyconfig: removed'
+EOF
+        OUT="$(cd "${deleted_target_fixture}" && PATH="${REAL_PATH}" API_DIFF_BASELINE=HEAD ./tools/api-diff 2>&1)"
+        RC=$?
+        check_rc "deleted-alias-target-exact-acknowledgement-succeeds" 0
+        check_contains "deleted-alias-target-acknowledgement-is-diagnostic" \
+            "Allowing acknowledged incompatible API change(s) for HEAD: #1234"
+    fi
+fi
+
 if (( fails > 0 )); then
     echo "${fails} test(s) failed"
     exit 1
 fi
-echo "All API-diff decision-flow tests passed"
+echo "All API-diff tests passed"


### PR DESCRIPTION
## Summary

Hardens the SDK API-diff gate for transparent aliases by covering internal and deleted target packages, rejecting aliases that cannot be scoped safely, and respecting actual Go module boundaries.

## Motivation / Context

This is a follow-up to the merged alias/semver contract work in #2124. Post-merge review found four edge cases that could either let incompatible reachable-type changes pass or compare the wrong API surface.

Fixes: N/A
Related: #2019, #2124

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK API compatibility tooling (`tools/api-diff*`)

## Implementation Notes

- Enables `apidiff -allow-internal` only for scoped transparent-alias target exports and comparisons; facade comparisons remain unchanged.
- Supports generic target aliases only when every type parameter and constraint is forwarded unchanged. Concrete, transformed, and narrowed instantiations fail closed before `apidiff`.
- Reports a baseline-reachable target package as removed when it has no current Go source, while retaining normal `apidiff` load failures for packages that still contain Go files.
- Uses module identity reported by `go list` instead of import-path prefixes, excluding replaced nested modules whose paths share the repository prefix.

## Testing

```bash
GOFLAGS=-mod=vendor go test -race -count=1 -cover ./tools/api-diff-closure/...
golangci-lint run -c .golangci.yaml ./tools/api-diff-closure/...
make test-shell
make api-diff
make lint
make qualify
```

- Focused race tests passed with 77.5% statement coverage.
- Affected-package lint passed with zero issues.
- The complete shell suite, live API-diff gate against `v0.18.0`, and full lint gate passed.
- `make qualify` was run on the rebased tree. Every package passed except three tests in `pkg/bundler/attestation` and one in `pkg/trust`; all four were blocked while fetching `https://tuf-repo-cdn.sigstore.dev/15.root.json` because the external CDN returned HTTP 403. Qualification stopped at the test target, so later qualification stages did not run.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No runtime rollout is required. This changes only repository API-compatibility validation and fails closed for unsupported or ambiguous alias shapes.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
