### PR TITLE
fix(bundler): create flux sources/ only when populated

### DIFF
--- a/pkg/bundler/deployer/flux/doc.go
+++ b/pkg/bundler/deployer/flux/doc.go
@@ -24,7 +24,9 @@ using the Flux toolkit.
 The package generates:
   - HelmRelease CRs for all components (helm.toolkit.fluxcd.io/v2)
   - HelmRepository source CRs for upstream chart repositories (source.toolkit.fluxcd.io/v1)
-  - GitRepository source CRs for local Helm chart sources (source.toolkit.fluxcd.io/v1)
+  - GitRepository source CRs for local Helm chart sources (source.toolkit.fluxcd.io/v1),
+    omitted under an OCI output reference, where local charts are consumed via
+    ArtifactGenerator + ExternalArtifact instead
   - Local Helm charts (Chart.yaml + templates/) for manifest-only components
   - A root kustomization.yaml (plain Kustomize) that orchestrates all resources
   - README with deployment instructions
@@ -107,7 +109,7 @@ components produce an ErrCodeInvalidRequest error at generation time.
 	├── kustomization.yaml              # Root Kustomize orchestration
 	├── README.md                       # Deployment instructions
 	├── checksums.txt                   # SHA256 checksums (optional)
-	├── sources/
+	├── sources/                        # Present only when a source CR is written
 	│   ├── gitrepo-<name>.yaml         # GitRepository (for local Helm charts)
 	│   ├── helmrepo-charts-jetstack-io.yaml
 	│   └── helmrepo-helm-ngc-nvidia-com-nvidia.yaml

--- a/pkg/bundler/deployer/flux/flux.go
+++ b/pkg/bundler/deployer/flux/flux.go
@@ -259,13 +259,11 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 		return nil, err
 	}
 
-	// Create sources directory.
+	// Resolve the sources directory path. Creation is deferred to
+	// writeSources, which creates it only when a source CR is written.
 	sourcesDir, err := deployer.SafeJoin(outputDir, "sources")
 	if err != nil {
 		return nil, err
-	}
-	if err := os.MkdirAll(sourcesDir, 0750); err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create sources directory", err)
 	}
 
 	// Resolve the chart puller for vendored bundles.
@@ -556,14 +554,42 @@ func isVendorable(ref recipe.ComponentRef) bool {
 	})
 }
 
