### PR TITLE
fix(api): normalize legacy recipe kind on bundle ingest

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -3147,15 +3147,18 @@ components:
         and aicr.run/v1alpha3 artifacts, plus legacy artifacts with absent or
         empty header fields, are
         accepted. The kind value Recipe is also accepted: it was the value this
-        contract published through v0.18.0, and the handler performs no kind
-        validation, so clients written against that spec must keep working.
-        apiVersion is the one validated header field — see below.
+        contract published through v0.18.0, so clients written against that
+        spec must keep working.
 
-        A legacy kind is echoed into the generated bundle's recipe.yaml rather
-        than normalized, and the CLI file loader accepts an absent or empty kind
-        but rejects Recipe. A bundle generated from a kind Recipe body is
-        therefore not reloadable via aicr bundle -r or aicr validate -r. Send
-        kind RecipeResult to keep the emitted artifact round-trippable.
+        A legacy kind is normalized on ingest rather than echoed: an absent,
+        empty, or Recipe kind is stamped as RecipeResult, so the generated
+        bundle's recipe.yaml always carries the canonical kind and reloads via
+        aicr bundle -r and aicr validate -r. Only kind is rewritten; a request
+        that omits apiVersion still yields an artifact with an empty
+        apiVersion, which every reader accepts as the legacy shape. Any kind
+        outside this enum is rejected with a 400, matching the /v2/bundle
+        decode path and the kind values the CLI file loader accepts for a
+        hydrated RecipeResult.
 
         apiVersion deliberately has no equivalent legacy window. The artifact
         group/version bump is a hard break with no transition period (see
@@ -3197,7 +3200,8 @@ components:
               type: string
               description: >
                 RecipeResult, the legacy Recipe value published through
-                v0.18.0, or empty for a legacy artifact
+                v0.18.0, or empty for a legacy artifact. The legacy values are
+                normalized to RecipeResult in the generated bundle.
               enum: ["", Recipe, RecipeResult]
             metadata:
               type: object

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -293,8 +293,10 @@ contains two contract gates:
 
   Runtime acceptance of the legacy header shapes is pinned separately by
   `TestBundleHandler_LegacyRecipeHeaders`, which posts absent, empty, and
-  `kind: Recipe` bodies to the handler and asserts 200. The spec gate alone
-  would only be checking the spec against itself.
+  `kind: Recipe` bodies to the handler, asserts 200, and round-trips the
+  emitted `recipe.yaml` back through the file loader to prove the ingest
+  normalization holds. The spec gate alone would only be checking the spec
+  against itself.
 
 Drift is a contract bug: clients conforming to the spec will reject
 inputs the server actually accepts, or generate types that reject

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -436,6 +436,13 @@ is queryable only: it carries no owning `Client`, so `MakeBundle`,
 `BundleComponents`, and `ValidateState` reject it. Use `Client.AdoptRecipe`
 when you need a bundle-able result.
 
+`AdoptRecipe` canonicalizes the artifact `Kind` on the copy it returns: an
+absent, empty, or legacy `Recipe` kind is stamped as `RecipeResult`, and any
+other kind is rejected with `ErrCodeInvalidRequest`. This keeps a bundle
+generated from an externally-decoded recipe reloadable by the file loader. The
+caller's own `RecipeResult` is never mutated, and `APIVersion` is validated but
+never rewritten.
+
 ## Errors
 
 All errors returned by the facade are `*pkg/errors.StructuredError`

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -569,8 +569,21 @@ For backward compatibility, the endpoint also accepts:
   strings after a decode/remarshal round trip.
 - The `kind: Recipe` value this contract published through v0.18.0.
 
-The handler does not validate `kind`, so all three shapes reach the bundler
-identically. `apiVersion` is the exception, validated as described next.
+All three shapes reach the bundler identically: the endpoint normalizes `kind`
+on ingest, stamping `kind: RecipeResult` when the request carries an absent,
+empty, or legacy `Recipe` kind. The generated bundle's `recipe.yaml`
+therefore always carries the canonical `kind` and reloads through
+`aicr bundle -r`, `aicr validate -r`, and the tooling that reads a bundle's
+`recipe.yaml` (TestGrid publication, evidence synthesis). Only `kind` is
+rewritten — a request that omits `apiVersion` still produces an artifact with
+an empty `apiVersion`, which every reader accepts as the legacy shape.
+
+Any other `kind` is rejected with a 400, so the endpoint never emits an artifact
+it would refuse to read back. This matches the `/v2/bundle` decode path, and the
+CLI file loader for the same values — `aicr bundle -r` accepts a
+`RecipeMetadata` file as an *overlay* to hydrate, but as a hydrated
+`RecipeResult` artifact it too accepts only `RecipeResult` or an absent kind.
+`apiVersion` is validated separately, as described next.
 
 `apiVersion` has no equivalent legacy window on purpose. An artifact
 group/version bump is a hard break with no transition period, so a recipe
@@ -581,18 +594,6 @@ This one is enforced. The shared artifact gate rejects any `apiVersion` outside
 as on the CLI file-load path, so a prior group/version fails rather than being
 silently accepted. An absent or empty `apiVersion` is still admitted as the
 legacy shape.
-
-**Round-trip caveat for `kind: Recipe`.** The header is copied into the
-generated bundle's `recipe.yaml` rather than normalized. The CLI file loader
-tolerates an absent or empty `kind` but rejects `Recipe`, so a bundle generated
-from a `kind: Recipe` body cannot be fed back through `aicr bundle -r` or
-`aicr validate -r`. Send `kind: RecipeResult` if you need the emitted artifact
-to remain reloadable.
-
-The same limit reaches the tooling that reads a bundle's `recipe.yaml`, so
-TestGrid publication and evidence synthesis also reject such a bundle. Only
-bundles generated from a `kind: Recipe` HTTP body are affected; the CLI always
-writes `RecipeResult`.
 
 #### Components
 

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -1467,6 +1467,78 @@ func TestAdoptRecipe_RejectsIncoherentRef(t *testing.T) {
 	}
 }
 
