### PR TITLE
ci: route go-build-release through install-go-licenses

### DIFF
--- a/.github/actions/go-build-release/action.yml
+++ b/.github/actions/go-build-release/action.yml
@@ -94,23 +94,13 @@ runs:
         install_goreleaser: 'true'
         goreleaser_version: ${{ steps.validate.outputs.goreleaser_version }}
 
+    # Clearing GOFLAGS is a correctness requirement for go-licenses (see
+    # install-go-licenses/action.yml). Keep the install here centralized so the
+    # notices guard can cover all of .github/ without flagging a duplicate.
     - name: Install go-licenses
-      shell: bash
-      env:
-        GO_LICENSES_VERSION: ${{ steps.validate.outputs.go_licenses_version }}
-      run: |
-        set -euo pipefail
-        if [[ -z "${GO_LICENSES_VERSION}" ]]; then
-          echo "::error::go_licenses_version input is required"
-          exit 1
-        fi
-        # 'go install' must run outside vendor mode, otherwise it errors
-        # with "cannot find module providing package". setup-go puts
-        # $(go env GOPATH)/bin on PATH, so the binary is reachable from
-        # later steps in this job.
-        GOFLAGS= go install "github.com/google/go-licenses/v2@${GO_LICENSES_VERSION}"
-        go-licenses --help >/dev/null
-        echo "go-licenses installed: ${GO_LICENSES_VERSION}"
+      uses: ./.github/actions/install-go-licenses
+      with:
+        version: ${{ steps.validate.outputs.go_licenses_version }}
 
     - name: Authenticate to registry
       uses: ./.github/actions/ghcr-login

--- a/tools/generate-notices_test.sh
+++ b/tools/generate-notices_test.sh
@@ -49,8 +49,9 @@ if ! grep -Eq "^[[:space:]]*GOFLAGS= go install[[:space:]]+['\"]?github\.com/goo
 fi
 # The assertion above proves at least one correct install exists, not that every
 # install is correct. A second install line appended to this action without
-# GOFLAGS= would leave it green, and the workflow scan below deliberately does
-# not cover .github/actions/, so nothing else would catch it.
+# GOFLAGS= would leave it green. The .github/ scan below excludes this
+# canonical action directory, so the per-line check here is what catches a
+# second unguarded install inside install-go-licenses itself.
 #
 # Every go-licenses install line must therefore MATCH IN FULL: a GOFLAGS-cleared
 # install and nothing else, bar a trailing comment. Excluding lines that merely
@@ -78,13 +79,64 @@ fi
 # leading pattern skips commented-out lines. The quote is optional and accepts
 # either form because every install site in this repo quotes the module path: a
 # pattern requiring bare whitespace matched only a form nobody writes, and one
-# accepting just `"` still let a single-quoted install through. Only workflows
-# are scanned - the action itself is where the real `GOFLAGS= go install` lives,
-# so widening this root would flag the canonical install as a violation of itself.
-if grep -rEn "^[[:space:]]*[^#]*go install[[:space:]]+['\"]?github\.com/google/go-licenses" \
-    "${REPO_ROOT}/.github/workflows/"; then
-    echo "FAIL: a workflow installs go-licenses inline;" >&2
+# accepting just `"` still let a single-quoted install through.
+#
+# Scan all of .github/ except the canonical install-go-licenses action itself —
+# that is where the real `GOFLAGS= go install` lives, so including it would flag
+# the install this guard exists to steer people toward. Every other .github/
+# consumer (workflows and composite actions) must use the shared action.
+#
+# Exclusion is path-aware (exact canonical directory), not --exclude-dir by
+# basename: a same-named directory elsewhere under .github/ must still fail.
+CANONICAL_INSTALL_DIR="${REPO_ROOT}/.github/actions/install-go-licenses"
+found_inline=0
+while IFS= read -r match; do
+    [[ -z "${match}" ]] && continue
+    path="${match%%:*}"
+    case "${path}" in
+        "${CANONICAL_INSTALL_DIR}/"*) continue ;;
+    esac
+    echo "${match}" >&2
+    found_inline=1
+done < <(grep -rEn "^[[:space:]]*[^#]*go install[[:space:]]+['\"]?github\.com/google/go-licenses" \
+    "${REPO_ROOT}/.github/" || true)
+if [[ ${found_inline} -ne 0 ]]; then
+    echo "FAIL: a .github/ workflow or action installs go-licenses inline;" >&2
     echo "use the ./.github/actions/install-go-licenses composite action instead." >&2
