### PR TITLE
fix(notices): anchor go-licenses test guards and cover the fail-closed path

### DIFF
--- a/tools/generate-notices_test.sh
+++ b/tools/generate-notices_test.sh
@@ -38,40 +38,54 @@ if [[ ! -f "${INSTALL_ACTION}" ]]; then
     echo "FAIL: ${INSTALL_ACTION} is missing" >&2
     exit 1
 fi
-if ! grep -q 'GOFLAGS= go install' "${INSTALL_ACTION}"; then
+# Anchor to the executable line, not the file. The action explains the GOFLAGS
+# contract in a comment that contains the same literal, so an unanchored
+# whole-file grep is satisfied by the prose and stays green even when the real
+# `run:` step drops `GOFLAGS=` - the exact regression this guard exists for.
+if ! grep -Eq "^[[:space:]]*GOFLAGS= go install[[:space:]]+['\"]?github\.com/google/go-licenses" \
+    "${INSTALL_ACTION}"; then
     echo "FAIL: the go-licenses install action does not clear GOFLAGS" >&2
+    exit 1
+fi
+# The assertion above proves at least one correct install exists, not that every
+# install is correct. A second install line appended to this action without
+# GOFLAGS= would leave it green, and the workflow scan below deliberately does
+# not cover .github/actions/, so nothing else would catch it.
+#
+# Every go-licenses install line must therefore MATCH IN FULL: a GOFLAGS-cleared
+# install and nothing else, bar a trailing comment. Excluding lines that merely
+# contain "GOFLAGS= go install" somewhere is not enough - `GOFLAGS= go install
+# <other>; go install <go-licenses>` contains it while leaving the go-licenses
+# install unguarded. `[^;&|]*$` rejects that by banning command separators, so
+# each line carries exactly one install and the prefix provably applies to it.
+install_violations=0
+while IFS= read -r install_line; do
+    if ! grep -Eq "^[[:space:]]*GOFLAGS= go install[[:space:]]+['\"]?github\.com/google/go-licenses[^;&|]*$" \
+        <<<"${install_line}"; then
+        echo "FAIL: ${INSTALL_ACTION}: go-licenses install is not GOFLAGS-cleared," >&2
+        echo "or chains other commands onto the same line:" >&2
+        echo "  ${install_line}" >&2
+        install_violations=1
+    fi
+done < <(grep -E "^[[:space:]]*[^#]*go install[[:space:]]+['\"]?github\.com/google/go-licenses" \
+    "${INSTALL_ACTION}")
+if [[ ${install_violations} -ne 0 ]]; then
     exit 1
 fi
 # Reject every inline install, not just one that forgets GOFLAGS: an inline step
 # also escapes the pinned version the composite action takes from
 # .settings.yaml, so a workflow could silently run a different go-licenses. The
-# leading pattern skips commented-out lines. Only workflows are scanned - the
-# action itself is where the real `GOFLAGS= go install` lives.
-if grep -rEn '^[[:space:]]*[^#]*go install[[:space:]]+github\.com/google/go-licenses' \
+# leading pattern skips commented-out lines. The quote is optional and accepts
+# either form because every install site in this repo quotes the module path: a
+# pattern requiring bare whitespace matched only a form nobody writes, and one
+# accepting just `"` still let a single-quoted install through. Only workflows
+# are scanned - the action itself is where the real `GOFLAGS= go install` lives,
+# so widening this root would flag the canonical install as a violation of itself.
+if grep -rEn "^[[:space:]]*[^#]*go install[[:space:]]+['\"]?github\.com/google/go-licenses" \
     "${REPO_ROOT}/.github/workflows/"; then
     echo "FAIL: a workflow installs go-licenses inline;" >&2
     echo "use the ./.github/actions/install-go-licenses composite action instead." >&2
     exit 1