+// TestAdoptRecipe_NormalizesKind pins issue #1953 at the adopt boundary: a
+// decoded body may carry an absent, empty, or legacy "Recipe" kind (all three
+// accepted by the /v1/bundle contract), and the adopted copy must be stamped
+// with the canonical kind so the emitted bundle recipe.yaml reloads through
+// the CLI file loader. An off-contract kind is rejected instead of echoed.
+func TestAdoptRecipe_NormalizesKind(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(WithRecipeSource(EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	tests := []struct {
+		name    string
+		kind    string
+		wantErr bool
+	}{
+		{name: "canonical kind (control)", kind: recipe.RecipeResultKind},
+		{name: "empty kind", kind: ""},
+		{name: "legacy Recipe kind", kind: "Recipe"},
+		{name: "off-contract kind", kind: "RecipeMetadata", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := &recipe.RecipeResult{
+				Kind:       tt.kind,
+				APIVersion: recipe.RecipeAPIVersion,
+				Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
+				ComponentRefs: []recipe.ComponentRef{
+					{
+						Name:    "gpu-operator",
+						Type:    recipe.ComponentTypeHelm,
+						Source:  "https://charts.example.com",
+						Chart:   "gpu-operator",
+						Version: "v1",
+					},
+				},
+			}
+
+			res, adoptErr := client.adoptRecipe(t.Context(), input)
+			if tt.wantErr {
+				if adoptErr == nil {
+					t.Fatalf("adoptRecipe accepted kind %q; want ErrCodeInvalidRequest", tt.kind)
+				}
+				var se *aicrerrors.StructuredError
+				if !stderrors.As(adoptErr, &se) {
+					t.Fatalf("expected *aicrerrors.StructuredError, got %T: %v", adoptErr, adoptErr)
+				}
+				if se.Code != aicrerrors.ErrCodeInvalidRequest {
+					t.Errorf("expected ErrCodeInvalidRequest, got %s", se.Code)
+				}
+				return
+			}
+			if adoptErr != nil {
+				t.Fatalf("adoptRecipe(kind=%q): %v", tt.kind, adoptErr)
+			}
+			if got := res.internal.Kind; got != recipe.RecipeResultKind {
+				t.Errorf("adopted kind = %q, want %q", got, recipe.RecipeResultKind)
+			}
+			// The caller-supplied recipe is never mutated (adoption deep-copies).
+			if input.Kind != tt.kind {
+				t.Errorf("input kind mutated to %q, want %q", input.Kind, tt.kind)
+			}
+		})
+	}
+}
+
 // blockingReadFileProvider parks ReadFile of a target file (e.g. registry.yaml)
 // on a signal, so a test can deterministically pin adoptRecipe inside its
 // registry-backed type back-fill while a second goroutine calls Close.

--- a/pkg/client/v1/bundle.go
+++ b/pkg/client/v1/bundle.go
@@ -162,6 +162,17 @@ func (c *Client) adoptRecipe(ctx context.Context, rec *recipe.RecipeResult) (*Re
 	cp := rec.DeepCopy()
 	cp.BindDataProvider(dp)
 
+	// Canonicalize the artifact kind before anything serializes the copy. The
+	// decoded body may carry an absent, empty, or legacy "Recipe" kind (all
+	// accepted by the /v1/bundle contract), and Kind has no omitempty, so
+	// without this the legacy value is echoed verbatim into the generated
+	// bundle's recipe.yaml — an artifact the CLI file loader then rejects,
+	// making the bundle non-reloadable via "aicr bundle -r" / "aicr validate
+	// -r". Accept liberally, emit canonically. See issue #1953.
+	if err := cp.NormalizeKind(); err != nil {
+		return nil, err
+	}
+
 	// An adopted RecipeResult is decoded from an external source (e.g. the
 	// POST /v1/bundle body) and never passes through the resolver, so
 	// canonicalize its component types and validate coherence here — otherwise

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -554,6 +554,48 @@ func (r *RecipeResult) backfillComponentTypes() error {
 	return nil
 }
 
+// NormalizeKind canonicalizes the artifact kind of an externally-supplied
+// RecipeResult so the artifact this build emits is always stamped with the
+// canonical kind, whatever legacy shape the caller sent. It is applied at the
+// ingest boundary that adopts a decoded RecipeResult (client adoptRecipe,
+// reached by POST /v1/bundle, POST /v2/bundle, and Client.AdoptRecipe) —
+// never on the resolve path, which stamps the header itself.
+//
+// Accept liberally, emit canonically:
+//   - an absent or empty kind (legacy artifacts predating the discriminator)
+//     and the legacy "Recipe" value this API contract published from v0.14.0
+//     through v0.18.0 are rewritten to RecipeResultKind;
+//   - RecipeResultKind passes through unchanged;
+//   - any other value is rejected with ErrCodeInvalidRequest.
+//
+// Without the rewrite a legacy kind survived into the generated bundle's
+// recipe.yaml (Kind has no omitempty), and LoadFromFileWithProvider rejects
+// "Recipe" — so a bundle generated from such a body could not be fed back
+// through "aicr bundle -r" or "aicr validate -r". Rejecting an unknown kind
+// matches DecodeRecipeResult (the strict v2 decode path) and the kind values
+// LoadFromFileWithProvider accepts for a hydrated artifact, so no boundary
+// silently emits an artifact it would not read back. (The file loader also
+// accepts RecipeMetadata, but as an overlay to hydrate rather than as a
+// RecipeResult; that input shape has no analog on this boundary.) Only Kind is
+// normalized: APIVersion is validated, never rewritten, because an artifact
+// group/version bump is a hard break with no transition window — see
+// docs/design/011-artifact-apiversion-policy.md. See issue #1953.
+func (r *RecipeResult) NormalizeKind() error {
+	if r == nil {
+		return nil
+	}
+	legacyKind := header.KindRecipe.String()
+	switch r.Kind {
+	case "", RecipeResultKind, legacyKind:
+		r.Kind = RecipeResultKind
+		return nil
+	default:
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe has kind %q, but %q is required; an absent kind and the legacy %q value are accepted and normalized",
+				r.Kind, RecipeResultKind, legacyKind))
+	}
+}
+
 // PrepareAndValidate normalizes a RecipeResult's component refs and rejects
 // incoherent ones, in the required order: validate the profile contract;
 // reject refs named with the reserved deployer override key (all refs, enabled

