### PR TITLE
test: convert literal test timeouts to named constants

### DIFF
--- a/pkg/bundler/bundler_dra_annotation_parity_test.go
+++ b/pkg/bundler/bundler_dra_annotation_parity_test.go
@@ -28,6 +28,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
+// draBundleMakeTimeout bounds each Make call this file's parity tests issue —
+// generous for a local render into a temp dir, short enough that a wedged
+// bundler fails the test instead of stalling the suite.
+const draBundleMakeTimeout = 30 * time.Second
+
 // TestMake_DRAChartVersionAnnotation_GeneratedArtifactParity is the
 // generated-artifact acceptance test the issue calls out. It bundles
 // the same recipe through two deployer code paths — the default Helm
@@ -114,7 +119,7 @@ func TestMake_DRAChartVersionAnnotation_GeneratedArtifactParity(t *testing.T) {
 			}
 
 			tmpDir := t.TempDir()
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), draBundleMakeTimeout)
 			defer cancel()
 			if _, err := b.Make(ctx, rr, tmpDir); err != nil {
 				t.Fatalf("Make() error = %v", err)
@@ -215,7 +220,7 @@ func TestMake_DRAChartVersionAnnotation_AllDeployersCarryAnnotation(t *testing.T
 			}
 
 			tmpDir := t.TempDir()
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), draBundleMakeTimeout)
 			defer cancel()
 			if _, err := b.Make(ctx, rr, tmpDir); err != nil {
 				t.Fatalf("Make() error = %v", err)
@@ -301,7 +306,7 @@ func TestMake_DRAChartVersionAnnotation_DisabledRecipeUnaffected(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), draBundleMakeTimeout)
 	defer cancel()
 	if _, err := b.Make(ctx, rr, tmpDir); err != nil {
 		t.Fatalf("Make() error = %v", err)

--- a/pkg/bundler/checksum/checksum_test.go
+++ b/pkg/bundler/checksum/checksum_test.go
@@ -30,6 +30,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
+// fifoCancelTimeout is the deadline the FIFO test relies on to fire while the
+// open would otherwise block forever — the expiry is the behavior under test,
+// so the value must stay short enough to keep the suite fast.
+const fifoCancelTimeout = 100 * time.Millisecond
+
 func TestGenerateChecksums(t *testing.T) {
 	t.Parallel()
 
@@ -591,7 +596,7 @@ func TestSHA256RawContext(t *testing.T) {
 		if err := unix.Mkfifo(fifo, 0600); err != nil {
 			t.Skipf("FIFO unsupported: %v", err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), fifoCancelTimeout)
 		defer cancel()
 		result := make(chan error, 1)
 		go func() {

--- a/pkg/bundler/deployer/localformat/vendor_write_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_write_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/bundler/deployer/localformat"
 )
 
+// vendorFetchTimeout bounds the vendor path's kustomize subprocess when the
+// source is an unresolvable .invalid host: NXDOMAIN comes back in
+// milliseconds, so reaching this bound means an internal retry loop wedged.
+const vendorFetchTimeout = 5 * time.Second
+
 // fakePuller is a black-box ChartPuller that returns canned bytes per
 // component. Used by vendor-path Write tests so we never depend on a
 // real `helm` binary.
@@ -352,7 +357,7 @@ func TestWrite_VendorCharts_KustomizeFallthrough(t *testing.T) {
 	// reason this would approach the budget is a misbehaving
 	// kustomize/git-library internal retry loop.
 	t.Setenv("GIT_TERMINAL_PROMPT", "0")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), vendorFetchTimeout)
 	defer cancel()
 
 	outDir := t.TempDir()

--- a/pkg/chainsaw/inprocess_test.go
+++ b/pkg/chainsaw/inprocess_test.go
@@ -29,6 +29,17 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
+// shortCircuitCtxTimeout bounds runs whose asserts are expected to fail, so
+// the retry loop short-circuits on context.Canceled instead of waiting out the
+// assert timeout handed to runChainsawTestInProcess — the YAML-declared value
+// (typically 5m) for the registry corpus, 1s for the table-driven cases.
+const shortCircuitCtxTimeout = 200 * time.Millisecond
+
+// inProcessRunTimeout bounds runs expected to complete normally against the
+// in-memory fetcher — generous for a fixture with no I/O, short enough that a
+// wedged retry loop fails the test rather than stalling the suite.
+const inProcessRunTimeout = 2 * time.Second
+
 // fakeFetcher is a minimal ResourceFetcher backed by an in-memory map.
 // Keyed by "<apiVersion>/<kind>/<namespace>/<name>" for Get, and by
 // "<apiVersion>/<kind>/<namespace>" for List (returns slice of items).
@@ -300,7 +311,7 @@ spec:
 // executor's unmarshaler and that the executor walks every step
 // without choking on a known structural pattern. Each check has its
 // own spec.timeouts.assert (typically 5m) — to keep the test fast we
-// wrap each invocation in a 200ms ctx so the retry loop short-
+// wrap each invocation in a shortCircuitCtxTimeout ctx so the retry loop short-
 // circuits via context.Canceled rather than waiting out the YAML-
 // declared timeout. Parity for assertion behavior (a healthy cluster
 // fixture produces Passed=true) is the load-bearing live-cluster
@@ -310,7 +321,7 @@ func TestRunChainsawTestInProcess_RegistryCorpusParses(t *testing.T) {
 		// Short ctx so retry loops short-circuit. The empty fake
 		// fetcher makes every assert fail (NotFound), which would
 		// otherwise wait out the YAML's 5m assert timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), shortCircuitCtxTimeout)
 		r := runChainsawTestInProcess(ctx, c.component, c.content, 5*time.Minute, newFakeFetcher())
 		cancel()
 		// We don't assert r.Passed; we assert no parse / schema
@@ -699,7 +710,7 @@ spec:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), shortCircuitCtxTimeout)
 			defer cancel()
 			r := runChainsawTestInProcess(ctx, "c", tt.yaml, time.Second, newFakeFetcher())
 
@@ -807,7 +818,7 @@ spec:
 			for _, name := range tt.present {
 				f.addGet("v1", "Pod", "ns", name, pod(name, "Running", nil))
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), inProcessRunTimeout)
 			defer cancel()
 
 			r := runChainsawTestInProcess(ctx, "c", tt.stream, time.Second, f)