-// writeSources writes HelmRepository and GitRepository source CRs to the sources directory.
+// writeSources writes HelmRepository and GitRepository source CRs to the
+// sources directory, creating that directory only when at least one CR is
+// written and removing a stale empty one from an earlier run otherwise.
 func (g *Generator) writeSources(helmSources map[string]*HelmRepoSourceData,
 	gitSources map[string]*GitRepoSourceData, sourcesDir string, output *deployer.Output) error {
+
+	// sources/ is created lazily, immediately before the first source CR is
+	// written. Both maps can be empty at once: an OCI --output suppresses
+	// GitRepository sources in favor of ArtifactGenerator + ExternalArtifact,
+	// and every remaining HelmRepository source disappears when no component
+	// carries an upstream Source or — the reachable case today — when
+	// --vendor-charts is set, since collectHelmSources skips every vendorable
+	// ref. An unconditional MkdirAll would then leave an empty directory that
+	// the bundle inventory validator rejects as unexpected. See issue #1947.
+	sourcesDirReady := false
+	ensureSourcesDir := func() error {
+		if sourcesDirReady {
+			return nil
+		}
+		if err := checkSourcesPath(sourcesDir); err != nil {
+			return err
+		}
+		if mkdirErr := os.MkdirAll(sourcesDir, 0750); mkdirErr != nil {
+			return errors.Wrap(errors.ErrCodeInternal, "failed to create sources directory", mkdirErr)
+		}
+		sourcesDirReady = true
+		return nil
+	}
 
 	// Write Helm sources in sorted order.
 	for _, key := range slices.Sorted(maps.Keys(helmSources)) {
 		src := helmSources[key]
 		filename := fmt.Sprintf("helmrepo-%s.yaml", src.Name)
+		if err := ensureSourcesDir(); err != nil {
+			return err
+		}
 		if err := writeTemplate(output, helmRepoSourceTemplate, src, sourcesDir, filename,
 			fmt.Sprintf("failed to write HelmRepository source %s", src.Name)); err != nil {
 			return err
@@ -574,12 +600,109 @@ func (g *Generator) writeSources(helmSources map[string]*HelmRepoSourceData,
 	for _, key := range slices.Sorted(maps.Keys(gitSources)) {
 		src := gitSources[key]
 		filename := fmt.Sprintf("gitrepo-%s.yaml", src.Name)
+		if err := ensureSourcesDir(); err != nil {
+			return err
+		}
 		if err := writeTemplate(output, gitRepoSourceTemplate, src, sourcesDir, filename,
 			fmt.Sprintf("failed to write GitRepository source %s", src.Name)); err != nil {
 			return err
 		}
 	}
 
+	// Generation writes directly into --output and the directory is not
+	// cleared between runs, so a failed pre-fix run leaves its empty sources/
+	// behind. Without this, retrying into that same directory reproduces the
+	// original failure even though nothing new is created.
+	if !sourcesDirReady {
+		return removeStaleSourcesDir(sourcesDir)
+	}
+
+	return nil
+}
+
+// checkSourcesPath rejects anything occupying the sources path that is not a
+// plain directory. Both the create and the remove path call it, so a
+// pre-existing file or symlink produces the same ErrCodeInvalidRequest
+// regardless of whether the recipe happens to contribute source CRs —
+// otherwise the identical user error would surface as INVALID_REQUEST for an
+// all-local OCI bundle and INTERNAL (from MkdirAll's ENOTDIR) for any bundle
+// carrying a source.
+//
+// The check matters most before removal, since os.Remove unlinks regular files
+// as readily as it removes empty directories. A pre-existing regular file at
+// this path reaches generation on every route: checksum.ValidateOutputRoot
+// runs first on the DefaultBundler path but permits regular files, rejecting
+// only symlinks and special objects.
+//
+// Lstat rather than Stat additionally rejects a symlink here. On the
+// DefaultBundler path that is redundant, since ValidateOutputRoot already
+// rejects a symlink anywhere under the output root before any deployer runs;
+// it still holds for a caller that constructs this Generator directly and
+// bypasses that check.
+//
+// The guarantee stops there. This is a check-then-act on a path, so a symlink
+// planted between this call and the MkdirAll or Remove that follows is not
+// caught. Closing that would require openat-based operations throughout, and
+// it buys nothing in a supported configuration: it takes a local process with
+// write access to --output, and anything with that access can already rewrite
+// the finished bundle and its checksums.
+func checkSourcesPath(sourcesDir string) error {
+	info, statErr := os.Lstat(sourcesDir)
+	switch {
+	case os.IsNotExist(statErr):
+		return nil
+	case statErr != nil:
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to inspect sources directory", statErr)
+	case info.Mode()&os.ModeSymlink != 0:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("output path %q is a symbolic link", sourcesDir))
+	case !info.IsDir():
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("output path %q exists and is not a directory", sourcesDir))
+	}
+	return nil
+}
+
+// removeStaleSourcesDir clears a sources/ left behind by an earlier run when
+// the current generation contributed no source CRs to it.
+//
+// Emptiness is checked explicitly rather than inferred from an os.Remove
+// errno, which keeps the intent readable and avoids platform-specific error
+// values. A populated sources/ is kept: its contents are reported by
+// validateExactTree as unexpected output, though only when checksums are
+// enabled, since that validator runs inside the IncludeChecksums path. With
+// checksums off a stale sources/ survives into the bundle, which is unchanged
+// from before this fix — a reused --output was never cleared, so stale files
+// of any kind already persisted.
+//
+// Anything that blocks removal of an empty directory fails generation rather
+// than being logged and ignored: leaving it behind either trips that same
+// validator or, when checksums are disabled, ships the bundle this fix exists
+// to prevent.
+func removeStaleSourcesDir(sourcesDir string) error {
+	if err := checkSourcesPath(sourcesDir); err != nil {
+		return err
+	}
+
+	entries, readErr := os.ReadDir(sourcesDir)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return nil
+		}
+		return errors.Wrap(errors.ErrCodeInternal,
+			"failed to inspect sources directory", readErr)
+	}
+	if len(entries) > 0 {
+		slog.Warn("keeping populated sources directory from an earlier run",
+			"path", sourcesDir, "entries", len(entries))
+		return nil
+	}
+
+	if rmErr := os.Remove(sourcesDir); rmErr != nil && !os.IsNotExist(rmErr) {
+		return errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to remove empty sources directory %q", sourcesDir), rmErr)
+	}
 	return nil
 }
 