--- a/pkg/recipe/metadata_test.go
+++ b/pkg/recipe/metadata_test.go
@@ -35,11 +35,14 @@ package recipe
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
 func TestRecipeMetadataSpecValidateDependencies(t *testing.T) {
@@ -2470,5 +2473,57 @@ func TestDeepMergeMap_NoSliceAliasing(t *testing.T) {
 	}
 	if got := src["env"].([]any)[0]; got != srcOriginalEnv {
 		t.Errorf("src env corrupted via dst alias: got %v want %v", got, srcOriginalEnv)
+	}
+}
+
+// TestRecipeResultNormalizeKind pins the ingest-boundary kind contract: the
+// legacy shapes this API accepted through v0.18.0 are rewritten to the
+// canonical kind so the emitted artifact reloads, the canonical value is a
+// no-op, and any other kind is rejected the way the file loader and the
+// strict v2 decode path already reject it. See issue #1953.
+func TestRecipeResultNormalizeKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		kind     string
+		wantKind string
+		wantErr  bool
+	}{
+		{name: "canonical kind is unchanged", kind: RecipeResultKind, wantKind: RecipeResultKind},
+		{name: "absent kind is stamped", kind: "", wantKind: RecipeResultKind},
+		{name: "legacy Recipe kind is normalized", kind: "Recipe", wantKind: RecipeResultKind},
+		{name: "unrelated artifact kind is rejected", kind: RecipeMetadataKind, wantKind: RecipeMetadataKind, wantErr: true},
+		{name: "unknown kind is rejected", kind: "Widget", wantKind: "Widget", wantErr: true},
+		{name: "wrong-case kind is rejected", kind: "reciperesult", wantKind: "reciperesult", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &RecipeResult{Kind: tt.kind}
+			err := r.NormalizeKind()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NormalizeKind() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if r.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", r.Kind, tt.wantKind)
+			}
+			if tt.wantErr && !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error code = %v, want %v", err, errors.ErrCodeInvalidRequest)
+			}
+		})
+	}
+}
+
+// TestRecipeResultNormalizeKindNilReceiver keeps the helper safe on the nil
+// receiver the surrounding validation helpers all tolerate.
+func TestRecipeResultNormalizeKindNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var r *RecipeResult
+	if err := r.NormalizeKind(); err != nil {
+		t.Errorf("NormalizeKind() on nil receiver = %v, want nil", err)
 	}
 }

