### PR TITLE
fix(validators): roll back partial Kubeflow Trainer installs

### DIFF
--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -473,27 +473,21 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 // pod to complete, and returns the benchmark logs.
 func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	accelerator recipe.CriteriaAcceleratorType, service recipe.CriteriaServiceType, variant ncclVariant, fabric ncclFabricType,
-	customRuntime string) (string, error) {
+	customRuntime string) (logs string, err error) {
 
 	dynamicClient := ctx.DynamicClient
 
-	// Ensure Kubeflow Trainer is installed. If it is already present we leave it
-	// alone; if we install it we clean it up after the test completes.
-	trainerInstalled, err := isTrainerInstalled(ctx.Ctx, dynamicClient)
+	// Ensure a usable Kubeflow Trainer. A complete installation already on the
+	// cluster is left alone and reports no resources; anything we install is ours
+	// to clean up after the test completes.
+	installedResources, err := ensureTrainerInstalled(ctx.Ctx, dynamicClient, ctx.Clientset.Discovery())
 	if err != nil {
-		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check Kubeflow Trainer installation", err)
+		return "", err
 	}
-	if !trainerInstalled {
-		slog.Info("Kubeflow Trainer not found, installing...")
-		var installedResources []trainerResourceRef
-		installedResources, err = installTrainer(ctx.Ctx, dynamicClient, ctx.Clientset.Discovery())
-		if err != nil {
-			return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to install Kubeflow Trainer", err)
-		}
-		defer deleteTrainer(dynamicClient, installedResources)
-		slog.Info("Kubeflow Trainer installed", "resources", len(installedResources))
-	} else {
-		slog.Info("Kubeflow Trainer already installed, proceeding")
+	if len(installedResources) > 0 {
+		defer func() {
+			err = foldCleanupError(err, deleteTrainer(dynamicClient, installedResources))
+		}()
 	}
 
 	// Clean up NCCL resources on every exit path. Registered after the trainer
@@ -520,7 +514,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	}
 
 	// Wait for launcher pod and get logs.
-	logs, err := waitForLauncherPodAndGetLogs(ctx, podHelper)
+	logs, err = waitForLauncherPodAndGetLogs(ctx, podHelper)
 	if err != nil {
 		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get launcher logs", err)
 	}

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestEnsureTrainerInstalled_CompleteInstallIsLeftAlone verifies a healthy
+// pre-existing Trainer is neither reinstalled nor claimed for cleanup: returning
+// resources here would make the benchmark delete a Trainer it does not own.
+func TestEnsureTrainerInstalled_CompleteInstallIsLeftAlone(t *testing.T) {
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+
+	refs, err := ensureTrainerInstalled(context.Background(), client, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0 (a Trainer we did not install must not be claimed for cleanup)", len(refs))
+	}
+}
+
+// TestEnsureTrainerInstalled_WaitsForPreexistingController covers the
+// already-installed branch: the probe checks presence, not readiness, so a
+// still-rolling controller must be waited out and reported distinctly rather
+// than driving TrainJobs at a controller with no webhook endpoints.
+func TestEnsureTrainerInstalled_WaitsForPreexistingController(t *testing.T) {
+	// Replace the ready controller with one reporting zero ready replicas. Drop by
+	// kind, not name: upstream gives the Deployment and its Service the same name.
+	objs := append(
+		withoutObject(completeTrainerInstall(), func(o runtime.Object) bool {
+			u, ok := o.(*unstructured.Unstructured)
+			return ok && u.GetKind() == "Deployment"
+		}),
+		notReadyTrainerDeployment(),
+	)
+	client := newTrainerFakeClient(objs...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		cancel() // the controller never becomes ready; stop the poll deterministically
+		return false, nil, nil
+	})
+	defer cancel()
+
+	refs, err := ensureTrainerInstalled(ctx, client, nil)
+	if err == nil {
+		t.Fatal("expected a not-ready pre-existing controller to fail, got nil error")
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0", len(refs))
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
+		t.Errorf("error code is not Timeout: %v", err)
+	}
+}
+
+// TestEnsureTrainerInstalled_RefusesToInstallOverForeignNamespace is the guard for
+// the destructive case: an incomplete Trainer installed elsewhere (a partial chart
+// install, a mid-upgrade, a non-default release name) must abort the install rather
+// than apply on top of it.
+//
+// Kustomize applies CRDs and RBAC before webhook configurations, so the per-object
+// ownership guard fires too late — a shared-name ClusterRoleBinding would already
+// have been repointed at our namespace, and updates are excluded from the rollback
+// set, so nothing restores it. Refusing before the first apply is the only point
+// where this is still reversible.
+func TestEnsureTrainerInstalled_RefusesToInstallOverForeignNamespace(t *testing.T) {
+	// A chart installation in kubeflow, incomplete enough that the probe rejects it
+	// (no CRDs), but discoverable through its admission configuration.
+	client := newTrainerFakeClient(
+		webhookConfigIn("ValidatingWebhookConfiguration", trainerValidatingWebhookConfig,
+			trainerValidatingWebhookName, "kubeflow"),
+	)
+
+	refs, err := ensureTrainerInstalled(context.Background(), client, nil)
+	if err == nil {
+		t.Fatal("expected the installer to refuse installing over an installation in another namespace")
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0", len(refs))
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		t.Errorf("error code is not Conflict: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kubeflow") {
+		t.Errorf("error does not name the live installation's namespace: %v", err)
+	}
+}
+
+// TestEnsureTrainerInstalled_PreservesProbeErrorCode is the regression guard for
+// the classification the probe added: re-wrapping with a hardcoded Internal here
+// would report a transient control-plane outage to the verdict as a product defect.
+func TestEnsureTrainerInstalled_PreservesProbeErrorCode(t *testing.T) {
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+	client.PrependReactor("get", resourceCRDs, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
+	})
+
+	_, err := ensureTrainerInstalled(context.Background(), client, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
+		t.Errorf("probe classification was overwritten; want Unavailable, got: %v", err)
+	}
+}
+
+// TestFoldCleanupError pins the fail-closed teardown contract: a cleanup failure
+// fails an otherwise-passing check (leaked cluster-scoped objects poison the next
+// run), but never masks a real benchmark failure.
+func TestFoldCleanupError(t *testing.T) {
+	benchErr := aicrErrors.New(aicrErrors.ErrCodeTimeout, "launcher pod never completed")
+	cleanupErr := aicrErrors.New(aicrErrors.ErrCodeUnavailable, "failed to delete 1 Trainer resource(s)")
+
+	tests := []struct {
+		name    string
+		bench   error
+		cleanup error
+		want    error
+	}{
+		{name: "clean run reports success", bench: nil, cleanup: nil, want: nil},
+		{name: "cleanup failure fails a passing benchmark", bench: nil, cleanup: cleanupErr, want: cleanupErr},
+		{name: "benchmark failure outranks cleanup failure", bench: benchErr, cleanup: cleanupErr, want: benchErr},
+		{name: "benchmark failure survives clean teardown", bench: benchErr, cleanup: nil, want: benchErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := foldCleanupError(tt.bench, tt.cleanup)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("got %v, want nil", got)
+				}
+				return
+			}
+			if !stderrors.Is(got, tt.want) {
+				t.Errorf("got %v, want it to wrap %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFoldCleanupError_PreservesCleanupCode verifies a transient teardown blip
+// stays retryable rather than being flattened to an internal fault.
+func TestFoldCleanupError_PreservesCleanupCode(t *testing.T) {
+	cleanupErr := aicrErrors.New(aicrErrors.ErrCodeUnavailable, "apiserver is down")
+
+	got := foldCleanupError(nil, cleanupErr)
+	if !stderrors.Is(got, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
+		t.Errorf("cleanup error code was flattened: %v", got)
+	}
+}

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -37,11 +39,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/yaml"
@@ -54,14 +59,69 @@ const (
 	// trainerKustomizePath is the path within the extracted archive to the manager overlay.
 	trainerKustomizePath = "manifests/overlays/manager"
 
-	// trainerCRDName is the CRD that signals the Trainer operator is installed.
-	trainerCRDName = "trainjobs.trainer.kubeflow.org"
+	// trainerCRDTrainJobs and trainerCRDTrainingRuntimes are the CRDs the NCCL
+	// benchmark needs. Both must be Established for the installation to count.
+	trainerCRDTrainJobs        = "trainjobs.trainer.kubeflow.org"
+	trainerCRDTrainingRuntimes = "trainingruntimes.trainer.kubeflow.org"
 
 	// trainerControllerDeployment is the Deployment name for the Trainer controller-manager.
 	trainerControllerDeployment = "kubeflow-trainer-controller-manager"
 
-	// trainerNamespace is the namespace where the Trainer operator is installed.
+	// trainerControllerService is the Service fronting the controller-manager's
+	// webhook port. Without it the admission webhooks have no endpoints and every
+	// TrainJob create is rejected.
+	trainerControllerService = "kubeflow-trainer-controller-manager"
+
+	// trainerNamespace is the namespace this validator's self-install uses. It is
+	// NOT the only layout: the kubeflow-trainer Helm chart the recipes deploy pins
+	// defaultNamespace: kubeflow (recipes/registry.yaml). The probe therefore
+	// discovers the live namespace rather than assuming this one.
 	trainerNamespace = "kubeflow-system"
+
+	// trainerValidatingWebhookConfig and trainerMutatingWebhookConfig are the
+	// admission configurations both supported deployment paths emit. The generic
+	// kubebuilder names in base/webhook/manifests.yaml never reach a cluster:
+	// base/webhook/kustomization.yaml patches /metadata/name to these, and the
+	// Helm chart renders the same two names.
+	trainerValidatingWebhookConfig = "validator.trainer.kubeflow.org"
+	trainerMutatingWebhookConfig   = "defaulter.trainer.kubeflow.org"
+
+	// trainerValidatingWebhookName and trainerMutatingWebhookName are Trainer-owned
+	// entries inside those configurations, used to tell a real Trainer install from
+	// an unrelated operator that happened to claim the same generic object name.
+	trainerValidatingWebhookName = "validator.trainjob.trainer.kubeflow.org"
+	trainerMutatingWebhookName   = "defaulter.trainjob.trainer.kubeflow.org"
+
+	// trainerWebhookSuffix marks a webhook entry as Trainer-owned. Used to refuse
+	// overwriting a generically-named admission configuration another operator owns.
+	trainerWebhookSuffix = ".trainer.kubeflow.org"
+
+	// jobSetCRDName identifies the JobSet dependency. TrainJobs run as JobSets, so
+	// a Trainer whose JobSet controller never becomes ready fails opaquely later.
+	jobSetCRDName = "jobsets.jobset.x-k8s.io"
+
+	// trainerManagerLabels locate the Trainer controller Deployment across both
+	// deployment paths. Neither its name nor app.kubernetes.io/name is stable: the
+	// chart derives the name from the release ({{ .Release.Name }}-controller-manager)
+	// and labels it app.kubernetes.io/name=kubeflow-trainer, while the kustomize
+	// overlay uses a fixed name and app.kubernetes.io/name=trainer. These two labels
+	// are set identically by both.
+	trainerComponentLabel = "app.kubernetes.io/component"
+	trainerComponentValue = "manager"
+	trainerPartOfLabel    = "app.kubernetes.io/part-of"
+	trainerPartOfValue    = "kubeflow"
+
+	// installAttemptAnnotation marks objects created by one installation attempt, so
+	// an ambiguous Create can only claim an object this attempt actually created.
+	installAttemptAnnotation = "aicr.nvidia.com/install-attempt"
+
+	// jobSetNameLabel/jobSetLabelValue locate the JobSet controller Deployment.
+	// A name lookup cannot work across both deployment paths: the kustomize overlay
+	// emits jobset-controller-manager, while the Helm chart's JobSet subchart derives
+	// its name from the release ({{ .Release.Name }}-jobset-controller). Both paths
+	// do set this label, so it is the only stable handle.
+	jobSetNameLabel  = "app.kubernetes.io/name"
+	jobSetLabelValue = "jobset"
 
 	// maxExtractedFileSize caps individual file sizes during tar extraction (50 MB).
 	maxExtractedFileSize = 50 * 1024 * 1024
@@ -78,33 +138,357 @@ const (
 	jobSetPromotedImageRepo = "registry.k8s.io/jobset/jobset"
 )
 
+// GVRs for the objects the Trainer lifecycle probes and waits on.
+var (
+	trainerCRDGVR = schema.GroupVersionResource{
+		Group: apiGroupAPIExtensions, Version: "v1", Resource: resourceCRDs,
+	}
+	trainerDeploymentGVR = schema.GroupVersionResource{
+		Group: "apps", Version: "v1", Resource: "deployments",
+	}
+	trainerServiceGVR = schema.GroupVersionResource{
+		Group: "", Version: "v1", Resource: "services",
+	}
+	trainerValidatingWebhookGVR = schema.GroupVersionResource{
+		Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations",
+	}
+	trainerMutatingWebhookGVR = schema.GroupVersionResource{
+		Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations",
+	}
+
+	// requiredTrainerCRDs are the CRDs a usable Trainer install implies: the two the
+	// benchmark consumes directly, plus JobSet, which TrainJobs are executed as.
+	// Kept as one list so the installed-state probe and the post-install wait
+	// cannot drift.
+	requiredTrainerCRDs = []string{trainerCRDTrainJobs, trainerCRDTrainingRuntimes, jobSetCRDName}
+)
+
+// trainerInstall describes a live Kubeflow Trainer installation the probe found,
+// including where it lives. The namespace is discovered rather than assumed
+// because the self-install overlay and the Helm chart use different ones.
+type trainerInstall struct {
+	Namespace  string
+	Service    string
+	Deployment string
+}
+
 // trainerResourceRef identifies a Kubernetes resource applied during Trainer installation,
 // so it can be deleted during cleanup.
 type trainerResourceRef struct {
 	GVR       schema.GroupVersionResource
 	Namespace string
 	Name      string
+
+	// UID of the object this installation created. Cleanup passes it as a delete
+	// precondition, so a same-named object recreated by another owner during a
+	// long benchmark is never deleted on our behalf.
+	UID k8stypes.UID
 }
 
-// isTrainerInstalled returns true when the Kubeflow Trainer CRD is present in the cluster.
-func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (bool, error) {
-	crdGVR := schema.GroupVersionResource{
-		Group: apiGroupAPIExtensions, Version: "v1", Resource: resourceCRDs,
+// String renders the resource identity for cleanup diagnostics.
+func (r trainerResourceRef) String() string {
+	if r.Namespace != "" {
+		return fmt.Sprintf("%s %s/%s", r.GVR.Resource, r.Namespace, r.Name)
 	}
-	_, err := dynamicClient.Resource(crdGVR).Get(ctx, trainerCRDName, metav1.GetOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return false, nil
+	return fmt.Sprintf("%s %s", r.GVR.Resource, r.Name)
+}
+
+// isTrainerInstalled reports whether a complete Kubeflow Trainer installation is
+// present: every CRD the benchmark needs is Established, the controller-manager
+// Deployment and its webhook Service exist, and both admission configurations
+// carry Trainer-owned webhook entries.
+//
+// A single-CRD probe is not enough. A failed install can leave that one CRD
+// behind, and a later run would then drive TrainJobs at a controller that was
+// never created (issue #2123). Anything short of the full set reports false so
+// the caller reinstalls, and only an API error the probe cannot classify is
+// returned as an error.
+func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (trainerInstall, bool, error) {
+	for _, crd := range requiredTrainerCRDs {
+		obj, found, err := getTrainerObject(ctx, dynamicClient, trainerCRDGVR, "", crd)
+		if err != nil {
+			return trainerInstall{}, false, err
 		}
-		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check for Kubeflow Trainer CRD", err)
+		if !found {
+			slog.Info("Kubeflow Trainer incomplete: CRD missing", "crd", crd)
+			return trainerInstall{}, false, nil
+		}
+		if !isCRDEstablished(obj) {
+			slog.Info("Kubeflow Trainer incomplete: CRD not established", "crd", crd)
+			return trainerInstall{}, false, nil
+		}
 	}
-	return true, nil
+
+	// The validating configuration is the authority on where Trainer lives: its
+	// webhook entries name the controller Service and its namespace, which is what
+	// makes this work for both the self-install overlay and the Helm chart.
+	install, found, err := discoverTrainerInstall(ctx, dynamicClient,
+		trainerValidatingWebhookGVR, trainerValidatingWebhookConfig, trainerValidatingWebhookName)
+	if err != nil || !found {
+		return trainerInstall{}, false, err
+	}
+
+	ok, err := hasTrainerWebhook(ctx, dynamicClient,
+		trainerMutatingWebhookGVR, trainerMutatingWebhookConfig, trainerMutatingWebhookName)
+	if err != nil {
+		return trainerInstall{}, false, err
+	}
+	if !ok {
+		slog.Info("Kubeflow Trainer incomplete: admission webhook missing",
+			"configuration", trainerMutatingWebhookConfig, "webhook", trainerMutatingWebhookName)
+		return trainerInstall{}, false, nil
+	}
+
+	// The controller Deployment is found by label: its name is release-derived on
+	// the Helm path, so a hardcoded name would misreport a non-default release as
+	// incomplete.
+	controller, found, err := findTrainerController(ctx, dynamicClient, install.Namespace)
+	if err != nil {
+		return trainerInstall{}, false, err
+	}
+	if !found {
+		slog.Info("Kubeflow Trainer incomplete: controller Deployment missing",
+			"namespace", install.Namespace)
+		return trainerInstall{}, false, nil
+	}
+	install.Deployment = controller
+
+	if _, found, err := getTrainerObject(ctx, dynamicClient, trainerServiceGVR,
+		install.Namespace, install.Service); err != nil {
+		return trainerInstall{}, false, err
+	} else if !found {
+		slog.Info("Kubeflow Trainer incomplete: controller Service missing",
+			"namespace", install.Namespace, "name", install.Service)
+		return trainerInstall{}, false, nil
+	}
+
+	slog.Info("Kubeflow Trainer installation is complete",
+		"namespace", install.Namespace, "service", install.Service, "deployment", install.Deployment)
+	return install, true, nil
+}
+
+// discoverTrainerInstall locates a Trainer installation from its admission
+// configuration, which names the controller Service and the namespace it lives in.
+// Returns nil when the configuration is absent or carries no Trainer webhook.
+//
+// Discovery beats a hardcoded namespace because the two supported deployment paths
+// disagree: the self-install kustomize overlay uses kubeflow-system, while the
+// kubeflow-trainer Helm chart the recipes deploy uses kubeflow. Assuming either one
+// reports the other as incomplete and triggers a reinstall that would rewrite the
+// live installation's cluster-scoped objects to point at the wrong namespace.
+func discoverTrainerInstall(ctx context.Context, dynamicClient dynamic.Interface,
+	gvr schema.GroupVersionResource, configName, webhookName string) (trainerInstall, bool, error) {
+
+	obj, found, err := getTrainerObject(ctx, dynamicClient, gvr, "", configName)
+	if err != nil || !found {
+		if err == nil {
+			slog.Info("Kubeflow Trainer incomplete: admission configuration missing",
+				"configuration", configName)
+		}
+		return trainerInstall{}, false, err
+	}
+
+	entries, _, err := unstructured.NestedSlice(obj.Object, "webhooks")
+	if err != nil {
+		return trainerInstall{}, false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("failed to read webhooks from %s %q", gvr.Resource, configName), err)
+	}
+
+	for _, e := range entries {
+		entry, ok := e.(map[string]interface{})
+		if !ok || entry[keyName] != webhookName {
+			continue
+		}
+		namespace, _, _ := unstructured.NestedString(entry, "clientConfig", "service", "namespace")
+		service, _, _ := unstructured.NestedString(entry, "clientConfig", "service", keyName)
+		if namespace == "" || service == "" {
+			// A URL-backed webhook has no Service to locate. Treat as unusable
+			// rather than guessing a namespace and reinstalling on top of it.
+			slog.Info("Kubeflow Trainer webhook has no Service reference; cannot locate the installation",
+				"configuration", configName, "webhook", webhookName)
+			return trainerInstall{}, false, nil
+		}
+		return trainerInstall{Namespace: namespace, Service: service}, true, nil
+	}
+
+	slog.Info("Kubeflow Trainer incomplete: admission webhook missing",
+		"configuration", configName, "webhook", webhookName)
+	return trainerInstall{}, false, nil
+}
+
+// getTrainerObject fetches one object. NotFound reports found=false with no
+// error, so callers can distinguish "absent" from "could not tell" and fail
+// closed on the latter.
+func getTrainerObject(ctx context.Context, dynamicClient dynamic.Interface,
+	gvr schema.GroupVersionResource, namespace, name string) (obj *unstructured.Unstructured, found bool, err error) {
+
+	// Single choke point for every read the probe makes, so this one check
+	// covers each of its loops: stop as soon as the caller gives up rather than
+	// working through the remaining resources.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, false, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
+			fmt.Sprintf("canceled before checking %s %q", gvr.Resource, name), ctxErr)
+	}
+
+	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+
+	obj, err = trainerResourceClient(dynamicClient, gvr, namespace).Get(getCtx, name, metav1.GetOptions{})
+	switch {
+	case err == nil:
+		// An object a concurrent run is tearing down is on its way out, so treat
+		// it as absent rather than waiting on a dying installation.
+		if obj.GetDeletionTimestamp() != nil {
+			slog.Info("Trainer resource is terminating; treating as absent",
+				"resource", gvr.Resource, "namespace", namespace, "name", name)
+			return nil, false, nil
+		}
+		return obj, true, nil
+	case k8serrors.IsNotFound(err):
+		return nil, false, nil
+	default:
+		return nil, false, aicrErrors.Wrap(trainerAPIErrorCode(err),
+			fmt.Sprintf("failed to check for %s %q", gvr.Resource, name), err)
+	}
+}
+
+// trainerAPIErrorCode classifies a failed Kubernetes API call on any Trainer
+// lifecycle path (probe, apply, teardown). These errors reach the validation
+// verdict, so collapsing everything to Internal would report a transient cluster
+// outage as a product defect.
+func trainerAPIErrorCode(err error) aicrErrors.ErrorCode {
+	switch {
+	case aicrErrors.IsTransient(err):
+		// Parent cancellation or our own DiagnosticTimeout expiring.
+		return aicrErrors.ErrCodeTimeout
+	case aicrErrors.IsNetworkError(err),
+		k8serrors.IsServiceUnavailable(err),
+		k8serrors.IsTooManyRequests(err),
+		k8serrors.IsServerTimeout(err),
+		k8serrors.IsTimeout(err):
+		// The cluster is unreachable or shedding load, not a code fault.
+		return aicrErrors.ErrCodeUnavailable
+	default:
+		return aicrErrors.ErrCodeInternal
+	}
+}
+
+// hasTrainerWebhook reports whether the named admission configuration exists and
+// serves the given Trainer webhook. The name check matters because the upstream
+// manifests use generic, unprefixed configuration names that another operator on
+// the cluster may already own.
+func hasTrainerWebhook(ctx context.Context, dynamicClient dynamic.Interface,
+	gvr schema.GroupVersionResource, configName, webhookName string) (bool, error) {
+
+	obj, found, err := getTrainerObject(ctx, dynamicClient, gvr, "", configName)
+	if err != nil || !found {
+		return false, err
+	}
+
+	entries, _, err := unstructured.NestedSlice(obj.Object, "webhooks")
+	if err != nil {
+		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("failed to read webhooks from %s %q", gvr.Resource, configName), err)
+	}
+	for _, e := range entries {
+		entry, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if entry[keyName] == webhookName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// trainerResourceClient returns the namespaced or cluster-scoped client for gvr.
+func trainerResourceClient(dynamicClient dynamic.Interface,
+	gvr schema.GroupVersionResource, namespace string) dynamic.ResourceInterface {
+
+	if namespace != "" {
+		return dynamicClient.Resource(gvr).Namespace(namespace)
+	}
+	return dynamicClient.Resource(gvr)
+}
+
+// ensureTrainerInstalled makes a usable Kubeflow Trainer available to the benchmark
+// and returns the resources it created, so the caller can delete them when the run
+// finishes. A complete pre-existing installation is left alone and reported as no
+// resources, so the benchmark never deletes a Trainer it does not own.
+func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface,
+	discoveryClient discovery.DiscoveryInterface) ([]trainerResourceRef, error) {
+
+	install, installed, err := isTrainerInstalled(ctx, dynamicClient)
+	if err != nil {
+		// PropagateOrWrap, not Wrap: the probe already classified this as
+		// Unavailable or Timeout where it could, and verdict consumers read the
+		// outermost code. Overwriting it here would report a transient
+		// control-plane outage as a product defect.
+		return nil, aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
+			"failed to check Kubeflow Trainer installation")
+	}
+
+	if !installed {
+		// Before applying anything, check for a live installation somewhere else.
+		// Kustomize applies CRDs and RBAC before webhook configurations, so by the
+		// time the admission-config ownership guard could fire, a shared-name
+		// ClusterRoleBinding would already have been repointed at our namespace —
+		// and updates are excluded from the rollback set, so nothing restores it.
+		// Refusing up front is the only point at which this is still reversible.
+		if live, found, derr := discoverTrainerInstall(ctx, dynamicClient,
+			trainerValidatingWebhookGVR, trainerValidatingWebhookConfig,
+			trainerValidatingWebhookName); derr != nil {
+			return nil, derr
+		} else if found && live.Namespace != trainerNamespace {
+			return nil, aicrErrors.New(aicrErrors.ErrCodeConflict, fmt.Sprintf(
+				"a Kubeflow Trainer installation exists in namespace %q but is incomplete; "+
+					"refusing to install into %q because that would rewrite its shared cluster-scoped resources",
+				live.Namespace, trainerNamespace))
+		}
+
+		slog.Info("Kubeflow Trainer not found or incomplete, installing...")
+		// installTrainer rolls back its own resources on failure, so there is
+		// nothing to clean up on the error path.
+		created, installErr := installTrainer(ctx, dynamicClient, discoveryClient)
+		if installErr != nil {
+			return nil, aicrErrors.PropagateOrWrap(installErr, aicrErrors.ErrCodeInternal,
+				"failed to install Kubeflow Trainer")
+		}
+		slog.Info("Kubeflow Trainer installed", "resources", len(created))
+		return created, nil
+	}
+
+	// The probe confirms every object exists; the controller may still be rolling.
+	// Wait for it here rather than reinstalling over a healthy Trainer we do not own.
+	slog.Info("Kubeflow Trainer already installed, waiting for controller readiness",
+		"namespace", install.Namespace)
+	if readyErr := waitForTrainerReady(ctx, dynamicClient, install.Namespace); readyErr != nil {
+		return nil, aicrErrors.PropagateOrWrap(readyErr, aicrErrors.ErrCodeTimeout,
+			"pre-existing Kubeflow Trainer controller is not ready")
+	}
+	return nil, nil
+}
+
+// foldCleanupError decides the check's verdict when teardown fails. A cleanup
+// failure leaks cluster-scoped CRDs, RBAC, and webhook configurations that would
+// silently poison the next run, so it fails an otherwise-passing check — but it
+// never masks a real benchmark failure, which is always the more useful signal.
+func foldCleanupError(benchErr, cleanupErr error) error {
+	if cleanupErr == nil || benchErr != nil {
+		return benchErr
+	}
+	return aicrErrors.PropagateOrWrap(cleanupErr, aicrErrors.ErrCodeInternal,
+		"NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
 }
 
 // installTrainer downloads the Kubeflow Trainer v2.2.0 archive from GitHub, builds the
 // kustomize manager overlay entirely in Go (no CLI), and applies every resource to the
-// cluster via the dynamic client.  It returns the list of resources it created so the
-// caller can defer deleteTrainer for cleanup.
+// cluster via the dynamic client.
+//
+// Installation is transactional: on success it returns the resources it created so
+// the caller can defer deleteTrainer for cleanup; on any failure it rolls those
+// resources back itself and returns none.
 func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discoveryClient discovery.DiscoveryInterface) ([]trainerResourceRef, error) {
 	slog.Info("Downloading Kubeflow Trainer archive", "url", trainerArchiveURL)
 
@@ -129,85 +513,467 @@ func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discov
 		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to build Trainer manifests", err)
 	}
 
+	objs, err := decodeTrainerObjects(resMap.Resources())
+	if err != nil {
+		return nil, err
+	}
+
 	// Build a REST mapper from live discovery so we can resolve GVK → GVR for each resource.
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
 
-	applied := make([]trainerResourceRef, 0, len(resMap.Resources()))
-	for _, res := range resMap.Resources() {
+	return installTrainerResources(ctx, dynamicClient, mapper, objs)
+}
+
+// decodeTrainerObjects converts kustomize build output into unstructured objects,
+// repointing the JobSet controller image off the garbage-collected staging
+// registry (issue #1430). Resources without a Kind are skipped. Decoding happens
+// before the first apply so a malformed manifest cannot leave a partial install.
+func decodeTrainerObjects(resources []*resource.Resource) ([]*unstructured.Unstructured, error) {
+	objs := make([]*unstructured.Unstructured, 0, len(resources))
+	for _, res := range resources {
 		// Convert to unstructured via YAML round-trip (guarantees plain Go types).
 		yamlBytes, err := res.AsYAML()
 		if err != nil {
-			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to marshal Trainer resource to YAML", err)
+			return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to marshal Trainer resource to YAML", err)
 		}
 
-		// Repoint the JobSet controller image off the garbage-collected staging registry
-		// onto the promoted production registry before applying (see issue #1430).
 		yamlBytes = rewriteJobSetStagingImage(yamlBytes)
 
 		obj := &unstructured.Unstructured{}
 		if unmarshalErr := yaml.Unmarshal(yamlBytes, obj); unmarshalErr != nil {
-			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse Trainer resource YAML", unmarshalErr)
+			return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to parse Trainer resource YAML", unmarshalErr)
+		}
+		if obj.GroupVersionKind().Kind == "" {
+			continue
+		}
+		objs = append(objs, obj)
+	}
+	return objs, nil
+}
+
+// installTrainerResources applies objs and waits until the Trainer dependency is
+// usable, rolling back every resource it created if any step fails. It is the
+// cluster-only core of installTrainer, split out so failure injection is testable
+// without reaching GitHub for the archive.
+//
+// On success it returns the resources it created, for the caller to delete once
+// the benchmark finishes. On failure it returns no resources: rollback already
+// removed them, so the caller has nothing left to clean up.
+func installTrainerResources(ctx context.Context, dynamicClient dynamic.Interface,
+	mapper apimeta.RESTMapper, objs []*unstructured.Unstructured) ([]trainerResourceRef, error) {
+
+	created, err := applyTrainerResources(ctx, dynamicClient, mapper, objs)
+	if err == nil {
+		err = waitForTrainerReady(ctx, dynamicClient, trainerNamespace)
+	}
+	if err != nil {
+		// contextcheck: rollback deliberately runs on a fresh context. ctx is
+		// usually the reason we are here (deadline exceeded), and cleanup of
+		// cluster-scoped resources must still complete.
+		return nil, rollbackTrainer(dynamicClient, created, err) //nolint:contextcheck
+	}
+
+	return created, nil
+}
+
+// waitForTrainerReady blocks until a freshly applied Trainer is usable: the CRDs
+// the NCCL test needs are Established, and the controller-manager has a ready
+// replica so its admission webhooks have endpoints.
+func waitForTrainerReady(ctx context.Context, dynamicClient dynamic.Interface, namespace string) error {
+	if err := waitForTrainerCRDsEstablished(ctx, dynamicClient); err != nil {
+		return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeTimeout, "Trainer CRDs not ready after install")
+	}
+	if err := waitForTrainerControllerReady(ctx, dynamicClient, namespace); err != nil {
+		return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeTimeout, "Trainer controller not ready after install")
+	}
+	// TrainJobs run as JobSets. A stale install still carrying the garbage-collected
+	// staging image (issue #1430) satisfies every other signal, so without this the
+	// failure only surfaces later as a TrainJob whose JobSet is never created.
+	if err := waitForJobSetControllerReady(ctx, dynamicClient, namespace); err != nil {
+		return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeTimeout, "JobSet controller not ready")
+	}
+	return nil
+}
+
+// waitForJobSetControllerReady waits for the JobSet controller the Trainer manager
+// overlay bundles. The overlay allows that resource to be omitted when JobSet is
+// managed separately, so an absent controller is not a failure — only a present
+// one that never becomes ready.
+func waitForJobSetControllerReady(ctx context.Context, dynamicClient dynamic.Interface, namespace string) error {
+	name, found, err := findJobSetController(ctx, dynamicClient, namespace)
+	if err != nil {
+		return err
+	}
+	if !found {
+		slog.Debug("No JobSet controller alongside Trainer; assuming JobSet is managed elsewhere",
+			"namespace", namespace)
+		return nil
+	}
+	return waitForDeploymentReady(ctx, dynamicClient, namespace,
+		name, defaults.TrainerControllerReadyTimeout)
+}
+
+// findJobSetController locates the JobSet controller Deployment beside Trainer by
+// label, since its name differs between deployment paths and the Helm one is
+// release-derived.
+func findJobSetController(ctx context.Context, dynamicClient dynamic.Interface,
+	namespace string) (string, bool, error) {
+
+	return findDeploymentByLabels(ctx, dynamicClient, namespace,
+		map[string]string{jobSetNameLabel: jobSetLabelValue}, "JobSet controller")
+}
+
+// findTrainerController locates the Trainer controller-manager Deployment by label
+// rather than by name, which is release-derived on the Helm path.
+func findTrainerController(ctx context.Context, dynamicClient dynamic.Interface,
+	namespace string) (string, bool, error) {
+
+	return findDeploymentByLabels(ctx, dynamicClient, namespace, map[string]string{
+		trainerComponentLabel: trainerComponentValue,
+		trainerPartOfLabel:    trainerPartOfValue,
+	}, "Trainer controller")
+}
+
+// findDeploymentByLabels returns the name of a live Deployment matching labels. The
+// selector is sent to the apiserver and re-checked on the result, because a specific
+// object is then selected from the response.
+func findDeploymentByLabels(ctx context.Context, dynamicClient dynamic.Interface,
+	namespace string, labels map[string]string, what string) (string, bool, error) {
+
+	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+
+	selector := make([]string, 0, len(labels))
+	for k, v := range labels {
+		selector = append(selector, k+"="+v)
+	}
+	slices.Sort(selector)
+
+	list, err := dynamicClient.Resource(trainerDeploymentGVR).Namespace(namespace).
+		List(listCtx, metav1.ListOptions{LabelSelector: strings.Join(selector, ",")})
+	if err != nil {
+		return "", false, aicrErrors.Wrap(trainerAPIErrorCode(err),
+			fmt.Sprintf("failed to list Deployments in %q while locating the %s", namespace, what), err)
+	}
+
+	for i := range list.Items {
+		item := &list.Items[i]
+		if item.GetDeletionTimestamp() != nil {
+			continue
+		}
+		got := item.GetLabels()
+		matched := true
+		for k, v := range labels {
+			if got[k] != v {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return item.GetName(), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// applyTrainerResources creates each object, updating any that already exist.
+//
+// The returned list holds only the resources this call actually created. Objects
+// that were already present are updated but deliberately excluded, so a rollback
+// never deletes a Trainer another owner installed.
+func applyTrainerResources(ctx context.Context, dynamicClient dynamic.Interface,
+	mapper apimeta.RESTMapper, objs []*unstructured.Unstructured) ([]trainerResourceRef, error) {
+
+	attemptID, err := newInstallAttemptID()
+	if err != nil {
+		return nil, err
+	}
+
+	created := make([]trainerResourceRef, 0, len(objs))
+	for _, obj := range objs {
+		// Abort the moment the caller gives up rather than issuing a Create per
+		// remaining object and relying on each API call to fail on its own. The
+		// error routes through the normal path, so rollback still runs.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return created, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
+				"Trainer installation canceled before all resources were applied", ctxErr)
 		}
 
 		gvk := obj.GroupVersionKind()
-		if gvk.Kind == "" {
-			continue
-		}
 
 		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			return created, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
 				fmt.Sprintf("failed to resolve REST mapping for %s", gvk), err)
 		}
 
 		ref := trainerResourceRef{GVR: mapping.Resource, Name: obj.GetName()}
-
-		applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 		if mapping.Scope.Name() == apimeta.RESTScopeNameNamespace {
 			ref.Namespace = obj.GetNamespace()
-			_, err = dynamicClient.Resource(mapping.Resource).Namespace(ref.Namespace).Create(applyCtx, obj, metav1.CreateOptions{})
-		} else {
-			_, err = dynamicClient.Resource(mapping.Resource).Create(applyCtx, obj, metav1.CreateOptions{})
 		}
+		client := trainerResourceClient(dynamicClient, mapping.Resource, ref.Namespace)
+
+		// Stamp the attempt marker only on the create, so an ambiguous failure can
+		// prove the object is ours. The update path below deliberately applies the
+		// unstamped object: we do not mark resources we did not create.
+		stamped := obj.DeepCopy()
+		annotations := stamped.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[installAttemptAnnotation] = attemptID
+		stamped.SetAnnotations(annotations)
+
+		applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+		createdObj, err := client.Create(applyCtx, stamped, metav1.CreateOptions{})
 		cancel()
 
-		if err != nil {
-			if k8serrors.IsAlreadyExists(err) {
-				// Update: enforce current resource state even when left from a prior partial install.
-				updateCtx, updateCancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
-				if mapping.Scope.Name() == apimeta.RESTScopeNameNamespace {
-					_, err = dynamicClient.Resource(mapping.Resource).Namespace(ref.Namespace).Update(updateCtx, obj, metav1.UpdateOptions{})
-				} else {
-					_, err = dynamicClient.Resource(mapping.Resource).Update(updateCtx, obj, metav1.UpdateOptions{})
-				}
-				updateCancel()
-				if err != nil {
-					slog.Warn("Failed to update existing Trainer resource, continuing", "kind", gvk.Kind, "name", obj.GetName(), "error", err)
-				} else {
-					slog.Info("Updated existing Trainer resource", "kind", gvk.Kind, "name", obj.GetName())
-				}
-				continue
+		switch {
+		case err == nil:
+			ref.UID = createdObj.GetUID()
+			created = append(created, ref)
+			slog.Info("Applied Trainer resource", "kind", gvk.Kind, "name", ref.Name, "namespace", ref.Namespace)
+		case k8serrors.IsAlreadyExists(err):
+			// Enforce current resource state even when left from a prior partial
+			// install. A failure here aborts: continuing would drive the benchmark
+			// at a Trainer whose configuration we could not confirm.
+			if updateErr := updateExistingTrainerResource(ctx, client, obj); updateErr != nil {
+				return created, aicrErrors.PropagateOrWrap(updateErr, aicrErrors.ErrCodeInternal,
+					fmt.Sprintf("failed to update existing %s %q", gvk.Kind, ref.Name))
 			}
-			return applied, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
-				fmt.Sprintf("failed to create %s %q", gvk.Kind, obj.GetName()), err)
+			slog.Info("Updated existing Trainer resource", "kind", gvk.Kind, "name", ref.Name, "namespace", ref.Namespace)
+		default:
+			// An ambiguous Create (timeout, dropped connection) may still have
+			// persisted the object. Claim it before failing, otherwise rollback
+			// cannot remove it and we leak exactly what this change exists to stop.
+			if claimed, ok := claimAmbiguousCreate(ctx, client, ref, attemptID, err); ok {
+				created = append(created, claimed)
+			}
+			return created, aicrErrors.Wrap(trainerAPIErrorCode(err),
+				fmt.Sprintf("failed to create %s %q", gvk.Kind, ref.Name), err)
+		}
+	}
+	return created, nil
+}
+
+// updateExistingTrainerResource overwrites a resource left behind by a prior or
+// concurrent install. It reads the live object for its resourceVersion, and for
+// Services carries over the server-assigned cluster IPs: those are immutable and
+// absent from the rendered manifest, so an update without them is rejected.
+//
+// A lost optimistic-concurrency race is retried with a fresh read, since an update
+// failure aborts the whole installation and a concurrent writer touching the same
+// leftover object should not be able to sink the benchmark. Every other error
+// surfaces on the first attempt.
+func updateExistingTrainerResource(ctx context.Context, client dynamic.ResourceInterface,
+	obj *unstructured.Unstructured) error {
+
+	updateCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+
+	// Both are reset per attempt, so after the loop each is non-nil only when the
+	// final attempt ended that way rather than at the write.
+	var readErr, ownershipErr error
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		readErr, ownershipErr = nil, nil
+
+		// Re-read on every attempt: a conflict means the resourceVersion just
+		// used is stale, so replaying it would conflict forever.
+		existing, getErr := client.Get(updateCtx, obj.GetName(), metav1.GetOptions{})
+		if getErr != nil {
+			readErr = getErr
+			return getErr
 		}
 
-		applied = append(applied, ref)
-		slog.Info("Applied Trainer resource", "kind", gvk.Kind, "name", obj.GetName(), "namespace", ref.Namespace)
+		// Upstream names the admission configurations generically, so an existing
+		// one may belong to a different operator. A full Update would replace its
+		// webhooks (and any injected caBundle), and because updates are excluded
+		// from the rollback set it would never be restored. Fail closed instead.
+		if isAdmissionConfigKind(existing.GetKind()) {
+			if !hasTrainerWebhookEntry(existing) {
+				ownershipErr = aicrErrors.New(aicrErrors.ErrCodeConflict,
+					fmt.Sprintf("%s %q exists but carries no %s webhook; refusing to overwrite another operator's configuration",
+						existing.GetKind(), existing.GetName(), trainerWebhookSuffix))
+				return ownershipErr
+			}
+			// A Trainer-owned configuration pointing at a different namespace is a
+			// live installation deployed another way (the Helm chart uses kubeflow,
+			// this installer uses kubeflow-system). Repointing it here would break
+			// that installation's admission path, and since updates are excluded
+			// from the rollback set, nothing would put it back.
+			if liveNS := webhookServiceNamespace(existing); liveNS != "" && liveNS != webhookServiceNamespace(obj) {
+				ownershipErr = aicrErrors.New(aicrErrors.ErrCodeConflict,
+					fmt.Sprintf("%s %q belongs to a Trainer installation in namespace %q; refusing to repoint it",
+						existing.GetKind(), existing.GetName(), liveNS))
+				return ownershipErr
+			}
+		}
+
+		updated := obj.DeepCopy()
+		updated.SetResourceVersion(existing.GetResourceVersion())
+		if updated.GetKind() == "Service" {
+			preserveServiceClusterIPs(existing, updated)
+		}
+
+		_, updateErr := client.Update(updateCtx, updated, metav1.UpdateOptions{})
+		return updateErr
+	})
+
+	switch {
+	case err == nil:
+		return nil
+	case ownershipErr != nil:
+		return ownershipErr
+	case readErr != nil:
+		return aicrErrors.Wrap(trainerAPIErrorCode(readErr), "failed to read existing resource for update", readErr)
+	default:
+		return aicrErrors.Wrap(trainerAPIErrorCode(err), "failed to update existing resource", err)
+	}
+}
+
+// claimAmbiguousCreate re-reads a resource whose Create failed inconclusively. A
+// timeout or dropped connection can be returned after the apiserver has already
+// persisted the object; without this the resource is absent from the rollback set
+// and leaks. Returns the ref with its UID when the object is there to claim.
+func claimAmbiguousCreate(ctx context.Context, client dynamic.ResourceInterface,
+	ref trainerResourceRef, attemptID string, createErr error) (trainerResourceRef, bool) {
+
+	// Only genuinely ambiguous failures can have persisted. A rejection (Forbidden,
+	// Invalid, TooManyRequests) definitively did not create anything, and probing
+	// after one risks claiming an object that was already there.
+	if !isAmbiguousCreateError(createErr) {
+		return ref, false
 	}
 
-	// Wait for the CRDs the NCCL test needs before returning.
-	if err := waitForTrainerCRDsEstablished(ctx, dynamicClient); err != nil {
-		return applied, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "Trainer CRDs not ready after install", err)
+	// contextcheck: deliberately not derived from ctx, which may itself be the
+	// reason Create failed; the object still has to be claimed for rollback.
+	getCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
+	defer cancel()
+	_ = ctx
+
+	obj, err := client.Get(getCtx, ref.Name, metav1.GetOptions{}) //nolint:contextcheck
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			slog.Warn("Could not determine whether an ambiguous create persisted",
+				"resource", ref.String(), "error", err)
+		}
+		return ref, false
 	}
 