--- a/pkg/bundler/deployer/flux/flux_test.go
+++ b/pkg/bundler/deployer/flux/flux_test.go
@@ -2263,11 +2263,14 @@ func TestGenerate_OCISourceName_SkipsGitSource(t *testing.T) {
 		t.Fatalf("Generate() error = %v", err)
 	}
 
-	// No gitrepo source files should exist.
+	// No gitrepo source files should exist. This component contributes no
+	// HelmRepository source either, so sources/ is not created at all —
+	// asserting its absence subsumes the gitrepo-file count. See issue #1947.
 	sourcesDir := filepath.Join(outputDir, "sources")
-	gitRepoFiles := listFilesWithPrefix(t, sourcesDir, "gitrepo-")
-	if len(gitRepoFiles) != 0 {
-		t.Errorf("expected 0 gitrepo source files when OCISourceName is set, got %d", len(gitRepoFiles))
+	if _, statErr := os.Stat(sourcesDir); !os.IsNotExist(statErr) {
+		gitRepoFiles := listFilesWithPrefix(t, sourcesDir, "gitrepo-")
+		t.Errorf("expected sources/ to be absent when no source CR is written, got stat err = %v, %d gitrepo files",
+			statErr, len(gitRepoFiles))
 	}
 }
 
@@ -2469,6 +2472,313 @@ func TestGenerate_OCISourceName_VendoredChart(t *testing.T) {
 	}
 	if strings.Contains(hrContent, "kind: GitRepository") {
 		t.Error("vendored HelmRelease should NOT reference GitRepository in OCI mode")
+	}
+}
+
+// TestGenerate_SourcesDirCreatedOnlyWhenPopulated verifies that sources/ is
+// emitted only when at least one source CR is written.
+//
+// A component contributes a HelmRepository source only when it resolves to a
+// remote Helm chart (non-empty Source), and --vendor-charts removes even
+// those, since collectHelmSources skips every vendorable ref. GitRepository
+// sources are suppressed entirely under an OCI output reference, where local
+// charts are consumed via ArtifactGenerator + ExternalArtifact. When both
+// filters apply, nothing is contributed and an unconditionally created
+// sources/ would remain empty. The bundle inventory validator walks the
+// finished tree and rejects any directory contributing no files, which failed
+// generation outright. See issue #1947.
+//
+// The cases below model the empty state with source-less components, which is
+// the same state --vendor-charts produces without needing a chart puller.
+//
+// IncludeChecksums is set so the assertion runs through
+// checksum.WriteChecksums → validateExactTree, the check that actually
+// rejected the empty directory, rather than only the proxy that sources/ is
+// absent.
+func TestGenerate_SourcesDirCreatedOnlyWhenPopulated(t *testing.T) {
+	t.Parallel()
+	localManifests := map[string]map[string][]byte{
+		"nfd-ocp": {
+			"nfd.yaml": []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nfd-ocp\n"),
+		},
+	}
+	localOnlyRefs := []recipe.ComponentRef{
+		{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm},
+	}
+	remoteChartRefs := []recipe.ComponentRef{
+		{
+			Name:      "cert-manager",
+			Namespace: "cert-manager",
+			Chart:     "cert-manager",
+			Version:   "v1.17.2",
+			Type:      recipe.ComponentTypeHelm,
+			Source:    "https://charts.jetstack.io",
+		},
+	}
+
+	tests := []struct {
+		name string
+		refs []recipe.ComponentRef
+		// manifests supplies local chart content; nil for remote-chart refs.
+		manifests map[string]map[string][]byte
+		// ociSourceName empty selects the local-directory (GitRepository) path.
+		ociSourceName string
+		// preCreateStale plants an empty sources/ before generation, as a
+		// pre-fix run would have left behind.
+		preCreateStale bool
+		wantSourcesDir bool
+	}{
+		{
+			name:           "OCI output, all-local components: no sources dir",
+			refs:           localOnlyRefs,
+			manifests:      localManifests,
+			ociSourceName:  "aicr-bundle",
+			wantSourcesDir: false,
+		},
+		{
+			name:           "OCI output, all-local components, stale empty sources dir removed",
+			refs:           localOnlyRefs,
+			manifests:      localManifests,
+			ociSourceName:  "aicr-bundle",
+			preCreateStale: true,
+			wantSourcesDir: false,
+		},
+		{
+			name:           "control: OCI output with a remote chart keeps sources dir",
+			refs:           remoteChartRefs,
+			ociSourceName:  "aicr-bundle",
+			wantSourcesDir: true,
+		},
+		{
+			name:           "control: local output writes a GitRepository source",
+			refs:           localOnlyRefs,
+			manifests:      localManifests,
+			wantSourcesDir: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			outputDir := t.TempDir()
+			sourcesDir := filepath.Join(outputDir, "sources")
+
+			if tt.preCreateStale {
+				if err := os.MkdirAll(sourcesDir, 0750); err != nil {
+					t.Fatalf("failed to plant stale sources dir: %v", err)
+				}
+			}
+
+			recipeResult := &recipe.RecipeResult{}
+			recipeResult.Metadata.Version = testVersion
+			recipeResult.ComponentRefs = tt.refs
+
+			g := &Generator{
+				RecipeResult:       recipeResult,
+				ComponentManifests: tt.manifests,
+				Version:            testVersion,
+				OCISourceName:      tt.ociSourceName,
+				IncludeChecksums:   true,
+			}
+
+			if _, err := g.Generate(context.Background(), outputDir); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+
+			info, statErr := os.Stat(sourcesDir)
+			switch {
+			case tt.wantSourcesDir:
+				if statErr != nil {
+					t.Fatalf("expected sources/ to exist, stat error = %v", statErr)
+				}
+				if !info.IsDir() {
+					t.Fatalf("expected sources/ to be a directory, got mode %v", info.Mode())
+				}
+				entries, readErr := os.ReadDir(sourcesDir)
+				if readErr != nil {
+					t.Fatalf("failed to read sources/: %v", readErr)
+				}
+				if len(entries) == 0 {
+					t.Error("expected sources/ to contain at least one source CR")
+				}
+			default:
+				if !os.IsNotExist(statErr) {
+					t.Errorf("expected sources/ to be absent, stat error = %v", statErr)
+				}
+			}
+		})
+	}
+}
+
+// TestGenerate_StaleSourcesPathIsNotDestroyed covers the guard shared by the
+// create and remove routes to the sources path. os.Remove unlinks regular
+// files as readily as it removes empty directories, so removal must not run
+// blind — and both routes must reject the same user error with the same code
+// rather than having the outcome decided by recipe shape.
+func TestGenerate_StaleSourcesPathIsNotDestroyed(t *testing.T) {
+	t.Parallel()
+	localManifests := map[string]map[string][]byte{
+		"nfd-ocp": {
+			"nfd.yaml": []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nfd-ocp\n"),
+		},
+	}
+	localOnlyRefs := []recipe.ComponentRef{
+		{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm},
+	}
+	remoteChartRefs := []recipe.ComponentRef{
+		{
+			Name:      "cert-manager",
+			Namespace: "cert-manager",
+			Chart:     "cert-manager",
+			Version:   "v1.17.2",
+			Type:      recipe.ComponentTypeHelm,
+			Source:    "https://charts.jetstack.io",
+		},
+	}
+
+	const fileContents = "not a directory\n"
+
+	tests := []struct {
+		name string
+		refs []recipe.ComponentRef
+		// plant places something at the sources path before generation.
+		plant     func(t *testing.T, sourcesDir string)
+		manifests map[string]map[string][]byte
+		wantErr   bool
+		// verify asserts the planted object survived generation intact.
+		verify func(t *testing.T, sourcesDir string)
+	}{
+		{
+			name:      "regular file rejected on the remove route",
+			refs:      localOnlyRefs,
+			manifests: localManifests,
+			plant: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				if err := os.WriteFile(sourcesDir, []byte(fileContents), 0600); err != nil {
+					t.Fatalf("failed to plant file: %v", err)
+				}
+			},
+			wantErr: true,
+			verify: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				got, err := os.ReadFile(sourcesDir) //nolint:gosec // test-controlled path
+				if err != nil {
+					t.Fatalf("planted file was destroyed: %v", err)
+				}
+				if string(got) != fileContents {
+					t.Errorf("planted file contents = %q, want %q", got, fileContents)
+				}
+			},
+		},
+		{
+			name: "regular file rejected on the create route",
+			refs: remoteChartRefs,
+			plant: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				if err := os.WriteFile(sourcesDir, []byte(fileContents), 0600); err != nil {
+					t.Fatalf("failed to plant file: %v", err)
+				}
+			},
+			wantErr: true,
+			verify: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				got, err := os.ReadFile(sourcesDir) //nolint:gosec // test-controlled path
+				if err != nil {
+					t.Fatalf("planted file was destroyed: %v", err)
+				}
+				if string(got) != fileContents {
+					t.Errorf("planted file contents = %q, want %q", got, fileContents)
+				}
+			},
+		},
+		{
+			name:      "symlink rejected and left in place",
+			refs:      localOnlyRefs,
+			manifests: localManifests,
+			plant: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				target := filepath.Join(t.TempDir(), "elsewhere")
+				if err := os.MkdirAll(target, 0750); err != nil {
+					t.Fatalf("failed to create symlink target: %v", err)
+				}
+				if err := os.Symlink(target, sourcesDir); err != nil {
+					t.Fatalf("failed to plant symlink: %v", err)
+				}
+			},
+			wantErr: true,
+			verify: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				info, err := os.Lstat(sourcesDir)
+				if err != nil {
+					t.Fatalf("planted symlink was destroyed: %v", err)
+				}
+				if info.Mode()&os.ModeSymlink == 0 {
+					t.Errorf("planted symlink replaced, mode = %v", info.Mode())
+				}
+			},
+		},
+		{
+			name:      "populated stale directory preserved",
+			refs:      localOnlyRefs,
+			manifests: localManifests,
+			plant: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				if err := os.MkdirAll(sourcesDir, 0750); err != nil {
+					t.Fatalf("failed to plant directory: %v", err)
+				}
+				stale := filepath.Join(sourcesDir, "gitrepo-stale.yaml")
+				if err := os.WriteFile(stale, []byte("stale\n"), 0600); err != nil {
+					t.Fatalf("failed to plant stale source CR: %v", err)
+				}
+			},
+			// Generation itself succeeds; the stale file is surfaced by the
+			// inventory validator, which runs only under IncludeChecksums.
+			wantErr: false,
+			verify: func(t *testing.T, sourcesDir string) {
+				t.Helper()
+				stale := filepath.Join(sourcesDir, "gitrepo-stale.yaml")
+				if _, err := os.Stat(stale); err != nil {
+					t.Fatalf("populated stale directory was destroyed: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			outputDir := t.TempDir()
+			sourcesDir := filepath.Join(outputDir, "sources")
+			tt.plant(t, sourcesDir)
+
+			recipeResult := &recipe.RecipeResult{}
+			recipeResult.Metadata.Version = testVersion
+			recipeResult.ComponentRefs = tt.refs
+
+			g := &Generator{
+				RecipeResult:       recipeResult,
+				ComponentManifests: tt.manifests,
+				Version:            testVersion,
+				OCISourceName:      "aicr-bundle",
+			}
+
+			_, err := g.Generate(context.Background(), outputDir)
+			switch {
+			case tt.wantErr && err == nil:
+				t.Fatal("expected Generate() to fail, got nil error")
+			case tt.wantErr:
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("expected ErrCodeInvalidRequest, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), sourcesDir) {
+					t.Errorf("expected error to name %q, got: %v", sourcesDir, err)
+				}
+			case err != nil:
+				t.Fatalf("Generate() error = %v", err)
+			}
+
+			tt.verify(t, sourcesDir)
+		})
 	}
 }
 