+    exit 1
+fi
+
+# Regression for the basename --exclude-dir trap: a same-named directory under
+# .github/ that is NOT the canonical action must still be flagged.
+EXCLUDE_REGRESSION_TMP="$(mktemp -d "${TMPDIR:-/tmp}/aicr-notices-exclude.XXXXXX")"
+mkdir -p \
+    "${EXCLUDE_REGRESSION_TMP}/.github/actions/install-go-licenses" \
+    "${EXCLUDE_REGRESSION_TMP}/.github/workflows/install-go-licenses"
+printf '%s\n' "GOFLAGS= go install 'github.com/google/go-licenses/v2@v0.0.0'" \
+    > "${EXCLUDE_REGRESSION_TMP}/.github/actions/install-go-licenses/action.yml"
+expected_sneaky="${EXCLUDE_REGRESSION_TMP}/.github/workflows/install-go-licenses/sneaky.yml"
+printf '%s\n' "GOFLAGS= go install 'github.com/google/go-licenses/v2@v0.0.0'" \
+    > "${expected_sneaky}"
+regression_hits=0
+regression_match_path=""
+while IFS= read -r match; do
+    [[ -z "${match}" ]] && continue
+    path="${match%%:*}"
+    case "${path}" in
+        "${EXCLUDE_REGRESSION_TMP}/.github/actions/install-go-licenses/"*) continue ;;
+    esac
+    regression_match_path="${path}"
+    regression_hits=$((regression_hits + 1))
+done < <(grep -rEn "^[[:space:]]*[^#]*go install[[:space:]]+['\"]?github\.com/google/go-licenses" \
+    "${EXCLUDE_REGRESSION_TMP}/.github/" || true)
+rm -rf "${EXCLUDE_REGRESSION_TMP}"
+# hits==1 alone is ambiguous: a filter that drops sneaky.yml and keeps the
+# canonical action.yml also yields one hit. Require the surviving path.
+if [[ ${regression_hits} -ne 1 ||
+      "${regression_match_path}" != "${expected_sneaky}" ]]; then
+    echo "FAIL: path-aware install-go-licenses exclusion missed a same-named" >&2
+    echo "directory under .github/ (hits=${regression_hits}, want 1;" >&2
+    echo "path=${regression_match_path}, want ${expected_sneaky})." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Route `.github/actions/go-build-release` through the shared `install-go-licenses` composite action, and widen the notices inline-install guard from `.github/workflows/` to all of `.github/` (excluding the canonical action).

## Motivation / Context

Fixes #2165. After #2159 centralized `go-licenses` install, `go-build-release` was the last inline site, which blocked widening the guard to cover `.github/actions/`.

Fixes: #2165
Related: #2159, #2163

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: CI (`.github/actions`, `tools/generate-notices_test.sh`)

## Implementation Notes

Behavior unchanged: still clears `GOFLAGS` and installs the pinned version. The release action now consumes `./.github/actions/install-go-licenses` with `version` from its existing validate step. The notices test scan excludes `install-go-licenses/` so the canonical install is not flagged as a self-violation.

## Testing

```bash
./tools/generate-notices_test.sh
make test-shell
make lint
```

All passed locally.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Touches the release install path; no product behavior change. Validate via merge-gate notices tests / next tag release path.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — `make test-shell` covers this change
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — widened existing guard
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)