### PR TITLE
fix(evidence): gate verdicts on cleanup and stop over-claiming

### DIFF
--- a/pkg/evidence/cncf/result_propagation_test.go
+++ b/pkg/evidence/cncf/result_propagation_test.go
@@ -248,6 +248,101 @@ case "${mode}" in
     autoscaler-absent)
         SECTION="cluster-autoscaling"
         ;;
+    dynamo-dispatch-list-failed)
+        # Drives the REAL collect_service_metrics dispatcher (no override): the
+        # Dynamo pod list fails while the namespace exists. The dispatcher must
+        # route to the Dynamo collector so the failure surfaces, rather than
+        # falling through to NIM/trainer and emitting unrelated evidence.
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            case " $* " in
+                *"dynamo-component-type=worker"*) return 1 ;;
+                *" get namespace dynamo-workload "*) return 0 ;;
+            esac
+            return 0
+        }
+        SECTION="service-metrics"
+        ;;
+    dynamo-dispatch-both-queries-failed)
+        # Both Dynamo probes fail (cluster-wide read failure: RBAC revoked,
+        # expired credentials, apiserver outage). The namespace state cannot be
+        # classified, so the dispatcher must NOT read that as "no workload" and
+        # fall through to NIM/trainer — it routes to Dynamo, which fails closed.
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            case " $* " in
+                *"dynamo-component-type=worker"*) return 1 ;;
+                *" get namespace dynamo-workload "*)
+                    echo "Error from server (Forbidden): namespaces \"dynamo-workload\" is forbidden" >&2
+                    return 1 ;;
+            esac
+            return 0
+        }
+        SECTION="service-metrics"
+        ;;
+    dynamo-workload-absent)
+        # No worker pods: the section MEASURES an existing workload and must
+        # never deploy one, so an absent workload is an absent prerequisite
+        # (SKIP), not a cue to apply the manifest.
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            return 0
+        }
+        collect_service_metrics() {
+            EVIDENCE_FILE="${EVIDENCE_DIR}/ai-service-metrics.md"
+            collect_service_metrics_dynamo
+        }
+        SECTION="service-metrics"
+        ;;
+    dynamo-workload-list-failed)
+        # The pod list fails: a read error must fail closed rather than be
+        # flattened into "no workload present".
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            case " $* " in
+                *"dynamo-component-type=worker"*) return 1 ;;
+            esac
+            return 0
+        }
+        collect_service_metrics() {
+            EVIDENCE_FILE="${EVIDENCE_DIR}/ai-service-metrics.md"
+            collect_service_metrics_dynamo
+        }
+        SECTION="service-metrics"
+        ;;
+    hpa-scaled-cleanup-ok|hpa-scaled-cleanup-failed)
+        # Both lanes observe a real scale-up (replicas>1 with a current metric),
+        # so hpa_scaled is true and the ONLY difference is whether the test
+        # namespace could be deleted. The section must not report PASS while its
+        # unbounded CUDA workload may still be running, so the cleanup lane has
+        # to flip the verdict to FAIL — and the control lane proves the FAIL is
+        # attributable to cleanup rather than to a stub that never passes.
+        kubectl() {
+            if [ "${1:-}" = "cluster-info" ]; then
+                return 0
+            fi
+            case " $* " in
+                *"averageValue"*) echo "75" ;;
+                *"currentReplicas"*) echo "2" ;;
+            esac
+            return 0
+        }
+        sleep() { return 0; }
+        if [ "${mode}" = "hpa-scaled-cleanup-failed" ]; then
+            cleanup_ns() { return 1; }
+        else
+            cleanup_ns() { return 0; }
+        fi
+        SECTION="hpa"
+        ;;
     dynamo-unhealthy)
         kubectl() {
             if [ "${1:-}" = "cluster-info" ]; then
@@ -527,6 +622,58 @@ func TestEvidenceResultPropagatesThroughCollector(t *testing.T) {
 			wantErr:        true,
 		},
 		{
+			name:              "dispatcher routes a failed Dynamo list to the Dynamo collector",
+			mode:              "dynamo-dispatch-list-failed",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "FAIL",
+			wantEvidence:      "the workload state is unknown",
+			singleVerdictFile: "ai-service-metrics.md",
+			wantErr:           true,
+		},
+		{
+			name:              "unclassifiable Dynamo namespace state fails closed",
+			mode:              "dynamo-dispatch-both-queries-failed",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "FAIL",
+			wantEvidence:      "the workload state is unknown",
+			singleVerdictFile: "ai-service-metrics.md",
+			wantErr:           true,
+		},
+		{
+			name:              "absent Dynamo workload skips instead of deploying",
+			mode:              "dynamo-workload-absent",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "SKIP",
+			wantEvidence:      "no running Dynamo workload in dynamo-workload",
+			singleVerdictFile: "ai-service-metrics.md",
+		},
+		{
+			name:              "Dynamo worker pod list failure fails closed",
+			mode:              "dynamo-workload-list-failed",
+			displayName:       "AI Service Metrics",
+			wantStatus:        "FAIL",
+			wantEvidence:      "the workload state is unknown",
+			singleVerdictFile: "ai-service-metrics.md",
+			wantErr:           true,
+		},
+		{
+			name:              "HPA scale-up with successful cleanup is pass",
+			mode:              "hpa-scaled-cleanup-ok",
+			displayName:       "Pod Autoscaling (HPA)",
+			wantStatus:        "PASS",
+			singleVerdictFile: "pod-autoscaling.md",
+			wantErr:           false,
+		},
+		{
+			name:              "HPA scale-up with failed cleanup is fail",
+			mode:              "hpa-scaled-cleanup-failed",
+			displayName:       "Pod Autoscaling (HPA)",
+			wantStatus:        "FAIL",
+			wantEvidence:      "the hpa-test namespace could not be deleted",
+			singleVerdictFile: "pod-autoscaling.md",
+			wantErr:           true,
+		},
+		{
 			name:              "present but unhealthy Dynamo is fail",
 			mode:              "dynamo-unhealthy",
 			displayName:       "AI Service Metrics",
@@ -598,6 +745,16 @@ func TestEvidenceResultPropagatesThroughCollector(t *testing.T) {
 					t.Fatalf("write trainer manifest fixture: %v", err)
 				}
 			}
+			if strings.HasPrefix(tt.mode, "hpa-") {
+				manifestDir := filepath.Join(dir, "manifests")
+				if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+					t.Fatalf("create manifest directory: %v", err)
+				}
+				manifestPath := filepath.Join(manifestDir, "hpa-gpu-test.yaml")
+				if err := os.WriteFile(manifestPath, []byte("---\n"), 0o600); err != nil {
+					t.Fatalf("write HPA manifest fixture: %v", err)
+				}
+			}
 			if strings.HasPrefix(tt.mode, "gang-") {
 				manifestDir := filepath.Join(dir, "manifests")
 				if err := os.MkdirAll(manifestDir, 0o755); err != nil {
@@ -652,7 +809,13 @@ func TestEvidenceResultPropagatesThroughCollector(t *testing.T) {
 				t.Errorf("result = %q, want %q", got, want)
 			}
 			if tt.wantEvidence != "" {
-				evidencePath := filepath.Join(outputDir, "ai-service-metrics.md")
+				// Assert against the artifact the case names, falling back to
+				// the service-metrics file the original lanes all used.
+				evidenceName := tt.singleVerdictFile
+				if evidenceName == "" {
+					evidenceName = "ai-service-metrics.md"
+				}
+				evidencePath := filepath.Join(outputDir, evidenceName)
 				evidence, evidenceErr := os.ReadFile(evidencePath)
 				if evidenceErr != nil {
 					t.Fatalf("read evidence artifact: %v", evidenceErr)

--- a/pkg/evidence/cncf/scripts/collect-evidence.sh
+++ b/pkg/evidence/cncf/scripts/collect-evidence.sh
@@ -207,8 +207,15 @@ cleanup_ns() {
     kubectl delete pods --all -n "$ns" --ignore-not-found --wait=true --timeout=30s &>/dev/null || true
     # Delete resourceclaims (finalizer removed after pod deletion)
     kubectl delete resourceclaims --all -n "$ns" --ignore-not-found --wait=true --timeout=30s &>/dev/null || true
-    # Now namespace can terminate cleanly
-    kubectl delete namespace "$ns" --ignore-not-found --timeout=60s &>/dev/null || true
+    # Now namespace can terminate cleanly. Unlike the best-effort deletes above
+    # (the namespace delete cascades them anyway), this result is returned to
+    # the caller: a refused namespace delete can leave a GPU workload running,
+    # which a section's verdict must not report as a clean PASS.
+    if ! kubectl delete namespace "$ns" --ignore-not-found --timeout=60s &>/dev/null; then
+        log_warn "Failed to delete namespace ${ns} — resources may still be running"
+        return 1
+    fi
+    return 0
 }
 
 # ensure_fresh_namespace deletes any prior run's namespace and VERIFIES it is
@@ -1759,7 +1766,31 @@ collect_service_metrics() {
     local dynamo_ns="dynamo-workload"
     local nim_ns="nim-workload"
 
-    if kubectl get pods -n "${dynamo_ns}" -l nvidia.com/dynamo-component-type=worker --no-headers 2>/dev/null | grep -q .; then
+    # Probe Dynamo with the status captured, not through a `| grep -q .`
+    # pipeline: a pipeline's status is grep's, so an RBAC, auth, or API error
+    # would be indistinguishable from "no workload" and would silently fall
+    # through to the NIM or trainer path — producing unrelated evidence after a
+    # failed read. A read failure is routed to the Dynamo collector, which
+    # fails closed.
+    local dynamo_pods="" dynamo_rc=0 route_dynamo=false
+    dynamo_pods=$(kubectl get pods -n "${dynamo_ns}" -l nvidia.com/dynamo-component-type=worker --no-headers 2>/dev/null) || dynamo_rc=$?
+    if [ "${dynamo_rc}" -ne 0 ]; then
+        # The pod list failed. ONLY a namespace confirmed absent means "no Dynamo
+        # workload here"; every other outcome — the namespace exists, or the
+        # namespace probe itself fails — is routed to the Dynamo collector so it
+        # fails closed. Falling through on an unclassifiable error would emit
+        # unrelated NIM or trainer evidence after a cluster-wide read failure.
+        local ns_err=""
+        if ns_err=$(kubectl get namespace "${dynamo_ns}" 2>&1 >/dev/null); then
+            route_dynamo=true
+        elif ! printf '%s' "${ns_err}" | grep -qi 'not found'; then
+            route_dynamo=true
+        fi
+    elif [ -n "${dynamo_pods}" ]; then
+        route_dynamo=true
+    fi
+
+    if [ "${route_dynamo}" = "true" ]; then
         collect_service_metrics_dynamo
     elif kubectl get pods -n "${nim_ns}" -l app.kubernetes.io/managed-by=k8s-nim-operator --no-headers 2>/dev/null | grep -q .; then
         collect_service_metrics_nim
@@ -1783,20 +1814,27 @@ for automatic target discovery.
 EOF
 
     local NS="dynamo-workload"
-    local deployed_dynamo=false
 
-    # Deploy Dynamo workload if not already running
-    if ! kubectl get pods -n "${NS}" -l nvidia.com/dynamo-component-type=worker --no-headers 2>/dev/null | grep -q .; then
-        local manifest="${SCRIPT_DIR}/manifests/dynamo-vllm-agg.yaml"
-        if [ -f "${manifest}" ]; then
-            log_info "Deploying Dynamo vLLM workload from embedded manifest..."
-            kubectl apply -f "${manifest}"
-            deployed_dynamo=true
-        else
-            log_warn "No Dynamo workload running and manifest not found at ${manifest}"
-            echo "**Result: SKIP (prerequisite absent)** — no Dynamo workload or deployment manifest was found." >> "${EVIDENCE_FILE}"
-            return
-        fi
+    # This section MEASURES an existing Dynamo workload; it never deploys one.
+    # collect_service_metrics routes here only when worker pods are already
+    # running, so a deploy-if-absent path could never execute — and deploying a
+    # workload the section would then have to tear down risks destroying
+    # user-owned resources (the manifest carries a cluster-scoped Queue).
+    # Deploying is the operator's step, documented under Cleanup below.
+    #
+    # A failed read must not be flattened into "absent": a transient API error
+    # would otherwise be reported as a missing prerequisite.
+    local worker_pods="" pods_rc=0
+    worker_pods=$(kubectl get pods -n "${NS}" -l nvidia.com/dynamo-component-type=worker --no-headers 2>/dev/null) || pods_rc=$?
+    if [ "${pods_rc}" -ne 0 ]; then
+        log_error "Could not list Dynamo worker pods in ${NS} (exit ${pods_rc})"
+        echo "**Result: FAIL** — could not list Dynamo worker pods in ${NS} (kubectl exit ${pods_rc}); the workload state is unknown." >> "${EVIDENCE_FILE}"
+        return
+    fi
+    if [ -z "${worker_pods}" ]; then
+        log_warn "No Dynamo worker pods running in ${NS}"
+        echo "**Result: SKIP (prerequisite absent)** — no running Dynamo workload in ${NS}; deploy one (see Cleanup below) to collect inference metrics evidence." >> "${EVIDENCE_FILE}"
+        return
     fi
 
     # Wait for Dynamo workload pods to be ready (poll every 15s, up to 5 minutes)
@@ -1981,19 +2019,18 @@ for r in data['data']['result']:
     fi
     kill "${pf_pid}" 2>/dev/null || true
 
-    # Cleanup deployed workload if we created it
-    if [ "${deployed_dynamo}" = "true" ] && [ "${NO_CLEANUP}" != "true" ]; then
-        log_info "Cleaning up deployed Dynamo workload..."
-        kubectl delete -f "${SCRIPT_DIR}/manifests/dynamo-vllm-agg.yaml" --ignore-not-found 2>/dev/null || true
-    fi
-
-    # Always document cleanup steps
+    # No cleanup: this section deploys nothing, so it owns nothing to delete.
+    # The workload it measures belongs to whoever deployed it.
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 
-## Cleanup
+## Workload Lifecycle
 
-**Delete workload namespace**
+This section measures a Dynamo workload that is already running; it neither
+deploys nor deletes one, so it leaves no residue on the cluster. To provision a
+workload for this evidence, and to remove it afterwards:
+
 ```
+$ kubectl apply -f manifests/dynamo-vllm-agg.yaml
 $ kubectl delete ns dynamo-workload
 ```
 EOF
@@ -2421,7 +2458,8 @@ with an implementation for advanced traffic management for inference services.
 3. **Gateway API CRDs** — All present (GatewayClass, Gateway, HTTPRoute, GRPCRoute, ReferenceGrant)
 4. **Active Gateway** — `inference-gateway` with class `agentgateway`, programmed with a load balancer address
 5. **Inference Extension CRDs** — InferencePool, InferenceObjective, InferenceModelRewrite installed
-6. **Result: PASS**
+
+The result is stated by the verdict line at the end of this section, after the checks run.
 
 ---
 
@@ -2772,12 +2810,17 @@ INVALID_CR
     echo "" >> "${EVIDENCE_FILE}"
     local crd_count
     crd_count=$(kubectl get crds 2>/dev/null | grep -c "apps\.nvidia\.com" || true)
-    local running_pods
-    running_pods=$(kubectl get pods -n "${nim_ns}" -l app.kubernetes.io/managed-by=k8s-nim-operator --no-headers 2>/dev/null | grep -c "Running" || true)
+    # Count pods with Ready=True, not phase Running: a Running pod may be 0/1
+    # ready (model still loading, or a persistent readiness failure), so a
+    # phase-based count can certify unready inference workloads as healthy.
+    local ready_pods
+    ready_pods=$(kubectl get pods -n "${nim_ns}" -l app.kubernetes.io/managed-by=k8s-nim-operator \
+        -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null \
+        | grep -c '^True$' || true)
 
-    if [ "${crd_count}" -gt 0 ] && [ "${running_pods}" -gt 0 ] && [ "${webhook_ok}" -gt 0 ]; then
-        echo "**Result: PASS** — NIM operator running, webhooks operational (webhook-attributed rejection verified), ${crd_count} CRDs registered, NIMService reconciled with ${running_pods} healthy inference pod(s)." >> "${EVIDENCE_FILE}"
-    elif [ "${crd_count}" -gt 0 ] && [ "${running_pods}" -gt 0 ]; then
+    if [ "${crd_count}" -gt 0 ] && [ "${ready_pods}" -gt 0 ] && [ "${webhook_ok}" -gt 0 ]; then
+        echo "**Result: PASS** — NIM operator running, webhooks operational (webhook-attributed rejection verified), ${crd_count} CRDs registered, NIMService reconciled with ${ready_pods} healthy inference pod(s)." >> "${EVIDENCE_FILE}"
+    elif [ "${crd_count}" -gt 0 ] && [ "${ready_pods}" -gt 0 ]; then
         echo "**Result: FAIL** — NIM operator running and NIMService reconciled, but a webhook-attributed rejection was not demonstrated (see the webhook test above)." >> "${EVIDENCE_FILE}"
     elif [ "${crd_count}" -gt 0 ]; then
         echo "**Result: FAIL** — NIMService found but no healthy inference pods." >> "${EVIDENCE_FILE}"
@@ -2916,8 +2959,13 @@ INVALID_CR
     else
         dgd_query_ok=false
     fi
-    local running_pods
-    running_pods=$(kubectl get pods -n dynamo-workload -l nvidia.com/dynamo-graph-deployment-name --no-headers 2>/dev/null | grep -c "Running" || true)
+    # Count pods with Ready=True, not phase Running: a Running pod may be 0/1
+    # ready (model still loading, or a persistent readiness failure), so a
+    # phase-based count can certify unready workloads as reconciled.
+    local ready_pods
+    ready_pods=$(kubectl get pods -n dynamo-workload -l nvidia.com/dynamo-graph-deployment-name \
+        -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null \
+        | grep -c '^True$' || true)
 
     if [ "${dgd_query_ok}" != "true" ]; then
         echo "**Result: FAIL** — DynamoGraphDeployment query failed (fail closed); rerun against a reachable API server." >> "${EVIDENCE_FILE}"
@@ -2927,8 +2975,8 @@ INVALID_CR
         # state on a stock inference cluster) must not convert an observed
         # webhook failure into a non-failing SKIP.
         echo "**Result: FAIL** — a webhook-attributed rejection was not demonstrated (see the webhook test above); operational webhooks are required regardless of whether a workload DynamoGraphDeployment exists." >> "${EVIDENCE_FILE}"
-    elif [ "${dgd_count}" -gt 0 ] && [ "${running_pods}" -gt 0 ]; then
-        echo "**Result: PASS** — Dynamo operator running, webhooks operational (webhook-attributed rejection verified), CRDs registered, DynamoGraphDeployment reconciled with ${running_pods} healthy workload pod(s)." >> "${EVIDENCE_FILE}"
+    elif [ "${dgd_count}" -gt 0 ] && [ "${ready_pods}" -gt 0 ]; then
+        echo "**Result: PASS** — Dynamo operator running, webhooks operational (webhook-attributed rejection verified), CRDs registered, DynamoGraphDeployment reconciled with ${ready_pods} healthy workload pod(s)." >> "${EVIDENCE_FILE}"
     elif [ "${dgd_count}" -gt 0 ]; then
         echo "**Result: FAIL** — DynamoGraphDeployment found but no healthy workload pods." >> "${EVIDENCE_FILE}"
     else
@@ -2955,7 +3003,8 @@ utilizing accelerators, including the ability to scale based on custom GPU metri
 3. **GPU Stress Workload** — Deployment running CUDA N-Body Simulation to generate GPU load
 4. **HPA Configuration** — Targets `gpu_utilization` with threshold of 50%
 5. **HPA Scale-Up** — Successfully scales replicas when GPU utilization exceeds target
-6. **Result: PASS**
+
+The result is stated by the verdict line at the end of this section, after the checks run.
 
 ---
 
@@ -3048,14 +3097,11 @@ EOF
 EOF
     capture "Pods after scale-up" kubectl get pods -n hpa-test -o wide
 
-    # Verdict — require actual scale-up for PASS
-    echo "" >> "${EVIDENCE_FILE}"
-    if [ "${hpa_scaled}" = "true" ]; then
-        echo "**Result: PASS** — HPA successfully read gpu_utilization metric and scaled replicas when utilization exceeded target threshold." >> "${EVIDENCE_FILE}"
-    else
-        echo "**Result: FAIL** — HPA did not scale replicas within the timeout. Check GPU workload, DCGM exporter, and prometheus-adapter configuration." >> "${EVIDENCE_FILE}"
-    fi
-
+    # Cleanup runs BEFORE the verdict so its outcome can gate the result. The
+    # test workload is an unbounded CUDA loop, so a namespace that refuses to
+    # delete pins GPUs indefinitely — reporting PASS in that state would
+    # certify an outcome the run did not achieve. evidence_result() requires
+    # exactly one verdict line per file, so this cannot be a second Result.
     cat >> "${EVIDENCE_FILE}" <<'EOF'
 
 ## Cleanup
@@ -3064,7 +3110,20 @@ EOF
         kubectl delete deploy gpu-workload -n hpa-test --ignore-not-found 2>/dev/null || true
         kubectl delete pods -n hpa-test -l app=gpu-workload --force --grace-period=0 2>/dev/null || true
     fi
-    capture "Delete test namespace" cleanup_ns hpa-test
+    local cleanup_ok=false
+    if capture "Delete test namespace" cleanup_ns hpa-test; then
+        cleanup_ok=true
+    fi
+
+    # Verdict — require actual scale-up AND a completed cleanup for PASS
+    echo "" >> "${EVIDENCE_FILE}"
+    if [ "${hpa_scaled}" = "true" ] && [ "${cleanup_ok}" = "true" ]; then
+        echo "**Result: PASS** — HPA successfully read gpu_utilization metric and scaled replicas when utilization exceeded target threshold." >> "${EVIDENCE_FILE}"
+    elif [ "${hpa_scaled}" = "true" ]; then
+        echo "**Result: FAIL** — HPA scaled correctly, but the hpa-test namespace could not be deleted. The GPU stress workload may still be running and pinning GPUs; delete the namespace manually before relying on this cluster." >> "${EVIDENCE_FILE}"
+    else
+        echo "**Result: FAIL** — HPA did not scale replicas within the timeout. Check GPU workload, DCGM exporter, and prometheus-adapter configuration." >> "${EVIDENCE_FILE}"
+    fi
 
     log_info "Pod autoscaling evidence collection complete."
 }

--- a/validators/conformance/cluster_autoscaling_check.go
+++ b/validators/conformance/cluster_autoscaling_check.go
@@ -182,14 +182,26 @@ func CheckClusterAutoscaling(ctx *validators.Context) error {
 				fmt.Sprintf("Created namespace=%s deployment=%s hpa=%s for nodePool=%s",
 					report.Namespace, report.DeploymentName, report.HPAName, report.NodePoolName))
 			recordRawTextArtifact(ctx, "Cluster Autoscaling Behavioral Test",
-				"kubectl get hpa && kubectl get nodes && kubectl get pods",
+				fmt.Sprintf("kubectl get hpa -n %s && kubectl get nodes && kubectl get pods -n %s",
+					report.Namespace, report.Namespace),
 				fmt.Sprintf("NodePool:              %s\nNamespace:             %s\nHPA desired/current:   %d/%d\nKarpenter nodes:       baseline=%d observed=%d\nScheduled pods:        %d/%d",
 					report.NodePoolName, report.Namespace, report.HPADesiredReplicas,
 					report.HPACurrentReplicas, report.BaselineNodeCount, report.ObservedNodeCount,
 					report.ScheduledPodCount, report.ObservedPodCount))
+			// The behavioral validation's deferred cleanup has already run by the
+			// time this executes, but a returning Delete call only means the
+			// request was accepted — the namespace terminates asynchronously.
+			// The artifact therefore records that deletion was requested, never
+			// that it completed; a rejected request is reported by the warning
+			// cleanup logs.
 			recordRawTextArtifact(ctx, "Delete test namespace",
-				"kubectl delete namespace cluster-auto-test-<id> --ignore-not-found",
-				fmt.Sprintf("Deleted namespace %s after cluster autoscaling test.", report.Namespace))
+				fmt.Sprintf("kubectl delete namespace %s --ignore-not-found", report.Namespace),
+				fmt.Sprintf("Deletion of namespace %s was requested after the cluster autoscaling test; "+
+					"the namespace terminates asynchronously and this artifact does not confirm it. "+
+					"If the request failed, the check logs a warning naming the namespace. "+
+					"Find leftovers from earlier runs with: "+
+					"kubectl get namespaces -o name | grep %s",
+					report.Namespace, clusterAutoTestPrefix))
 			return nil
 		}
 		slog.Debug("behavioral validation failed for NodePool",
@@ -235,8 +247,14 @@ func validateClusterAutoscaling(ctx context.Context, clientset kubernetes.Interf
 		slog.Debug("cleaning up cluster autoscaling test namespace", "namespace", nsName)
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 		defer cleanupCancel()
-		_ = k8s.IgnoreNotFound(clientset.CoreV1().Namespaces().Delete(
-			cleanupCtx, nsName, metav1.DeleteOptions{}))
+		// Surface a failed delete: silently discarding it leaves the namespace
+		// (and anything still running in it) behind with no operator-visible
+		// signal, while the recorded artifact describes a cleanup that ran.
+		if err := k8s.IgnoreNotFound(clientset.CoreV1().Namespaces().Delete(
+			cleanupCtx, nsName, metav1.DeleteOptions{})); err != nil {
+			slog.Warn("failed to delete cluster autoscaling test namespace; delete it manually",
+				"namespace", nsName, "error", err)
+		}
 	}()
 
 	// Baseline: count existing Karpenter nodes for this pool before creating test resources.

--- a/validators/conformance/pod_autoscaling_check.go
+++ b/validators/conformance/pod_autoscaling_check.go
@@ -266,13 +266,25 @@ pollLoop:
 		fmt.Sprintf("Created namespace=%s deployment=%s hpa=%s via Kubernetes API",
 			hpaReport.Namespace, hpaReport.DeploymentName, hpaReport.HPAName))
 	recordRawTextArtifact(ctx, "HPA Behavioral Test",
-		"kubectl get hpa -n hpa-test && kubectl get deploy -n hpa-test",
+		fmt.Sprintf("kubectl get hpa -n %s && kubectl get deploy -n %s",
+			hpaReport.Namespace, hpaReport.Namespace),
 		fmt.Sprintf("Namespace:            %s\nHPA:                  %s\nScale-up desired:     %d\nScale-up current:     %d\nDeployment scale-up:  %d\nDeployment scale-down:%d",
 			hpaReport.Namespace, hpaReport.HPAName, hpaReport.ScaleUpDesiredReplicas,
 			hpaReport.ScaleUpCurrentReplicas, hpaReport.ScaleUpDeploymentReplica, hpaReport.ScaleDownReplica))
+	// The namespace is randomized per run, so the replay command must name the
+	// actual namespace. validateHPABehavior's deferred cleanup has already run
+	// by the time this executes, but a returning Delete call only means the
+	// request was accepted — the namespace terminates asynchronously. The
+	// artifact therefore records that deletion was requested, never that it
+	// completed; a rejected request is reported by the warning cleanup logs.
 	recordRawTextArtifact(ctx, "Delete test namespace",
-		"kubectl delete namespace hpa-test --ignore-not-found",
-		fmt.Sprintf("Deleted namespace %s after HPA behavioral test.", hpaReport.Namespace))
+		fmt.Sprintf("kubectl delete namespace %s --ignore-not-found", hpaReport.Namespace),
+		fmt.Sprintf("Deletion of namespace %s was requested after the HPA behavioral test; "+
+			"the namespace terminates asynchronously and this artifact does not confirm it. "+
+			"If the request failed, the check logs a warning naming the namespace. "+
+			"Find leftovers from earlier runs with: "+
+			"kubectl get namespaces -o name | grep %s",
+			hpaReport.Namespace, hpaTestPrefix))
 	return nil
 }
 
