### PR TITLE
chore(sdk): prune stale v0.18.0 API-diff acknowledgement

### DIFF
--- a/pkg/client/v1/api-diff-exceptions.yaml
+++ b/pkg/client/v1/api-diff-exceptions.yaml
@@ -14,11 +14,4 @@
 
 # Intentional API compatibility breaks. Each entry is tied to the active release
 # baseline and must be removed when that baseline advances; stale entries fail the gate.
-acknowledgements:
-  - baseline: v0.18.0
-    issue: '#1891, #2095'
-    summary: BundleOptions and Snapshot gained []byte fields, making both structs non-comparable.
-    rationale: BinaryAttestation enables verified in-image provenance; Raw preserves agent-emitted snapshots without dropping fields unknown to the client.
-    incompatible_changes:
-      - 'BundleOptions: old is comparable, new is not'
-      - 'Snapshot: old is comparable, new is not'
+acknowledgements: []


### PR DESCRIPTION
## Summary

Removes the stale `v0.18.0` acknowledgement from `pkg/client/v1/api-diff-exceptions.yaml`, leaving `acknowledgements: []`.

## Motivation / Context

The active baseline is now `v0.19.0` and its diff is clean, so the `v0.18.0` entry no longer describes any change the gate is evaluating. `make api-diff` reports it on every run:

```
⚠️  Prunable API-diff acknowledgement baseline(s) in pkg/client/v1/api-diff-exceptions.yaml: v0.18.0;
    active baseline is v0.19.0 and its diff is clean. Remove the acknowledgement(s) for non-active baselines.
```

The file's own header states the contract: "Each entry is tied to the active release baseline and must be removed when that baseline advances."

**This is a latent trap, not just dead weight.** `tools/api-diff` warns about a stale baseline only while the diff stays clean. The moment a genuinely incompatible change lands, the same stale entry triggers a hard `EXIT_STALE_ACKNOWLEDGEMENT` failure — so the next author to break the SDK facade would be handed a confusing stale-acknowledgement error about someone else's v0.18.0 entry instead of a report of their own diff. Pruning now keeps that failure legible.

Fixes: N/A
Related: #1891, #2095 (the changes the pruned entry acknowledged)

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `pkg/client/v1` API-diff gate configuration

## Implementation Notes

`acknowledgements: []` is the supported empty form — it is the exact shape `tools/api-diff_test.sh` uses for its `EMPTY_EXCEPTIONS` fixture, and the validator requires `.acknowledgements` to be a sequence, which an empty list satisfies. No Go code, no public API, and no gate logic changes.

## Testing

Config-only change to the file that drives the api-diff gate, so verification is the gate itself plus the lint suite rather than a full `make qualify` (no Go source, docs, recipes, or build config is touched):

```bash
make api-diff   # "No incompatible SDK facade or transparent-alias target changes since v0.19.0."
                # prunable-baseline warning no longer emitted
make lint       # "Completed Go and YAML lints and ensured license headers"
```

The first `make api-diff` attempt failed with `load packages: context deadline exceeded` against a cold build cache; the rerun passed. Unrelated to this change.

## Risk Assessment

- [x] **Low** — Removes an inert acknowledgement; the gate re-derives everything else from the release baseline. Trivially revertible.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — covered via `make lint` / `make api-diff`; no Go code changed
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [ ] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
