### PR TITLE
fix(notices): resolve GOROOT explicitly for go-licenses

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -66,6 +66,27 @@ This action runs `tools/setup-tools --skip-go --skip-docker` in auto mode, which
 - Skips Go (handled by `actions/setup-go`) and Docker (pre-installed on runners)
 - Uses the same installation logic as local development
 
+#### `install-go-licenses/`
+**Purpose**: Install the pinned `go-licenses` with `GOFLAGS` cleared
+**When to use**: Any job running `make license-check`, `make notices`, or `make notices-check`
+**Inputs**:
+- `version` (required): go-licenses version from `load-versions` (`.settings.yaml` `linting.go_licenses`)
+
+`go-licenses` publishes no binary release, so it cannot come from
+`setup-build-tools` (which installs from binary releases) and must be
+`go install`ed. Clearing `GOFLAGS` is a correctness requirement rather than a
+preference: `-trimpath` strips the binary's baked-in `GOROOT`, which makes
+`go-licenses` classify every package as standard library and report an empty
+dependency graph while still exiting `0`. The install is centralized here so no
+caller can silently drop that contract.
+
+**Example**:
+```yaml
+- uses: ./.github/actions/install-go-licenses
+  with:
+    version: ${{ steps.versions.outputs.go_licenses }}
+```
+
 #### `load-versions/`
 **Purpose**: Load tool versions from `.settings.yaml` as workflow outputs
 **When to use**: When you need version values in workflow steps

--- a/.github/actions/install-go-licenses/action.yml
+++ b/.github/actions/install-go-licenses/action.yml
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Install go-licenses'
+description: 'Install the pinned go-licenses with GOFLAGS cleared so the binary keeps a usable GOROOT'
+
+# go-licenses has no binary release, so it must be `go install`ed rather than
+# fetched like the tools in setup-build-tools. The install is centralized here
+# because clearing GOFLAGS is a correctness requirement, not a preference, and a
+# caller that forgets it fails silently:
+#
+#   * -trimpath strips the binary's baked-in GOROOT. go-licenses decides whether
+#     a package is standard library by matching its source path against
+#     go/build's GOROOT, so an empty GOROOT collapses the prefix to "/", every
+#     absolute path matches, and the ENTIRE dependency graph is reported as
+#     stdlib — the tool then writes nothing and exits 0. `make license-check`
+#     passes while inspecting zero packages; `make notices` emits nothing.
+#   * -mod=vendor makes the install resolve against this repo's vendor tree,
+#     which does not contain go-licenses.
+#
+# Mirrors the `GOFLAGS= go install` convention in tools/setup-tools, which
+# tools/setup-tools_test.sh asserts for every versioned Go tool install.
+
+inputs:
+  version:
+    description: 'go-licenses version pinned in .settings.yaml (linting.go_licenses, via load-versions)'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate go-licenses version input
+      shell: bash
+      env:
+        GO_LICENSES_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if [[ -z "${GO_LICENSES_VERSION}" ]]; then
+          echo "::error::version is required (expected .settings.yaml linting.go_licenses via load-versions)"
+          exit 1
+        fi
+
+    - name: Install go-licenses
+      shell: bash
+      env:
+        GO_LICENSES_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        GOFLAGS= go install "github.com/google/go-licenses/v2@${GO_LICENSES_VERSION}"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -363,8 +363,9 @@ jobs:
           cache-dependency-path: |
             go.sum
             vendor/modules.txt
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses/v2@${{ steps.versions.outputs.go_licenses }}
+      - uses: ./.github/actions/install-go-licenses
+        with:
+          version: ${{ steps.versions.outputs.go_licenses }}
       - name: Report licenses
         env:
           GOFLAGS: -mod=vendor
@@ -563,8 +564,9 @@ jobs:
           cache-dependency-path: |
             go.sum
             vendor/modules.txt
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses/v2@${{ steps.versions.outputs.go_licenses }}
+      - uses: ./.github/actions/install-go-licenses
+        with:
+          version: ${{ steps.versions.outputs.go_licenses }}
       - name: Verify committed THIRD_PARTY_NOTICES.md is up to date
         env:
           GOFLAGS: -mod=vendor