--- a/pkg/cli/bundle.go
+++ b/pkg/cli/bundle.go
@@ -648,7 +648,8 @@ Argo CD:
 
 Flux:
   - kustomization.yaml: Root Kustomize orchestration
-  - sources/: HelmRepository and GitRepository source CRs
+  - sources/: HelmRepository and GitRepository source CRs (omitted when no
+    component contributes a source, as with --vendor-charts and an OCI output)
   - <component>/helmrelease.yaml: Flux HelmRelease with inline values
   - README.md: Deployment instructions
   - checksums.txt: SHA256 checksums of generated files


### PR DESCRIPTION
## Summary

Create the flux bundle's `sources/` directory lazily, so a bundle whose components contribute no source CR omits it entirely instead of emitting an empty directory that fails bundle inventory validation. Also remove an empty `sources/` left behind by an earlier failed run, so retrying into the same output directory succeeds.

## Motivation / Context

`aicr bundle --deployer flux` with an OCI output reference fails with:

```
[INVALID_REQUEST] bundle contains an unexpected directory: "sources"
```

`Generate` created `<output>/sources` unconditionally, then wrote source CRs into it only for components contributing one. Two independent filters can empty both maps at once:

- `gitSources` is deliberately left empty when `OCISourceName != ""`, which the CLI sets only when `--output` is an OCI reference — local charts are consumed via `ArtifactGenerator` + `ExternalArtifact` instead.
- `collectHelmSources` skips every ref with `Source == ""`, and additionally skips every vendorable ref under `--vendor-charts`.