@@ -335,8 +347,14 @@ func validateHPABehavior(ctx context.Context, clientset kubernetes.Interface) (*
 		slog.Debug("cleaning up HPA test namespace", "namespace", nsName)
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 		defer cleanupCancel()
-		_ = k8s.IgnoreNotFound(clientset.CoreV1().Namespaces().Delete(
-			cleanupCtx, nsName, metav1.DeleteOptions{}))
+		// Surface a failed delete: silently discarding it leaves the namespace
+		// (and anything still running in it) behind with no operator-visible
+		// signal, while the recorded artifact describes a cleanup that ran.
+		if err := k8s.IgnoreNotFound(clientset.CoreV1().Namespaces().Delete(
+			cleanupCtx, nsName, metav1.DeleteOptions{})); err != nil {
+			slog.Warn("failed to delete HPA test namespace; delete it manually",
+				"namespace", nsName, "error", err)
+		}
 	}()
 
 	// Create test Deployment (simple sleep pod, 1 replica, no GPU).


### PR DESCRIPTION
## Summary

Fixes the defects in the CNCF conformance evidence pipeline where cleanup failures were silently swallowed and generated artifacts asserted outcomes the run never verified.

## Motivation / Context

Signed conformance evidence is a provenance claim. When cleanup fails silently or a summary pre-declares PASS, the artifact stops describing what was actually true at collection time.

