### PR TITLE
fix(ci): watch the license gate's own inputs in the deps path filter

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -71,10 +71,37 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
             deps:
+              # Inputs to the verify-licenses gate, which runs `make
+              # license-check` over the vendored dependency graph. Watch the
+              # dependency manifests and the vendor tree, plus every input that
+              # defines the check itself, so a change to the gate cannot skip
+              # its own gate: the Makefile recipe is the check's contract, the
+              # install-go-licenses action supplies the binary it runs (that
+              # action clears GOFLAGS, without which -trimpath strips GOROOT and
+              # the check passes while inspecting zero packages), and this
+              # workflow defines the job. The entry replaced here named
+              # '.github/workflows/verify-licenses.yaml', which was deleted in
+              # 3c9f6ec5 when the job moved into this workflow, so the filter
+              # had stopped watching anything the job actually consumes.
+              #
+              # The toolchain pins are watched too, because the job resolves
+              # them through load-versions before running the check: .go-version
+              # supplies the Go toolchain (which determines the `go list std`
+              # ignore set) and .settings.yaml supplies linting.go_licenses (the
+              # go-licenses build that classifies packages). Both reach the gate
+              # only via that action, so all three paths must be watched or a
+              # version bump silently skips the gate it changes — #814 bumped
+              # go-licenses touching only .settings.yaml, and #1204 bumped Go
+              # touching only .go-version.
               - 'go.mod'
               - 'go.sum'
               - 'vendor/**'
-              - '.github/workflows/verify-licenses.yaml'
+              - 'Makefile'
+              - '.go-version'
+              - '.settings.yaml'
+              - '.github/actions/install-go-licenses/**'
+              - '.github/actions/load-versions/**'
+              - '.github/workflows/merge-gate.yaml'
             renovate:
               # Watch every input the verify-renovate job consumes — including
               # the Makefile target that runs the validator — so changes to the


### PR DESCRIPTION
## Summary

`verify-licenses` was gated on a `deps` path filter that watched a deleted file, so a PR changing the license gate merged without that gate running. Replace the dead entry and watch the inputs the job actually consumes.

## Motivation / Context

`verify-licenses` runs `make license-check` and is gated on `needs.check-paths.outputs.deps == 'true'`. The `deps` filter matched only:

```yaml
deps:
  - 'go.mod'
  - 'go.sum'
  - 'vendor/**'
  - '.github/workflows/verify-licenses.yaml'
```

That last path does not exist. `.github/workflows/verify-licenses.yaml` was deleted in `3c9f6ec5` when the job was folded into `merge-gate.yaml`; the filter entry was added in #651 and never updated to follow it. The result is that nothing in the filter watched any input the job actually consumes — not the `license-check` recipe, not the action that installs `go-licenses`, not the workflow that now defines the job, and not the toolchain pins (`.go-version`, `.settings.yaml`) the job resolves through `load-versions`.

This is a supply-chain gate that could not validate changes to itself.

It is not hypothetical. #2159 repaired `make license-check` after finding it passed while inspecting zero packages: a `-trimpath`-linked `go-licenses` carries no baked-in `GOROOT`, so the stdlib prefix collapses to `/`, every package is classified as standard library, and the tool writes nothing and exits 0. That PR rewrote the `Makefile` recipe and added the `install-go-licenses` composite action — and `verify-licenses` was skipped on it. The repaired gate was never run against the real dependency graph before merging. `notices-freshness` and the `tests` suite passed, which is what made the gap easy to miss.

Fixes: #2164
Related: #2159, #2163

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: merge-gate path filters

## Implementation Notes

The added entries mirror the reasoning the sibling `notices` filter already documents — *"Makefile is included because the `notices`/`notices-check` recipes are the generation/check contract — a change to them must not be able to skip its own gate."* The `deps` filter simply never got that treatment.