-fi
-
-# The behavioral case below runs the real generator, which needs yq to verify
-# its release-target matrix. Without it the script exits on that check instead of
-# the guard under test, which would read as a defect rather than a missing tool.
-# Skip with one clear message locally; fail in CI, where the guard must actually
-# be exercised. The variant check mirrors setup-tools: Python yq wraps jq.
-yq_unavailable=""
-if ! command -v yq >/dev/null 2>&1; then
-    yq_unavailable="yq is not installed"
-elif ! yq --version 2>/dev/null | grep -q "mikefarah/yq"; then
-    yq_unavailable="yq at $(command -v yq) is not mikefarah/yq (Go-based)"
-fi
-if [[ -n "${yq_unavailable}" ]]; then
-    if [[ -n "${CI:-}" ]]; then
-        echo "FAIL: ${yq_unavailable}; the notices guard cannot be verified in CI" >&2
-        exit 1
-    fi
-    echo "SKIP: ${yq_unavailable}; run 'make tools-setup' to install the pinned version"
-    exit 0
 fi
 
 TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/aicr-notices-test.XXXXXX")"
@@ -116,6 +130,100 @@ assert_goroot_exported() {
     done < "${GO_LICENSES_PROBE}"
 }
 
+# ---------------------------------------------------------------------------
+# license-check cases. These need only the stub go-licenses and the real `go`,
+# never the generator, so they run BEFORE the yq gate below: a missing yq must
+# not silently disable the half of the suite that does not depend on it.
+# ---------------------------------------------------------------------------
+
+# The license-check gate shares the defect: with no usable GOROOT, go-licenses
+# inspects nothing and exits 0, so the gate passes vacuously. Exercise the real
+# target against the stub rather than reading the Makefile.
+: > "${GO_LICENSES_PROBE}"
+set +e
+license_output="$(
+    cd "${REPO_ROOT}" && env -u GOROOT PATH="${TEST_TMP}/bin:${PATH}" \
+        make license-check 2>&1
+)"
+license_rc=$?
+set -e
+
+if [[ ${license_rc} -ne 0 ]]; then
+    echo "FAIL: 'make license-check' failed against a stub go-licenses:" >&2
+    echo "${license_output}" >&2
+    exit 1
+fi
+
+assert_goroot_exported "make license-check"
+echo "make license-check exports a usable GOROOT to go-licenses"
+
+# Negative control for the recipe's GOROOT validation branch. Without it the
+# positive case above passes just as happily when that branch is deleted, so the
+# fail-closed half of the gate would be unprotected.
+#
+# The stub must make `go env GOROOT` PRINT an unusable path while EXITING 0.
+# Exporting GOROOT=/nonexistent does not work: the real `go env` rejects it and
+# exits 2, so `set -e` aborts the recipe before the branch is ever reached and
+# the case would pass against a recipe with no validation at all.
+REAL_GO="$(command -v go)"
+cat > "${TEST_TMP}/bin/go" <<EOF
+#!/usr/bin/env bash
+# Only the GOROOT lookup is faked; everything else defers to the real toolchain.
+if [[ "\${1:-}" == "env" && "\${2:-}" == "GOROOT" && \$# -eq 2 ]]; then
+    printf '%s\n' "${TEST_TMP}/not-a-goroot"
+    exit 0
+fi
+exec "${REAL_GO}" "\$@"
+EOF
+chmod +x "${TEST_TMP}/bin/go"
+
+set +e
+unusable_output="$(
+    cd "${REPO_ROOT}" && env -u GOROOT PATH="${TEST_TMP}/bin:${PATH}" \
+        make license-check 2>&1
+)"
+unusable_rc=$?
+set -e
+find "${TEST_TMP}/bin/go" -maxdepth 0 -delete
+
+if [[ ${unusable_rc} -eq 0 ]]; then
+    echo "FAIL: 'make license-check' exited 0 with an unusable GOROOT." >&2
+    echo "The recipe must fail closed rather than run go-licenses against a" >&2
+    echo "GOROOT that makes every package look like standard library." >&2
+    echo "${unusable_output}" >&2
+    exit 1
+fi
+
+if ! grep -q "could not resolve a usable GOROOT" <<<"${unusable_output}"; then
+    echo "FAIL: 'make license-check' failed for the wrong reason:" >&2
+    echo "${unusable_output}" >&2
+    exit 1
+fi
+echo "make license-check fails closed when GOROOT is unusable"
+
+# ---------------------------------------------------------------------------
+# Generator case. This one runs the real generator, which needs yq to verify its
+# release-target matrix. Without it the script exits on that check instead of the
+# guard under test, which would read as a defect rather than a missing tool.
+# Skip with one clear message locally; fail in CI, where the guard must actually
+# be exercised. The variant check mirrors setup-tools: Python yq wraps jq.
+# ---------------------------------------------------------------------------
+yq_unavailable=""
+if ! command -v yq >/dev/null 2>&1; then
+    yq_unavailable="yq is not installed"
+elif ! yq --version 2>/dev/null | grep -q "mikefarah/yq"; then
+    yq_unavailable="yq at $(command -v yq) is not mikefarah/yq (Go-based)"
+fi
+if [[ -n "${yq_unavailable}" ]]; then
+    if [[ -n "${CI:-}" ]]; then
+        echo "FAIL: ${yq_unavailable}; the notices guard cannot be verified in CI" >&2
+        exit 1
+    fi
+    echo "SKIP: ${yq_unavailable}; run 'make tools-setup' to install the pinned version"
+    exit 0
+fi
+
+: > "${GO_LICENSES_PROBE}"
 set +e
 stderr_output="$(
     cd "${REPO_ROOT}" && env -u GOROOT PATH="${TEST_TMP}/bin:${PATH}" \
@@ -146,24 +254,3 @@ fi
 
 assert_goroot_exported "generate-notices"
 echo "generate-notices fails closed on an empty go-licenses collection"
-
-# The license-check gate shares the defect: with no usable GOROOT, go-licenses
-# inspects nothing and exits 0, so the gate passes vacuously. Exercise the real
-# target against the stub rather than reading the Makefile.
-: > "${GO_LICENSES_PROBE}"
-set +e
-license_output="$(
-    cd "${REPO_ROOT}" && env -u GOROOT PATH="${TEST_TMP}/bin:${PATH}" \
-        make license-check 2>&1
-)"
-license_rc=$?
-set -e
-
-if [[ ${license_rc} -ne 0 ]]; then
-    echo "FAIL: 'make license-check' failed against a stub go-licenses:" >&2
-    echo "${license_output}" >&2
-    exit 1
-fi
-
-assert_goroot_exported "make license-check"
-echo "make license-check exports a usable GOROOT to go-licenses"