Fixes: #2133
Related: #2097, #1529, #2223

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/cncf`, `validators/conformance`

## Implementation Notes

**HPA reported PASS through a failed cleanup.** The verdict was written before cleanup ran, and `cleanup_ns` discarded the namespace-delete result, so a refused delete left an unbounded CUDA loop pinning GPUs while the evidence said PASS.

`cleanup_ns` now returns the namespace-delete status (the pod and resourceclaim deletes stay best-effort — the namespace delete cascades them). Cleanup moved above the verdict, and PASS now requires both a scale-up and a completed cleanup. The ordering is forced rather than stylistic: `evidence_result()` accepts exactly one `**Result:` line per file and fails closed on conflicting verdicts, so a cleanup failure has to gate the verdict rather than append a second one.

**NIM and Dynamo operator verdicts certified unready pods.** Both counted pods with `grep -c "Running"`. Phase `Running` includes 0/1-ready pods — a model still loading, or a persistent readiness failure — so either verdict could report "healthy inference pod(s)" for a workload that never became ready. Both now count pods with `Ready=True`, and the variable was renamed `running_pods` → `ready_pods` so it no longer misdescribes what it holds.

Observed live rather than only in theory: while a real Dynamo vLLM worker loaded its model on an AKS H100 cluster, `grep -c "Running"` returned 2 while the Ready count returned 1 — the frontend was serving and the only GPU worker was not. The old logic does not just fail at zero; it over-counts partially-ready deployments.

#2133 scoped this to NIM; the Dynamo verdict is the same defect a few hundred lines down in the same file, so it is fixed here rather than in a near-duplicate follow-up.

**Conformance validators discarded delete errors and over-claimed.** Both deferred namespace deletes dropped their error; they now log a warning naming the namespace. `pod_autoscaling_check.go`'s replay command also hardcoded the literal `hpa-test` while the actual namespace is randomized (`hpa-test-<hex>`).

Both artifacts asserted `Deleted namespace %s`. The deferred cleanup has in fact already run by the time the caller records the artifact, but a returning `Namespaces().Delete` only means the request was accepted — the namespace terminates asynchronously, and the call can fail outright. The artifacts now state that deletion was *requested*, name the actual namespace, and give a prefix-grep discovery path for leftovers.

**The dispatcher flattened read errors.** `collect_service_metrics` selected its branch with `kubectl get pods ... | grep -q .`, whose exit status is grep's. An RBAC, authentication, or apiserver failure was therefore indistinguishable from "no workload" and fell through to the NIM or trainer path, emitting unrelated evidence after a failed read — and the fail-closed probe inside the Dynamo collector never saw it, because the dispatcher decides whether that collector runs at all.

The dispatcher now captures the exit status and routes a read failure to the Dynamo collector. Fall-through happens only on a namespace confirmed `NotFound`; a namespace that exists, or a namespace probe that itself fails, both fail closed. Three lanes cover it, one of which drives the real dispatcher rather than replacing it.

**Summaries pre-declared a result.** The gateway and HPA section overviews contained `6. **Result: PASS**` before any check ran. They now defer to the verdict line, matching the wording #2097 established for the other three sections.

**Dynamo metrics — the deploy path is removed rather than hardened.** The section deployed a workload when it saw none and deleted the whole manifest afterwards, and its probe flattened API errors into "absent".

That path could not execute: `collect_service_metrics` routes into the Dynamo collector only when worker pods already exist (`:1762`), and the deploy-if-absent branch inside tested the identical condition (`:1789`), so it never fired. The guard predates #2133 (#463, 2026-03-25).

Hardening it would also have been insufficient. The manifest ships a **cluster-scoped `Queue/dynamo`**, and `dynamo-platform` creates a queue of that exact name with a different spec — verified on an AKS H100 cluster: the platform's queue carries `parentQueue: dynamo-default` and `quota: -1`, the manifest's carries `parentQueue: default-parent-queue` and `quota: 0`. Applying the manifest would silently repoint the platform's queue and zero its quotas; `kubectl delete -f` at cleanup would delete it. Making that safe needs per-resource ownership probing and tracking, in a branch that cannot run.

So the deploy and cleanup paths are removed. The section now measures an existing workload, owns nothing, and deletes nothing; deploying stays the operator's step, documented in the emitted evidence. The probe fails closed on a read error and reports an absent workload as SKIP, each covered by a harness lane. `dynamo-vllm-agg.yaml` is left unchanged, since nothing in the collector applies or deletes it any more.

Detail in https://github.com/NVIDIA/aicr/issues/2133#issuecomment-5320919471 and https://github.com/NVIDIA/aicr/issues/2133#issuecomment-5321452931.

## Testing

Static checks on the changed files:

```bash
go build ./validators/...                                         # pass
go vet ./validators/conformance/...                               # pass
golangci-lint run -c .golangci.yaml ./validators/conformance/...  # 0 issues
bash -n pkg/evidence/cncf/scripts/collect-evidence.sh             # pass
shellcheck -S warning pkg/evidence/cncf/scripts/collect-evidence.sh
yamllint pkg/evidence/cncf/scripts/manifests/dynamo-vllm-agg.yaml # pass
```

`shellcheck` reports two warnings (SC2034 at L37, SC2069 at L2367). Both are pre-existing on untouched lines — verified present on the base commit.

Behavioral checks against a live EKS GB200 cluster (`yljtrxpmzu-dgxc-k8s-aws-use1-non-prod`, kubectl v1.34):

- **Ready-vs-Running discrimination.** A pod held at Running but never Ready (failing exec readiness probe): the old `grep -c "Running"` counted it as 1 healthy pod, the new `Ready=True` count returns 0. Control first on a healthy namespace — both approaches returned 17, confirming the new logic does not undercount ready pods.
- **Namespace probe.** The NotFound match was confirmed against real kubectl stderr for an absent namespace, so the probe classifies it as absent rather than as a read failure.
- **`cleanup_ns` return semantics.** Absent namespace, successful delete, and `NO_CLEANUP=true` all return 0 as intended.

Unit coverage for the cleanup gate itself: `hpa-scaled-cleanup-ok` and `hpa-scaled-cleanup-failed` in `result_propagation_test.go` differ only in whether the namespace delete succeeds. Removing the cleanup condition from the verdict makes the failure lane fail while the control lane still passes, so the assertion tracks the gate rather than a stub that never passes.

All test namespaces were deleted and their removal verified; nothing was left on the cluster.

End-to-end run of the HPA section on an AKS H100 UAT cluster (`aicr-uat-31034819439`, K8s v1.35) — the section this PR's main fix governs:

- **Result: PASS.** The CUDA workload reached 100% GPU utilization (293W) and the HPA scaled 1 → 2 replicas.
- The emitted `pod-autoscaling.md` confirms the reordering: `## Cleanup` at line 244 precedes the verdict at line 252, there is exactly one column-zero `**Result:` line, and the summary no longer pre-declares PASS.
- The `hpa-test` namespace was deleted and no GPU workloads were left behind.

