### PR TITLE
docs(sdk): attach each criteria converter's godoc to its own function

### DIFF
--- a/pkg/client/v1/translate.go
+++ b/pkg/client/v1/translate.go
@@ -247,11 +247,6 @@ func WrapCriteria(c *recipe.Criteria) *Criteria {
 	}
 }
 
-// toInternalCriteria translates a facade Criteria back into the
-// pkg/recipe.Criteria enum-typed shape the resolver consumes. The string
-// values are wrapped in the corresponding pkg/recipe enum types without
-// validation — registry-strict mode at resolve time is the gate that
-// rejects unknown values (with ErrCodeInvalidRequest).
 // ToInternalCriteria projects a facade Criteria back onto the upstream
 // pkg/recipe shape, parsing the plain-string fields into their enum types.
 // Returns nil for nil input.
@@ -264,6 +259,11 @@ func ToInternalCriteria(c *Criteria) *recipe.Criteria {
 	return toInternalCriteria(c)
 }
 
+// toInternalCriteria translates a facade Criteria back into the
+// pkg/recipe.Criteria enum-typed shape the resolver consumes. The string
+// values are wrapped in the corresponding pkg/recipe enum types without
+// validation — registry-strict mode at resolve time is the gate that
+// rejects unknown values (with ErrCodeInvalidRequest).
 func toInternalCriteria(c *Criteria) *recipe.Criteria {
 	if c == nil {
 		return nil


### PR DESCRIPTION
## Summary

Separates the `ToInternalCriteria` and `toInternalCriteria` doc comments so each attaches to its own function. Comment-only; no non-comment line changes.

## Motivation / Context

The `ToInternalCriteria` paragraph landed in #2243 with no blank line separating it from the pre-existing `toInternalCriteria` block, so Go reads the two as one contiguous comment attached to the exported function. On merged `main`:

```
$ go doc ./pkg/client/v1.ToInternalCriteria
func ToInternalCriteria(c *Criteria) *recipe.Criteria
    toInternalCriteria translates a facade Criteria back into the
    pkg/recipe.Criteria enum-typed shape the resolver consumes. The string
    values are wrapped in the corresponding pkg/recipe enum types without
    validation — registry-strict mode at resolve time is the gate that rejects
    unknown values (with ErrCodeInvalidRequest). ToInternalCriteria projects
```

So the public, semver-pinned symbol documents itself under the wrong lowercase name and leads with the unexported helper's semantics, while `toInternalCriteria` is left with no doc at all. It would also trip revive's `exported` comment rule if that linter is enabled later.

Caught in review of #2243 ([thread](https://github.com/NVIDIA/aicr/pull/2243#discussion_r3806396981)). Landing it standalone rather than folding into #2245 because that issue may be a while out, and leaving incorrect documentation on the stability-guaranteed surface in the meantime is the thing worth avoiding.

Related: #2243, #2026

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK facade (`pkg/client/v1`)

## Implementation Notes

Each block now sits directly above the function it describes. After:

```
$ go doc ./pkg/client/v1.ToInternalCriteria
func ToInternalCriteria(c *Criteria) *recipe.Criteria
    ToInternalCriteria projects a facade Criteria back onto the upstream
    pkg/recipe shape, parsing the plain-string fields into their enum types.
    Returns nil for nil input.
```

and `toInternalCriteria` carries its own doc again.

## Testing

```bash
make qualify   # exit 0
```

Verified the diff touches no executable line:

```bash
git diff -U0 pkg/client/v1/translate.go | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[+-]\s*//' | grep -vE '^[+-]\s*$'
# (no output)
```

`go doc` output before and after is quoted above; the existing `TestToInternalCriteria` still passes unchanged.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Comment-only, single file.

**Rollout notes:** N/A.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
