### PR TITLE
fix(validators): wait on the discovered Trainer controller name

### DIFF
--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -42,6 +42,67 @@ func TestEnsureTrainerInstalled_CompleteInstallIsLeftAlone(t *testing.T) {
 	}
 }
 
+// TestEnsureTrainerInstalled_WaitsOnDiscoveredControllerName pins the discovered
+// controller name to the readiness wait. The probe locates the Deployment by label
+// because the Helm chart derives its name from the release, so a chart install
+// under a non-default release name is found under a name the self-install overlay
+// never uses. Waiting on the fixed overlay name instead would poll a Deployment
+// that does not exist, and waitForDeploymentReady treats NotFound as
+// not-ready-yet: a healthy controller would be reported as never ready after the
+// full timeout.
+func TestEnsureTrainerInstalled_WaitsOnDiscoveredControllerName(t *testing.T) {
+	const releaseDerivedName = "kft-custom-release-controller-manager"
+
+	// A complete chart-style install in kubeflow whose controller carries a
+	// release-derived name rather than the overlay's fixed one.
+	objs := append(
+		withoutObject(trainerInstallIn("kubeflow"), func(o runtime.Object) bool {
+			u, ok := o.(*unstructured.Unstructured)
+			return ok && u.GetKind() == "Deployment"
+		}),
+		readyTrainerDeploymentNamed("kubeflow", releaseDerivedName),
+	)
+	client := newTrainerFakeClient(objs...)
+
+	// Fail fast instead of polling out the readiness timeout: a Get for any other
+	// name means the discovered name never reached the wait.
+	var polled []string
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.PrependReactor("get", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get, ok := action.(k8stesting.GetActionImpl)
+		if !ok {
+			return false, nil, nil
+		}
+		polled = append(polled, get.GetName())
+		if get.GetName() != releaseDerivedName {
+			cancel()
+		}
+		return false, nil, nil
+	})
+
+	refs, err := ensureTrainerInstalled(ctx, client, nil)
+	if err != nil {
+		t.Fatalf("unexpected error waiting on the discovered controller %q (polled %v): %v",
+			releaseDerivedName, polled, err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0", len(refs))
+	}
+	// Without this the name assertion below is a range over an empty slice: if the
+	// readiness wait ever stops issuing Deployment Gets (a switch to the watch
+	// pattern used elsewhere in this file), the loop body would never run and this
+	// guard would pass green while verifying nothing.
+	if len(polled) == 0 {
+		t.Fatal("readiness wait issued no Deployment Get; the name assertion below would be vacuous")
+	}
+	for _, name := range polled {
+		if name != releaseDerivedName {
+			t.Errorf("readiness wait polled %q, want the discovered name %q", name, releaseDerivedName)
+		}
+	}
+}
+
 // TestEnsureTrainerInstalled_WaitsForPreexistingController covers the
 // already-installed branch: the probe checks presence, not readiness, so a
 // still-rolling controller must be waited out and reported distinctly rather

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -462,8 +462,8 @@ func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface
 	// The probe confirms every object exists; the controller may still be rolling.
 	// Wait for it here rather than reinstalling over a healthy Trainer we do not own.
 	slog.Info("Kubeflow Trainer already installed, waiting for controller readiness",
-		"namespace", install.Namespace)
-	if readyErr := waitForTrainerReady(ctx, dynamicClient, install.Namespace); readyErr != nil {
+		"namespace", install.Namespace, "deployment", install.Deployment)
+	if readyErr := waitForTrainerReady(ctx, dynamicClient, install.Namespace, install.Deployment); readyErr != nil {
 		return nil, aicrErrors.PropagateOrWrap(readyErr, aicrErrors.ErrCodeTimeout,
 			"pre-existing Kubeflow Trainer controller is not ready")
 	}