`validateExactTree` in `pkg/bundler/checksum/inventory.go` then walks the finished tree and rejects any directory absent from `expectedDirectories` — an empty directory contributes no files, so it never enters that set.

**The issue's stated reproduction no longer fails on `main`.** A plain `--service ocp` recipe now resolves components that carry upstream chart repositories (`prometheus-community`, `registry.k8s.io/dra-driver`), so `helmSources` is non-empty and `sources/` is populated. Both the merge-base and this branch generate byte-identical bundles for it.

The defect itself is still live, and reachable through a supported flag combination — `--vendor-charts` with an OCI output. Because `ShouldVendor` returns true for any Helm component with a repository and no tag/path, vendoring removes every remaining `HelmRepository` source, and the OCI output has already removed the `GitRepository` one. Verified against the merge-base binary:

```bash
aicr bundle -r ocp.yaml -o oci://localhost:5999/aicr-test:v1 \
  --deployer flux --flux-oci-source-name aicr-bundle --vendor-charts \
  --accelerated-node-selector nvidia.com/gpu.present=true \
  --accelerated-node-toleration nvidia.com/gpu:NoSchedule \
  --system-node-selector node-role=system
# [INVALID_REQUEST] bundle contains an unexpected directory: "sources"
```

That path is **not** OCP-specific: `h100-eks-training` fails identically on the merge-base. The issue's OCP framing and its `sources/` table describe a state the current catalog no longer produces; the scope is broader and the trigger is different, but the root cause and the fix are exactly as the issue diagnosed.

