### PR TITLE
test(releasepolicy): fix flaky blocked-command timing assertions

### DIFF
--- a/tests/releasepolicy/release_scripts_test.go
+++ b/tests/releasepolicy/release_scripts_test.go
@@ -1366,22 +1366,32 @@ func TestReleaseHomebrewBehavior(t *testing.T) {
 	}
 }
 
+// blockedCommandTimeoutSeconds is the AICR_NETWORK_TIMEOUT_SECONDS value the
+// blocked-command subtests configure. blockedCommandBudget scales the wall-clock
+// assertion off it with generous headroom: the elapsed time also covers shell
+// startup and process spawning, so a tight bound only produces flakes under
+// load. The assertion exists solely to catch an indefinite hang — the "script
+// failed" and "artifact not mutated" assertions prove the real behavior.
+const (
+	blockedCommandTimeoutSeconds = 1
+	blockedCommandBudget         = 10 * blockedCommandTimeoutSeconds * time.Second
+)
+
 func TestReleaseNetworkBoundsTerminateBlockedCommands(t *testing.T) {
-	t.Parallel()
 	t.Run("candidate resolver", func(t *testing.T) {
-		t.Parallel()
 		fixture := newReleaseFixture(t)
 		writeExecutable(t, filepath.Join(fixture.bin, "timeout"), fakeTimeout)
 		writeExecutable(t, filepath.Join(fixture.bin, "crane"), blockingCommand)
 		output := filepath.Join(fixture.dir, "digests.json")
-		environment := append(fixture.environment(), "AICR_NETWORK_TIMEOUT_SECONDS=1")
+		environment := append(fixture.environment(),
+			fmt.Sprintf("AICR_NETWORK_TIMEOUT_SECONDS=%d", blockedCommandTimeoutSeconds))
 		started := time.Now()
 		result := runScript(t, environment, ".github/scripts/release-images.sh", "resolve", output)
 		if result.err == nil {
 			t.Fatal("resolver accepted a blocked registry command")
 		}
-		if elapsed := time.Since(started); elapsed > 4*time.Second {
-			t.Errorf("resolver timeout took %s, want under 4s", elapsed)
+		if elapsed := time.Since(started); elapsed > blockedCommandBudget {
+			t.Errorf("resolver timeout took %s, want under %s", elapsed, blockedCommandBudget)
 		}
 		if _, err := os.Stat(output); !os.IsNotExist(err) {
 			t.Errorf("timed-out resolver published output: %v", err)
@@ -1392,7 +1402,6 @@ func TestReleaseNetworkBoundsTerminateBlockedCommands(t *testing.T) {
 	})
 
 	t.Run("Homebrew checksum fetch", func(t *testing.T) {
-		t.Parallel()
 		dir := t.TempDir()
 		bin := filepath.Join(dir, "bin")
 		formulaDir := filepath.Join(dir, "tap", "Formula")
@@ -1416,15 +1425,15 @@ func TestReleaseNetworkBoundsTerminateBlockedCommands(t *testing.T) {
 		environment := append(os.Environ(),
 			"PATH="+bin+":"+os.Getenv("PATH"),
 			"RELEASE_TAG=v1.2.3",
-			"AICR_NETWORK_TIMEOUT_SECONDS=1",
+			fmt.Sprintf("AICR_NETWORK_TIMEOUT_SECONDS=%d", blockedCommandTimeoutSeconds),
 		)
 		started := time.Now()
 		result := runScript(t, environment, ".github/scripts/publish-homebrew.sh", candidate, filepath.Join(dir, "tap"))
 		if result.err == nil {
 			t.Fatal("Homebrew publisher accepted a blocked checksum request")
 		}
-		if elapsed := time.Since(started); elapsed > 4*time.Second {
-			t.Errorf("Homebrew timeout took %s, want under 4s", elapsed)
+		if elapsed := time.Since(started); elapsed > blockedCommandBudget {
+			t.Errorf("Homebrew timeout took %s, want under %s", elapsed, blockedCommandBudget)
 		}
 		if got := readOptional(t, destination); got != existing {
 			t.Error("timed-out checksum request modified the tap")


### PR DESCRIPTION
## Summary

Scale the wall-clock bound in `TestReleaseNetworkBoundsTerminateBlockedCommands` off the configured network timeout instead of hardcoding 4s, and run its two timing subtests serially.

## Motivation / Context

Both subtests set `AICR_NETWORK_TIMEOUT_SECONDS=1` and then asserted elapsed `< 4*time.Second`. The measured elapsed time also covers shell startup, process spawning, and the fake `timeout`/`curl`, so under concurrent machine load the overhead alone blew the budget — observed failures at 4.35s, 4.26s, and 5.33s, while the subtests pass in ~2s when run isolated. Busy CI runners are exposed to the same contention.

The bound was also doing almost no work. The assertions on either side of it already prove the real behavior: `result.err == nil` fails the test if the script accepted the blocked request, and a separate check confirms the tap (or resolver output) was not modified. The timing assertion can only detect an indefinite hang, and 4s on a 1s timeout left no headroom for that to be a useful signal.

Fixes: N/A
Related: #2152 (parallelized these subtests)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: tests (`tests/releasepolicy`)

## Implementation Notes

- Added `blockedCommandTimeoutSeconds = 1` and `blockedCommandBudget = 10 * blockedCommandTimeoutSeconds * time.Second`. Both subtests now derive the env var *and* the assertion from the same constants, so changing the timeout keeps the bound proportional.
- A comment records why the headroom is generous: the assertion's only detectable failure mode is an indefinite hang, so 10x costs no coverage.
- Dropped `t.Parallel()` from the two timing subtests and their parent (36 -> 33 `t.Parallel()` calls in the file; nothing else was touched). This partly reverts #2152 for these two subtests.

**Removing the parallelism costs nothing — it is faster here, not slower.** The obvious objection is that this trades speed for stability, but measurement says otherwise. The dominant contention was the package's own 30+ parallel subtests competing for process spawn, not external load, so serializing these two makes them *finish sooner*: 1.4s/1.5s serial versus 4-5s parallel under load. Package wall-clock time does not regress.

## Testing

```bash
go test ./tests/releasepolicy/ -run TestReleaseNetworkBoundsTerminateBlockedCommands
go test -race ./tests/releasepolicy/
golangci-lint run -c .golangci.yaml ./tests/releasepolicy/...
```

- Targeted test: PASS; subtests 1.39s and 1.53s against the 10s budget (~7x headroom).
- Full package with `-race`: PASS (53.2s). Full package `-count=1`: PASS (50.5s).
- Lint: 0 issues.

**Flake reproduced on the base commit and confirmed fixed.** Running the pre-change version of this file on the same machine under the same load reproduces the failure exactly:

```
--- FAIL: TestReleaseNetworkBoundsTerminateBlockedCommands/candidate_resolver (5.05s)
    release_scripts_test.go:1384: resolver timeout took 5.006141417s, want under 4s
--- FAIL: TestReleaseNetworkBoundsTerminateBlockedCommands/Homebrew_checksum_fetch (5.22s)
    release_scripts_test.go:1427: Homebrew timeout took 5.124353417s, want under 4s
```

The changed version passes in the same conditions at 1.39s/1.53s. These match the originally reported failures (4.35s, 4.26s, 5.33s).

**Full `make qualify` was run.** Every test stage passed, including the package this PR fixes:

```
ok  github.com/NVIDIA/aicr/tests/releasepolicy  77.579s
```

That run is itself a useful signal: `tests/releasepolicy` is the package whose timing assertions were flaking, and it passed under the sustained load of a full gate — the same conditions that produced the original failures.

The gate exited non-zero on `lint-go`, which is an artifact of the local checkout rather than a finding against this change. Every reported issue resolved to `../nvsentinel-detect/` — a sibling git worktree holding an unrelated branch — because `./...` walked out of the worktree into its neighbour. None were in `release_scripts_test.go`, the only file this PR touches. Scoped to the real package, lint is clean:

```
$ golangci-lint run -c .golangci.yaml ./tests/releasepolicy/...
0 issues.
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — test-only change, no production behavior affected.

## Checklist

- [x] Tests pass locally (scoped `go test -race ./tests/releasepolicy/`, and full `make qualify`)
- [x] Linter passes (`golangci-lint run -c .golangci.yaml ./tests/releasepolicy/...` — 0 issues)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (N/A — fixes an existing test)
- [ ] I updated docs if user-facing behavior changed (N/A — no user-facing change)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

