### PR TITLE
fix(bundler): reject --dynamic on local-chart argocd-helm components

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1594,7 +1594,7 @@ The `--deployer` flag controls how deployment artifacts are generated:
 |--------|-------------|
 | `helm` | (Default) Generates Helm charts with values for deployment. Supports `--dynamic`. |
 | `argocd` | Generates Argo CD Application manifests for GitOps deployment. Does **not** support `--dynamic`. |
-| `argocd-helm` | Generates a Helm chart app-of-apps for Argo CD. All non-profile-owned values overridable at install time via `helm --set`; a profiled recipe ships a lock template that rejects overrides on profile-owned paths. Use `--dynamic` to pre-populate specific paths. |
+| `argocd-helm` | Generates a Helm chart app-of-apps for Argo CD. All non-profile-owned values overridable at install time via `helm --set`; a profiled recipe ships a lock template that rejects overrides on profile-owned paths. Use `--dynamic` to pre-populate specific paths for components that resolve to remote Helm charts. `--dynamic` naming a local-chart or non-Helm component is rejected (those components bake values at bundle time and have no install-time stub surface). |
 | `flux` | Generates Flux HelmRelease manifests for GitOps deployment. Supports `--dynamic` via ConfigMap `valuesFrom`. |
 | `helmfile` | Generates a `helmfile.yaml` release graph driven by the upstream [helmfile](https://helmfile.readthedocs.io/) CLI (`helmfile apply` / `diff` / `destroy`). Supports `--dynamic` via per-release `cluster-values.yaml`. Requires the `helmfile` binary at deploy time. |
 
@@ -1997,7 +1997,7 @@ Before deploying, fill in `cluster-values.yaml` with cluster-specific values.
 
 **Argo CD deployer behavior:**
 
-The `--deployer argocd-helm` generates a Helm chart app-of-apps where all non-profile-owned values are overridable at install time. When the recipe carries a selected profile, `templates/aicr-profile-lock.yaml` fails the install if a value is supplied for a profile-owned path. Static values are baked into the chart as files; dynamic overrides are merged on top at render time. Use `--dynamic` to pre-populate specific paths in the root `values.yaml`:
+The `--deployer argocd-helm` generates a Helm chart app-of-apps where all non-profile-owned values are overridable at install time. When the recipe carries a selected profile, `templates/aicr-profile-lock.yaml` fails the install if a value is supplied for a profile-owned path. Static values are baked into the chart as files; dynamic overrides are merged on top at render time. Use `--dynamic` to pre-populate specific paths in the root `values.yaml` for components that resolve to remote Helm charts. Local-chart components (Helm with no upstream `Source`, common on OCP overlays) and non-Helm components have no install-time stub surface — `--dynamic` naming them is rejected rather than silently dropped.
 
 ```shell
 helm install aicr-bundle ./bundle \

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -742,9 +742,17 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 	}
 
 	for _, ref := range g.RecipeResult.ComponentRefs {
-		// Skip non-Helm components (Kustomize, manifest-only)
+		// Skip non-Helm components (Kustomize, manifest-only) and local
+		// charts (Helm with empty Source — values are baked at bundle time).
+		// --dynamic for those components used to be silently dropped (#1949):
+		// the request looked successful but the root values.yaml carried no
+		// stub, so install-time overrides had nowhere to land.
 		isHelmChart := ref.Type != recipe.ComponentTypeKustomize && ref.Source != ""
 		if !isHelmChart {
+			if paths, ok := g.DynamicValues[ref.Name]; ok && len(paths) > 0 {
+				return nil, 0, nil, errors.New(errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("--dynamic is not supported for component %q under --deployer argocd-helm: it resolves to a local chart or non-Helm source with no install-time values surface", ref.Name))
+			}
 			continue
 		}
 

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm.go
@@ -747,7 +747,10 @@ func (g *Generator) writeStaticValuesAndBuildStubs(outputDir string) ([]string, 
 		// --dynamic for those components used to be silently dropped (#1949):
 		// the request looked successful but the root values.yaml carried no
 		// stub, so install-time overrides had nowhere to land.
-		isHelmChart := ref.Type != recipe.ComponentTypeKustomize && ref.Source != ""
+		// HasExternalChart is the canonical classifier (Helm, case-insensitive,
+		// with a non-empty Source); a bare Type!=Kustomize check would treat
+		// an uncanonicalized "kustomize" ref as a chart and keep the silent drop.
+		isHelmChart := ref.HasExternalChart()
 		if !isHelmChart {
 			if paths, ok := g.DynamicValues[ref.Name]; ok && len(paths) > 0 {
 				return nil, 0, nil, errors.New(errors.ErrCodeInvalidRequest,

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -89,7 +89,7 @@ func TestGenerate(t *testing.T) {
 			name: "dynamic paths stubbed in root values.yaml",
 			input: &Generator{
 				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
-					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
+					{Name: "gpu-operator", Namespace: "gpu-operator", Type: recipe.ComponentTypeHelm, Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
 				}),
 				ComponentValues: map[string]map[string]any{
 					"gpu-operator": {"driver": map[string]any{"version": "580", "registry": "nvcr.io"}},
@@ -148,7 +148,7 @@ func TestGenerate(t *testing.T) {
 			name: "transformed template uses values",
 			input: &Generator{
 				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
-					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
+					{Name: "gpu-operator", Namespace: "gpu-operator", Type: recipe.ComponentTypeHelm, Source: "https://helm.ngc.nvidia.com/nvidia", Chart: "gpu-operator", Version: "v24.9.0"},
 				}),
 				ComponentValues: map[string]map[string]any{
 					"gpu-operator": {"driver": map[string]any{"version": "580"}},
@@ -189,7 +189,7 @@ func TestGenerate(t *testing.T) {
 			name: "deployment steps reference helm install",
 			input: &Generator{
 				RecipeResult: newRecipeResult("1.0.0", []recipe.ComponentRef{
-					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1.0.0"},
+					{Name: "gpu-operator", Namespace: "gpu-operator", Type: recipe.ComponentTypeHelm, Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1.0.0"},
 				}),
 				ComponentValues: map[string]map[string]any{"gpu-operator": {}},
 				Version:         "test",
@@ -214,7 +214,7 @@ func TestGenerate(t *testing.T) {
 			name: "Chart.yaml has correct version from recipe",
 			input: &Generator{
 				RecipeResult: newRecipeResult("2.5.0", []recipe.ComponentRef{
-					{Name: "gpu-operator", Namespace: "gpu-operator", Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1.0.0"},
+					{Name: "gpu-operator", Namespace: "gpu-operator", Type: recipe.ComponentTypeHelm, Source: "https://charts.example.com", Chart: "gpu-operator", Version: "v1.0.0"},
 				}),
 				ComponentValues: map[string]map[string]any{"gpu-operator": {}},
 				Version:         "test",

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -958,6 +958,43 @@ func TestGenerate_DataFiles(t *testing.T) {
 	}
 }
 
+// TestGenerate_DynamicRejectedForLocalChart verifies --dynamic fails closed
+// when the named component is a local chart (Helm with empty Source). Before
+// #1949 the request was silently dropped: Generate exited 0 and the root
+// values.yaml carried no stub, so install-time overrides had nowhere to land.
+func TestGenerate_DynamicRejectedForLocalChart(t *testing.T) {
+	localManifest := map[string][]byte{
+		"nfd.yaml": []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nfd\n"),
+	}
+	gen := &Generator{
+		RecipeResult: newRecipeResult("v1.0.0", []recipe.ComponentRef{
+			{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm, Source: ""},
+		}),
+		ComponentValues: map[string]map[string]any{
+			"nfd-ocp": {"image": map[string]any{"tag": "v1"}},
+		},
+		ComponentPostManifests: map[string]map[string][]byte{
+			"nfd-ocp": localManifest,
+		},
+		Version: "test",
+		RepoURL: "https://github.com/example/repo.git",
+		DynamicValues: map[string][]string{
+			"nfd-ocp": {"image.tag"},
+		},
+	}
+
+	_, err := gen.Generate(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("Generate() error = nil, want ErrCodeInvalidRequest for --dynamic on local chart")
+	}
+	if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+		t.Fatalf("Generate() error code = %v, want ErrCodeInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "nfd-ocp") || !strings.Contains(err.Error(), "--dynamic") {
+		t.Fatalf("Generate() error = %v, want mention of --dynamic and component name", err)
+	}
+}
+
 // TestGenerate_StaticDirCreatedOnlyWhenPopulated verifies that static/ is
 // emitted only when at least one component contributes a values file.
 //

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -963,35 +963,56 @@ func TestGenerate_DataFiles(t *testing.T) {
 // #1949 the request was silently dropped: Generate exited 0 and the root
 // values.yaml carried no stub, so install-time overrides had nowhere to land.
 func TestGenerate_DynamicRejectedForLocalChart(t *testing.T) {
-	localManifest := map[string][]byte{
-		"nfd.yaml": []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nfd\n"),
+	tests := []struct {
+		name string
+		ref  recipe.ComponentRef
+	}{
+		{
+			name: "local helm chart empty source",
+			ref:  recipe.ComponentRef{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm, Source: ""},
+		},
+		{
+			// HasExternalChart is case-insensitive for Helm; a lowercase
+			// "kustomize" must not be mistaken for a remote chart just because
+			// Source is set (the pre-#1949 Type!=Kustomize check would).
+			name: "uncanonicalized kustomize with source",
+			ref: recipe.ComponentRef{
+				Name: "nfd-ocp", Namespace: "nfd",
+				Type: recipe.ComponentType("kustomize"), Source: "https://example.com/overlay",
+			},
+		},
 	}
-	gen := &Generator{
-		RecipeResult: newRecipeResult("v1.0.0", []recipe.ComponentRef{
-			{Name: "nfd-ocp", Namespace: "nfd", Type: recipe.ComponentTypeHelm, Source: ""},
-		}),
-		ComponentValues: map[string]map[string]any{
-			"nfd-ocp": {"image": map[string]any{"tag": "v1"}},
-		},
-		ComponentPostManifests: map[string]map[string][]byte{
-			"nfd-ocp": localManifest,
-		},
-		Version: "test",
-		RepoURL: "https://github.com/example/repo.git",
-		DynamicValues: map[string][]string{
-			"nfd-ocp": {"image.tag"},
-		},
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localManifest := map[string][]byte{
+				"nfd.yaml": []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nfd\n"),
+			}
+			gen := &Generator{
+				RecipeResult: newRecipeResult("v1.0.0", []recipe.ComponentRef{tt.ref}),
+				ComponentValues: map[string]map[string]any{
+					"nfd-ocp": {"image": map[string]any{"tag": "v1"}},
+				},
+				ComponentPostManifests: map[string]map[string][]byte{
+					"nfd-ocp": localManifest,
+				},
+				Version: "test",
+				RepoURL: "https://github.com/example/repo.git",
+				DynamicValues: map[string][]string{
+					"nfd-ocp": {"image.tag"},
+				},
+			}
 
-	_, err := gen.Generate(context.Background(), t.TempDir())
-	if err == nil {
-		t.Fatal("Generate() error = nil, want ErrCodeInvalidRequest for --dynamic on local chart")
-	}
-	if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
-		t.Fatalf("Generate() error code = %v, want ErrCodeInvalidRequest", err)
-	}
-	if !strings.Contains(err.Error(), "nfd-ocp") || !strings.Contains(err.Error(), "--dynamic") {
-		t.Fatalf("Generate() error = %v, want mention of --dynamic and component name", err)
+			_, err := gen.Generate(context.Background(), t.TempDir())
+			if err == nil {
+				t.Fatal("Generate() error = nil, want ErrCodeInvalidRequest for --dynamic on unsupported component")
+			}
+			if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("Generate() error code = %v, want ErrCodeInvalidRequest", err)
+			}
+			if !strings.Contains(err.Error(), "nfd-ocp") || !strings.Contains(err.Error(), "--dynamic") {
+				t.Fatalf("Generate() error = %v, want mention of --dynamic and component name", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fail closed when `--dynamic` names a local-chart or non-Helm component under `--deployer argocd-helm`, instead of silently dropping the request.

## Motivation / Context

Fixes #1949. Components with empty `Source` (OCP local charts) skip the stub path in `writeStaticValuesAndBuildStubs`; before this change `aicr bundle` exited 0 with no install-time surface for those paths.

Fixes: #1949
Related: #1942, #1944, #1947

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Smallest option from the issue: reject loudly. Documents the local-chart exclusion in `cli-reference.md`. Does not emit stubs for local charts (option 3) — that would need a larger install-time surface design.

## Testing

```bash
go test -race ./pkg/bundler/deployer/argocdhelm/...
golangci-lint run -c .golangci.yaml ./pkg/bundler/deployer/argocdhelm/...
./tools/check-docs-mdx
```

All passed locally. Added `TestGenerate_DynamicRejectedForLocalChart`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Callers that previously relied on the silent no-op for `--dynamic` on local charts will now get `ErrCodeInvalidRequest`. That is intentional fail-closed behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — package tests with `-race`
- [x] Linter passes (`make lint`) — golangci-lint on affected package + MDX
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)