Fixes: #1947
Related: #1942, #1944

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: N/A

## Implementation Notes

This mirrors the approach taken for `argocd-helm` in #1944, as the issue suggested.

The `MkdirAll` moves behind an `ensureSourcesDir` closure invoked immediately before the first source CR is written. Bundles that do write sources are unaffected — the directory is created at the same point in the flow, with the same permissions, before the same write.

Lazy creation alone does not help a user who already hit the bug. Generation writes directly into `--output` and does not clear it between runs, so the failed run's empty `sources/` is still on disk and a plain retry reproduces the same error. When nothing is written, the directory is therefore removed.

The path is guarded in one place, `checkSourcesPath`, shared by the create and remove routes. `os.Remove` unlinks regular files as readily as it removes empty directories, so removal must not run blind; and `MkdirAll` reports a non-directory only as a generic `ENOTDIR`, so without a shared guard the same user error surfaced as `INVALID_REQUEST` for an all-local bundle and `INTERNAL` for any bundle carrying a source — the outcome decided by recipe shape rather than by the mistake. `Lstat` rather than `Stat` also rejects a symlink planted after `checksum.ValidateOutputRoot` ran, which permits pre-existing regular files, and a symlink gets its own message rather than being reported as "not a directory".

Emptiness is checked explicitly rather than inferred from an `os.Remove` errno, which keeps the intent readable and avoids platform-specific error values. A populated `sources/` is kept and reported by `validateExactTree` as unexpected output — though only when checksums are enabled, since that validator runs inside the `IncludeChecksums` path. With checksums off a stale `sources/` survives into the bundle, unchanged from before this fix: a reused `--output` was never cleared, so stale files of any kind already persisted.

The `flux` deployer carries the behavior change. Package documentation was updated alongside the code so it no longer describes `sources/` as unconditional, and notes that GitRepository sources are omitted under an OCI output reference.

`pkg/cli/bundle.go` is touched for one line: the `aicr bundle --help` output listed `- sources/: HelmRepository and GitRepository source CRs` under an unconditional `Flux:` tree, which this change makes false. It is now qualified with the condition. This is the help text for the behavior the PR changes, not adjacent cleanup.