--- a/pkg/server/bundle_handler_test.go
+++ b/pkg/server/bundle_handler_test.go
@@ -22,9 +22,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/NVIDIA/aicr/pkg/bundler/attestation"
 	"github.com/NVIDIA/aicr/pkg/bundler/result"
@@ -764,10 +768,115 @@ func TestBundleHandler_LegacyRecipeHeaders(t *testing.T) {
 			h.HandleBundles(w, req)
 
 			if w.Code != http.StatusOK {
-				t.Errorf("status = %d, want %d. Body: %s", w.Code, http.StatusOK, w.Body.String())
+				t.Fatalf("status = %d, want %d. Body: %s", w.Code, http.StatusOK, w.Body.String())
+			}
+
+			// Round-trip: the emitted artifact must carry the canonical kind
+			// and load back through the CLI file loader, whatever legacy
+			// header shape the body used. Before #1953 a legacy "Recipe" kind
+			// was echoed into recipe.yaml, which the loader rejects.
+			emitted := bundleRecipeYAML(t, w.Body.Bytes())
+			var emittedHeader struct {
+				Kind string `yaml:"kind"`
+			}
+			if err := yaml.Unmarshal(emitted, &emittedHeader); err != nil {
+				t.Fatalf("unmarshal emitted recipe.yaml header: %v", err)
+			}
+			if emittedHeader.Kind != recipe.RecipeResultKind {
+				t.Errorf("emitted recipe.yaml kind = %q, want %q", emittedHeader.Kind, recipe.RecipeResultKind)
+			}
+
+			// Named recipePath, not path: the file-level `path` import is used
+			// by bundleRecipeYAML below.
+			recipePath := filepath.Join(t.TempDir(), "recipe.yaml")
+			if err := os.WriteFile(recipePath, emitted, 0o600); err != nil {
+				t.Fatalf("write emitted recipe: %v", err)
+			}
+			if _, err := recipe.LoadFromFileWithProvider(
+				t.Context(), recipePath, "", "v-test", nil,
+			); err != nil {
+				t.Errorf("emitted recipe.yaml is not reloadable: %v", err)
 			}
 		})
 	}
