### PR TITLE
fix(skills): reap leaked cross-review refs/cr/* and temp diffs

### DIFF
--- a/.agents/skills/aicr-cross-review/SKILL.md
+++ b/.agents/skills/aicr-cross-review/SKILL.md
@@ -16,7 +16,7 @@ user-invocable: true
 # automatic path that removing the explicit nested call did not.
 disallowed-tools: Skill
 argument-hint: "<PR-number-or-URL>"
-version: 0.3.21
+version: 0.3.22
 ---
 
 # AICR Cross-Review: Multi-Agent PR Review with Consensus
@@ -98,6 +98,85 @@ ones under review. Ask for a trusted checkout. This catches the accidental case 
    session's active review. (Each worktree adds sandbox deny-list paths; at ~70 the
    profile exceeded the OS spawn-arg limit and every sandboxed Bash call failed with
    `E2BIG`. Recovery needs a fresh session.)
+3. Reap dead runs' pinned inputs. A session killed between Batch B and Phase 5 leaks
+   its two `refs/cr/*` and its temp diff file permanently — nothing else reclaims
+   them, and they accumulate in the same slow way the worktrees above do.
+
+   ```bash
+   RUNS="$(git -C "<repo-path>" rev-parse --path-format=absolute --git-common-dir)/cr-runs"
+   find "$RUNS" -maxdepth 1 -type f -mmin +1440 -delete 2>/dev/null || true
+   git -C "<repo-path>" for-each-ref --format='%(refname)' 'refs/cr/pr*' 'refs/cr/base*' |
+   while read -r REF; do
+     KEY=${REF#refs/cr/}                                  # want <n>-<SID>
+     case "$KEY" in pr*) KEY=${KEY#pr};; base*) KEY=${KEY#base};; esac
+     case "$KEY" in *-*) ;; *) continue;; esac             # must have both components
+     case "${KEY%-*}" in ''|*[!0-9]*) continue;; esac      # <n> is a PR number
+     case "${KEY##*-}" in ??????) ;; *) continue;; esac    # <SID> is mktemp's six chars
+     [ -e "$RUNS/$KEY" ] || git -C "<repo-path>" update-ref -d "$REF"
+   done
+   find "${TMPDIR:-/tmp}" -maxdepth 1 -type f -name 'cross-review-pr*.??????' -mmin +1440 -delete 2>/dev/null || true
+   ```
+
+   Liveness comes from the per-run marker Batch B drops in `cr-runs/`, not from the
+   ref and not from the diff file. Both alternatives are broken:
+
+   - **Not the ref.** `git gc` packs `refs/cr/*` into `packed-refs`, after which the
+     per-ref file under `.git/refs/cr/` no longer exists and an mtime gate silently
+     stops reaping — and `git fetch`, which Batch B runs, triggers `gc --auto`. The
+     two substitutes fail too: `refs/cr/*` has no reflog (`core.logAllRefUpdates`
+     covers only `refs/heads`, `refs/remotes`, `refs/notes`, and `HEAD`), and
+     `%(creatordate)` is the *commit's* date, so a ref created a minute ago on
+     yesterday's `main` reports "21 hours ago".
+   - **Not the diff file.** `TMPDIR` is not stable across sessions, or even within
+     one: under Claude Code's sandbox it is `/tmp/claude-<uid>`, and with the sandbox
+     bypassed it is the shell default (`/var/folders/…/T/` on macOS). A reaper that
+     tested for the diff file would miss a live session's file whenever the two
+     disagree and delete that session's pinned refs — the one thing this skill must
+     never do.
+
+   `cr-runs/` sits next to the refs it guards, under the **common** git dir, so every
+   worktree of a clone shares one view, exactly as `refs/cr/*` are shared. Git ignores
+   unknown entries there, so nothing packs or prunes it and the marker keeps a real
+   creation timestamp. The last `find` is only a temp-file janitor: it reclaims diff
+   files in whatever `TMPDIR` this session sees, and reclaiming none is harmless.
+
+   **The three `case` guards are the safety boundary, and all three are load-bearing.**
+   A candidate must have both components, a numeric `<n>`, and a six-character `<SID>`
+   before it can be deleted. Prefix-stripping alone is not enough: `refs/cr/pr*` also
+   matches `refs/cr/private-ABC123`, which strips to `ivate-ABC123` and would pass a
+   suffix-only check. Hand-made bookmarks (`refs/cr/2183-r5`, `refs/cr/2187-test`) are
+   deliberate, often pin active work, and must survive — the only names that now
+   collide are a literal `pr<digits>-<six characters>` or `base<digits>-<six
+   characters>`, since the loop accepts both prefixes, so do not use either shape
+   for one. `find … -delete` rather than `rm` for the same reason as everywhere else in
+   this skill: managed permission policies gate `rm:*` behind a prompt. The janitor
+   is `-type f` so a directory that happens to match the diff-file pattern is never
+   removed.
+
+   **The marker key is `<n>-<SID>`, never `<SID>` alone.** `mktemp` guarantees the
+   full filename it returns is unique; it does not reserve the suffix. Two concurrent
+   reviews of *different* PRs pass different templates, so both can be handed the same
+   six characters — their refs stay distinct, but a `<SID>`-keyed marker would be one
+   shared file, and whichever run finished first would delete the other's protection.
+   Reviews of the *same* PR are safe whenever they share a `TMPDIR`, since `mktemp`
+   guarantees distinct names within one directory. It guarantees nothing across
+   directories, so same-PR runs under different `TMPDIR` roots can still collide —
+   but on `$SID` itself, which makes `PRREF` and `BASEREF` collide first. That is a
+   property of how Batch B derives `$SID`, not of this reaper, and is left to a
+   follow-up.
+
+   **The gate is 24 hours, and it must stay far above any real run.** Nothing enforces
+   an end-to-end limit on a review: Codex gets a five-wait, ~45-minute budget in the
+   Review phase and again in Cross-review, with Verify on top. A gate near the
+   expected duration would let a later Phase 1 reap a *live* run's marker, then its
+   refs, and the temp-file janitor would take its `DIFFPATH` with them — the run would
+   destroy itself. The gate measures **age since Batch B stamped the marker, not
+   inactivity** — the marker is written once and never refreshed — so a run still
+   alive a day later is outside every documented budget and is treated as dead. The
+   temp-file janitor is gated independently, on each diff file's own mtime, so
+   refreshing the marker would not cover `DIFFPATH` either way. Since this reaper
+   exists for leaks that accumulate over days, waiting a day to collect one costs
+   nothing. Do not tune it down toward the expected runtime.
 
 **Batch B — after A** (needs `HEAD_SHA` and `baseRefName`). `gh pr diff` takes no
 SHA argument, so pin the diff with `git fetch`. Refs and the diff file are
@@ -110,6 +189,13 @@ BASE="<baseRefName>"                    # from step 1 — never hardcode "main"
 DIFFPATH=$(mktemp "${TMPDIR:-/tmp}/cross-review-pr<n>.XXXXXX")   # must end in X on macOS
 SID=${DIFFPATH##*.}                     # reuse mktemp's unique suffix to scope the refs
 PRREF="refs/cr/pr<n>-$SID"; BASEREF="refs/cr/base<n>-$SID"
+# Liveness marker for Batch A step 3's reaper, written BEFORE the refs exist so no
+# concurrent reaper can ever see a ref without its marker. Keyed by <n>-$SID — mktemp
+# guarantees the full filename is unique, not the suffix, so a $SID-only key would
+# collide with a concurrent review of a DIFFERENT PR. Under the common git dir, so
+# every worktree of this clone shares one view.
+RUNS="$(git -C "<repo-path>" rev-parse --path-format=absolute --git-common-dir)/cr-runs"
+RUNMARK="$RUNS/<n>-$SID"; mkdir -p "$RUNS"; : > "$RUNMARK"
 # Fetch from the canonical repo by URL, not from `origin`: in GitHub's standard fork
 # layout `origin` is the contributor's fork, and refs/pull/* exist only on the canonical
 # repository.
@@ -119,12 +205,13 @@ git -C "<repo-path>" fetch "https://github.com/NVIDIA/aicr.git" \
 # otherwise abort before the names are ever printed, leaving them unreclaimable.
 if [ "$(git -C "<repo-path>" rev-parse "$PRREF")" != "<HEAD_SHA>" ]; then
   git -C "<repo-path>" update-ref -d "$PRREF"; git -C "<repo-path>" update-ref -d "$BASEREF"
-  find "$DIFFPATH" -maxdepth 0 -delete; echo "HEAD moved since setup — restart the review"; exit 1
+  find "$DIFFPATH" "$RUNMARK" -maxdepth 0 -delete
+  echo "HEAD moved since setup — restart the review"; exit 1
 fi
 # Echo the names FIRST: under `set -e` an empty or failing diff aborts, and any
 # echo below it would never run — leaking the refs and the temp file with a random
 # suffix nobody recorded, which Phase 5 then cannot clean up.
-echo "DIFFPATH=$DIFFPATH"; echo "PRREF=$PRREF"; echo "BASEREF=$BASEREF"
+echo "DIFFPATH=$DIFFPATH"; echo "PRREF=$PRREF"; echo "BASEREF=$BASEREF"; echo "RUNMARK=$RUNMARK"
 git -C "<repo-path>" diff "$BASEREF...$PRREF" > "$DIFFPATH"
 test -s "$DIFFPATH"                     # a real PR diff is never empty
 # repoNotes source, pinned to the BASE ref — a fork PR must not be able to rewrite
@@ -136,7 +223,7 @@ git -C "<repo-path>" show "$BASEREF":.claude/CLAUDE.md 2>/dev/null || echo "(no 
 echo "BASE_SHA=$(git -C "<repo-path>" rev-parse "$BASEREF")"
 ```
 
-Capture `DIFFPATH`, `BASE_SHA`, `PRREF`, `BASEREF` — shell variables do not persist
+Capture `DIFFPATH`, `BASE_SHA`, `PRREF`, `BASEREF`, `RUNMARK` — shell variables do not persist
 between Bash calls and Phase 5 needs the ref names.
 
 Then build `repoNotes` for the Claude reviewer only (never fed to Codex — lean-context
@@ -842,7 +929,12 @@ posting it) so no finding is left as a bare one-liner.
   earlier abort path would otherwise fail the call and skip the ref cleanup below —
   and delete the
   two scoped refs captured in Phase 1 (`git -C "<repo-path>" update-ref -d "$PRREF"`,
-  same for `"$BASEREF"` — use the exact names echoed there, not a guess). Confirm no
+  same for `"$BASEREF"` — use the exact names echoed there, not a guess) and the
+  `RUNMARK` liveness marker (`find "<the RUNMARK echoed in Phase 1>" -maxdepth 0
+  -delete 2>/dev/null || true`). Delete the marker **last**: it is what tells Phase 1
+  Batch A step 3 the refs are still in use, so removing it before the refs invites a
+  concurrent session's reaper into the gap. If this run is killed before any of it
+  runs, step 3 reaps all three on a later run. Confirm no
   `${TMPDIR:-/tmp}/cr-rabbit.*` worktree path remains in `git worktree list` — write the
   fallback out, since setup creates the worktree under `${TMPDIR:-/tmp}` and with `TMPDIR`
   unset a bare `$TMPDIR/cr-rabbit.*` names `/cr-rabbit.*` while the leak sits in `/tmp` —


### PR DESCRIPTION
## Summary

Adds a bounded reaper to the `aicr-cross-review` skill's Phase 1 so a review session killed mid-run no longer leaks its two `refs/cr/*` and its temp diff file permanently.

## Motivation / Context

Phase 1 Batch B pins each review's inputs by fetching two session-scoped refs, `refs/cr/pr<n>-<SID>` and `refs/cr/base<n>-<SID>`, where `<SID>` is the `mktemp` suffix shared with the temp diff file. Phase 5 deletes both on a clean finish, and the skill correctly forbids deleting another session's refs — a live review must not have its pinned inputs yanked.

Nothing reclaims a dead run's. One clone had accumulated 14 `refs/cr/*` plus an orphaned `${TMPDIR}/cross-review-pr*.<SID>`, the oldest from runs long finished. This is the same slow-accumulation class as the worktree leak that reached `E2BIG` at ~70 worktrees and needed a fresh session to recover. The CodeRabbit lane already reaps its `cr-rabbit.*` worktrees at 120 minutes; the ref side had no equivalent.

Fixes: N/A
Related: #2172

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.agents/skills/aicr-cross-review/SKILL.md`

## Implementation Notes

Batch B drops a liveness marker at `<common-git-dir>/cr-runs/<n>-<SID>` before creating the refs, and Phase 5 deletes it last. A new Batch A step reaps markers older than 24 hours, deletes any skill-shaped ref whose marker is gone, then reclaims stale temp diff files.

**Liveness is keyed on that marker, and both obvious alternatives are wrong.** This is the only non-trivial decision here.

- **Not the ref.** `git gc` packs `refs/cr/*` into `packed-refs`, after which the per-ref file under `.git/refs/cr/` no longer exists and an mtime gate silently stops reaping. `git fetch` — which Batch B itself runs — triggers `gc --auto`, so this is reachable in normal use, and a reaper that degrades silently is the worst shape for this class of fix. The substitutes fail too: `refs/cr/*` has no reflog, since `core.logAllRefUpdates` covers only `refs/heads`, `refs/remotes`, `refs/notes`, and `HEAD`; and `%(creatordate)` is the *commit's* date, so a ref created a minute ago on yesterday's `main` reports "21 hours ago".
- **Not the temp diff file.** `TMPDIR` is not stable across sessions, or even within one. Under the Claude Code sandbox it is `/tmp/claude-<uid>`; with the sandbox bypassed it is the shell default (`/var/folders/…/T/` on macOS). A reaper keyed on the diff file would fail to see a live session's file whenever the two disagree and would delete that session's pinned refs — precisely what the skill must never do.

The marker sits under the **common** git dir, so every worktree of a clone shares one view exactly as `refs/cr/*` do. Git ignores unknown entries there, so nothing packs or prunes it and it keeps a real creation timestamp. The temp-file `find` is now only a janitor: it reclaims diff files in whatever `TMPDIR` this session sees, and reclaiming none is harmless.

**The key is `<n>-<SID>`, not `<SID>`.** `mktemp` guarantees the full filename it returns is unique; it does not reserve the suffix. Two concurrent reviews of *different* PRs pass different templates, so both can receive the same six characters. Their refs stay distinct, but a `<SID>`-keyed marker would be a single shared file, and whichever run finished first would strip the other's protection. Reviews of the *same* PR are safe whenever they share a `TMPDIR`, since `mktemp` guarantees distinct names within one directory. It guarantees nothing across directories, so same-PR runs under different `TMPDIR` roots can still collide — but on `$SID` itself, which makes `PRREF` and `BASEREF` collide before the marker does. That is a property of how Batch B derives `$SID` on `main` today, untouched by this PR, and is left to a follow-up rather than folded in here.

**The gate is 24 hours, deliberately far above any real run.** Nothing enforces an end-to-end limit on a review: Codex gets a five-wait, ~45-minute budget in the Review phase and again in Cross-review, with Verify on top. A gate near the expected duration would let a later Phase 1 reap a *live* run's marker and then its refs, with the temp-file janitor taking its `DIFFPATH` too — the run would destroy itself. The gate measures age since Batch B stamped the marker, not inactivity — the marker is written once and never refreshed — so a run still alive a day later is outside every documented budget and is treated as dead. The temp-file janitor is gated independently, on each diff file's own mtime, so refreshing the marker would not cover `DIFFPATH` either way. Since this reaper exists for leaks that accumulate over days, waiting a day to collect one costs nothing.

**Bounds.** Deletion is gated by three checks, all load-bearing: a candidate must split into two components, carry a numeric `<n>`, and end in a six-character `<SID>`. Prefix-stripping alone would not do — `refs/cr/pr*` also matches `refs/cr/private-ABC123`, which strips to `ivate-ABC123` and would pass a suffix-only check. Hand-made bookmarks such as `refs/cr/2183-r5` and `refs/cr/2187-test` — deliberate, and often pinning active work — therefore survive unless named literally `pr<digits>-<six characters>`. The temp-file janitor is `-type f`, so a directory matching the diff-file pattern is never removed, and deletion uses `find … -delete` rather than `rm`, consistent with the rest of the skill: managed permission policies gate `rm:*` behind a confirmation prompt, and a background lane blocked on a prompt stalls the review.

No `workflow.mjs` change is needed — the refs are created and deleted entirely on the SKILL.md side.

## Testing

Doc-only change to a skill file. Nothing in `Makefile`, `tools/`, or `.github/workflows/` lints `SKILL.md`, and there are no Go, YAML, or `docs/` changes, so `make qualify` cannot regress from this and was not run.

The reaper was verified empirically in a scratch repository under every hostile condition at once: `git gc --prune=now` first, so all refs are packed and no per-ref mtime exists; `TMPDIR` exported to a path unrelated to the producer's, reproducing the cross-session mismatch; two different PRs handed the *same* `mktemp` suffix, one finished and one live; a dead run aged past the gate; a live run four hours in; hand-made bookmarks that survive prefix-stripping (`private-ABC123`, `base-line-DEPLOY`, `prod-v1beta`, `pr123456`) alongside ordinary ones; and a directory matching the janitor's diff-file pattern.

```
--- surviving refs ---
refs/cr/2183-final
refs/cr/2183-r5
refs/cr/2187-test
refs/cr/base-line-DEPLOY
refs/cr/base2195-ABC123
refs/cr/pr123456
refs/cr/pr2195-ABC123
refs/cr/pr2201-LONGAA
refs/cr/private-ABC123
refs/cr/prod-v1beta
--- janitor dir survived? ---
YES
```

Every live and deliberate ref survived; only the dead runs' refs and markers were reaped. Two results carry the weight: `pr2195-ABC123` survived while `pr2183-ABC123` was reaped, though the two shared a suffix that a `<SID>`-keyed marker would have conflated; and `private-ABC123` survived, which a suffix-only check would have deleted.

The two ref-timestamp traps were confirmed separately: `git reflog show refs/cr/...` returns nothing, and `%(creatordate)` reports the commit's date. `git rev-parse --path-format=absolute --git-common-dir` was confirmed to resolve to the same path from a linked worktree and from the main checkout, matching how `refs/cr/*` are shared. The ~45-minute-per-phase Codex wait budget behind the 24-hour gate is documented at `workflow.mjs:261`.

## Out of Scope

`$SID` is derived from `DIFFPATH`, and `mktemp` guarantees uniqueness only within a single directory. Two same-PR runs under different `TMPDIR` roots can therefore be handed the same suffix, which collides `PRREF` and `BASEREF` — one run's fetch force-updates the other's pinned refs. That is pre-existing on `main`: `DIFFPATH=$(mktemp …)`, `SID=${DIFFPATH##*.}`, and both ref assignments are unchanged by this PR, which touches only the `echo` line beneath them. Fixing it means restructuring Batch B's identity scheme, a strictly larger change than the leak this PR addresses, so it is left to a follow-up.

**Known limitation, accepted.** The temp-file janitor's `cross-review-pr*.??????` glob would also match contrived names such as `cross-review-private.ABC123`. `mktemp` cannot produce those, and this skill is the only writer of `cross-review-pr*` into `TMPDIR`, so the glob's realistic population is exactly the diff files it collects. Validating `<n>` numerically would mean converting a single `find … -delete` into a loop, which is not worth it against a failure mode of a stale scratch file surviving a day longer.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Affects only agent-facing skill instructions; no product code, no user-facing behavior.

One transition caveat, stated for completeness: refs created under the older instructions carry no marker, so the first run of the new ones reclaims them. For the leaked refs this PR is about that is exactly the intended cleanup. But a review still *in flight* under the old instructions at that moment would also lose its pinned refs and have to be restarted. The window is one-time and narrow — it closes as soon as every clone has the new instructions — and the cost is a restarted review, not lost work.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [ ] Linter passes (`make lint`) — N/A, no linted file types changed
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, skill instructions have no test harness; verified empirically, output above
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

