### PR TITLE
fix: suffix UAT artifact names with run_attempt

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -823,7 +823,7 @@ jobs:
         if: always() && steps.conformance.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-aws-evidence-pointer-${{ github.run_id }}
+          name: uat-aws-evidence-pointer-${{ github.run_id }}-${{ github.run_attempt }}
           path: evidence/pointer.yaml
           retention-days: 90
           if-no-files-found: error
@@ -861,7 +861,7 @@ jobs:
         if: failure() && steps.prep.outcome != 'skipped'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-aws-debug-${{ github.run_id }}
+          name: uat-aws-debug-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             snapshot.yaml
             recipe.yaml

--- a/.github/workflows/uat-azure.yaml
+++ b/.github/workflows/uat-azure.yaml
@@ -862,7 +862,7 @@ jobs:
         if: always() && steps.conformance.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-azure-evidence-pointer-${{ github.run_id }}
+          name: uat-azure-evidence-pointer-${{ github.run_id }}-${{ github.run_attempt }}
           path: evidence/pointer.yaml
           # Org policy caps at 90d; anything higher is silently clamped.
           retention-days: 90
@@ -890,7 +890,7 @@ jobs:
         if: failure() && (steps.prep.outcome != 'skipped' || steps.client.outcome == 'success')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-azure-debug-${{ github.run_id }}
+          name: uat-azure-debug-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             snapshot.yaml
             recipe.yaml

--- a/.github/workflows/uat-gcp.yaml
+++ b/.github/workflows/uat-gcp.yaml
@@ -759,7 +759,7 @@ jobs:
         if: always() && steps.conformance.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-gcp-evidence-pointer-${{ github.run_id }}
+          name: uat-gcp-evidence-pointer-${{ github.run_id }}-${{ github.run_attempt }}
           path: evidence/pointer.yaml
           # Org policy caps at 90d; anything higher is silently clamped.
           retention-days: 90
@@ -797,7 +797,7 @@ jobs:
         if: failure() && steps.prep.outcome != 'skipped'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-gcp-debug-${{ github.run_id }}
+          name: uat-gcp-debug-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             snapshot.yaml
             recipe.yaml

--- a/.github/workflows/uat-kind.yaml
+++ b/.github/workflows/uat-kind.yaml
@@ -305,7 +305,7 @@ jobs:
         if: always() && steps.conformance.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-kind-${{ inputs.intent }}-evidence-pointer-${{ github.run_id }}
+          name: uat-kind-${{ inputs.intent }}-evidence-pointer-${{ github.run_id }}-${{ github.run_attempt }}
           path: evidence/pointer.yaml
           retention-days: 90
           if-no-files-found: error
@@ -322,7 +322,7 @@ jobs:
         if: failure() && steps.prep.outcome != 'skipped'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: uat-kind-${{ inputs.intent }}-debug-${{ github.run_id }}
+          name: uat-kind-${{ inputs.intent }}-debug-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             snapshot.yaml
             recipe.yaml


### PR DESCRIPTION
## Summary

Suffix all 8 `upload-artifact` steps across the four UAT workflows (`uat-aws.yaml`, `uat-azure.yaml`, `uat-gcp.yaml`, `uat-kind.yaml`) with `-${{ github.run_attempt }}`, so each re-run attempt gets its own artifact name instead of colliding on `github.run_id` alone.

## Motivation / Context

Fixes: #1928
Related: N/A

`Re-run failed jobs` preserves prior-attempt artifacts, so `run_id`-only names collide into two same-named live artifacts, which both `gh run download -n` and this repo's `download_debug()` (`.agents/skills/aicr-uat-report/uat_report.py`) silently mishandle.

Verified via reproduction on a throwaway workflow (push → fail → `gh run rerun --failed`): with `run_id`-only names, two identically-named live artifacts existed after the re-run and `gh run download -n <name>` silently returned only one attempt's content. With the `run_attempt` suffix, both attempts' artifacts were independently and correctly retrievable by name.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.github/workflows/uat-{aws,azure,gcp,kind}.yaml`

## Implementation Notes

Pure artifact-naming change, no logic changes. No change needed in `uat_report.py`: `DEBUG_ARTIFACT_HINT` is a substring match on `"debug"` so it still matches the suffixed names, and the multi-artifact subdirectory branch added in #1914 already handles a run having more than one live debug artifact — it now also gets a real case to protect, where before this fix its `slug()`-keyed subdirectory would have collided for same-named artifacts from different attempts.

## Testing

```bash
# N/A - YAML-only change to workflow files, no Go/CLI code paths affected
make lint-yaml   # passes
```

Empirically reproduced and verified the fix on a throwaway workflow (not included in this PR): pushed a job that uploads then force-fails, re-ran with `gh run rerun --failed`, confirmed both pre-fix (name collision, ambiguous download) and post-fix (distinct names, both attempts cleanly retrievable) behavior. Full details in the linked issue's comments.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — pure artifact-naming change, no behavior change to test execution, no schema/API impact.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (`make lint`) — `make lint-yaml` passes
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, no new functionality
- [x] I updated docs if user-facing behavior changed — N/A, internal CI artifact naming only
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
