### PR TITLE
test(serializer): cover cancellation during HTTP body read

### DIFF
--- a/pkg/serializer/cancellation_test.go
+++ b/pkg/serializer/cancellation_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -193,4 +194,61 @@ func TestCancellation_HTTPTemplate(t *testing.T) {
 	var buf bytes.Buffer
 	err := NewTemplateWriter(srv.URL, &buf).Serialize(ctx, struct{}{})
 	wantCanceledAndNotTransient(t, err, "http template")
+}
+
+// blockingBody is a response body that never yields data until the context is
+// done, then reports why. It makes the body-read cancellation deterministic:
+// a real server races the client's header processing, so a cancel fired from
+// the handler can land while Client.Do is still returning and never reach the
+// read at all.
+type blockingBody struct{ ctx context.Context } //nolint:containedctx // the body's whole job is to block on it
+
+func (b blockingBody) Read([]byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+func (b blockingBody) Close() error { return nil }
+
+// blockingTransport returns headers immediately with a body that blocks, so
+// Client.Do succeeds and the failure can only come from io.ReadAll.
+type blockingTransport struct{}
+
+func (blockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       blockingBody{ctx: req.Context()},
+		Request:    req,
+	}, nil
+}
+
+// TestCancellation_HTTPDuringBodyRead exercises the io.ReadAll branch, which
+// TestCancellation_HTTP does not reach.
+//
+// That test cancels before response headers arrive, so it fails inside
+// Client.Do and never enters the body read — the body-read classification had
+// no coverage at all. Verified by mutation: deleting that branch left the
+// whole package green.
+//
+// The message assertion pins this to the intended branch. Without it a timing
+// shift could satisfy the test through the Do path, which is exactly how the
+// gap went unnoticed.
+func TestCancellation_HTTPDuringBodyRead(t *testing.T) {
+	t.Parallel()
+
+	reader := NewHTTPReader()
+	reader.Client = &http.Client{Transport: blockingTransport{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	t.Cleanup(cancel)
+
+	_, err := reader.ReadWithContext(ctx, "http://body-read.test/snapshot.yaml")
+	wantCanceledAndNotTransient(t, err, "http body read")
+	if err != nil && !strings.Contains(err.Error(), "body read") {
+		t.Errorf("error = %v, want it to come from the body-read branch", err)
+	}
 }


### PR DESCRIPTION
## Summary

Adds test coverage for the `io.ReadAll` cancellation branch in `HTTPReader.ReadWithContext`, which shipped in #2229 without any. Test-only; no production change.

## Motivation / Context

#2229 routed every serializer read path's cancellation through `abortError` so an operator abort is coded `ErrCodeCanceled` and reports non-transient. One of those branches — the response-body read — was never exercised.

`TestCancellation_HTTP` cancels before response headers arrive, so it fails inside `Client.Do` and returns before the body read begins. **Verified by mutation against merged `main`:** deleting the body-read branch from `http.go` leaves the entire `pkg/serializer` suite green.

Caught in review of #2229 ([thread](https://github.com/NVIDIA/aicr/pull/2229#discussion_r3803512578)); the fix landed but the test did not make the merge.

Related: #2229, #2022

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/serializer`

## Implementation Notes

**Not written with `httptest`, deliberately.** The obvious approach — flush response headers from the handler, then cancel — is a race rather than a test. The handler signalling "headers flushed" does not mean the client has finished processing them and returned from `Do`. That attempt failed with:

```
[CANCELED] http request for url http://127.0.0.1:56287 canceled: Get "...": context canceled
want it to come from the body-read branch
```

The right classification arriving from the wrong branch. Flushing narrows the window; it does not close it, and a test that lands in the intended branch only sometimes is worse than no test at all.

Instead a stub `http.RoundTripper` returns headers immediately over a body whose `Read` blocks until the request context is done. `Do` cannot fail, so the error can only come from `io.ReadAll`. No sleep-based sequencing of the assertion.

**The message assertion is load-bearing.** Alongside the code and transience checks, the test asserts the error text names the body-read branch. Without it a future timing shift could satisfy this through the `Do` path — which is precisely how the original gap went unnoticed.

## Testing

```bash
make qualify   # exit 0
```

Mutation-verified against merged `main`: removing the body-read branch from `ReadWithContext` now fails on all three assertions —

```
error = [INTERNAL] failed to read response body: context canceled, want code CANCELED
canceled read reports transient; a retry loop would re-enter on an operator abort
error = [INTERNAL] ..., want it to come from the body-read branch
```

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Test-only, single file, no production code touched.

**Rollout notes:** N/A.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