A second full collection was then run on the same cluster with `dynamo-platform`, `grove`, and `agentgateway` installed, so the Dynamo and gateway sections execute against a live vLLM workload instead of skipping: **8 PASS / 0 FAIL / 1 SKIP** (the SKIP is Cluster Autoscaling, which requires EKS or GKE).

That run exercised the three sections the first collection could not reach:

- **AI Service Metrics** → PASS via the Dynamo branch — the first live execution of the rewritten `collect_service_metrics_dynamo`, taking the measure-only path rather than the trainer fallback.
- **Robust AI Operator** → PASS via the Dynamo branch, reporting "reconciled with 2 healthy workload pod(s)" from the new `Ready=True` count.
- **Inference Gateway** → PASS, previously SKIP — the section whose summary heredoc this PR edits had never run live.

Across all 9 emitted artifacts: exactly one column-zero `**Result:` verdict per file, and no summary pre-declaring PASS. In `pod-autoscaling.md` the `## Cleanup` stanza precedes the verdict, and `ai-service-metrics.md` carries the new `## Workload Lifecycle` note in place of a cleanup stanza.

Nothing owned by the platform was touched: after the run, `Queue/dynamo` still carried `parentQueue: dynamo-default` and `quota: -1`, the `dynamo-workload` namespace was Active, and the DynamoGraphDeployment still reported `True` with both pods running. (This confirms the section deletes nothing; it is not a demonstration that the old code would have deleted here, since with a workload present the old `deployed_dynamo` also stayed false. The `Queue` hazard is established by comparing the two specs, above.)