### PR DESCRIPTION
## Summary

The guards added with the `go-licenses` GOROOT fix in #2159 pass in the states they exist to reject. Anchor them to what they actually assert, add the missing negative control for `make license-check`, and stop the yq gate from discarding the assertions that do not need yq.

## Motivation / Context

#2159 fixed a real defect: a `-trimpath`-linked `go-licenses` carries no baked-in `GOROOT`, so the stdlib prefix collapses to `/`, the whole dependency graph is classified as standard library, and `make license-check` passes while inspecting nothing. The runtime fixes in that PR are correct and are not changed here.

What is changed is the enforcement around them. Each guard was verified by mutation: reproduce the regression it names, then check whether the suite goes red. Most did not.

- **The install-action assertion was a presence check.** Beyond being satisfied by a comment (below), it proved only that *at least one* correct install exists. A second install line appended to the same action without `GOFLAGS=` left it green, and the workflow scan deliberately does not cover `.github/actions/`, so nothing else caught it. Every go-licenses install line must now match in full — a `GOFLAGS=`-cleared install and nothing else, bar a trailing comment. Matching in full rather than excluding lines that merely *contain* the prefix matters: `GOFLAGS= go install <other>; go install <go-licenses>` contains it while leaving the go-licenses install unguarded, so the trailing `[^;&|]*$` bans command separators and pins one install per line.

- **The install-action assertion is satisfied by a comment.** `tools/generate-notices_test.sh` did a whole-file `grep -q 'GOFLAGS= go install'`, and `install-go-licenses/action.yml` contains that literal twice — once at line 32 explaining the contract in prose, once at line 60 as the real `run:` step. Deleting `GOFLAGS=` from line 60 left the suite green, so the exact `-trimpath` regression the action exists to prevent could return undetected.