--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,23 @@ license: ## Add/verify license headers in source files
 #### so unrelated MPL-2.0 deps still fail closed for review. The go-cleanhttp /
 #### go-retryablehttp pair, and the HashiCorp Vault client subtree (#1577, the
 #### hashivault:// KMS signing provider), are the approved exceptions.
+####
+#### go-licenses identifies standard library packages by matching their source
+#### path against go/build's GOROOT, which is empty in a binary linked with
+#### -trimpath. With an empty GOROOT the prefix collapses to "/", EVERY package
+#### looks like stdlib, and this gate inspects nothing yet still exits 0 — a
+#### silent false PASS. Resolve GOROOT explicitly below so the check cannot pass
+#### vacuously regardless of how go-licenses was installed.
 license-check: ## Check license is approved
 	@echo "Checking license headers..."
-	@STDLIB_IGNORE=$$(go list std 2>/dev/null | cut -d'/' -f1 | sort -u | paste -sd ',' -) && \
+	@set -e; \
+	GOROOT="$$(go env GOROOT)"; \
+	if [ -z "$$GOROOT" ] || [ ! -d "$$GOROOT" ]; then \
+	    echo "ERROR: could not resolve a usable GOROOT via 'go env GOROOT'." >&2; \
+	    exit 1; \
+	fi; \
+	export GOROOT; \
+	STDLIB_IGNORE=$$(go list std 2>/dev/null | cut -d'/' -f1 | sort -u | paste -sd ',' -) && \
 	go-licenses check ./... \
         --allowed_licenses=MIT,BSD-2-Clause,BSD-3-Clause,Apache-2.0,ISC,Zlib \
         --ignore=github.com/hashicorp/go-cleanhttp \

--- a/tools/generate-notices
+++ b/tools/generate-notices
@@ -163,6 +163,21 @@ export GOFLAGS="-mod=vendor"
 # here lets go-licenses cross-list each target platform without a C toolchain.
 export CGO_ENABLED=0
 
+# go-licenses decides whether a package is standard library by testing its
+# source path against go/build's GOROOT, and a Go binary only carries a baked-in
+# GOROOT when it was linked WITHOUT -trimpath. An exported GOFLAGS=-trimpath (a
+# common local default) therefore yields a go-licenses whose GOROOT is empty, so
+# the stdlib prefix collapses to "/" and EVERY absolute source path matches: the
+# tool classifies the whole dependency graph as stdlib, writes nothing, and
+# exits 0. Pass the active GOROOT explicitly so the output never depends on how
+# the binary happened to be built.
+GOROOT="$(go env GOROOT)"
+if [[ -z "${GOROOT}" || ! -d "${GOROOT}" ]]; then
+    echo "ERROR: could not resolve a usable GOROOT via 'go env GOROOT' (got '${GOROOT}')." >&2
+    exit 1
+fi
+export GOROOT
+
 # The released binaries ship for multiple OS/arch targets (see .goreleaser.yaml:
 # aicr → darwin+linux × amd64+arm64, aicrd → linux × amd64+arm64). go-licenses
 # resolves the dependency graph for the HOST platform by default, so a macOS
@@ -241,6 +256,20 @@ for platform in "${PLATFORMS[@]}"; do
         --save_path="${platform_save}" \
         --force \
         --ignore="${ignore}"
+
+    # Fail closed on an empty save. 'go-licenses save' exits 0 when it finds no
+    # third-party packages at all (see the GOROOT note above), leaving save_path
+    # missing entirely — which surfaced only as a bare ENOENT from the 'cp'
+    # below. Report the actual cause, and never let a silently-empty collection
+    # reach the notices file.
+    if [[ ! -d "${platform_save}" ]] || [[ -z "$(ls -A "${platform_save}" 2>/dev/null)" ]]; then
+        echo "ERROR: 'go-licenses save' collected no licenses for ${goos}/${goarch}." >&2
+        echo "The tool exits 0 in this state, so this is almost always go-licenses" >&2
+        echo "failing to locate GOROOT and treating every package as standard library." >&2
+        echo "Reinstall it without -trimpath:" >&2
+        echo "  GOFLAGS= go install github.com/google/go-licenses/v2@\$(yq -r .linting.go_licenses .settings.yaml)" >&2
+        exit 1
+    fi
 
     # Merge into the shared tree. A module's license text is identical across
     # platforms, so overwriting is a no-op; modules present on only one platform