A third collection covered the NIM path on the same cluster, with `k8s-nim-operator` installed and a `NIMService` serving `nvcr.io/nim/meta/llama-3.1-8b-instruct` on an H100 node: **7 PASS / 0 FAIL / 2 SKIP** (Inference Gateway, since agentgateway had been removed by then, and Cluster Autoscaling). Both NIM-specific sections passed:

- **AI Service Metrics** → PASS via the NIM branch, scraping `/v1/metrics`.
- **Robust AI Operator** → PASS via the NIM branch, reporting "9 CRDs registered, NIMService reconciled with **1 healthy inference pod(s)**" — the `Ready=True` count this PR introduces, on the operator #2133 item 5 actually names.

Every changed code path now has live coverage; nothing in the diff is exercised only by unit lanes.

**`make qualify`:** clears `test-shell`, `lint`, `tuning-check`, `license-check`, `api-diff`, `scan`, and `e2e`. One failure remains — `TestHelmPinnedVersionExplicitVersionPull` in `pkg/oci`, which compares the locally installed helm binary (`v4.2.3`) against the `.settings.yaml` pin (`v4.2.4`). It is a local toolchain mismatch: this PR touches neither `pkg/oci` nor tooling.

## Risk Assessment

- [x] **Low** — Isolated change, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Verdicts get stricter — an HPA run whose cleanup fails now reports FAIL where it previously reported PASS, and the NIM and Dynamo verdicts require Ready pods rather than Running ones. Both are the intended correction; a run that legitimately passed before still passes. The Dynamo manifest now requires the `dynamo-workload` namespace to exist, which the collector creates; anyone applying that manifest by hand needs `kubectl create namespace dynamo-workload` first, documented in the manifest header.

## Checklist

- [x] Tests pass locally — `make qualify` green apart from 9 pre-existing `api-diff` shell-test failures that reproduce unchanged on base `main` (see Testing)
- [x] Linter passes (golangci-lint, shellcheck, yamllint, `bash -n` on changed files)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — two harness lanes covering the cleanup gate, verified to fail when the gate is removed
- [x] I updated docs if user-facing behavior changed (manifest header documents the namespace prerequisite)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