+}
+
+// TestBundleHandler_UnsupportedRecipeKind pins the other half of the ingest
+// kind contract: only the shapes BundleRecipeRequest advertises ("",
+// RecipeResult, and the legacy Recipe) are accepted. An off-contract kind is
+// rejected rather than echoed into an artifact the CLI file loader would then
+// refuse to read back — matching the file loader and the strict /v2/bundle
+// decode path. See issue #1953.
+func TestBundleHandler_UnsupportedRecipeKind(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []string{"RecipeMetadata", "Snapshot", "reciperesult"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			var body map[string]any
+			if err := json.Unmarshal(resolveEmbeddedBundleBody(t), &body); err != nil {
+				t.Fatalf("unmarshal fixture: %v", err)
+			}
+			body["kind"] = kind
+			encoded, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal body: %v", err)
+			}
+
+			h := newTestBundleHandler(t)
+			req := httptest.NewRequest(http.MethodPost, "/v1/bundle", bytes.NewReader(encoded))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.HandleBundles(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d. Body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+			// Assert the reason, not just the status: a 400 from an unrelated
+			// decode change would otherwise keep this green for the wrong reason.
+			var resp struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal error response: %v (body: %s)", err, w.Body.String())
+			}
+			if resp.Code != string(aicrerrors.ErrCodeInvalidRequest) {
+				t.Errorf("error code = %q, want %q", resp.Code, aicrerrors.ErrCodeInvalidRequest)
+			}
+			if !strings.Contains(resp.Message, kind) {
+				t.Errorf("error message %q does not name the rejected kind %q", resp.Message, kind)
+			}
+		})
+	}
+}
+
+// bundleRecipeYAML returns the bundle's recipe.yaml from an in-memory bundle
+// zip response, failing the test when the archive does not contain one.
+func bundleRecipeYAML(t *testing.T, archive []byte) []byte {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		t.Fatalf("open bundle zip: %v", err)
+	}
+	for _, f := range zr.File {
+		if path.Base(f.Name) != "recipe.yaml" {
+			continue
+		}
+		rc, openErr := f.Open()
+		if openErr != nil {
+			t.Fatalf("open %s in zip: %v", f.Name, openErr)
+		}
+		data, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			t.Fatalf("read %s in zip: %v", f.Name, readErr)
+		}
+		return data
+	}
+	t.Fatal("bundle zip contains no recipe.yaml")
+	return nil
 }
 
 func TestBundleHandler_StreamZipFailureBeforeCommit(t *testing.T) {


### PR DESCRIPTION
## Summary

Normalize the recipe `kind` on bundle ingest: an absent, empty, or legacy `Recipe` kind is stamped as `RecipeResult` before the recipe reaches the bundler, so the generated `recipe.yaml` is always canonical and reloadable.

## Motivation / Context

`POST /v1/bundle` copied the request body's `kind` verbatim into the generated bundle's `recipe.yaml`. `Kind` has no `omitempty`, so the legacy `Recipe` value this contract published from v0.14.0 through v0.18.0 survived into the artifact — and `pkg/recipe`'s file loader rejects it.

A bundle generated from such a body therefore could not be fed back through `aicr bundle -r` or `aicr validate -r`, nor read by the tooling that consumes a bundle's `recipe.yaml` (TestGrid publication, evidence synthesis). PR #1943 aligned the published contract with what the handler accepts and documented this as a caveat; this PR fixes the runtime side and removes the caveat.

Fixes: #1953
Related: #1943

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK facade (`pkg/client/v1`), OpenAPI contract (`api/aicr/v1/server.yaml`), integrator SDK docs

## Implementation Notes

**Accept liberally, emit canonically.** New `(*recipe.RecipeResult).NormalizeKind()` stamps `RecipeResultKind` when the decoded value is absent, empty, or the legacy `Recipe`. Any other kind is rejected with `ErrCodeInvalidRequest` (HTTP 400), matching both the file loader and the strict `/v2/bundle` decode path — so no boundary emits an artifact it would refuse to read back. The rejected values are already outside the enum the `BundleRecipeRequest` schema publishes.

**Placed in the facade, not the handler.** Normalization runs in `pkg/client/v1`'s `adoptRecipe`, which covers every decode-then-bundle caller (`POST /v1/bundle`, `POST /v2/bundle`, and the SDK's `Client.AdoptRecipe`) rather than the REST path alone. It is applied to the deep copy `adoptRecipe` already makes, so the caller's own recipe is untouched.