--- a/tools/generate-notices_test.sh
+++ b/tools/generate-notices_test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify the notices generator fails closed when go-licenses collects nothing.
+#
+# go-licenses decides what is standard library by matching a package's source
+# path against go/build's GOROOT. A binary linked with -trimpath carries no
+# GOROOT, the prefix collapses to "/", every absolute path matches, and the tool
+# reports the entire dependency graph as stdlib: it writes no files and exits 0.
+# That used to surface as an unrelated "cp: .../linux_amd64/.: No such file or
+# directory" from the merge step, and the same silence makes 'go-licenses check'
+# pass without inspecting anything.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GENERATE_NOTICES="${SCRIPT_DIR}/generate-notices"
+
+bash -n "${GENERATE_NOTICES}"
+
+# CI installs go-licenses through a shared composite action. An install that
+# inherits -trimpath produces a binary with no GOROOT at all, which is the same
+# defect one indirection further out, so pin the contract here too.
+INSTALL_ACTION="${REPO_ROOT}/.github/actions/install-go-licenses/action.yml"
+if [[ ! -f "${INSTALL_ACTION}" ]]; then
+    echo "FAIL: ${INSTALL_ACTION} is missing" >&2
+    exit 1
+fi
+if ! grep -q 'GOFLAGS= go install' "${INSTALL_ACTION}"; then
+    echo "FAIL: the go-licenses install action does not clear GOFLAGS" >&2
+    exit 1
+fi
+# Reject every inline install, not just one that forgets GOFLAGS: an inline step
+# also escapes the pinned version the composite action takes from
+# .settings.yaml, so a workflow could silently run a different go-licenses. The
+# leading pattern skips commented-out lines. Only workflows are scanned - the
+# action itself is where the real `GOFLAGS= go install` lives.
+if grep -rEn '^[[:space:]]*[^#]*go install[[:space:]]+github\.com/google/go-licenses' \
+    "${REPO_ROOT}/.github/workflows/"; then
+    echo "FAIL: a workflow installs go-licenses inline;" >&2
+    echo "use the ./.github/actions/install-go-licenses composite action instead." >&2
+    exit 1
+fi
+
+# The behavioral case below runs the real generator, which needs yq to verify
+# its release-target matrix. Without it the script exits on that check instead of
+# the guard under test, which would read as a defect rather than a missing tool.
+# Skip with one clear message locally; fail in CI, where the guard must actually
+# be exercised. The variant check mirrors setup-tools: Python yq wraps jq.
+yq_unavailable=""
+if ! command -v yq >/dev/null 2>&1; then
+    yq_unavailable="yq is not installed"
+elif ! yq --version 2>/dev/null | grep -q "mikefarah/yq"; then
+    yq_unavailable="yq at $(command -v yq) is not mikefarah/yq (Go-based)"
+fi
+if [[ -n "${yq_unavailable}" ]]; then
+    if [[ -n "${CI:-}" ]]; then
+        echo "FAIL: ${yq_unavailable}; the notices guard cannot be verified in CI" >&2
+        exit 1
+    fi
+    echo "SKIP: ${yq_unavailable}; run 'make tools-setup' to install the pinned version"
+    exit 0
+fi
+
+TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/aicr-notices-test.XXXXXX")"
+trap 'rm -rf "${TEST_TMP}"' EXIT
+
+# Stand in for a go-licenses that classifies every package as stdlib: succeeds,
+# emits nothing, creates no save_path. It also records the GOROOT each
+# invocation actually received, which is what the callers must supply.
+GO_LICENSES_PROBE="${TEST_TMP}/goroot-seen"
+export GO_LICENSES_PROBE
+mkdir -p "${TEST_TMP}/bin"
+cat > "${TEST_TMP}/bin/go-licenses" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${GOROOT-}" >> "${GO_LICENSES_PROBE}"
+exit 0
+EOF
+chmod +x "${TEST_TMP}/bin/go-licenses"
+
+# Assert go-licenses ran with a usable GOROOT in its ENVIRONMENT. Checking the
+# call site's text is not enough: a bare `GOROOT=...` assignment satisfies a
+# grep but never reaches the child process, leaving the exact silent-stdlib
+# failure this suite exists to catch. Every caller is run with GOROOT unset so
+# the only way the stub can observe one is if the caller exported it.
+assert_goroot_exported() {
+    local context="$1" seen
+    if [[ ! -s "${GO_LICENSES_PROBE}" ]]; then
+        echo "FAIL: ${context}: go-licenses was never invoked" >&2
+        exit 1
+    fi
+    while IFS= read -r seen; do
+        if [[ -z "${seen}" ]]; then
+            echo "FAIL: ${context}: go-licenses ran with no GOROOT in its environment." >&2
+            echo "Assigning GOROOT is not enough - it must be exported, or go-licenses" >&2
+            echo "falls back to its (possibly empty) baked-in GOROOT and reports every" >&2
+            echo "package as standard library while still exiting 0." >&2
+            exit 1
+        fi
+        if [[ ! -d "${seen}" ]]; then
+            echo "FAIL: ${context}: go-licenses received GOROOT='${seen}', not a directory" >&2
+            exit 1
+        fi
+    done < "${GO_LICENSES_PROBE}"
+}
+
+set +e
+stderr_output="$(
+    cd "${REPO_ROOT}" && env -u GOROOT PATH="${TEST_TMP}/bin:${PATH}" \
+        OUTPUT="${TEST_TMP}/NOTICES.md" \
+        LICENSES_DIR="${TEST_TMP}/licenses-cache" \
+        bash "${GENERATE_NOTICES}" 2>&1 >/dev/null
+)"
+rc=$?
+set -e
+
+if [[ ${rc} -eq 0 ]]; then
+    echo "FAIL: generate-notices exited 0 after go-licenses collected nothing" >&2
+    exit 1
+fi
+
+if ! grep -q "collected no licenses" <<<"${stderr_output}"; then
+    echo "FAIL: generate-notices did not report the empty collection as the cause." >&2
+    echo "stderr was:" >&2
+    echo "${stderr_output}" >&2
+    exit 1
+fi
+
+# An empty collection must never reach the notices file.
+if [[ -e "${TEST_TMP}/NOTICES.md" ]]; then
+    echo "FAIL: generate-notices wrote a notices file from an empty collection" >&2
+    exit 1
+fi
+
+assert_goroot_exported "generate-notices"
+echo "generate-notices fails closed on an empty go-licenses collection"
+
+# The license-check gate shares the defect: with no usable GOROOT, go-licenses
+# inspects nothing and exits 0, so the gate passes vacuously. Exercise the real
+# target against the stub rather than reading the Makefile.
+: > "${GO_LICENSES_PROBE}"
+set +e
+license_output="$(
+    cd "${REPO_ROOT}" && env -u GOROOT PATH="${TEST_TMP}/bin:${PATH}" \
+        make license-check 2>&1
+)"
+license_rc=$?
+set -e
+
+if [[ ${license_rc} -ne 0 ]]; then
+    echo "FAIL: 'make license-check' failed against a stub go-licenses:" >&2
+    echo "${license_output}" >&2
+    exit 1
+fi
+
+assert_goroot_exported "make license-check"
+echo "make license-check exports a usable GOROOT to go-licenses"


