### PR TITLE
ci: reject whitespace-only PR title subjects; sync agent rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -610,7 +610,8 @@ CI also posts per-package deltas post-push via `go-coverage-report` (`on-push-co
 - Area labels are auto-assigned by `.github/labeler.yml` based on changed file paths (e.g., `area/recipes`, `area/ci`, `area/api`, `area/cli`, `area/bundler`, `area/collector`, `area/validator`, `area/docs`, `area/infra`, `area/tests`). You may also add them manually when the auto-labeler wouldn't match (e.g., issue-only PRs or cross-cutting changes).
 - Do NOT add issue priority labels `P0`, `P1`, or `P2` to PRs; they are reserved for issues and automation removes them from pull requests
 - Do NOT add `size/*` labels (auto-assigned by bot)
-- Keep the PR title under 70 characters; use the description for details
+- **PR titles are linted.** CI enforces Conventional Commits format — `type: subject`, `type(scope): subject`, `type!: subject`, or `type(scope)!: subject`, where `!` marks a breaking change. Valid types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`. Scopes may be mixed case (`fix(GB200):`). A malformed title fails the check; editing the title re-runs it automatically. The title is the whole commit message on `main` (`squash_merge_commit_message: BLANK`) and cannot be corrected after merge
+- Keep the PR title to 70 characters or fewer; use the description for details. Over 70 warns but does not block — dependency-bot titles embed pseudo-versions that cannot be shortened
 
 **Issue policy:**
 - Set an **org issue type** on new issues. This is a GitHub-native field (shown in the standard issue view, distinct from repo `area/*`/`theme/*` labels) that categorizes the issue. Valid types: `Task`, `Bug`, `Enhancement`, `Epic`, `Initiative`, `Documentation`.

--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -74,12 +74,15 @@ jobs:
             ];
 
             // type(scope)!: subject -- scope and the breaking-change "!" are
-            // both optional; subject must be non-empty. Scope allows mixed
+            // both optional; the subject must contain a non-whitespace
+            // character -- `.+` alone would accept "fix:   ", which under
+            // squash_merge_commit_message: BLANK lands on main as an
+            // effectively empty commit message. Scope allows mixed
             // case: Conventional Commits does not define a lowercase-only
             // scope grammar, and fix(GB200): / fix(H100): / feat(API): are
             // all plausible here.
             const PATTERN = new RegExp(
-              `^(${TYPES.join('|')})(\\([a-zA-Z0-9][a-zA-Z0-9._/-]*\\))?(!)?: .+$`
+              `^(${TYPES.join('|')})(\\([a-zA-Z0-9][a-zA-Z0-9._/-]*\\))?(!)?: +\\S.*$`
             );
 
             // Advisory only. CONTRIBUTING.md asks for titles under this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,7 +610,8 @@ CI also posts per-package deltas post-push via `go-coverage-report` (`on-push-co
 - Area labels are auto-assigned by `.github/labeler.yml` based on changed file paths (e.g., `area/recipes`, `area/ci`, `area/api`, `area/cli`, `area/bundler`, `area/collector`, `area/validator`, `area/docs`, `area/infra`, `area/tests`). You may also add them manually when the auto-labeler wouldn't match (e.g., issue-only PRs or cross-cutting changes).
 - Do NOT add issue priority labels `P0`, `P1`, or `P2` to PRs; they are reserved for issues and automation removes them from pull requests
 - Do NOT add `size/*` labels (auto-assigned by bot)
-- Keep the PR title under 70 characters; use the description for details
+- **PR titles are linted.** CI enforces Conventional Commits format — `type: subject`, `type(scope): subject`, `type!: subject`, or `type(scope)!: subject`, where `!` marks a breaking change. Valid types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`. Scopes may be mixed case (`fix(GB200):`). A malformed title fails the check; editing the title re-runs it automatically. The title is the whole commit message on `main` (`squash_merge_commit_message: BLANK`) and cannot be corrected after merge
+- Keep the PR title to 70 characters or fewer; use the description for details. Over 70 warns but does not block — dependency-bot titles embed pseudo-versions that cannot be shortened
 
 **Issue policy:**
 - Set an **org issue type** on new issues. This is a GitHub-native field (shown in the standard issue view, distinct from repo `area/*`/`theme/*` labels) that categorizes the issue. Valid types: `Task`, `Bug`, `Enhancement`, `Epic`, `Initiative`, `Documentation`.


### PR DESCRIPTION
## Summary

Two review findings from #2221 were fixed after it merged, so they never reached `main`. This carries them over.

The commit is a cherry-pick of `75121230c`, pushed to the branch about a minute after @mchmarny merged #2221 at `d1b840e90`. The push landed on the fork branch but the PR was already closed.

## Motivation / Context

Both findings are from @njhensley's review of #2221.

**1. A whitespace-only subject passes the title check.** The subject matcher was `: .+$`. `.` matches spaces, so `fix:` followed by two or more spaces is accepted — only the single-trailing-space `fix: ` was rejected. This contradicts the code's own comment claiming the subject must be non-empty, and under `squash_merge_commit_message: BLANK` such a title lands on `main` as an effectively empty commit message.

Now `: +\S.*$` — at least one space, then a non-whitespace character. `fix:subject` stays rejected, so the single-space requirement is unchanged.

**2. The agent rules contradict the gate.** `AGENTS.md` and `.claude/CLAUDE.md` — "the canonical source for coding-agent rules" — said only *"Keep the PR title under 70 characters"*, phrased as a hard directive. #2221 inverted that: length is advisory, format is enforced. Agents author titles from that file, so they would learn the now-advisory length rule and nothing about the now-enforced Conventional Commits format, then fail the check.

Both files now document the four accepted forms, the valid types, mixed-case scopes, and that over-70 warns rather than blocks.

Refs: #2219

## Note on placement

An earlier revision of this PR moved the check into `merge-gate.yaml` and added a companion workflow to re-run the gate on title edits. That is reverted: per the Slack thread, PR-metadata gates such as title validation **stay separate**, because a title edit does not change the commit SHA and `merge-gate` subscribes only to `opened`/`synchronize`/`reopened`. `Check PR Title` is being added to the main ruleset's required status checks separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Other: `.github/workflows/pr-title-lint.yaml`, `AGENTS.md`, `.claude/CLAUDE.md`

## Testing

Regex re-extracted from the workflow as written and run against real and control data:

```
14 must-reject — all correctly rejected, including the whitespace cases:
  "fix:", "fix: ", "fix:  ", "fix:    ", "fix: <tab>", "fix:subject",
  "Fix the thing", "FIX: x", "feature(x): y", "fix(): empty",
  "fix (b): y", "update docs", "fix bundler: y", "Add Slinky slurm-operator as platform-slurm"

10 must-accept — all correctly accepted:
  "fix: real subject", "fix:  double space", "fix(bundler): x", "docs: add ADR-019",
  "feat(recipe)!: x", "fix!: no scope", the 81-char renovate title,
  "fix(a/b.c-d): x", "fix(GB200): uppercase", "feat(API): uppercase"

81 real merged titles — 1 rejection, the known non-conforming
  "Add Slinky slurm-operator as platform-slurm"
```

Repo gates (CI/docs-only change — no Go, so tests and e2e cannot regress):

```
make lint-yaml              # pass
actionlint                  # clean
make check-agents-sync      # OK: AGENTS.md is in sync with .claude/CLAUDE.md
make check-docs-mdx         # OK
make check-docs-filenames   # OK
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

Tightening the pattern can only reject titles that previously passed; verified none of the 81 merged titles are affected.

## Checklist

- [x] Linter passes
- [x] I did not skip/disable tests to make CI green