**`apiVersion` stays strict — deliberately.** An artifact group/version bump is a hard break with no transition window (see `docs/design/011-artifact-apiversion-policy.md`), so a prior version must be regenerated rather than migrated; normalizing it would paper over that policy. The existing gate in `ValidateCoherence` still rejects an unsupported non-empty `apiVersion`. Only `kind` is rewritten, so a body that omits `apiVersion` still yields an artifact with an empty `apiVersion` — the legacy shape every reader accepts. The docs and the schema description say exactly this rather than claiming the artifact is wholesale "canonical".

**On the file loader comparison.** The rejection is described as matching the `/v2/bundle` decode path and the kind values the CLI file loader accepts *for a hydrated `RecipeResult`*. The loader is not a blanket match: it accepts `kind: RecipeMetadata` as an overlay to hydrate (`pkg/recipe/loader.go:105`), an input shape that has no analog on this boundary.

**SDK surface.** `Client.AdoptRecipe` gains a rejection path that `make api-diff` cannot detect (it compares signatures, not behavior), so the kind contract is documented on the integrator page alongside the existing `WrapResolved` guidance.

## Testing

```bash
make qualify
golangci-lint run -c .golangci.yaml ./pkg/recipe/... ./pkg/client/v1/... ./pkg/server/...
```

`make qualify` passes end to end (exit 0): coverage 82.9% (threshold 80%), lint, tuning-check, e2e, scan, license-check, and api-diff — the last reporting *"No incompatible SDK facade or transparent-alias target changes since v0.19.0"*. Targeted `golangci-lint` on the three changed Go packages: 0 issues.

Per-package coverage: `pkg/recipe` 89.0%, `pkg/client/v1` 83.1%, `pkg/server` 82.3%.

Test changes:

- `TestBundleHandler_LegacyRecipeHeaders` now round-trips the emitted artifact: it extracts `recipe.yaml` from the response zip, asserts the canonical kind, and reloads it through `recipe.LoadFromFileWithProvider`. This converts a 200-only assertion into an end-to-end gate. Verified as a control — on the unfixed tree, 5 subtests fail, including the exact loader rejection `recipe file has kind "Recipe", but "RecipeResult" is required`.
- `TestBundleHandler_UnsupportedRecipeKind` pins the 400 for off-contract kinds, asserting the `INVALID_REQUEST` code and that the message names the rejected kind — not just the status, so an unrelated future 400 cannot keep it green for the wrong reason.
- `TestAdoptRecipe_NormalizesKind` pins the facade boundary, including that the caller's input recipe is not mutated.
- `TestRecipeResultNormalizeKind` covers the helper directly (canonical control, both legacy shapes, three rejected shapes, nil receiver).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** The legacy request shapes PR #1943 preserved continue to be accepted; only the *emitted* artifact changes, and it changes to the canonical form the CLI already writes. One behavior change worth calling out: a request carrying a kind outside the published enum (e.g. `Snapshot`) now gets a 400 instead of a 200 with a non-reloadable bundle.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