-	// Wait for the controller-manager to be ready so the ValidatingWebhookConfiguration
-	// backing Service can serve requests before the caller creates TrainingRuntime resources.
-	if err := waitForTrainerControllerReady(ctx, dynamicClient); err != nil {
-		return applied, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout, "Trainer controller not ready after install", err)
+	// Presence is not ownership. Without a matching marker this object predates the
+	// attempt or belongs to someone else, and claiming it would let rollback delete
+	// a resource we never created.
+	if obj.GetAnnotations()[installAttemptAnnotation] != attemptID {
+		slog.Warn("Create failed and a same-named resource exists that this attempt did not create; leaving it alone",
+			"resource", ref.String())
+		return ref, false
 	}
 
-	return applied, nil
+	ref.UID = obj.GetUID()
+	slog.Warn("Create failed but the resource exists and is ours; claiming it for rollback",
+		"resource", ref.String())
+	return ref, true
+}
+
+// isAmbiguousCreateError reports whether a failed Create may still have persisted
+// the object. Deterministic rejections are excluded.
+func isAmbiguousCreateError(err error) bool {
+	return k8serrors.IsTimeout(err) ||
+		k8serrors.IsServerTimeout(err) ||
+		k8serrors.IsServiceUnavailable(err) ||
+		k8serrors.IsUnexpectedServerError(err) ||
+		aicrErrors.IsNetworkError(err) ||
+		aicrErrors.IsTransient(err)
+}
+
+// newInstallAttemptID returns a random marker identifying one installation attempt.
+func newInstallAttemptID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := cryptorand.Read(buf); err != nil {
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			"failed to generate an install attempt id", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// webhookServiceNamespace returns the namespace of the controller Service an
+// admission configuration points at, or "" when it names none.
+func webhookServiceNamespace(obj *unstructured.Unstructured) string {
+	entries, _, err := unstructured.NestedSlice(obj.Object, "webhooks")
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		entry, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if ns, _, _ := unstructured.NestedString(entry, "clientConfig", "service", "namespace"); ns != "" {
+			return ns
+		}
+	}
+	return ""
+}
+
+// isAdmissionConfigKind reports whether kind is one of the generically-named
+// admission configurations another operator on the cluster could own.
+func isAdmissionConfigKind(kind string) bool {
+	return kind == "ValidatingWebhookConfiguration" || kind == "MutatingWebhookConfiguration"
+}
+
+// hasTrainerWebhookEntry reports whether an admission configuration carries at
+// least one Kubeflow Trainer webhook, which is what marks it as ours to replace.
+func hasTrainerWebhookEntry(obj *unstructured.Unstructured) bool {
+	entries, _, err := unstructured.NestedSlice(obj.Object, "webhooks")
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		entry, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := entry[keyName].(string); ok && strings.HasSuffix(name, trainerWebhookSuffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// preserveServiceClusterIPs copies the apiserver-assigned cluster IPs from the
+// live Service onto the replacement. They cannot be unset once assigned.
+func preserveServiceClusterIPs(existing, updated *unstructured.Unstructured) {
+	if ip, found, err := unstructured.NestedString(existing.Object, "spec", "clusterIP"); err == nil && found {
+		if setErr := unstructured.SetNestedField(updated.Object, ip, "spec", "clusterIP"); setErr != nil {
+			slog.Warn("Failed to preserve Service clusterIP", "name", updated.GetName(), "error", setErr)
+		}
+	}
+	if ips, found, err := unstructured.NestedStringSlice(existing.Object, "spec", "clusterIPs"); err == nil && found {
+		if setErr := unstructured.SetNestedStringSlice(updated.Object, ips, "spec", "clusterIPs"); setErr != nil {
+			slog.Warn("Failed to preserve Service clusterIPs", "name", updated.GetName(), "error", setErr)
+		}
+	}
+}
+
+// rollbackTrainer removes everything a failed installation created and returns
+// cause. A cleanup failure is folded into the returned error rather than logged
+// and dropped, so leaked cluster-scoped resources are never mistaken for a clean
+// failure.
+func rollbackTrainer(dynamicClient dynamic.Interface, created []trainerResourceRef, cause error) error {
+	if len(created) == 0 {
+		return cause
+	}
+
+	slog.Warn("Rolling back partial Kubeflow Trainer installation",
+		"resources", len(created), "cause", cause)
+
+	cleanupErr := deleteTrainer(dynamicClient, created)
+	if cleanupErr == nil {
+		return cause
+	}
+	return aicrErrors.WrapWithContext(aicrErrors.ErrCodeInternal,
+		fmt.Sprintf("Trainer installation failed and rollback left resources behind: %v", cleanupErr),
+		cause, map[string]interface{}{"rollbackError": cleanupErr.Error()})
 }
 
 // rewriteJobSetStagingImage rewrites any reference to the garbage-collected JobSet
@@ -231,38 +997,81 @@ func rewriteJobSetStagingImage(yamlBytes []byte) []byte {
 // application order so dependents are deleted before their owners.
 // Uses context.Background() because the parent context may already be canceled at
 // defer time; cleanup must still complete.
-func deleteTrainer(dynamicClient dynamic.Interface, resources []trainerResourceRef) {
+//
+// Every resource is attempted even after a failure, and all failures are returned
+// together, each naming the resource that leaked. An already-deleted resource
+// counts as success.
+func deleteTrainer(dynamicClient dynamic.Interface, resources []trainerResourceRef) error {
 	slog.Info("Deleting installed Kubeflow Trainer resources", "count", len(resources))
+
+	var failures []string
+	// A teardown failure fails an otherwise-passing benchmark, so the code has to
+	// distinguish a cluster blip from a real fault. Transient unless proven
+	// otherwise; one deterministic failure makes the whole cleanup Internal.
+	code := aicrErrors.ErrCodeUnavailable
 	for _, ref := range slices.Backward(resources) {
-		deleteCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
-
-		var err error
-		if ref.Namespace != "" {
-			err = dynamicClient.Resource(ref.GVR).Namespace(ref.Namespace).Delete(deleteCtx, ref.Name, metav1.DeleteOptions{})
-		} else {
-			err = dynamicClient.Resource(ref.GVR).Delete(deleteCtx, ref.Name, metav1.DeleteOptions{})
+		err := deleteTrainerResource(dynamicClient, ref)
+		if err == nil {
+			slog.Info("Deleted Trainer resource", "resource", ref.String())
+			continue
 		}
-		cancel()
 
-		if err != nil && !k8serrors.IsNotFound(err) {
-			slog.Error("Failed to delete Trainer resource", "gvr", ref.GVR.Resource, "name", ref.Name, "error", err)
-		} else {
-			slog.Info("Deleted Trainer resource", "gvr", ref.GVR.Resource, "name", ref.Name)
+		slog.Error("Failed to delete Trainer resource", "resource", ref.String(), "error", err)
+		failures = append(failures, fmt.Sprintf("%s: %v", ref, err))
+		if trainerAPIErrorCode(err) == aicrErrors.ErrCodeInternal {
+			code = aicrErrors.ErrCodeInternal
 		}
 	}
+
+	if len(failures) > 0 {
+		return aicrErrors.New(code,
+			fmt.Sprintf("failed to delete %d Trainer resource(s):\n  - %s",
+				len(failures), strings.Join(failures, "\n  - ")))
+	}
+	return nil
+}
+
+// deleteTrainerResource deletes one resource, retrying transient API failures.
+// Because a cleanup failure fails an otherwise-good benchmark, a momentary
+// control-plane blip must not sink the run; deterministic failures (Forbidden,
+// admission rejections) return on the first attempt rather than burning backoff.
+// An already-deleted resource counts as success.
+func deleteTrainerResource(dynamicClient dynamic.Interface, ref trainerResourceRef) error {
+	return retry.OnError(retry.DefaultBackoff,
+		func(err error) bool { return trainerAPIErrorCode(err) == aicrErrors.ErrCodeUnavailable },
+		func() error {
+			deleteCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
+			defer cancel()
+
+			opts := metav1.DeleteOptions{}
+			if ref.UID != "" {
+				opts.Preconditions = &metav1.Preconditions{UID: &ref.UID}
+			}
+
+			err := trainerResourceClient(dynamicClient, ref.GVR, ref.Namespace).
+				Delete(deleteCtx, ref.Name, opts)
+			switch {
+			case err == nil, k8serrors.IsNotFound(err):
+				return nil
+			case k8serrors.IsConflict(err):
+				// The UID moved on: what is there now was recreated by someone
+				// else, so the object we created is already gone. Not ours to delete.
+				slog.Info("Trainer resource was replaced by another owner; leaving it alone",
+					"resource", ref.String())
+				return nil
+			default:
+				return err
+			}
+		})
 }
 
 // waitForTrainerCRDsEstablished waits for the two CRDs that the NCCL test requires
 // to reach the Established condition after Trainer installation.
 func waitForTrainerCRDsEstablished(ctx context.Context, dynamicClient dynamic.Interface) error {
-	crds := []string{
-		"trainjobs.trainer.kubeflow.org",
-		"trainingruntimes.trainer.kubeflow.org",
-	}
 	waitCtx, cancel := context.WithTimeout(ctx, defaults.TrainerCRDEstablishedTimeout)
 	defer cancel()
 
-	for _, crd := range crds {
+	for _, crd := range requiredTrainerCRDs {
 		slog.Info("Waiting for Trainer CRD to be established", "crd", crd)
 		if err := waitForCRDEstablished(waitCtx, dynamicClient, crd); err != nil {
 			// Preserve the structured code from the re-check path (Unavailable /
@@ -276,32 +1085,49 @@ func waitForTrainerCRDsEstablished(ctx context.Context, dynamicClient dynamic.In
 // waitForTrainerControllerReady polls the controller-manager Deployment until at
 // least one replica is ready, ensuring the ValidatingWebhookConfiguration can
 // serve admission requests before the caller creates Trainer custom resources.
-func waitForTrainerControllerReady(ctx context.Context, dynamicClient dynamic.Interface) error {
-	slog.Info("Waiting for Trainer controller-manager to become ready",
-		"deployment", trainerControllerDeployment, "namespace", trainerNamespace)
+func waitForTrainerControllerReady(ctx context.Context, dynamicClient dynamic.Interface, namespace string) error {
+	return waitForDeploymentReady(ctx, dynamicClient, namespace,
+		trainerControllerDeployment, defaults.TrainerControllerReadyTimeout)
+}
 
-	deployGVR := schema.GroupVersionResource{
-		Group: "apps", Version: "v1", Resource: "deployments",
-	}
+// waitForDeploymentReady polls a Deployment until at least one replica is ready.
+//
+// Terminal authorization failures return immediately: looping the full timeout on
+// a persistent Forbidden would report a generic readiness timeout and hide the
+// real cause. Every poll logs what it observed, so a stuck wait leaves a trail
+// rather than a silent gap followed by a bare timeout.
+func waitForDeploymentReady(ctx context.Context, dynamicClient dynamic.Interface,
+	namespace, name string, timeout time.Duration) error {
 
-	waitCtx, cancel := context.WithTimeout(ctx, defaults.TrainerControllerReadyTimeout)
+	slog.Info("Waiting for Deployment to become ready", "deployment", name, "namespace", namespace)
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	for {
-		deploy, err := dynamicClient.Resource(deployGVR).Namespace(trainerNamespace).
-			Get(waitCtx, trainerControllerDeployment, metav1.GetOptions{})
-		if err == nil {
+		deploy, err := dynamicClient.Resource(trainerDeploymentGVR).Namespace(namespace).
+			Get(waitCtx, name, metav1.GetOptions{})
+		switch {
+		case err == nil:
 			readyReplicas, _, _ := unstructured.NestedInt64(deploy.Object, "status", "readyReplicas")
 			if readyReplicas >= 1 {
-				slog.Info("Trainer controller-manager is ready", "readyReplicas", readyReplicas)
+				slog.Info("Deployment is ready", "deployment", name, "readyReplicas", readyReplicas)
 				return nil
 			}
+			slog.Debug("Deployment not ready yet", "deployment", name, "readyReplicas", readyReplicas)
+		case k8serrors.IsForbidden(err), k8serrors.IsUnauthorized(err):
+			return aicrErrors.Wrap(aicrErrors.ErrCodeUnauthorized,
+				fmt.Sprintf("not permitted to read Deployment %s/%s", namespace, name), err)
+		default:
+			slog.Debug("Failed to read Deployment while waiting for readiness",
+				"deployment", name, "namespace", namespace, "error", err)
 		}
 
 		select {
 		case <-waitCtx.Done():
 			return aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
-				"timed out waiting for Trainer controller-manager to become ready", waitCtx.Err())
+				fmt.Sprintf("timed out waiting for Deployment %s/%s to become ready", namespace, name),
+				waitCtx.Err())
 		case <-time.After(defaults.TrainerControllerPollInterval):
 		}
 	}
@@ -311,16 +1137,12 @@ func waitForTrainerControllerReady(ctx context.Context, dynamicClient dynamic.In
 // It checks the current state first so the fast path (already established) returns
 // immediately without starting a watch.
 func waitForCRDEstablished(ctx context.Context, dynamicClient dynamic.Interface, crdName string) error {
-	crdGVR := schema.GroupVersionResource{
-		Group: apiGroupAPIExtensions, Version: "v1", Resource: resourceCRDs,
-	}
-
-	existing, err := dynamicClient.Resource(crdGVR).Get(ctx, crdName, metav1.GetOptions{})
+	existing, err := dynamicClient.Resource(trainerCRDGVR).Get(ctx, crdName, metav1.GetOptions{})
 	if err == nil && isCRDEstablished(existing) {
 		return nil
 	}
 
-	watcher, err := dynamicClient.Resource(crdGVR).Watch(ctx, metav1.ListOptions{
+	watcher, err := dynamicClient.Resource(trainerCRDGVR).Watch(ctx, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + crdName,
 	})
 	if err != nil {
@@ -339,7 +1161,7 @@ func waitForCRDEstablished(ctx context.Context, dynamicClient dynamic.Interface,
 				}
 				// Watch closed without cancellation — re-Get before failing, in
 				// case the CRD was established during the closure window.
-				recheck, getErr := dynamicClient.Resource(crdGVR).Get(ctx, crdName, metav1.GetOptions{})
+				recheck, getErr := dynamicClient.Resource(trainerCRDGVR).Get(ctx, crdName, metav1.GetOptions{})
 				switch {
 				case getErr == nil:
 					if isCRDEstablished(recheck) {

--- a/validators/performance/trainer_probe_test.go
+++ b/validators/performance/trainer_probe_test.go
@@ -1,0 +1,732 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"net"
+	"testing"
+	"time"
+
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// webhookConfig builds an admission configuration carrying a single named webhook
+// pointing at the controller Service in the default self-install namespace.
+func webhookConfig(kind, name, webhookName string) *unstructured.Unstructured {
+	return webhookConfigIn(kind, name, webhookName, trainerNamespace)
+}
+
+// webhookConfigIn builds an admission configuration whose webhook targets the
+// controller Service in the given namespace, which is how the probe discovers
+// where Trainer is installed.
+func webhookConfigIn(kind, name, webhookName, namespace string) *unstructured.Unstructured {
+	obj := newTestObject("admissionregistration.k8s.io/v1", kind, "", name)
+	if err := unstructured.SetNestedSlice(obj.Object, []interface{}{
+		map[string]interface{}{
+			keyName: webhookName,
+			"clientConfig": map[string]interface{}{
+				"service": map[string]interface{}{
+					keyName:     trainerControllerService,
+					"namespace": namespace,
+				},
+			},
+		},
+	}, "webhooks"); err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// trainerInstallIn returns a complete Trainer installation laid out in the given
+// namespace, as either supported deployment path produces.
+func trainerInstallIn(namespace string) []runtime.Object {
+	deploy := newTestObject("apps/v1", "Deployment", namespace, trainerControllerDeployment)
+	// Both deployment paths label the controller this way; the probe locates it by
+	// label because the Helm name is release-derived.
+	deploy.SetLabels(map[string]string{
+		trainerComponentLabel: trainerComponentValue,
+		trainerPartOfLabel:    trainerPartOfValue,
+	})
+	if err := unstructured.SetNestedField(deploy.Object, int64(1), "status", "readyReplicas"); err != nil {
+		panic(err)
+	}
+	return []runtime.Object{
+		establishedCRD(trainerCRDTrainJobs),
+		establishedCRD(trainerCRDTrainingRuntimes),
+		establishedCRD(jobSetCRDName),
+		deploy,
+		newTestObject("v1", "Service", namespace, trainerControllerService),
+		webhookConfigIn("ValidatingWebhookConfiguration", trainerValidatingWebhookConfig,
+			trainerValidatingWebhookName, namespace),
+		webhookConfigIn("MutatingWebhookConfiguration", trainerMutatingWebhookConfig,
+			trainerMutatingWebhookName, namespace),
+	}
+}
+
+// malformedWebhookConfig builds an admission configuration whose entries are not
+// objects, exercising the probe's tolerance of unexpected shapes.
+func malformedWebhookConfig(kind, name string) *unstructured.Unstructured {
+	obj := newTestObject("admissionregistration.k8s.io/v1", kind, "", name)
+	if err := unstructured.SetNestedSlice(obj.Object,
+		[]interface{}{"not-an-object"}, "webhooks"); err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func trainerControllerSvc() *unstructured.Unstructured {
+	return newTestObject("v1", "Service", trainerNamespace, trainerControllerService)
+}
+
+// completeTrainerInstall returns every object the installed-state probe requires.
+func completeTrainerInstall() []runtime.Object {
+	return trainerInstallIn(trainerNamespace)
+}
+
+// withoutObject returns objs minus every object that drop matches.
+func withoutObject(objs []runtime.Object, drop func(runtime.Object) bool) []runtime.Object {
+	kept := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		if drop(o) {
+			continue
+		}
+		kept = append(kept, o)
+	}
+	return kept
+}
+
+func dropByName(name string) func(runtime.Object) bool {
+	return func(o runtime.Object) bool {
+		u, ok := o.(*unstructured.Unstructured)
+		return ok && u.GetName() == name
+	}
+}
+
+// TestIsTrainerInstalled_CompleteInstall is the positive control, run against both
+// supported layouts. The self-install overlay lands in kubeflow-system; the Helm
+// chart the recipes deploy (registry.yaml pins defaultNamespace: kubeflow) lands in
+// kubeflow. A probe that recognized only one would report the other as incomplete
+// and reinstall over a healthy Trainer.
+func TestIsTrainerInstalled_CompleteInstall(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "self-install overlay layout", namespace: trainerNamespace},
+		{name: "helm chart layout", namespace: "kubeflow"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTrainerFakeClient(trainerInstallIn(tt.namespace)...)
+
+			install, installed, err := isTrainerInstalled(context.Background(), client)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !installed {
+				t.Fatal("complete Trainer installation reported as not installed")
+			}
+			if install.Namespace != tt.namespace {
+				t.Errorf("discovered namespace = %q, want %q", install.Namespace, tt.namespace)
+			}
+		})
+	}
+}
+
+// TestTrainerUpstreamNamesLocked pins the object names the probe looks up to the
+// literals both supported deployment paths actually emit. The fixtures above are
+// built from these same constants, so they cannot catch a wrong value — only a
+// literal comparison can.
+//
+// Values verified against kubeflow/trainer v2.2.0: the generic kubebuilder names
+// in manifests/base/webhook/manifests.yaml are replaced by
+// manifests/base/webhook/patch_{validating,mutating}.yaml, each an `op: replace`
+// on /metadata/name. The kubeflow-trainer Helm chart renders the same two names.
+// Getting these wrong makes the probe look up objects that never exist, so it can
+// never report installed and every run reinstalls over a healthy Trainer.
+func TestTrainerUpstreamNamesLocked(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"validating webhook configuration", trainerValidatingWebhookConfig, "validator.trainer.kubeflow.org"},
+		{"mutating webhook configuration", trainerMutatingWebhookConfig, "defaulter.trainer.kubeflow.org"},
+		{"validating webhook entry", trainerValidatingWebhookName, "validator.trainjob.trainer.kubeflow.org"},
+		{"mutating webhook entry", trainerMutatingWebhookName, "defaulter.trainjob.trainer.kubeflow.org"},
+		{"controller deployment", trainerControllerDeployment, "kubeflow-trainer-controller-manager"},
+		{"controller service", trainerControllerService, "kubeflow-trainer-controller-manager"},
+		{"jobset crd", jobSetCRDName, "jobsets.jobset.x-k8s.io"},
+		{"jobset name label", jobSetNameLabel, "app.kubernetes.io/name"},
+		{"jobset label value", jobSetLabelValue, "jobset"},
+		{"trainjob crd", trainerCRDTrainJobs, "trainjobs.trainer.kubeflow.org"},
+		{"trainingruntime crd", trainerCRDTrainingRuntimes, "trainingruntimes.trainer.kubeflow.org"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("got %q, want %q (must match upstream v2.2.0)", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsTrainerInstalled_PartialInstallRejected is the regression guard for the
+// single-CRD probe: any missing piece of the Trainer dependency must report false
+// so the caller reinstalls rather than driving a broken controller.
+func TestIsTrainerInstalled_PartialInstallRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		objs []runtime.Object
+	}{
+		{
+			name: "leaked TrainJob CRD from a failed install is not a complete install",
+			objs: []runtime.Object{establishedCRD(trainerCRDTrainJobs)},
+		},
+		{
+			name: "TrainingRuntime CRD missing",
+			objs: withoutObject(completeTrainerInstall(), dropByName(trainerCRDTrainingRuntimes)),
+		},
+		{
+			name: "controller Deployment missing",
+			objs: withoutObject(completeTrainerInstall(), func(o runtime.Object) bool {
+				u, ok := o.(*unstructured.Unstructured)
+				return ok && u.GetKind() == "Deployment"
+			}),
+		},
+		{
+			name: "webhook Service missing",
+			objs: withoutObject(completeTrainerInstall(), func(o runtime.Object) bool {
+				u, ok := o.(*unstructured.Unstructured)
+				return ok && u.GetKind() == "Service"
+			}),
+		},
+		{
+			name: "ValidatingWebhookConfiguration missing",
+			objs: withoutObject(completeTrainerInstall(), func(o runtime.Object) bool {
+				u, ok := o.(*unstructured.Unstructured)
+				return ok && u.GetKind() == "ValidatingWebhookConfiguration"
+			}),
+		},
+		{
+			name: "MutatingWebhookConfiguration missing",
+			objs: withoutObject(completeTrainerInstall(), func(o runtime.Object) bool {
+				u, ok := o.(*unstructured.Unstructured)
+				return ok && u.GetKind() == "MutatingWebhookConfiguration"
+			}),
+		},
+		{
+			name: "CRD present but not established",
+			objs: append(
+				withoutObject(completeTrainerInstall(), dropByName(trainerCRDTrainJobs)),
+				newTestObject(apiGroupAPIExtensions+"/v1", "CustomResourceDefinition", "", trainerCRDTrainJobs),
+			),
+		},
+		{
+			name: "webhook configuration owned by an unrelated operator",
+			objs: append(
+				withoutObject(completeTrainerInstall(), dropByName(trainerValidatingWebhookConfig)),
+				webhookConfig("ValidatingWebhookConfiguration", trainerValidatingWebhookConfig,
+					"validator.other.example.com"),
+			),
+		},
+		{
+			name: "mutating webhook configuration owned by an unrelated operator",
+			objs: append(
+				withoutObject(completeTrainerInstall(), dropByName(trainerMutatingWebhookConfig)),
+				webhookConfig("MutatingWebhookConfiguration", trainerMutatingWebhookConfig,
+					"defaulter.other.example.com"),
+			),
+		},
+		{
+			name: "webhook configuration with a malformed entry",
+			objs: append(
+				withoutObject(completeTrainerInstall(), dropByName(trainerValidatingWebhookConfig)),
+				malformedWebhookConfig("ValidatingWebhookConfiguration", trainerValidatingWebhookConfig),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTrainerFakeClient(tt.objs...)
+
+			_, installed, err := isTrainerInstalled(context.Background(), client)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if installed {
+				t.Error("incomplete Trainer installation reported as installed")
+			}
+		})
+	}
+}
+
+// TestIsTrainerInstalled_APIErrorSurfaces verifies the probe fails closed: an API
+// error it cannot classify is returned rather than reported as "not installed",
+// which would trigger a needless reinstall.
+func TestIsTrainerInstalled_APIErrorSurfaces(t *testing.T) {
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+	client.PrependReactor("get", resourceCRDs, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	_, installed, err := isTrainerInstalled(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected API error to surface, got nil")
+	}
+	if installed {
+		t.Error("reported installed on API error, want not-installed")
+	}
+}
+
+// TestIsTrainerInstalled_TerminatingObjectIsNotInstalled verifies an object being
+// torn down by a concurrent run is not counted as present. Otherwise a run starting
+// during another's teardown takes the already-installed branch and waits out the
+// readiness timeout against a dying controller instead of reinstalling.
+func TestIsTrainerInstalled_TerminatingObjectIsNotInstalled(t *testing.T) {
+	terminating := establishedCRD(trainerCRDTrainJobs)
+	terminating.SetDeletionTimestamp(&metav1.Time{Time: metav1.Now().Time})
+
+	objs := append(withoutObject(completeTrainerInstall(), dropByName(trainerCRDTrainJobs)), terminating)
+	client := newTrainerFakeClient(objs...)
+
+	_, installed, err := isTrainerInstalled(context.Background(), client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if installed {
+		t.Error("a terminating Trainer object was counted as installed")
+	}
+}
+
+// TestApplyTrainerResources_RefusesForeignWebhookConfig verifies install fails
+// closed rather than overwriting an admission configuration owned by another
+// operator. Upstream names these generically, and because an update excludes the
+// object from the rollback set, a clobbered foreign config is never restored.
+func TestApplyTrainerResources_RefusesForeignWebhookConfig(t *testing.T) {
+	foreign := webhookConfig("ValidatingWebhookConfiguration",
+		trainerValidatingWebhookConfig, "validator.other.example.com")
+	client := newTrainerFakeClient(foreign)
+
+	objs := []*unstructured.Unstructured{
+		webhookConfig("ValidatingWebhookConfiguration",
+			trainerValidatingWebhookConfig, trainerValidatingWebhookName),
+	}
+
+	_, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected install to refuse overwriting a foreign webhook configuration")
+	}
+
+	got, getErr := client.Resource(trainerValidatingWebhookGVR).
+		Get(context.Background(), trainerValidatingWebhookConfig, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("unexpected error: %v", getErr)
+	}
+	entries, _, _ := unstructured.NestedSlice(got.Object, "webhooks")
+	if len(entries) != 1 {
+		t.Fatalf("webhooks = %d entries, want 1", len(entries))
+	}
+	if name := entries[0].(map[string]interface{})[keyName]; name != "validator.other.example.com" {
+		t.Errorf("foreign webhook config was clobbered: entry name = %v", name)
+	}
+}
+
+// TestApplyTrainerResources_UpdatesOwnWebhookConfig is the counterpart: a config
+// that does carry Trainer entries is ours to re-apply, so the refusal above must
+// not block the ordinary repair path.
+func TestApplyTrainerResources_UpdatesOwnWebhookConfig(t *testing.T) {
+	client := newTrainerFakeClient(
+		webhookConfig("ValidatingWebhookConfiguration",
+			trainerValidatingWebhookConfig, trainerValidatingWebhookName),
+	)
+
+	objs := []*unstructured.Unstructured{
+		webhookConfig("ValidatingWebhookConfiguration",
+			trainerValidatingWebhookConfig, trainerValidatingWebhookName),
+	}
+
+	if _, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs); err != nil {
+		t.Fatalf("re-applying our own webhook configuration should succeed, got: %v", err)
+	}
+}
+
+// TestWaitForDeploymentReady_TerminalErrorFailsFast verifies an RBAC failure is
+// reported for what it is instead of looping to a generic readiness timeout that
+// hides the cause.
+func TestWaitForDeploymentReady_TerminalErrorFailsFast(t *testing.T) {
+	client := newTrainerFakeClient()
+	client.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "deployments"}, trainerControllerDeployment, errBoom)
+	})
+
+	err := waitForDeploymentReady(context.Background(), client,
+		trainerNamespace, trainerControllerDeployment, time.Minute)
+	if err == nil {
+		t.Fatal("expected forbidden Get to fail fast, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeUnauthorized, "")) {
+		t.Errorf("error code is not Unauthorized: %v", err)
+	}
+}
+
+// TestWaitForJobSetControllerReady_AbsentIsNotAFailure verifies the bundled JobSet
+// check is skipped when JobSet is managed elsewhere: the Trainer overlay lets that
+// resource be omitted, so requiring it would break those clusters.
+func TestWaitForJobSetControllerReady_AbsentIsNotAFailure(t *testing.T) {
+	client := newTrainerFakeClient()
+
+	if err := waitForJobSetControllerReady(context.Background(), client, trainerNamespace); err != nil {
+		t.Errorf("absent bundled JobSet controller should be skipped, got: %v", err)
+	}
+}
+
+// TestWaitForJobSetControllerReady_PresentButNotReady is the #1430 guard: a stale
+// install whose JobSet controller is stuck in ImagePullBackOff must be caught here
+// rather than surfacing much later as a TrainJob whose JobSet is never created.
+//
+// Run against both layouts because the controller's name differs between them and
+// the Helm one is release-derived, so only the shared label locates it reliably.
+func TestWaitForJobSetControllerReady_PresentButNotReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		deployment string
+	}{
+		{
+			name:       "kustomize overlay layout",
+			namespace:  trainerNamespace,
+			deployment: "jobset-controller-manager",
+		},
+		{
+			name:       "helm chart layout with a release-derived name",
+			namespace:  "kubeflow",
+			deployment: "kubeflow-trainer-jobset-controller",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertJobSetNotReady(t, tt.namespace, tt.deployment)
+		})
+	}
+}
+
+// assertJobSetNotReady drives waitForJobSetControllerReady against an unready
+// JobSet controller and requires it to fail rather than silently skip.
+func assertJobSetNotReady(t *testing.T, namespace, deployment string) {
+	t.Helper()
+
+	notReady := newTestObject("apps/v1", "Deployment", namespace, deployment)
+	notReady.SetLabels(map[string]string{jobSetNameLabel: jobSetLabelValue})
+	if err := unstructured.SetNestedField(notReady.Object, int64(0), "status", "readyReplicas"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	client := newTrainerFakeClient(notReady)
+
+	// Let the readiness poll observe the unready controller once, then cancel from
+	// the reactor: deterministic and timer-free.
+	ctx, cancel := context.WithCancel(context.Background())
+	client.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		cancel()
+		return false, nil, nil
+	})
+	defer cancel()
+
+	if err := waitForJobSetControllerReady(ctx, client, namespace); err == nil {
+		t.Error("a present-but-unready JobSet controller must fail readiness")
+	}
+}
+
+// TestIsTrainerInstalled_StopsOnCanceledContext verifies the probe aborts instead
+// of issuing its remaining reads once the caller has given up.
+func TestIsTrainerInstalled_StopsOnCanceledContext(t *testing.T) {
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, installed, err := isTrainerInstalled(ctx, client)
+	if err == nil {
+		t.Fatal("expected canceled context to abort the probe, got nil error")
+	}
+	if installed {
+		t.Error("reported installed on canceled context, want not-installed")
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "get" {
+			t.Errorf("probed %q after cancellation; the loop must abort first",
+				action.GetResource().Resource)
+		}
+	}
+}
+
+// TestTrainerProbeErrorCode verifies a failed probe read keeps the distinction
+// between "the cluster is unreachable right now" and "the code is broken". The
+// probe error reaches the validation verdict, so collapsing everything to
+// ErrCodeInternal would misreport a transient outage as a product defect.
+func TestTrainerAPIErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want aicrErrors.ErrorCode
+	}{
+		{
+			name: "canceled context is a timeout",
+			err:  context.Canceled,
+			want: aicrErrors.ErrCodeTimeout,
+		},
+		{
+			name: "expired deadline is a timeout",
+			err:  context.DeadlineExceeded,
+			want: aicrErrors.ErrCodeTimeout,
+		},
+		{
+			name: "apiserver unavailable is a service outage",
+			err:  apierrors.NewServiceUnavailable("apiserver is down"),
+			want: aicrErrors.ErrCodeUnavailable,
+		},
+		{
+			name: "throttled request is a service outage",
+			err:  apierrors.NewTooManyRequests("slow down", 1),
+			want: aicrErrors.ErrCodeUnavailable,
+		},
+		{
+			name: "server timeout is a service outage",
+			err: apierrors.NewServerTimeout(
+				schema.GroupResource{Resource: "services"}, "get", 1),
+			want: aicrErrors.ErrCodeUnavailable,
+		},
+		{
+			name: "request timeout is a service outage",
+			err:  apierrors.NewTimeoutError("request timed out", 1),
+			want: aicrErrors.ErrCodeUnavailable,
+		},
+		{
+			name: "connectivity failure is a service outage",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: errBoom},
+			want: aicrErrors.ErrCodeUnavailable,
+		},
+		{
+			name: "unrecognized failure stays internal",
+			err:  errBoom,
+			want: aicrErrors.ErrCodeInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trainerAPIErrorCode(tt.err); got != tt.want {
+				t.Errorf("trainerAPIErrorCode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsTrainerInstalled_UnavailableAPISurfacesAsUnavailable is the end-to-end
+// half of the classification: an apiserver outage during the probe must not be
+// reported to the caller as an internal fault.
+func TestIsTrainerInstalled_UnavailableAPISurfacesAsUnavailable(t *testing.T) {
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+	client.PrependReactor("get", resourceCRDs, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
+	})
+
+	_, _, err := isTrainerInstalled(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
+		t.Errorf("error code is not Unavailable: %v", err)
+	}
+}
+
+// TestUpdateExistingTrainerResource_PreservesServiceClusterIPs pins why aborting on
+// update failure is safe: re-applying the Trainer Service over a leftover one must
+// carry the apiserver-assigned cluster IPs, which are immutable and absent from the
+// rendered manifest. Dropping them makes every repair attempt fail.
+func TestUpdateExistingTrainerResource_PreservesServiceClusterIPs(t *testing.T) {
+	live := trainerControllerSvc()
+	if err := unstructured.SetNestedField(live.Object, "10.96.0.42", "spec", "clusterIP"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := unstructured.SetNestedStringSlice(live.Object, []string{"10.96.0.42"}, "spec", "clusterIPs"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	client := newTrainerFakeClient(live)
+	svcClient := client.Resource(trainerServiceGVR).Namespace(trainerNamespace)
+
+	// The rendered manifest carries no cluster IP, as kustomize output does not.
+	if err := updateExistingTrainerResource(context.Background(), svcClient, trainerControllerSvc()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := svcClient.Get(context.Background(), trainerControllerService, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ip, found, err := unstructured.NestedString(got.Object, "spec", "clusterIP")
+	if err != nil || !found {
+		t.Fatalf("clusterIP not preserved (found=%v err=%v)", found, err)
+	}
+	if ip != "10.96.0.42" {
+		t.Errorf("clusterIP = %q, want 10.96.0.42", ip)
+	}
+
+	// clusterIPs is copied by a separate branch, and the apiserver rejects a
+	// dropped clusterIPs exactly as it rejects a dropped clusterIP.
+	ips, found, err := unstructured.NestedStringSlice(got.Object, "spec", "clusterIPs")
+	if err != nil || !found {
+		t.Fatalf("clusterIPs not preserved (found=%v err=%v)", found, err)
+	}
+	if len(ips) != 1 || ips[0] != "10.96.0.42" {
+		t.Errorf("clusterIPs = %v, want [10.96.0.42]", ips)
+	}
+}
+
+// TestUpdateExistingTrainerResource_PreservesDualStackClusterIPs covers the
+// dual-stack shape, where dropping the second address is just as fatal as
+// dropping the first.
+func TestUpdateExistingTrainerResource_PreservesDualStackClusterIPs(t *testing.T) {
+	want := []string{"10.96.0.42", "fd00::42"}
+
+	live := trainerControllerSvc()
+	if err := unstructured.SetNestedField(live.Object, want[0], "spec", "clusterIP"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := unstructured.SetNestedStringSlice(live.Object, want, "spec", "clusterIPs"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	client := newTrainerFakeClient(live)
+	svcClient := client.Resource(trainerServiceGVR).Namespace(trainerNamespace)
+
+	if err := updateExistingTrainerResource(context.Background(), svcClient, trainerControllerSvc()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := svcClient.Get(context.Background(), trainerControllerService, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ips, found, err := unstructured.NestedStringSlice(got.Object, "spec", "clusterIPs")
+	if err != nil || !found {
+		t.Fatalf("clusterIPs not preserved (found=%v err=%v)", found, err)
+	}
+	if len(ips) != len(want) || ips[0] != want[0] || ips[1] != want[1] {
+		t.Errorf("clusterIPs = %v, want %v", ips, want)
+	}
+}
+
+// TestUpdateExistingTrainerResource_RetriesOnConflict verifies a lost optimistic-
+// concurrency race is retried rather than failing the install. Since an update
+// failure now aborts the whole benchmark, a concurrent writer touching the same
+// leftover Trainer object must not be able to sink an otherwise-good run.
+func TestUpdateExistingTrainerResource_RetriesOnConflict(t *testing.T) {
+	client := newTrainerFakeClient(trainerControllerSvc())
+	svcClient := client.Resource(trainerServiceGVR).Namespace(trainerNamespace)
+
+	var updates, reads int
+	client.PrependReactor("update", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		if updates == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "services"}, trainerControllerService, errBoom)
+		}
+		return false, nil, nil
+	})
+	client.PrependReactor("get", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+		reads++
+		return false, nil, nil
+	})
+
+	if err := updateExistingTrainerResource(context.Background(), svcClient, trainerControllerSvc()); err != nil {
+		t.Fatalf("conflict should have been retried, got: %v", err)
+	}
+	if updates != 2 {
+		t.Errorf("update attempts = %d, want 2 (one conflict, one success)", updates)
+	}
+	// The retry is only correct if it re-reads: replaying the resourceVersion that
+	// just conflicted would conflict forever against a real apiserver.
+	if reads != 2 {
+		t.Errorf("reads = %d, want 2 (each retry must re-read the live object)", reads)
+	}
+}
+
+// TestUpdateExistingTrainerResource_DoesNotRetryOtherErrors verifies only conflicts
+// are retried; a genuine failure surfaces on the first attempt rather than burning
+// the backoff budget.
+func TestUpdateExistingTrainerResource_DoesNotRetryOtherErrors(t *testing.T) {
+	client := newTrainerFakeClient(trainerControllerSvc())
+	svcClient := client.Resource(trainerServiceGVR).Namespace(trainerNamespace)
+
+	var updates int
+	client.PrependReactor("update", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	if err := updateExistingTrainerResource(context.Background(), svcClient, trainerControllerSvc()); err == nil {
+		t.Fatal("expected non-conflict error to surface, got nil")
+	}
+	if updates != 1 {
+		t.Errorf("update attempts = %d, want 1 (non-conflict errors must not retry)", updates)
+	}
+}
+
+// TestTrainerResourceRefString verifies cleanup diagnostics name namespaced and
+// cluster-scoped resources unambiguously.
+func TestTrainerResourceRefString(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  trainerResourceRef
+		want string
+	}{
+		{
+			name: "namespaced resource includes its namespace",
+			ref: trainerResourceRef{
+				GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+				Namespace: trainerNamespace, Name: "kubeflow-trainer-config",
+			},
+			want: "configmaps kubeflow-system/kubeflow-trainer-config",
+		},
+		{
+			name: "cluster-scoped resource omits the namespace",
+			ref:  trainerResourceRef{GVR: trainerCRDGVR, Name: trainerCRDTrainJobs},
+			want: "customresourcedefinitions trainjobs.trainer.kubeflow.org",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ref.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/validators/performance/trainer_rollback_test.go
+++ b/validators/performance/trainer_rollback_test.go
@@ -1,0 +1,662 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// trainerListKinds covers every GVR the trainer lifecycle code Lists or Watches,
+// so the dynamic fake client can serve them without a real REST mapper.
+var trainerListKinds = map[schema.GroupVersionResource]string{
+	trainerCRDGVR:               "CustomResourceDefinitionList",
+	trainerDeploymentGVR:        "DeploymentList",
+	trainerServiceGVR:           "ServiceList",
+	trainerValidatingWebhookGVR: "ValidatingWebhookConfigurationList",
+	trainerMutatingWebhookGVR:   "MutatingWebhookConfigurationList",
+	{Group: "", Version: "v1", Resource: "configmaps"}:     "ConfigMapList",
+	{Group: "", Version: "v1", Resource: "secrets"}:        "SecretList",
+	{Group: "apps", Version: "v1", Resource: "daemonsets"}: "DaemonSetList",
+}
+
+func newTrainerFakeClient(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(), trainerListKinds, objs...)
+}
+
+// newTrainerTestMapper builds a REST mapper covering the kinds the rollback
+// tests apply, so applyTrainerResources can resolve GVK -> GVR without live
+// discovery.
+func newTrainerTestMapper() apimeta.RESTMapper {
+	m := apimeta.NewDefaultRESTMapper(nil)
+	m.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, apimeta.RESTScopeNamespace)
+	m.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}, apimeta.RESTScopeNamespace)
+	m.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}, apimeta.RESTScopeNamespace)
+	m.Add(schema.GroupVersionKind{
+		Group: apiGroupAPIExtensions, Version: "v1", Kind: "CustomResourceDefinition",
+	}, apimeta.RESTScopeRoot)
+	m.Add(schema.GroupVersionKind{
+		Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfiguration",
+	}, apimeta.RESTScopeRoot)
+	m.Add(schema.GroupVersionKind{
+		Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration",
+	}, apimeta.RESTScopeRoot)
+	return m
+}
+
+// errBoom is the injected failure used by the reactors below.
+var errBoom = stderrors.New("boom")
+
+// establishedCRD builds a CRD object whose Established condition is True, as the
+// installed-state probe and the post-install wait both require.
+func establishedCRD(name string) *unstructured.Unstructured {
+	obj := newTestObject(apiGroupAPIExtensions+"/v1", "CustomResourceDefinition", "", name)
+	if err := unstructured.SetNestedSlice(obj.Object, []interface{}{
+		map[string]interface{}{"type": "Established", "status": "True"},
+	}, "status", "conditions"); err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// readyTrainerDeployment builds the Trainer controller-manager Deployment with a
+// ready replica, satisfying waitForTrainerControllerReady.
+func readyTrainerDeployment() *unstructured.Unstructured {
+	obj := newTestObject("apps/v1", "Deployment", trainerNamespace, trainerControllerDeployment)
+	if err := unstructured.SetNestedField(obj.Object, int64(1), "status", "readyReplicas"); err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// notReadyTrainerDeployment builds the Trainer controller-manager Deployment with
+// no ready replica, as during a rollout or an ImagePullBackOff.
+func notReadyTrainerDeployment() *unstructured.Unstructured {
+	obj := newTestObject("apps/v1", "Deployment", trainerNamespace, trainerControllerDeployment)
+	obj.SetLabels(map[string]string{
+		trainerComponentLabel: trainerComponentValue,
+		trainerPartOfLabel:    trainerPartOfValue,
+	})
+	if err := unstructured.SetNestedField(obj.Object, int64(0), "status", "readyReplicas"); err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func newTestObject(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": name},
+	}}
+	if namespace != "" {
+		obj.SetNamespace(namespace)
+	}
+	return obj
+}
+
+// trainerConfigMapName is the ConfigMap the rollback tests apply first, so it is
+// the resource whose presence proves whether rollback ran.
+const trainerConfigMapName = "kubeflow-trainer-config"
+
+// configMapExists reports whether the applied ConfigMap is still present.
+func configMapExists(t *testing.T, client *dynamicfake.FakeDynamicClient) bool {
+	t.Helper()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	_, err := client.Resource(gvr).Namespace(trainerNamespace).
+		Get(context.Background(), trainerConfigMapName, metav1.GetOptions{})
+	if err == nil {
+		return true
+	}
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+	t.Fatalf("unexpected error getting ConfigMap %s/%s: %v", trainerNamespace, trainerConfigMapName, err)
+	return false
+}
+
+// TestInstallTrainerResources_RollsBackOnApplyFailure is the core regression guard
+// for issue #2123: when a later resource fails to apply, every resource this
+// installation already created must be deleted before the error is returned.
+func TestInstallTrainerResources_RollsBackOnApplyFailure(t *testing.T) {
+	client := newTrainerFakeClient()
+	client.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
+	}
+
+	refs, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected apply failure, got nil error")
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0 (rollback owns cleanup, caller must not re-delete)", len(refs))
+	}
+	if configMapExists(t, client) {
+		t.Error("ConfigMap created before the failure was not rolled back")
+	}
+}
+
+// TestInstallTrainerResources_LeavesPreexistingResources verifies rollback deletes
+// only what this installation created. A resource that already existed (and was
+// therefore updated, not created) must survive the rollback.
+func TestInstallTrainerResources_LeavesPreexistingResources(t *testing.T) {
+	existing := newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName)
+	client := newTrainerFakeClient(existing)
+	client.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
+	}
+
+	if _, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs); err == nil {
+		t.Fatal("expected apply failure, got nil error")
+	}
+	if !configMapExists(t, client) {
+		t.Error("pre-existing ConfigMap was deleted; rollback must only remove resources it created")
+	}
+}
+
+// TestInstallTrainerResources_UpdateFailureStopsInstall pins the fix for the
+// warning-only update path: a failed update of an existing resource must abort
+// the installation rather than continue against a half-configured Trainer.
+func TestInstallTrainerResources_UpdateFailureStopsInstall(t *testing.T) {
+	existing := newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert")
+	client := newTrainerFakeClient(existing)
+	client.PrependReactor("update", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
+	}
+
+	_, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected update failure to abort installation, got nil error")
+	}
+	if configMapExists(t, client) {
+		t.Error("ConfigMap created before the update failure was not rolled back")
+	}
+}
+
+// TestInstallTrainerResources_RollsBackOnCRDEstablishTimeout covers the readiness
+// half of the fix: resources apply cleanly but the CRDs never reach Established,
+// so the installation must not leak them.
+func TestInstallTrainerResources_RollsBackOnCRDEstablishTimeout(t *testing.T) {
+	client := newTrainerFakeClient()
+	// Fail the establishment watch outright rather than waiting out a deadline:
+	// deterministic and timer-free, so the test cannot flake under load.
+	client.PrependWatchReactor(resourceCRDs, func(k8stesting.Action) (bool, watch.Interface, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+	}
+
+	refs, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected CRD establishment timeout, got nil error")
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0", len(refs))
+	}
+	if configMapExists(t, client) {
+		t.Error("applied ConfigMap was not rolled back after CRD establishment timeout")
+	}
+}
+
+// TestInstallTrainerResources_RollsBackOnControllerReadyTimeout covers the case
+// where the CRDs establish but the controller-manager never becomes ready.
+func TestInstallTrainerResources_RollsBackOnControllerReadyTimeout(t *testing.T) {
+	client := newTrainerFakeClient(establishedCRD(trainerCRDTrainJobs),
+		establishedCRD(trainerCRDTrainingRuntimes), establishedCRD(jobSetCRDName))
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+	}
+
+	// Let the readiness poll observe the absent controller once, then cancel from
+	// the reactor: deterministic, and not coupled to the poll interval.
+	ctx, cancel := context.WithCancel(context.Background())
+	client.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		cancel()
+		return false, nil, nil
+	})
+	defer cancel()
+
+	refs, err := installTrainerResources(ctx, client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected controller readiness timeout, got nil error")
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0", len(refs))
+	}
+	if configMapExists(t, client) {
+		t.Error("applied ConfigMap was not rolled back after controller readiness timeout")
+	}
+}
+
+// TestInstallTrainerResources_SucceedsWhenReady is the positive control: with the
+// CRDs established and the controller ready, the created resources are returned
+// to the caller for later cleanup rather than rolled back.
+func TestInstallTrainerResources_SucceedsWhenReady(t *testing.T) {
+	client := newTrainerFakeClient(
+		establishedCRD(trainerCRDTrainJobs),
+		establishedCRD(trainerCRDTrainingRuntimes),
+		establishedCRD(jobSetCRDName),
+		readyTrainerDeployment(),
+	)
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+	}
+
+	refs, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("refs = %d, want 1", len(refs))
+	}
+	if !configMapExists(t, client) {
+		t.Error("successful install must leave its resources in place")
+	}
+}
+
+// TestInstallTrainerResources_CleanupFailureNamesResource pins the requirement
+// that a rollback which cannot delete a resource surfaces that resource's
+// identity, so an operator can find the leak.
+func TestInstallTrainerResources_CleanupFailureNamesResource(t *testing.T) {
+	client := newTrainerFakeClient()
+	client.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+	client.PrependReactor("delete", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
+	}
+
+	_, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), trainerConfigMapName) {
+		t.Errorf("error does not name the leaked resource: %v", err)
+	}
+}
+
+// TestInstallTrainerResources_StopsApplyingOnCanceledContext verifies the apply
+// loop honors cancellation. Without the check it would keep issuing Create calls
+// for every remaining object, relying on each API call to fail on its own.
+func TestInstallTrainerResources_StopsApplyingOnCanceledContext(t *testing.T) {
+	client := newTrainerFakeClient()
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	refs, err := installTrainerResources(ctx, client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected canceled context to abort the install, got nil error")
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0", len(refs))
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "create" {
+			t.Errorf("applied %q after context cancellation; the loop must abort first",
+				action.GetResource().Resource)
+		}
+	}
+}
+
+// TestDeleteTrainer_RetriesTransientFailures verifies a momentary control-plane
+// blip during teardown does not fail the check. Because a cleanup failure now
+// fails an otherwise-passing benchmark, an unretried 503 would turn a good NCCL
+// measurement into a false red on nightly UAT.
+func TestDeleteTrainer_RetriesTransientFailures(t *testing.T) {
+	client := newTrainerFakeClient()
+	var attempts int
+	client.PrependReactor("delete", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		attempts++
+		if attempts == 1 {
+			return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
+		}
+		return true, nil, nil
+	})
+
+	refs := []trainerResourceRef{{
+		GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+		Namespace: trainerNamespace, Name: trainerConfigMapName,
+	}}
+
+	if err := deleteTrainer(client, refs); err != nil {
+		t.Fatalf("transient delete failure should have been retried, got: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("delete attempts = %d, want 2 (one transient failure, one success)", attempts)
+	}
+}
+
+// TestDeleteTrainer_PersistentTransientFailureIsUnavailable verifies a teardown
+// that keeps failing transiently reports a retryable code, so triage can tell a
+// cluster outage from a product defect.
+func TestDeleteTrainer_PersistentTransientFailureIsUnavailable(t *testing.T) {
+	client := newTrainerFakeClient()
+	client.PrependReactor("delete", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
+	})
+
+	refs := []trainerResourceRef{{
+		GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+		Namespace: trainerNamespace, Name: trainerConfigMapName,
+	}}
+
+	err := deleteTrainer(client, refs)
+	if err == nil {
+		t.Fatal("expected persistent transient failure to surface, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
+		t.Errorf("error code is not Unavailable: %v", err)
+	}
+}
+
+// TestDeleteTrainer_DeterministicFailureIsInternal verifies a deterministic
+// failure is neither retried nor laundered into a retryable-looking outage.
+func TestDeleteTrainer_DeterministicFailureIsInternal(t *testing.T) {
+	client := newTrainerFakeClient()
+	var attempts int
+	client.PrependReactor("delete", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		attempts++
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "configmaps"}, trainerConfigMapName, errBoom)
+	})
+
+	refs := []trainerResourceRef{{
+		GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+		Namespace: trainerNamespace, Name: trainerConfigMapName,
+	}}
+
+	err := deleteTrainer(client, refs)
+	if err == nil {
+		t.Fatal("expected forbidden delete to surface, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeInternal, "")) {
+		t.Errorf("error code is not Internal: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("delete attempts = %d, want 1 (deterministic failures must not retry)", attempts)
+	}
+}
+
+// TestApplyTrainerResources_ClassifiesTransientCreateFailure verifies the write
+// path classifies like the read path: a transient apiserver failure during Create
+// must not be reported as a product defect.
+func TestApplyTrainerResources_ClassifiesTransientCreateFailure(t *testing.T) {
+	client := newTrainerFakeClient()
+	client.PrependReactor("create", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
+	})
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+	}
+
+	_, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected create failure, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
+		t.Errorf("error code is not Unavailable: %v", err)
+	}
+}
+
+// TestDeleteTrainer_LeavesReplacedObjectAlone verifies cleanup never deletes a
+// same-named object that another owner recreated while the benchmark ran. The UID
+// precondition is what makes "never delete what we didn't create" hold over time,
+// not just at apply time.
+func TestDeleteTrainer_LeavesReplacedObjectAlone(t *testing.T) {
+	client := newTrainerFakeClient()
+	var sawPrecondition bool
+	client.PrependReactor("delete", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		del, ok := action.(k8stesting.DeleteActionImpl)
+		if ok && del.DeleteOptions.Preconditions != nil && del.DeleteOptions.Preconditions.UID != nil {
+			sawPrecondition = true
+		}
+		// The apiserver rejects a UID precondition that no longer matches.
+		return true, nil, apierrors.NewConflict(
+			schema.GroupResource{Resource: "configmaps"}, trainerConfigMapName, errBoom)
+	})
+
+	refs := []trainerResourceRef{{
+		GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+		Namespace: trainerNamespace, Name: trainerConfigMapName, UID: "original-uid",
+	}}
+
+	if err := deleteTrainer(client, refs); err != nil {
+		t.Errorf("a replaced object is not ours to delete and must not fail cleanup, got: %v", err)
+	}
+	if !sawPrecondition {
+		t.Error("delete was issued without a UID precondition")
+	}
+}
+
+// TestApplyTrainerResources_ClaimsAmbiguousCreate verifies a Create that fails
+// inconclusively but persisted is still claimed for rollback. Without this the
+// object is absent from the rollback set and leaks, which is the exact failure
+// this change exists to close.
+func TestApplyTrainerResources_ClaimsAmbiguousCreate(t *testing.T) {
+	client := newTrainerFakeClient()
+	client.PrependReactor("create", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(k8stesting.CreateActionImpl)
+		if !ok {
+			return false, nil, nil
+		}
+		// Persist the object exactly as submitted (carrying this attempt's marker),
+		// then report a transport failure, as an apiserver timeout after a
+		// successful write does.
+		if err := client.Tracker().Create(action.GetResource(), create.Object, action.GetNamespace()); err != nil {
+			return true, nil, err
+		}
+		return true, nil, apierrors.NewTimeoutError("request timed out", 1)
+	})
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+	}
+
+	created, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected the ambiguous create to surface as an error")
+	}
+	if len(created) != 1 {
+		t.Fatalf("created = %d, want 1 (a persisted object must be claimed for rollback)", len(created))
+	}
+	if created[0].Name != trainerConfigMapName {
+		t.Errorf("claimed %q, want %q", created[0].Name, trainerConfigMapName)
+	}
+}
+
+// TestApplyTrainerResources_DoesNotClaimForeignObjects is the ownership half of
+// the ambiguous-create recovery. Presence is not ownership: an object that this
+// attempt did not create must never enter the rollback set, or cleanup deletes a
+// resource the validator never installed.
+func TestApplyTrainerResources_DoesNotClaimForeignObjects(t *testing.T) {
+	tests := []struct {
+		name      string
+		preexist  map[string]string // annotations on the object already in the cluster
+		createErr error
+	}{
+		{
+			name:      "object with no attempt marker",
+			preexist:  nil,
+			createErr: apierrors.NewTimeoutError("request timed out", 1),
+		},
+		{
+			name:      "object marked by a different attempt",
+			preexist:  map[string]string{installAttemptAnnotation: "some-other-attempt"},
+			createErr: apierrors.NewTimeoutError("request timed out", 1),
+		},
+		{
+			name:      "deterministic rejection is never probed",
+			preexist:  nil,
+			createErr: apierrors.NewTooManyRequests("slow down", 1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName)
+			if tt.preexist != nil {
+				existing.SetAnnotations(tt.preexist)
+			}
+			client := newTrainerFakeClient(existing)
+			client.PrependReactor("create", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, tt.createErr
+			})
+
+			objs := []*unstructured.Unstructured{
+				newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+			}
+
+			created, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+			if err == nil {
+				t.Fatal("expected the create failure to surface")
+			}
+			if len(created) != 0 {
+				t.Errorf("created = %d, want 0 (a foreign object must not be claimed for rollback)", len(created))
+			}
+		})
+	}
+}
+
+// TestApplyTrainerResources_StampsCreatedObjects verifies created resources carry
+// the attempt marker, which is what lets an ambiguous retry prove ownership.
+func TestApplyTrainerResources_StampsCreatedObjects(t *testing.T) {
+	client := newTrainerFakeClient()
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+	}
+
+	if _, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := client.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}).
+		Namespace(trainerNamespace).Get(context.Background(), trainerConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.GetAnnotations()[installAttemptAnnotation] == "" {
+		t.Error("created resource carries no install-attempt marker")
+	}
+}
+
+// TestApplyTrainerResources_RefusesToRepointForeignInstall verifies the installer
+// will not steal a Trainer installation deployed another way. The Helm chart the
+// recipes deploy lands in kubeflow; repointing its admission configuration at this
+// installer's namespace would break its admission path, and since updates are
+// excluded from the rollback set nothing would put it back.
+func TestApplyTrainerResources_RefusesToRepointForeignInstall(t *testing.T) {
+	chartInstalled := webhookConfigIn("ValidatingWebhookConfiguration",
+		trainerValidatingWebhookConfig, trainerValidatingWebhookName, "kubeflow")
+	client := newTrainerFakeClient(chartInstalled)
+
+	objs := []*unstructured.Unstructured{
+		webhookConfigIn("ValidatingWebhookConfiguration", trainerValidatingWebhookConfig,
+			trainerValidatingWebhookName, trainerNamespace),
+	}
+
+	_, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected the installer to refuse repointing another installation's webhooks")
+	}
+
+	got, getErr := client.Resource(trainerValidatingWebhookGVR).
+		Get(context.Background(), trainerValidatingWebhookConfig, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("unexpected error: %v", getErr)
+	}
+	if ns := webhookServiceNamespace(got); ns != "kubeflow" {
+		t.Errorf("live installation was repointed to %q, want it left at kubeflow", ns)
+	}
+}
+
+// TestDeleteTrainer_ToleratesNotFound verifies cleanup treats an already-deleted
+// resource as success, so a partially garbage-collected install still reports clean.
+func TestDeleteTrainer_ToleratesNotFound(t *testing.T) {
+	client := newTrainerFakeClient()
+	refs := []trainerResourceRef{
+		{GVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			Namespace: trainerNamespace, Name: "gone"},
+	}
+	if err := deleteTrainer(client, refs); err != nil {
+		t.Errorf("deleteTrainer on missing resource = %v, want nil", err)
+	}
+}
+
+// TestDeleteTrainer_AggregatesFailures verifies every failed delete is reported,
+// not just the first, and that each carries its resource identity.
+func TestDeleteTrainer_AggregatesFailures(t *testing.T) {
+	client := newTrainerFakeClient()
+	client.PrependReactor("delete", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+
+	cmGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	refs := []trainerResourceRef{
+		{GVR: cmGVR, Namespace: trainerNamespace, Name: "first"},
+		{GVR: cmGVR, Namespace: trainerNamespace, Name: "second"},
+	}
+
+	err := deleteTrainer(client, refs)
+	if err == nil {
+		t.Fatal("expected aggregated delete error, got nil")
+	}
+	for _, want := range []string{"first", "second"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing resource %q: %v", want, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Makes Kubeflow Trainer self-installation transactional: `installTrainer` now rolls back every resource it created when any later apply, update, or readiness step fails, instead of leaking them.

## Motivation / Context

The NCCL performance validator self-installs Kubeflow Trainer when its probe CRD is absent. `installTrainer` returned the partial resource list alongside an error, but the caller only registered `deleteTrainer` **after** a successful install, so the partial list was discarded on every error path. A failed check could leave cluster-scoped CRDs, RBAC, webhook configurations, and controller resources behind, and the single-CRD installed-state probe would then classify that wreckage as a complete install on the next run.

Fixes: #2123
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `validators/performance` (in-pod performance validator)

## Implementation Notes

**Rollback ownership.** `installTrainerResources` is the new cluster-only core of `installTrainer`, split out so failure injection is testable without fetching the archive from GitHub. It applies, waits, and on any failure calls `rollbackTrainer` and returns *no* resources, so the caller has nothing left to clean up. `applyTrainerResources` appends to the rollback set only on a successful `Create`; a resource that already existed is updated but excluded, so rollback never deletes a Trainer this validator did not install.

**Update failures are now fatal**, per the issue's acceptance criteria. That is only safe if the update path actually works, so updates now re-read the live object for its `resourceVersion` and carry over server-assigned Service cluster IPs. Without that, re-applying the Trainer Service over a leftover one is rejected on an immutable field, and what used to be a swallowed warning would have become a hard failure on every repair attempt.

**Installed-state probe.** Now checks both required CRDs are `Established`, the controller `Deployment` and webhook `Service` exist, and both admission configurations carry Trainer-owned webhook entries. The webhook-entry match matters: upstream ships these as `validating-webhook-configuration` / `mutating-webhook-configuration` with no name prefix, so the object name alone does not prove a Trainer install. The probe fails closed - an API error it cannot classify is returned rather than reported as "not installed".

**Two behavior changes worth a reviewer's attention:**

1. **A cleanup failure now fails the check** even when the benchmark itself passed (`deleteTrainer` returns an aggregated error naming each resource). This is acceptance criterion 5 in the issue. The rationale is that leaked cluster-scoped CRDs and webhooks silently poison later runs, so surfacing beats logging and dropping. It does mean a transient API error during teardown can fail an otherwise-good measurement. Easy to soften to a warning if you would rather not couple the two.
2. **The already-installed path now waits for controller readiness** rather than proceeding immediately. Since the probe deliberately checks object presence and not `readyReplicas`, this waits out a rolling controller instead of reinstalling over a healthy Trainer we do not own. It fast-paths when the controller is already ready.

## Testing

```bash
make qualify
```

Passed end to end: unit tests with `-race`, coverage gate, `go vet`, golangci-lint, tuning-check, e2e (24/24), vulnerability scan, license check, and api-diff ("No incompatible SDK facade or transparent-alias target changes since v0.19.0").

New failure-injection tests cover every scenario the issue asks for - partial apply, CRD establishment timeout, controller readiness timeout, update failure, and cleanup failure - plus a positive control, pre-existing-resource preservation, and the hardened probe.

`validators/` is excluded from the repo coverage floor (Makefile:264), but per-function coverage on the changed code:

| Function | Coverage |
|---|---|
| `installTrainerResources` | 100.0% |
| `rollbackTrainer` | 100.0% |
| `deleteTrainer` | 100.0% |
| `waitForTrainerReady` | 100.0% |
| `applyTrainerResources` | 95.2% |
| `isTrainerInstalled` | 92.6% |
| `updateExistingTrainerResource` | 91.7% |

The probe tests were verified to genuinely catch the bug by temporarily restoring the legacy single-CRD probe: all 8 partial-install cases failed against it, then passed against the fix.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Confined to `validators/performance`, which runs in-pod during the NCCL benchmark. No public API, CLI, or recipe surface changes.

**Rollout notes:** No migration needed. On a cluster carrying leftovers from a previously failed install, the hardened probe will now classify that state as incomplete and repair it via the update path rather than running against it.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed (N/A - the Trainer self-install is internal validator behavior and is not described in `docs/`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