Two details are mirrored from `argocd-helm`, which has moved on since #1944: retaining a populated stale directory logs at `slog.Warn` rather than `slog.Debug` (it is the only user-visible signal when checksums are off), and the guard's doc comment carries the full rationale including the accepted check-then-act limitation — an `Lstat` cannot close the window between the check and the following `MkdirAll`/`Remove`, and closing it buys nothing against a local process that already has write access to `--output`.

The only user-facing documentation change is the `aicr bundle --help` line above. The `docs/` tree needs none: the two pages that describe a flux `sources/` directory — `docs/user/cli-reference.md` and `docs/integrator/supply-chain-verification.md` — both document the local-directory Git-source path, where `collectGitSources` always contributes a `GitRepository` and `sources/` is therefore always populated. Both remain accurate.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race ./pkg/bundler/deployer/flux/ ./pkg/cli/ -count=1
GOFLAGS="-mod=vendor" go test -race ./pkg/bundler/... -count=1
GOFLAGS="-mod=vendor" golangci-lint run -c .golangci.yaml ./pkg/bundler/deployer/flux/... ./pkg/cli/...
```

The flux and cli packages pass with the race detector, all of `pkg/bundler/...` passes, and affected-package lint reports 0 issues.

**End-to-end.** With `--vendor-charts` and an OCI output, the OCP recipe goes from exit 2 (`unexpected directory: "sources"`) on the merge-base to generating cleanly on this branch, with `sources/` correctly absent and the run failing only at the push against the deliberately unreachable registry (`SERVICE_UNAVAILABLE`) — the same terminal state as any recipe that never had the bug.

**Regression sweep.** Binaries built from this branch and from the merge-base were run against all 103 embedded catalog overlays on the `flux` deployer, in both output modes (local directory and OCI reference), comparing whole output trees:

| Result | Count |
|---|---|
| Byte-identical to baseline | 204 |
| Differing output | 0 |
| Regressions | 0 |

The two remaining pairs are `base.yaml`, a non-leaf overlay both binaries reject identically with the same `has no criteria` error. This sweep does not pass `--vendor-charts`, so it characterizes the no-change guarantee on the paths that already worked; the vendored path is covered by the end-to-end check above.

**Regression tests.** `TestGenerate_SourcesDirCreatedOnlyWhenPopulated` is table-driven with four cases and sets `IncludeChecksums: true`, so it exercises `checksum.WriteChecksums` → `validateExactTree` — the check that actually rejected the empty directory — rather than asserting only the proxy that `sources/` is absent. Two cases cover the defect (all-local components under an OCI output, with and without a stale empty `sources/` planted first); two are controls that must keep the directory (a remote chart under an OCI output, and the local-directory GitRepository path). On the merge-base both defect cases fail with the real `bundle contains an unexpected directory: "sources"` error and both controls pass, so the test cannot pass vacuously.

`TestGenerate_StaleSourcesPathIsNotDestroyed` covers the guard's safety across both routes to the sources path. A regular file is rejected with the path named, its contents intact, and the same `ErrCodeInvalidRequest` asserted for a recipe reaching `removeStaleSourcesDir` and one reaching `ensureSourcesDir` — so the two routes cannot drift apart. A symlink is rejected and left in place, and a populated stale directory is preserved. On the merge-base the two file cases report `INTERNAL` instead and the symlink case does not fail at all; the populated-directory case passes either way, serving as a control.

One existing test changed: `TestGenerate_OCISourceName_SkipsGitSource` asserted "0 gitrepo files" by reading `sources/`, which no longer exists in that scenario. It now asserts the directory's absence, which subsumes the original claim.

Package coverage: `pkg/bundler/deployer/flux` 85.6% → 86.0% (+0.4%).

`make qualify` passes in full on this branch (exit 0), covering race-detector tests, `go vet`, golangci-lint, e2e, the vulnerability scan, the license check, and api-diff. Total coverage is 82.9%, above the 80% floor in `.settings.yaml`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

The behavior change is confined to one deployer, with one line of CLI help text updated to match it. Its effects are to skip creating a directory that would otherwise be empty, and to remove that directory when a previous run left it behind. Bundles that populate `sources/` follow an identical code path; a non-empty `sources/` is never removed, and a non-directory or symlink at that path is reported rather than deleted. The 204-pair sweep shows byte-identical output everywhere the bundle previously generated.

**Rollout notes:** No migration or flag. Bundles that would have contained an empty `sources/` could not be generated at all, so no existing artifact layout changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