### PR DESCRIPTION
## Summary

`go-licenses` silently reports an empty dependency graph when its baked-in `GOROOT` is missing, which broke `make tidy` and made `make license-check` pass while inspecting nothing. Resolve `GOROOT` explicitly at both call sites and fail closed on an empty collection.

## Motivation / Context

`go-licenses` decides whether a package is standard library by testing its source path against `go/build`'s `GOROOT`, and a Go binary only carries a baked-in `GOROOT` when it was linked **without** `-trimpath`. With `GOFLAGS=-trimpath` exported in the environment (a common local default), `go install go-licenses` produces a binary whose `GOROOT` is empty. The stdlib prefix then collapses to `/`, every absolute source path matches, and the tool classifies the **entire** dependency graph as standard library — writing nothing and exiting `0`.

That silence surfaced two ways:

1. **`make tidy` failed** with an error that pointed nowhere near the cause:

   ```
   Collecting licenses for linux/amd64...
   cp: /var/folders/.../aicr-notices.fhoCkZ/linux_amd64/.: No such file or directory
   make[1]: *** [notices] Error 1
   ```

   `tools/generate-notices` merged a `save_path` that `go-licenses save` had never created.

2. **`make license-check` passed vacuously** — a silent false PASS in a supply-chain gate. Reproduced on `main`: the target exits `0` having inspected zero packages, so a disallowed license would not have been caught.

