### PR TITLE
docs(bundling): add -n to Helm adoption kubectl examples

### DIFF
--- a/docs/user/bundling.md
+++ b/docs/user/bundling.md
@@ -185,8 +185,10 @@ hook-injected resource (name and kind from the new
 `templates/` if you still have that bundle):
 
 ```bash
-kubectl label <kind>/<name> app.kubernetes.io/managed-by=Helm --overwrite
-kubectl annotate <kind>/<name> \
+# Include -n <ns> for namespaced kinds (same <ns> as release-namespace below).
+# Omit -n for cluster-scoped kinds (CRD, ClusterRole, NicClusterPolicy, …).
+kubectl label -n <ns> <kind>/<name> app.kubernetes.io/managed-by=Helm --overwrite
+kubectl annotate -n <ns> <kind>/<name> \
   meta.helm.sh/release-name=<component>-post \
   meta.helm.sh/release-namespace=<ns> --overwrite
 ```


### PR DESCRIPTION
## Summary

Add `-n <ns>` to the vendored-mixed migration Helm-adoption `kubectl label` / `annotate` examples in `docs/user/bundling.md`, with a note to omit it for cluster-scoped kinds.

## Motivation / Context

Follow-up to non-blocking review feedback on #2061: without `-n`, namespaced resources resolve against the operator's current context namespace and adoption can `NotFound` partway through (e.g. Gateway / AgentgatewayParameters in `agentgateway-system`).

Fixes: N/A
Related: #2061

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Uses the same `<ns>` already shown in `meta.helm.sh/release-namespace`. Comments in the bash fence document when to include vs omit `-n`.

## Testing

```bash
./tools/check-docs-mdx
```

MDX safety check passed locally. Docs-only change.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — documentation only

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A docs-only
- [x] Linter passes (`make lint`) — MDX gate run via `./tools/check-docs-mdx`
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)