--- a/pkg/collector/gpu/gpu_test.go
+++ b/pkg/collector/gpu/gpu_test.go
@@ -24,6 +24,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/measurement"
 )
 
+// expiredCtxTimeout is short enough that the context is guaranteed already
+// expired by the time Collect is called — the tests using it assert the
+// deadline-exceeded path, so any non-trivial value would defeat the point.
+const expiredCtxTimeout = 1 * time.Nanosecond
+
 func TestHardwareSubtype(t *testing.T) {
 	t.Run("with resolved SKU emits model", func(t *testing.T) {
 		st := hardwareSubtype(&HardwareInfo{
@@ -138,7 +143,7 @@ func TestCollector_ContextTimeout(t *testing.T) {
 		info: &HardwareInfo{GPUPresent: true, GPUCount: 1, DetectionSource: "nfd"},
 	}))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	ctx, cancel := context.WithTimeout(context.Background(), expiredCtxTimeout)
 	defer cancel()
 	time.Sleep(10 * time.Millisecond)
 

--- a/pkg/collector/k8s/discovery_test.go
+++ b/pkg/collector/k8s/discovery_test.go
@@ -36,6 +36,11 @@ import (
 
 const testDiscoveryGroupVersion = "example.test/v1"
 
+// discoveryCancelTimeout is the deadline the cancellation test relies on to
+// fire while discovery requests are still in flight — the expiry is the
+// behavior under test, not a safety net.
+const discoveryCancelTimeout = 100 * time.Millisecond
+
 func TestCollectorDiscovery_CancelsAllDiscoveryRequests(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -386,7 +391,7 @@ func TestKubernetesCollector_BlockedDiscoveryHonorsDeadline(t *testing.T) {
 		RestConfig: config,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), discoveryCancelTimeout)
 	defer cancel()
 	type result struct {
 		err error

--- a/pkg/collector/k8s/server_test.go
+++ b/pkg/collector/k8s/server_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// expiredCtxTimeout is short enough that the context is guaranteed already
+// expired by the time Collect is called — the test using it asserts the
+// deadline-exceeded path, so any non-trivial value would defeat the point.
+const expiredCtxTimeout = 1 * time.Nanosecond
+
 func TestKubernetesCollector_Collect(t *testing.T) {
 	t.Setenv("NODE_NAME", "test-node")
 
@@ -115,7 +120,7 @@ func TestKubernetesCollector_CollectWithCanceledContext(t *testing.T) {
 
 func TestKubernetesCollector_CollectWithTimeout(t *testing.T) {
 	// Create a context with very short timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	ctx, cancel := context.WithTimeout(context.Background(), expiredCtxTimeout)
 	defer cancel()
 
 	// Wait for context to timeout

--- a/pkg/evidence/internal/boundedio/boundedio_test.go
+++ b/pkg/evidence/internal/boundedio/boundedio_test.go
@@ -24,6 +24,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
+// wedgedReadTimeout is the deadline the wedged-read tests rely on to fire
+// while fn is still blocked — the expiry is the behavior under test, so it
+// stays tiny to keep the suite fast.
+const wedgedReadTimeout = 10 * time.Millisecond
+
 func isCode(err error, code errors.ErrorCode) bool {
 	return stderrors.Is(err, errors.New(code, ""))
 }
@@ -47,7 +52,7 @@ func TestDo_DeadlineSurfacesTimeout(t *testing.T) {
 	release := make(chan struct{})
 	defer close(release)
 
-	err := doWithTimeout(context.Background(), 10*time.Millisecond, "wedged read", func() error {
+	err := doWithTimeout(context.Background(), wedgedReadTimeout, "wedged read", func() error {
 		<-release
 		return nil
 	})
@@ -126,7 +131,7 @@ func TestDo_CallerUnblocksWhileWorkerRuns(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- doWithTimeout(context.Background(), 10*time.Millisecond, "wedged read", func() error {
+		errCh <- doWithTimeout(context.Background(), wedgedReadTimeout, "wedged read", func() error {
 			close(started)
 			<-release
 			close(finished)

--- a/pkg/evidence/verifier/crosscheck_test.go
+++ b/pkg/evidence/verifier/crosscheck_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/evidence/attestation"
 )
 
+// unreachablePullTimeout bounds the materialize calls that dial an
+// intentionally unreachable registry, so flaky DNS or a slow stack cannot pay
+// the production two-minute pull timeout.
+const unreachablePullTimeout = 250 * time.Millisecond
+
 func i64ptr(v int64) *int64 { return &v }
 
 func TestCrossCheckPointerSigner(t *testing.T) {
@@ -156,7 +161,7 @@ func TestMaterializeBundle_TagOnlyWithAllowFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DetectInputForm: %v", err)
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), unreachablePullTimeout)
 	defer cancel()
 	_, err = MaterializeBundle(ctx,
 		VerifyOptions{Input: unreachable, AllowUnpinnedTag: true},

--- a/pkg/k8s/agent/job_watch_test.go
+++ b/pkg/k8s/agent/job_watch_test.go
@@ -29,6 +29,11 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
+// jobWatchTimeout bounds waits driven by fake-clientset watch events — ample
+// for an in-memory watcher, short enough that a wait which never observes its
+// event fails the test instead of stalling the suite.
+const jobWatchTimeout = 5 * time.Second
+
 // TestWaitForJobDeletion_AlreadyDeleted exercises the fast-path Get returning
 // NotFound (no Job exists in the clientset).
 func TestWaitForJobDeletion_AlreadyDeleted(t *testing.T) {
@@ -174,7 +179,7 @@ func TestFindOrWatchPodName_WatchAddedEvent(t *testing.T) {
 		JobName:   "test-job",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), jobWatchTimeout)
 	defer cancel()
 
 	name, err := d.findOrWatchPodName(ctx)

--- a/pkg/k8s/pod/wait_termination_test.go
+++ b/pkg/k8s/pod/wait_termination_test.go
@@ -33,6 +33,16 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
+// terminationWaitTimeout bounds waits that are expected to return on a watch
+// event the test itself sends — hitting this bound means the wait never
+// observed the event, not that the test is slow.
+const terminationWaitTimeout = 2 * time.Second
+
+// expiringCtxTimeout is the deliberately short deadline used by the tests that
+// assert the timeout path: no terminal event is ever sent, so this bound is the
+// behavior under test rather than a safety net.
+const expiringCtxTimeout = 50 * time.Millisecond
+
 // fakeWatchReactor returns a reactor function suitable for PrependWatchReactor
 // that always serves the supplied watcher.
 func fakeWatchReactor(w watch.Interface) k8stesting.WatchReactionFunc {
@@ -175,7 +185,7 @@ func TestWaitForTermination_WatchClosureRetrySucceeds(t *testing.T) {
 		second.Modify(modified)
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), terminationWaitTimeout)
 	defer cancel()
 
 	if err := pod.WaitForTermination(ctx, client, "default", "test-pod"); err != nil {
@@ -218,7 +228,7 @@ func TestWaitForTermination_WatchClosureRetryFails(t *testing.T) {
 		second.Stop()
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), terminationWaitTimeout)
 	defer cancel()
 
 	err := pod.WaitForTermination(ctx, client, "default", "test-pod")
@@ -244,7 +254,7 @@ func TestWaitForTermination_ContextTimeout(t *testing.T) {
 	w := watch.NewFake()
 	client.PrependWatchReactor("pods", fakeWatchReactor(w))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), expiringCtxTimeout)
 	defer cancel()
 
 	err := pod.WaitForTermination(ctx, client, "default", "test-pod")

--- a/pkg/oci/helm_checkpoint_c_test.go
+++ b/pkg/oci/helm_checkpoint_c_test.go
@@ -44,6 +44,11 @@ import (
 	apperrors "github.com/NVIDIA/aicr/pkg/errors"
 )
 
+// pushServerTimeout bounds the push exercised against the local httptest
+// registry — a loopback round trip is sub-millisecond, so approaching this
+// bound means the handshake wedged rather than that the test is slow.
+const pushServerTimeout = 5 * time.Second
+
 var checkpointCHelmFiles = []string{
 	"Chart.yaml",
 	"templates/_helpers.tpl",
@@ -889,7 +894,7 @@ func TestPushFrozenDescriptorCancelsAcceptedUploadAndClosesSource(t *testing.T) 
 	accepted := make(chan struct{})
 	putStarted := make(chan struct{})
 	putDone := make(chan error, 1)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), pushServerTimeout)
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch {
 		case request.Method == http.MethodHead:

--- a/pkg/recipe/builder_test.go
+++ b/pkg/recipe/builder_test.go
@@ -27,6 +27,16 @@ import (
 	errs "github.com/NVIDIA/aicr/pkg/errors"
 )
 
+// adequateBuildTimeout is the "plenty of headroom" deadline for the
+// cancellation table's non-canceled case — it must not be the reason a build
+// fails, so the case proves cancellation and nothing else.
+const adequateBuildTimeout = 5 * time.Second
+
+// handlerBudgetTimeout mirrors the 30s HTTP-handler deadline the builder's
+// internal 25s budget must fit inside; the budget test asserts the builder
+// returns before this outer bound fires.
+const handlerBudgetTimeout = 30 * time.Second
+
 // TestBuilder_BuildFromCriteria_ContextCancellation tests context cancellation
 // during recipe building to ensure proper timeout handling and error propagation.
 func TestBuilder_BuildFromCriteria_ContextCancellation(t *testing.T) {
@@ -48,7 +58,7 @@ func TestBuilder_BuildFromCriteria_ContextCancellation(t *testing.T) {
 			name: "normal operation with adequate timeout",
 			setupCtx: func() (context.Context, context.CancelFunc) {
 				// Provide adequate timeout for normal operation
-				return context.WithTimeout(context.Background(), 5*time.Second)
+				return context.WithTimeout(context.Background(), adequateBuildTimeout)
 			},
 			wantTimeout: false,
 		},
@@ -100,7 +110,7 @@ func TestBuilder_BuildFromCriteria_ContextCancellation(t *testing.T) {
 // respects the 25-second timeout budget for recipe building.
 func TestBuilder_BuildFromCriteria_TimeoutBudget(t *testing.T) {
 	// Create context with 30s timeout (handler-level)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), handlerBudgetTimeout)
 	defer cancel()
 
 	builder := NewBuilder()

--- a/pkg/trust/trust_test.go
+++ b/pkg/trust/trust_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
+// sigstoreFetchTimeout bounds the network-backed integration tests that pull
+// from the public Sigstore TUF CDN — generous for a healthy CDN, short enough
+// that a hung fetch fails the test rather than the whole suite's deadline.
+const sigstoreFetchTimeout = 30 * time.Second
+
 func TestGetTrustedMaterial(t *testing.T) {
 	t.Parallel()
 
@@ -62,7 +67,7 @@ func TestUpdate_Success(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), sigstoreFetchTimeout)
 	defer cancel()
 
 	material, err := Update(ctx)
@@ -108,7 +113,7 @@ func TestResolveSigningConfig(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), sigstoreFetchTimeout)
 	defer cancel()
 
 	sc, err := ResolveSigningConfig(ctx)

--- a/tests/releasepolicy/release_reverify_test.go
+++ b/tests/releasepolicy/release_reverify_test.go
@@ -32,6 +32,16 @@ import (
 
 const reverifyWorkflow = ".github/workflows/release-reverify.yaml"
 
+// reverifyStepTimeout bounds the bash subprocess each single reverify-step
+// test spawns against staged fixtures — no network, so anything near this
+// bound means a wedged shell rather than a slow machine.
+const reverifyStepTimeout = 30 * time.Second
+
+// reverifyScenarioTimeout bounds the multi-step scenario runs, which stage and
+// verify a full release archive and so legitimately need more headroom than a
+// single step.
+const reverifyScenarioTimeout = 60 * time.Second
+
 // reverifySBOMFloor mirrors the workflow's SBOM_SIGNING_FLOOR env value and is
 // asserted against it, so raising the floor has to move this constant and with
 // it the below/above-floor cases below.
@@ -1264,7 +1274,7 @@ func runReverifyCloseStep(t *testing.T, script, tag string, issues []closableIss
 	}
 	closedFile := filepath.Join(root, "closed.txt")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), reverifyStepTimeout)
 	defer cancel()
 	command := exec.CommandContext(ctx, "bash", reverifyStepShell(t, root, script)...)
 	command.Dir = root
@@ -1494,7 +1504,7 @@ func runReverifyClassifier(t *testing.T, script string, opts reverifyOptions) (s
 	outputs := filepath.Join(root, "outputs")
 	summary := filepath.Join(root, "summary.md")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), reverifyScenarioTimeout)
 	defer cancel()
 	command := exec.CommandContext(ctx, "bash", reverifyStepShell(t, root, script)...)
 	command.Dir = root

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -52,6 +52,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// endpointReadySuccessTimeout bounds the success-path readiness probe so a
+// regression that breaks the accept condition fails in milliseconds rather
+// than blocking up to defaults.InferenceHealthTimeout.
+const endpointReadySuccessTimeout = 250 * time.Millisecond
+
+// endpointReadyFailureTimeout is the deliberately tiny deadline for the
+// never-ready case: the expiry is the behavior under test, so it must stay far
+// below defaults.InferenceHealthTimeout.
+const endpointReadyFailureTimeout = 50 * time.Millisecond
+
 func TestHasDynamoPlatform(t *testing.T) {
 	tests := []struct {
 		name string
@@ -3057,7 +3067,7 @@ func TestWaitForEndpointReady_AcceptsOnFirstRealCompletion(t *testing.T) {
 	// InferenceHealthTimeout (5 m). 250 ms is comfortable headroom over the
 	// 3-call/1 ms expected critical path while still tight enough to surface
 	// a stuck loop.
-	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), endpointReadySuccessTimeout)
 	defer cancel()
 	if err := waitForEndpointReadyWithInterval(ctx, srv.URL, "test-model", time.Millisecond, defaults.InferenceHealthTimeout); err != nil {
 		t.Fatalf("waitForEndpointReady returned error: %v", err)
@@ -3079,7 +3089,7 @@ func TestWaitForEndpointReady_TimesOutWhenAlwaysEmpty(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), endpointReadyFailureTimeout)
 	defer cancel()
 
 	err := waitForEndpointReadyWithInterval(ctx, srv.URL, "test-model", time.Millisecond, defaults.InferenceHealthTimeout)

--- a/validators/performance/nccl_trainjob_retry_test.go
+++ b/validators/performance/nccl_trainjob_retry_test.go
@@ -30,6 +30,11 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
+// admissionRetryGiveUpTimeout bounds the parent context so the admission retry
+// loop gives up quickly instead of waiting out
+// defaults.TrainJobAdmissionRetryTimeout — the expiry is the behavior asserted.
+const admissionRetryGiveUpTimeout = 50 * time.Millisecond
+
 // webhookDenialRaw builds the Kubeflow Trainer validating webhook's raw
 // rejection of a TrainJob whose referenced TrainingRuntime is not yet visible to
 // the webhook's informer cache — the StatusError the API server returns from
@@ -162,7 +167,7 @@ func TestApplyTrainJobWithRetry_TimesOutWhenWebhookNeverCatchesUp(t *testing.T) 
 
 	// Bound the parent context tightly so the retry loop gives up quickly
 	// rather than waiting out TrainJobAdmissionRetryTimeout.
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), admissionRetryGiveUpTimeout)
 	defer cancel()
 
 	err := applyTrainJobWithRetry(ctx, client, "aicr-validation",


### PR DESCRIPTION
## Summary

Converts the remaining literal `context.WithTimeout(..., N*time.Unit)` call sites in test files onto file-local named constants, completing the pattern PR #2044 established for the two files it touched.

## Motivation / Context

PR #2044 (review round) established a pattern for test subprocess deadlines: a file-local named constant with a one-line comment instead of a bare literal, per the AGENTS.md Constants Rule. The repo-wide sweep was deliberately deferred from that PR to keep it scoped.

Fixes: #2056
Related: #2044

## Type of Change

- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Other: `pkg/chainsaw`, `pkg/evidence`, `pkg/oci`, `pkg/trust`, `validators/performance`, `tests/releasepolicy`

## Implementation Notes

**Naming.** Each constant is named for what it bounds (`terminationWaitTimeout`, `sigstoreFetchTimeout`, `reverifyStepTimeout`) and carries a short comment explaining why the value is what it is — generous-but-bounded safety net, or a deliberately tiny deadline whose expiry is the behavior under test.

**Deadline kinds stay separate.** Files that mix both kinds declare two constants rather than collapsing semantically different values under one name. Examples:

- `pkg/k8s/pod/wait_termination_test.go` — `terminationWaitTimeout` (2s safety net) and `expiringCtxTimeout` (50ms, the timeout path under test)
- `pkg/chainsaw/inprocess_test.go` — `shortCircuitCtxTimeout` (200ms, forces the retry loop to short-circuit) and `inProcessRunTimeout` (2s, normal completion)
- `pkg/recipe/builder_test.go` — `adequateBuildTimeout` (5s, must not be the reason a build fails) and `handlerBudgetTimeout` (30s, mirrors the HTTP-handler budget)
- `validators/performance/inference_perf_test.go` — `endpointReadySuccessTimeout` and `endpointReadyFailureTimeout`

**Scope notes:**

- Constants are file-local, not added to `pkg/defaults` — that package is production configuration.
- No timeout value changes; this is a pure naming change.
- The issue's file list was written against an older `main`. PR #2088 has since replaced the literal deadlines in `tests/releasepolicy/release_scripts_test.go` and `release_workflow_test.go` with `scriptBudget(t)` — derived from the test binary's own `-timeout` and capped at the `scriptHangCap` constant — which also resolves the load-sensitive 10s per-script deadline the issue asked to reconsider. The two remaining releasepolicy sites live in `release_reverify_test.go`. `pkg/evidence/internal/boundedio/boundedio_test.go` is new since the issue was filed and matches the same grep, so it is included.
- Elapsed-time assertions (`time.Since(started) > 4*time.Second` in `release_scripts_test.go`) are left alone — per the issue's guidance, wall-clock upper bounds proving bounded behavior are a different kind of value from context deadlines.

After this change the sweep grep returns nothing:

```
grep -rn 'WithTimeout([^,]*, [0-9][0-9]*\*time\.' --include='*_test.go' pkg/ validators/ tools/ tests/ | grep -v 'defaults\.'
```

## Testing

`make qualify` passes on this branch — the full CI-equivalent gate, not a subset:

```
Coverage: 82.8% (threshold: 80%)
Coverage check passed
...
No incompatible SDK facade or transparent-alias target changes since v0.19.0.
Codebase qualification completed
```

That covers coverage-gated tests with `-race`, golangci-lint + yamllint + license headers, the shell test suite, tuning-check, e2e, the Grype scan, the license allowlist, and api-diff. Package-scoped `go vet`, `go test -race`, `golangci-lint run`, and `gofmt -l` were also run against every affected package and are clean.

No coverage delta is expected or observed — no statements were added or removed from any non-test file.

Note for anyone reproducing locally: `tools/api-diff_test.sh` needs `mktemp -d` to succeed. Under a restrictive sandbox that call is denied, `STUB_DIR` silently becomes empty, every fixture path resolves to the filesystem root, and the suite reports ~96 spurious failures. Run `make qualify` outside the sandbox.

## Risk Assessment

- [x] **Low** — Test-only, mechanical, no timeout value changes, easy to revert.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, no new functionality
- [ ] I updated docs if user-facing behavior changed — N/A, no user-facing behavior
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