- **The inline-install scan matched a form nobody writes.** The pattern required whitespace directly before the module path, so it caught `go install github.com/...` but missed `go install "github.com/..."`. Every install site in this repo quotes the path, so a quoted inline install added to a workflow was not detected. Both quote forms are now accepted — matching only `"` would still let a single-quoted install through.

- **`make license-check` had no negative case.** The stub `go-licenses` exits 0 unconditionally and the only assertions were "exit 0" plus the GOROOT probe. Deleting the recipe's validation branch left the suite green, so the export half was covered and the fail-closed half was not.

- **The yq gate disabled the cases that do not need yq.** It exited 0 for the whole file, but the `license-check` cases never invoke the generator and have no yq dependency. On a machine without mikefarah yq, `make test` ran none of the new assertions.

Fixes: N/A
Related: #2159

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: third-party notices test guards

## Implementation Notes

**The inline-install scan stays scoped to `.github/workflows/`.** Widening it to all of `.github/` looks like the obvious companion fix and is wrong: once the quote is optional, the pattern matches the canonical `install-go-licenses` action itself, and the pre-existing install in `go-build-release`. The guard would then flag the very install it exists to steer people toward. The comment records that reasoning so the next reader does not re-derive it.

**The negative control stubs `go env GOROOT` rather than exporting `GOROOT`.** Setting `GOROOT=/nonexistent` looks equivalent and is vacuous: the real `go env GOROOT` rejects an invalid `GOROOT` and exits 2, so `set -e` aborts the recipe before the validation branch is ever reached. That test passes against a recipe with no validation at all. The stub instead prints an unusable path while exiting 0, which is the only state that actually reaches the branch. Everything other than the `GOROOT` lookup defers to the real toolchain, so the rest of the recipe runs unmodified.

**Ordering.** The shared fixtures (temp dir, stub `go-licenses`, `assert_goroot_exported`) moved above the yq gate so the `license-check` cases can run first. The gate now guards only the generator case, which is the sole consumer of yq.

No production code changed; this is test-only.

## Testing

```bash
make test-shell   # exit 0, 0 failures
bash tools/generate-notices_test.sh
```

Each guard was verified as a control/mutant pair — the mutation must pass before the change and fail after, or the guard is decoration:

| Mutation | before | after |
|---|---|---|
| Delete `GOFLAGS=` from the action's `run:` step | exit 0 | exit 1 |
| Append a second install to the action *without* `GOFLAGS=` | exit 0 | exit 1 |
| Append a second install *with* `GOFLAGS=` (legitimate) | exit 0 | exit 0 (no false positive) |
| Chain an unguarded install onto a `GOFLAGS=` line (`...; go install ...`) | exit 0 | exit 1 |
| Add a double-quoted inline `go install` to a workflow | exit 0 | exit 1 |
| Add a single-quoted inline `go install` to a workflow | exit 0 | exit 1 |
| Delete the `license-check` GOROOT validation branch | no case existed | exit 1 |
| yq unavailable | SKIP, zero assertions ran | 2 assertions run, then SKIP |

`make test-shell` passes with zero failures, and the suite's three assertions run:

```
Running tools/generate-notices_test.sh...
make license-check exports a usable GOROOT to go-licenses
make license-check fails closed when GOROOT is unusable
generate-notices fails closed on an empty go-licenses collection
```

Also ran `bash -n` and `shellcheck -S warning` on the changed file, both clean.

Full `make qualify` was not run. The change is a single shell test file with no Go source, so the Go build, race tests, coverage gate, e2e, scan, and api-diff lanes cannot regress from it; `make test-shell` is the lane that actually executes the changed file, and it passes.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — test-only, no runtime or released-artifact behavior change. Worth noting for reviewers: these guards now genuinely fail on the states they name, so they can start failing on a future change that would previously have passed unexamined. That is the intent.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — `make test-shell`; no Go source changed
- [x] Linter passes (`make lint`) — `shellcheck -S warning` and `bash -n` on the changed file
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed — N/A, no user-facing behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