@@ -564,7 +564,9 @@ func installTrainerResources(ctx context.Context, dynamicClient dynamic.Interfac
 
 	created, err := applyTrainerResources(ctx, dynamicClient, mapper, objs)
 	if err == nil {
-		err = waitForTrainerReady(ctx, dynamicClient, trainerNamespace)
+		// No discovered name here: these objects were just applied from the overlay,
+		// so the controller carries its fixed self-install name.
+		err = waitForTrainerReady(ctx, dynamicClient, trainerNamespace, "")
 	}
 	if err != nil {
 		// contextcheck: rollback deliberately runs on a fresh context. ctx is
@@ -579,11 +581,17 @@ func installTrainerResources(ctx context.Context, dynamicClient dynamic.Interfac
 // waitForTrainerReady blocks until a freshly applied Trainer is usable: the CRDs
 // the NCCL test needs are Established, and the controller-manager has a ready
 // replica so its admission webhooks have endpoints.
-func waitForTrainerReady(ctx context.Context, dynamicClient dynamic.Interface, namespace string) error {
+//
+// deployment is the controller-manager's live name. The probe discovers it by
+// label because the Helm chart derives the name from the release, so a caller
+// that already located the installation must pass what it found rather than let
+// this fall back to the fixed self-install name. Empty means "not discovered"
+// (the post-install path, which applied the overlay's own fixed name).
+func waitForTrainerReady(ctx context.Context, dynamicClient dynamic.Interface, namespace, deployment string) error {
 	if err := waitForTrainerCRDsEstablished(ctx, dynamicClient); err != nil {
 		return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeTimeout, "Trainer CRDs not ready after install")
 	}
-	if err := waitForTrainerControllerReady(ctx, dynamicClient, namespace); err != nil {
+	if err := waitForTrainerControllerReady(ctx, dynamicClient, namespace, deployment); err != nil {
 		return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeTimeout, "Trainer controller not ready after install")
 	}
 	// TrainJobs run as JobSets. A stale install still carrying the garbage-collected
@@ -1085,9 +1093,21 @@ func waitForTrainerCRDsEstablished(ctx context.Context, dynamicClient dynamic.In
 // waitForTrainerControllerReady polls the controller-manager Deployment until at
 // least one replica is ready, ensuring the ValidatingWebhookConfiguration can
 // serve admission requests before the caller creates Trainer custom resources.
-func waitForTrainerControllerReady(ctx context.Context, dynamicClient dynamic.Interface, namespace string) error {
+//
+// An empty deployment falls back to the self-install overlay's fixed name, which
+// is correct only for an installation this validator just applied. Waiting on that
+// name against a chart installation under a non-default release name would poll a
+// Deployment that does not exist: waitForDeploymentReady treats NotFound as
+// not-ready-yet, so it would burn the full timeout and report a healthy controller
+// as never ready.
+func waitForTrainerControllerReady(ctx context.Context, dynamicClient dynamic.Interface,
+	namespace, deployment string) error {
+
+	if deployment == "" {
+		deployment = trainerControllerDeployment
+	}
 	return waitForDeploymentReady(ctx, dynamicClient, namespace,
-		trainerControllerDeployment, defaults.TrainerControllerReadyTimeout)
+		deployment, defaults.TrainerControllerReadyTimeout)
 }
 
 // waitForDeploymentReady polls a Deployment until at least one replica is ready.

--- a/validators/performance/trainer_probe_test.go
+++ b/validators/performance/trainer_probe_test.go
@@ -60,16 +60,7 @@ func webhookConfigIn(kind, name, webhookName, namespace string) *unstructured.Un
 // trainerInstallIn returns a complete Trainer installation laid out in the given
 // namespace, as either supported deployment path produces.
 func trainerInstallIn(namespace string) []runtime.Object {
-	deploy := newTestObject("apps/v1", "Deployment", namespace, trainerControllerDeployment)
-	// Both deployment paths label the controller this way; the probe locates it by
-	// label because the Helm name is release-derived.
-	deploy.SetLabels(map[string]string{
-		trainerComponentLabel: trainerComponentValue,
-		trainerPartOfLabel:    trainerPartOfValue,
-	})
-	if err := unstructured.SetNestedField(deploy.Object, int64(1), "status", "readyReplicas"); err != nil {
-		panic(err)
-	}
+	deploy := readyTrainerDeploymentNamed(namespace, trainerControllerDeployment)
 	return []runtime.Object{
 		establishedCRD(trainerCRDTrainJobs),
 		establishedCRD(trainerCRDTrainingRuntimes),

--- a/validators/performance/trainer_rollback_test.go
+++ b/validators/performance/trainer_rollback_test.go
@@ -98,12 +98,25 @@ func readyTrainerDeployment() *unstructured.Unstructured {
 // notReadyTrainerDeployment builds the Trainer controller-manager Deployment with
 // no ready replica, as during a rollout or an ImagePullBackOff.
 func notReadyTrainerDeployment() *unstructured.Unstructured {
-	obj := newTestObject("apps/v1", "Deployment", trainerNamespace, trainerControllerDeployment)
+	return trainerDeploymentNamed(trainerNamespace, trainerControllerDeployment, 0)
+}
+
+// readyTrainerDeploymentNamed builds a controller Deployment reporting one ready
+// replica under an arbitrary name, covering the Helm path where the name is
+// derived from the release rather than fixed by the overlay.
+func readyTrainerDeploymentNamed(namespace, name string) *unstructured.Unstructured {
+	return trainerDeploymentNamed(namespace, name, 1)
+}
+
+// trainerDeploymentNamed builds a controller Deployment carrying the labels both
+// deployment paths set, which is how the probe locates it.
+func trainerDeploymentNamed(namespace, name string, readyReplicas int64) *unstructured.Unstructured {
+	obj := newTestObject("apps/v1", "Deployment", namespace, name)
 	obj.SetLabels(map[string]string{
 		trainerComponentLabel: trainerComponentValue,
 		trainerPartOfLabel:    trainerPartOfValue,
 	})
-	if err := unstructured.SetNestedField(obj.Object, int64(0), "status", "readyReplicas"); err != nil {
+	if err := unstructured.SetNestedField(obj.Object, readyReplicas, "status", "readyReplicas"); err != nil {
 		panic(err)
 	}
 	return obj


### PR DESCRIPTION
## Summary

Thread the Trainer controller Deployment name discovered by the probe into the readiness wait, which still polled the fixed self-install name.

## Motivation / Context

Fixes: N/A
Related: #2171

#2171 changed the probe to locate the controller-manager Deployment by label, because the Helm chart derives its name from the release name while the kustomize self-install overlay uses a fixed one. The discovered name is stored in `trainerInstall.Deployment`, but nothing read it — `waitForTrainerControllerReady` continued to poll `trainerControllerDeployment`.

On a chart installation under a non-default release name the probe therefore reported the installation complete, and `ensureTrainerInstalled` then waited on a Deployment that does not exist. `waitForDeploymentReady` treats NotFound as not-ready-yet, so it polled out the full `TrainerControllerReadyTimeout` (2 minutes) and failed the NCCL check with "pre-existing Kubeflow Trainer controller is not ready" against a perfectly healthy cluster.

Scope of the impact, stated precisely: AICR's own deployments are **not** affected. `recipes/components/kubeflow-trainer/values.yaml` pins `fullnameOverride: kubeflow-trainer`, so an AICR-deployed chart always renders `kubeflow-trainer-controller-manager` — the name the wait already used — and `recipes/checks/kubeflow-trainer/health-check.yaml` asserts that same fixed name. That is why this was reported as non-blocking on #2171 rather than holding the merge.

What the fix protects is the case the label lookup was added for in the first place: a Trainer the validator finds already installed on the cluster by some path other than an AICR recipe, under a different release name or `fullnameOverride`. The probe accepts such an installation by label and then, before this change, waited on a name it had just declined to rely on — the two halves disagreed. Threading the discovered name makes them consistent and removes an assigned-but-never-read field that invites exactly this class of drift.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`validators/performance`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

`waitForTrainerReady` and `waitForTrainerControllerReady` take the discovered name. An empty name falls back to `trainerControllerDeployment`, which is correct for the post-install path: those objects were just applied from the overlay, so the controller carries the overlay's own fixed name and there is nothing to discover.

The test fixture builders were consolidated — `notReadyTrainerDeployment` and the inline Deployment in `trainerInstallIn` now share one `trainerDeploymentNamed` helper, so a controller fixture under an arbitrary name does not duplicate the label set a third time.

No user-visible behavior changes, so no docs updates.

## Testing

```bash
GOFLAGS="-mod=vendor" go test -race -count=1 -run Trainer ./validators/performance/   # ok
golangci-lint run -c .golangci.yaml ./validators/performance/...                      # 0 issues
```

`TestEnsureTrainerInstalled_WaitsOnDiscoveredControllerName` is the regression guard. It builds a complete install in `kubeflow` whose controller carries a release-derived name, and records every Deployment name the readiness wait polls. It fails closed if the wait issues no Get at all, so the name assertion cannot degrade into a range over an empty slice should `waitForDeploymentReady` ever move to the watch pattern used elsewhere in this file — verified by stubbing the wait to issue no Gets and confirming the guard fires.

Reverting the fix makes it fail with the evidence inline, and fail fast rather than burning the 2-minute timeout:

```
--- FAIL: TestEnsureTrainerInstalled_WaitsOnDiscoveredControllerName (0.00s)
    unexpected error waiting on the discovered controller "kft-custom-release-controller-manager"
    (polled [kubeflow-trainer-controller-manager]): [TIMEOUT] timed out waiting for Deployment
    kubeflow/kubeflow-trainer-controller-manager to become ready: context canceled
```

Full `make qualify` was not run. The change is confined to one package under `validators/`, which is excluded from the coverage floor, and the package's own tests plus its pinned-version lint pass. The rest of the package's suite cannot run in this sandbox because `inference_perf_test.go` binds an `httptest` port; that is unrelated to this change and is covered in CI.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A. Behavior is unchanged for default release names; the fix only affects the path that previously timed out.

## Checklist

- [x] Tests pass locally — package tests with `-race`; see Testing for scope and what was not run
- [x] Linter passes — `golangci-lint` at the pinned version on the changed package
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