Confirmed root cause by building the same probe with and without `-trimpath`:

```
runtime.GOROOT()="/opt/homebrew/Cellar/go/1.26.5/libexec"   # go build
runtime.GOROOT()=""                                          # go build -trimpath
```

Fixes: N/A
Related: #2158 — separate root cause (vendor path casing); both surfaced while running `make tidy` after `13f6057d`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: third-party notices generator, license-check gate, merge-gate workflow

## Implementation Notes

Fixing this at the call sites rather than only at install time is deliberate: it repairs already-installed binaries and any install path we do not control (a hand-run `go install`, a runner whose environment carries `-trimpath`). `GOROOT` is derived from `go env GOROOT`, so it always matches the toolchain actually in use, including after a `GOTOOLCHAIN` switch.

- `tools/generate-notices` — resolve and export `GOROOT` (validated non-empty and a real directory) before invoking `go-licenses`.
- `tools/generate-notices` — fail closed when a per-platform `save` collects nothing, reporting the actual cause instead of a bare `ENOENT` from the following `cp`. An empty collection can no longer reach the notices file.
- `Makefile` (`license-check`) — same explicit `GOROOT` resolution, so the gate cannot pass vacuously.
- `.github/actions/install-go-licenses/` — new composite action that installs the pinned version with `GOFLAGS` cleared, matching `tools/setup-tools` and the convention already asserted by `tools/setup-tools_test.sh`. Both merge-gate jobs now call it instead of installing inline.

CI installs `go-licenses` through a new `install-go-licenses` composite action instead of repeating the install inline in both merge-gate jobs, so the `GOFLAGS` contract lives in one place. It is a dedicated primitive rather than an addition to `setup-build-tools`, because that action deliberately installs from binary releases ("go install puts in GOPATH which isn't in PATH") and `go-licenses` publishes none.

No Go source changed.

## Testing

```bash
make qualify   # exit 0
```

Verification performed:

- **Original failure fixed** — `make tidy` now exits `0`; `make notices` writes 204 Go modules + 130 Python packages.
- **Output is correct, not merely non-empty** — the regenerated `THIRD_PARTY_NOTICES.md` is **byte-identical** to the committed file, and `make notices-check` passes.
- **False PASS closed** — `make license-check` now genuinely walks the dependency graph (emits per-package warnings for non-Go sources) and still passes.
- **New regression test** `tools/generate-notices_test.sh`, wired into `make test-shell` → `make test`:
  - Behavioral: with a stub `go-licenses` that exits `0` and writes nothing (exactly the observed failure mode), the generator must exit non-zero, name the cause, and write no notices file.
  - Confirmed the test **fails against the pre-fix script** and passes after; the stub reproduces the original `cp: ... No such file or directory` on the old code.
  - Both call sites are verified by **execution, not by grepping the source**: each runs with `GOROOT` unset against a stub that records the `GOROOT` it actually received, so a bare assignment that is never exported fails the test. Verified by deleting `export GOROOT` from the Makefile and from `tools/generate-notices` in turn — each deletion fails the suite (exit 1).
  - Asserts the composite action clears `GOFLAGS`, and that no workflow installs `go-licenses` inline without it. Both guards verified to fail against the pre-fix workflow.
  - Skips locally when `mikefarah/yq` is absent, fails in CI — matching `tools/api-diff_test.sh`.
- `make qualify` details: coverage 82.9% (threshold 80%), golangci-lint 0 issues, e2e chainsaw 24/24 passed, scan + api-diff clean.

One unrelated flake was seen on the first `qualify` run: `tests/releasepolicy/TestReleaseResolverBehavior/Docker_manifest_list`. It passes standalone on both this branch and pristine `main`, and passed on re-run under the full suite — pre-existing timing sensitivity in a package this PR does not touch (parallelized recently in `9198f361`), not a regression from this change.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — build tooling only, no runtime or released-artifact behavior change. Worth noting for reviewers: `license-check` now actually enforces the allowed-license policy, so it can legitimately start failing on a dependency that was previously waved through unexamined. It passes on `main` today.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed — N/A, no user-facing behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