- **`Makefile`** — the `license-check` recipe is the gate's contract.
- **`.github/actions/install-go-licenses/**`** — supplies the binary the check runs. That action clears `GOFLAGS`; without it `-trimpath` strips `GOROOT` and the check passes vacuously, so a change there can silently neuter the gate.
- **`.github/workflows/merge-gate.yaml`** — now defines the job. This also makes the fix self-validating: a PR editing the filter triggers the gate the filter controls, which is why `verify-licenses` should run on **this** PR rather than reporting `verify-licenses-skip`.
- **`.go-version`, `.settings.yaml`, `.github/actions/load-versions/**`** — the toolchain pins and the action that resolves them. The job runs `load-versions` and consumes its `go` and `go_licenses` outputs before invoking the check, so these reach the gate only through that action. Without them a version bump skips the gate it changes — and both cases are routine: #814 bumped `go-licenses` touching only `.settings.yaml`, and #1204 bumped Go touching only `.go-version`.

  This last one is the sharpest case. `.github/renovate.json5` matches `google/go-licenses` under `matchUpdateTypes: ["patch", "pin", "digest"]` with `automerge: true`, so a bump to the license checker itself can **auto-merge with no human in the loop** — while the gate that would have exercised the new binary reports green by skipping. `.go-version` bumps likewise land in their own PR (`matchFileNames: [".go-version"]`) and matched neither `deps` nor `notices`.

The dead `.github/workflows/verify-licenses.yaml` entry is removed. A comment records why, so the next reader does not re-derive the history.

Only `verify-licenses` (`if: deps == 'true'`) and `verify-licenses-skip` (`if: deps != 'true'`) consume this output — verified — so no other job's triggering changes.

## Testing

```bash
actionlint .github/workflows/merge-gate.yaml   # clean
yamllint .github/workflows/merge-gate.yaml     # clean
```

Parsed the rendered filter to confirm the intended paths and the absence of the dead one:

```
go.mod
go.sum
vendor/**
Makefile
.go-version
.settings.yaml
.github/actions/install-go-licenses/**
.github/actions/load-versions/**
.github/workflows/merge-gate.yaml
```

Simulated the filter against real historical PRs to confirm the previously-skipping cases now trigger, and that unrelated changes still do not:

| Change | `deps` | matched by |
|---|---|---|
| #814 — go-licenses bump | true | `.settings.yaml` |
| #1204 — Go bump | true | `.go-version` |
| this PR | true | `.github/workflows/merge-gate.yaml` |
| a `load-versions` edit | true | `.github/actions/load-versions/**` |
| an unrelated docs PR | false | — |

The remaining textual occurrence of `verify-licenses.yaml` in the file is the explanatory comment, not a filter entry.

**The real test is this PR's own check run.** Before this change a PR touching only `merge-gate.yaml` produced `deps=false` and `verify-licenses-skip`. With it, `verify-licenses` should run and `make license-check` should pass. Please confirm that in the checks below before merging — that is the behavior the issue is about.

Full `make qualify` was not run: this changes a CI path filter only, with no Go source, no recipe data, and no shell/tooling change, so the Go build, race tests, coverage gate, e2e, scan, and api-diff lanes cannot regress from it. `actionlint` and `yamllint` are the lanes that cover the changed file.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No runtime or released-artifact change. One expected behavior change for reviewers: `verify-licenses` now runs on more PRs — any change to `Makefile`, this workflow, the install or `load-versions` actions, or the toolchain pins in `.go-version` / `.settings.yaml`. Renovate version bumps will now pull in a 10-minute job that previously skipped; that is the intent, since a bump is exactly when the gate should run. Because the gate previously passed vacuously and was repaired only in #2159, it can legitimately start failing on a dependency that was waved through unexamined. It passes on `main` today. That extra signal is the point of the fix, but it is worth knowing before the first red run.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go source changed; `actionlint` + `yamllint` clean
- [x] Linter passes (`make lint`) — `actionlint` and `yamllint` on the changed file
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A; the filter's correctness is observable in this PR's own check run
- [ ] I updated docs if user-facing behavior changed — N/A, no user-facing behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
