### PR TITLE
fix(uat): pin helm-diff plugin with verified checksum

### DIFF
--- a/.github/RENOVATE.md
+++ b/.github/RENOVATE.md
@@ -9,7 +9,7 @@ Self-hosted Renovate keeps the project's dependencies up to date across `go.mod`
 
 - Configuration: [`.github/renovate.json5`](renovate.json5)
 - Workflow: [`.github/workflows/renovate.yaml`](workflows/renovate.yaml)
-- Companion script: [`tools/update-chainsaw-checksums`](../tools/update-chainsaw-checksums)
+- Companion scripts: [`tools/update-chainsaw-checksums`](../tools/update-chainsaw-checksums), [`tools/update-helmfile-checksums`](../tools/update-helmfile-checksums), [`tools/update-helm-diff-checksums`](../tools/update-helm-diff-checksums)
 
 Policy choices (schedule, cooldown, auto-merge scope, group consolidation) are documented inline in `renovate.json5`. This doc covers what's covered, how to extend coverage, and the known gotchas.
 
@@ -25,6 +25,8 @@ Policy choices (schedule, cooldown, auto-merge scope, group consolidation) are d
 | `.settings.yaml` (28 tool entries) | custom regex manager (`# renovate:` annotations) |
 | `.settings.yaml` `nvkind` SHA | dedicated git-refs digest customManager (`# renovate-digest:`) |
 | `.settings.yaml` `chainsaw_checksums` | `postUpgradeTasks` → `tools/update-chainsaw-checksums` |
+| `.settings.yaml` `helmfile_checksums` | `postUpgradeTasks` → `tools/update-helmfile-checksums` |
+| `.settings.yaml` `helm_diff_checksums` | `postUpgradeTasks` → `tools/update-helm-diff-checksums` |
 | `.go-version` (Go toolchain) | dedicated `golang-version` customManager (`go-toolchain` group) |
 
 The `go` directive in `go.mod` is intentionally not bumped — the Go toolchain version is owned by `.go-version`. Makefile (`GOTOOLCHAIN`), the `load-versions` composite action, `install-karpenter-kwok`, and validator Dockerfiles (`--build-arg GO_VERSION`) all read from that single file.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -319,6 +319,16 @@
       },
     },
 
+    // ---- helm-diff bumps refresh per-arch SHA256 checksums via post-upgrade script ----
+    {
+      matchDepNames: ["databus23/helm-diff"],
+      postUpgradeTasks: {
+        commands: ["./tools/update-helm-diff-checksums {{{newVersion}}}"],
+        fileFilters: [".settings.yaml"],
+        executionMode: "update",
+      },
+    },
+
     // ---- aiperf-bench base image is capped below python 3.14 ----
     // PR #1906 auto-bumped this to 3.14 and broke the UAT validator image
     // build (aiperf's pyzmq/uvloop had no cp314 wheels, and the single-stage

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -124,5 +124,16 @@ jobs:
           # not), which then breaks E2E/CLI E2E at the sha256 verify step.
           # `[a-z-]+` (not `[a-z]+`) so hyphenated tool names match too, e.g.
           # tools/update-helm-diff-checksums.
+          #
+          # The stale-checksum symptom above is not uniform across the three
+          # tools. A hook that runs but *fails* (renamed asset, egress blip)
+          # leaves the new version pinned against the old checksums, and only
+          # helmfile/chainsaw fail a PR-gating job for it — qualification.yaml
+          # feeds their sha256 into setup-build-tools, which verifies it.
+          # helm_diff_checksums is read solely by tests/uat/lib/phases.sh, so a
+          # stale helm-diff pin stays green on every PR check and first surfaces
+          # in nightly UAT, across all clouds. Renovate's "Artifact update
+          # problem" warning in the PR body is the signal to heed; helm-diff is
+          # deliberately not auto-merged, so a human sees it.
           RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^\\./tools/update-[a-z-]+-checksums "]'
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -122,5 +122,7 @@ jobs:
           # checksums getting committed alongside a version bump (the version
           # changes but the helmfile_checksums/chainsaw_checksums block does
           # not), which then breaks E2E/CLI E2E at the sha256 verify step.
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^\\./tools/update-[a-z]+-checksums "]'
+          # `[a-z-]+` (not `[a-z]+`) so hyphenated tool names match too, e.g.
+          # tools/update-helm-diff-checksums.
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^\\./tools/update-[a-z-]+-checksums "]'
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -84,6 +84,15 @@ testing_tools:
   helm: 'v4.2.4'
   # renovate: datasource=github-releases depName=databus23/helm-diff depType=testing_tools
   helm_diff: 'v3.15.11'
+  # helm_diff_checksums are refreshed automatically by tools/update-helm-diff-checksums
+  # via Renovate postUpgradeTasks whenever the helm-diff version above is bumped.
+  # The darwin_* keys name GOOS (matching the sibling blocks); upstream labels
+  # those release assets "macos".
+  helm_diff_checksums:
+    linux_amd64: 'ed54aa5a14a51a6e44cf8ab6020aaa9e56779b4d33bc2adf07abea6b240a5e7c'
+    linux_arm64: '1c38c487ec348fe5ef2b10c61deddff79f0fa5bfbab762b302874578e6dc2d2c'
+    darwin_amd64: '833e1054d0cfe28bbd6f2edc4c1d5b786968b7732f8df6fe99b67c3bf12bf7bb'
+    darwin_arm64: 'ba489cc4a5998ad259fbc18c454f2319da26ba4c8f469e7acb587a07e61072cd'
   # renovate: datasource=github-releases depName=helmfile/helmfile depType=testing_tools
   helmfile: 'v1.7.4'
   # helmfile_checksums are refreshed automatically by tools/update-helmfile-checksums

--- a/tests/uat/lib/phases.sh
+++ b/tests/uat/lib/phases.sh
@@ -437,13 +437,18 @@ phase_install() {
   command -v helmfile >/dev/null || { echo "helmfile not on PATH" >&2; exit 1; }
   command -v helm     >/dev/null || { echo "helm not on PATH"     >&2; exit 1; }
   command -v curl     >/dev/null || { echo "curl not on PATH"     >&2; exit 1; }
+  command -v gpg      >/dev/null || { echo "gpg not on PATH"      >&2; exit 1; }
 
   # Read helm-diff version from the single source of truth (.settings.yaml).
   local SCRIPT_DIR
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local REPO_ROOT="${SCRIPT_DIR}/../../.."
   local HELM_DIFF_VERSION
-  HELM_DIFF_VERSION="$(yq -r '.testing_tools.helm_diff' "${REPO_ROOT}/.settings.yaml")"
+  HELM_DIFF_VERSION="$(yq -r '.testing_tools.helm_diff // ""' "${REPO_ROOT}/.settings.yaml")"
+  if [[ -z "${HELM_DIFF_VERSION}" ]]; then
+    echo "::error::testing_tools.helm_diff is not pinned in .settings.yaml" >&2
+    exit 1
+  fi
 
   # Declared separately from the assignment: `local x="$(...)"` would mask the
   # substitution's exit status behind local's own success.
@@ -471,21 +476,27 @@ phase_install() {
       echo "helm-diff ${installed_ver} installed; removing to pin ${HELM_DIFF_VERSION}"
       helm plugin remove diff
     fi
-    # Install the exact bytes we verified. Three independent gates, all on one
+    # Install the exact bytes we verified. Four independent gates, all on one
     # downloaded copy — helm never re-fetches, so there is no window in which a
     # hostile cache can substitute different bytes between check and install:
     #
-    #   1. SHA256 matches the .settings.yaml pin  — fixes *which* release.
+    #   1. SHA256 matches the .settings.yaml pin  — fixes *which* bytes.
     #   2. The .prov clearsign carries VALIDSIG for the pinned maintainer
     #      fingerprint                            — proves upstream authorship.
     #   3. The SHA256 recorded inside that signed .prov equals the pin
     #                                             — binds (2) to (1), so the
-    #      signature covers our bytes rather than some other signed release.
+    #      signature covers our bytes, not some other signed release.
+    #   4. The version inside that signed .prov equals the requested version
+    #                                             — the only gate that survives
+    #      a poisoned pin; see its comment below.
     #
-    # Gate 3 is what lets us pass --verify=false safely. Helm's own --verify
-    # only establishes (2): it would accept any validly signed helm-diff
-    # release, including an older one replayed by a compromised cache, which
-    # is a downgrade past the pin. Doing the checks here is strictly stronger.
+    # Gate 1 is the load-bearing control against a *replayed older release*: a
+    # stale tarball carries a genuine upstream signature but the wrong hash, so
+    # it is rejected before any signature is examined. That is what helm's own
+    # --verify cannot do — it establishes only (2) and would accept any validly
+    # signed release — and it is why passing --verify=false here is strictly
+    # stronger rather than weaker. Gates 3 and 4 cover what Gate 1 cannot: a pin
+    # that was poisoned at refresh time, when the hash alone proves nothing.
     # The cost is a cosmetic `PROVENANCE: unsigned` in `helm plugin list`.
     #
     # The tarball is staged as diff.tgz because helm's local-tarball installer
@@ -535,22 +546,49 @@ phase_install() {
         echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
         exit 1
       fi
+      # VALIDSIG's first field is the fingerprint of the key that actually made
+      # the signature and its last field is the primary key's, which differ once
+      # a maintainer signs with a dedicated subkey. Accept the pin in either
+      # position so a legitimate future subkey does not false-reject.
       if ! gpg --verify --status-fd=1 "${tarball}.prov" 2>/dev/null \
-          | grep -q "^\[GNUPG:\] VALIDSIG ${HELM_DIFF_KEY_FPR} "; then
+          | awk -v fpr="${HELM_DIFF_KEY_FPR}" \
+              '$1=="[GNUPG:]" && $2=="VALIDSIG" && ($3==fpr || $NF==fpr) {found=1} END{exit !found}'; then
         echo "::error::helm-diff provenance is not validly signed by ${HELM_DIFF_KEY_FPR}" >&2
         exit 1
       fi
 
+      # Decode once: gates 3 and 4 both read the signed body.
+      prov_body="$(gpg --decrypt "${tarball}.prov" 2>/dev/null)"
+
       # Gate 3: that signature covers the bytes we just pinned. The .prov keys
       # its files map by the upstream asset name, not our staged filename.
-      prov_sha="$(gpg --decrypt "${tarball}.prov" 2>/dev/null \
-        | awk -v a="${HELM_DIFF_FILE}:" '$1==a {gsub(/"|sha256:/,"",$2); print $2}')"
+      prov_sha="$(awk -v a="${HELM_DIFF_FILE}:" \
+        '$1==a {gsub(/"|sha256:/,"",$2); print $2}' <<<"${prov_body}")"
       if [[ "${prov_sha}" != "${HELM_DIFF_SHA256}" ]]; then
         echo "::error::helm-diff provenance records sha256 ${prov_sha:-<none>} for ${HELM_DIFF_FILE}, pinned ${HELM_DIFF_SHA256}" >&2
         exit 1
       fi
-      echo "helm-diff verified (${HELM_DIFF_SHA_KEY}: ${HELM_DIFF_SHA256}, signed by ${HELM_DIFF_KEY_FPR})"
 
+      # Gate 4: the signed body names the release we asked for. Gates 1-3 all
+      # reduce to "these bytes match the pin", so they cannot detect a pin that
+      # was itself poisoned: tools/update-helm-diff-checksums derives the pin
+      # from an *unsigned* checksums.txt, and the asset filename carries no
+      # version, so a compromised release/CDN can seed the pin with an older
+      # release's hashes and then serve that older, genuinely signed tarball
+      # here. Only the version inside the signature distinguishes them.
+      prov_ver="$(awk '$1=="version:" {gsub(/"/,"",$2); print $2; exit}' <<<"${prov_body}")"
+      if [[ "${prov_ver}" != "${HELM_DIFF_VERSION#v}" ]]; then
+        echo "::error::helm-diff provenance is for version ${prov_ver:-<none>}, requested ${HELM_DIFF_VERSION#v} — possible downgrade" >&2
+        exit 1
+      fi
+      echo "helm-diff verified (${HELM_DIFF_SHA_KEY}: ${HELM_DIFF_SHA256}, version ${prov_ver} signed by ${HELM_DIFF_KEY_FPR})"
+
+      # --verify=false skips helm's provenance check, not helm-diff's install
+      # hook, which still runs. The gates above constrain the .tgz bytes, not
+      # what the hook does: today it finds the bundled diff/bin/diff and skips
+      # downloading, so nothing unverified is fetched. A bump that stops
+      # shipping that prebuilt binary would silently reintroduce a fetch and
+      # must be caught in review.
       helm plugin install "${tarball}" --verify=false
     ) || exit 1
   fi

--- a/tests/uat/lib/phases.sh
+++ b/tests/uat/lib/phases.sh
@@ -399,9 +399,44 @@ phase_prep() {
   echo "::endgroup::"
 }
 
+# Print the SHA256 of a file, using whichever of sha256sum (Linux) or shasum
+# (macOS) is present. Fails closed when neither is: a runner that cannot verify
+# a pinned checksum must not proceed to install the artifact.
+uat_sha256() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file}" | awk '{print $1}'
+  else
+    echo "::error::neither sha256sum nor shasum is available; cannot verify checksums" >&2
+    return 1
+  fi
+}
+
+# Map the host to a helm-diff release-asset suffix and the matching
+# .settings.yaml checksum key. Upstream labels macOS assets "macos" while the
+# checksum keys use GOOS names, so the two differ on Darwin.
+uat_helm_diff_platform() {
+  local os arch
+  case "$(uname -s)" in
+    Linux)  os=linux ;;
+    Darwin) os=darwin ;;
+    *) echo "::error::unsupported OS $(uname -s) for helm-diff install" >&2; return 1 ;;
+  esac
+  case "$(uname -m)" in
+    x86_64|amd64)  arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *) echo "::error::unsupported architecture $(uname -m) for helm-diff install" >&2; return 1 ;;
+  esac
+  # "<asset-suffix> <checksum-key>"
+  echo "${os/darwin/macos}-${arch} ${os}_${arch}"
+}
+
 phase_install() {
   command -v helmfile >/dev/null || { echo "helmfile not on PATH" >&2; exit 1; }
   command -v helm     >/dev/null || { echo "helm not on PATH"     >&2; exit 1; }
+  command -v curl     >/dev/null || { echo "curl not on PATH"     >&2; exit 1; }
 
   # Read helm-diff version from the single source of truth (.settings.yaml).
   local SCRIPT_DIR
@@ -409,6 +444,20 @@ phase_install() {
   local REPO_ROOT="${SCRIPT_DIR}/../../.."
   local HELM_DIFF_VERSION
   HELM_DIFF_VERSION="$(yq -r '.testing_tools.helm_diff' "${REPO_ROOT}/.settings.yaml")"
+
+  # Declared separately from the assignment: `local x="$(...)"` would mask the
+  # substitution's exit status behind local's own success.
+  local HELM_DIFF_PLATFORM
+  HELM_DIFF_PLATFORM="$(uat_helm_diff_platform)" || exit 1
+  local HELM_DIFF_ASSET HELM_DIFF_SHA_KEY
+  read -r HELM_DIFF_ASSET HELM_DIFF_SHA_KEY <<<"${HELM_DIFF_PLATFORM}"
+  local HELM_DIFF_SHA256
+  HELM_DIFF_SHA256="$(yq -r ".testing_tools.helm_diff_checksums.${HELM_DIFF_SHA_KEY} // \"\"" \
+    "${REPO_ROOT}/.settings.yaml")"
+  if [[ -z "${HELM_DIFF_SHA256}" ]]; then
+    echo "::error::no helm-diff checksum pinned for ${HELM_DIFF_SHA_KEY} in .settings.yaml; refresh with tools/update-helm-diff-checksums ${HELM_DIFF_VERSION}" >&2
+    exit 1
+  fi
 
   echo "::group::Install helm-diff plugin (${HELM_DIFF_VERSION})"
   # Check installed version; reinstall if missing or at a different version so the
@@ -428,15 +477,43 @@ phase_install() {
     # release key, pin it to the published fingerprint (fail closed on
     # mismatch), export it to a legacy keyring, and verify against it.
     #
-    # Run in a subshell with an EXIT trap so the temp GNUPGHOME/keyring are
-    # removed on every path — including a set -e (L41) abort, where a RETURN
+    # The signature proves the maintainer signed whatever was served; it does
+    # not pin *which* release we accept. So also gate on a SHA256 from
+    # .settings.yaml, bumped deliberately by tools/update-helm-diff-checksums.
+    # We fetch a copy to hash and helm then re-downloads: helm 4's local-tarball
+    # installer derives the expected archive root from the file's basename
+    # (helm-diff-linux-amd64), but helm-diff's tarball is rooted at diff/, so
+    # `helm plugin install <local .tgz>` cannot be used. helm's .prov check
+    # against the pinned key still covers that second fetch.
+    #
+    # Run in a subshell with an EXIT trap so the temp GNUPGHOME/keyring/tarball
+    # are removed on every path — including a set -e (L41) abort, where a RETURN
     # trap would not fire. The subshell keeps the trap and temp vars scoped to
-    # this block without disturbing the parent shell's traps.
+    # this block without disturbing the parent shell's traps. Its `|| exit 1`
+    # does not rely on the caller's set -e: a failed checksum or fingerprint
+    # check must abort even if phase_install is ever invoked in a condition
+    # context, where errexit is suppressed for the whole function body.
     (
       HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
+      HELM_DIFF_URL="https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-${HELM_DIFF_ASSET}.tgz"
       GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
       HELM_DIFF_KEYRING="$(mktemp)"
-      trap 'rm -rf "${GNUPGHOME}" "${HELM_DIFF_KEYRING}"' EXIT
+      HELM_DIFF_TARBALL="$(mktemp)"
+      trap 'rm -rf "${GNUPGHOME}" "${HELM_DIFF_KEYRING}" "${HELM_DIFF_TARBALL}"' EXIT
+
+      # No --max-time: the tarball is ~33 MB and a slow-but-progressing
+      # transfer should not be killed. --retry-max-time bounds the retry window.
+      curl -fsSL --connect-timeout 10 \
+        --retry 3 --retry-delay 0 --retry-max-time 180 --retry-connrefused \
+        -o "${HELM_DIFF_TARBALL}" "${HELM_DIFF_URL}"
+      actual_sha="$(uat_sha256 "${HELM_DIFF_TARBALL}")"
+      if [[ "${actual_sha}" != "${HELM_DIFF_SHA256}" ]]; then
+        echo "::error::helm-diff tarball checksum mismatch for ${HELM_DIFF_URL}" >&2
+        echo "::error::expected ${HELM_DIFF_SHA256} (.settings.yaml testing_tools.helm_diff_checksums.${HELM_DIFF_SHA_KEY}), got ${actual_sha}" >&2
+        exit 1
+      fi
+      echo "helm-diff tarball checksum OK (${HELM_DIFF_SHA_KEY}: ${HELM_DIFF_SHA256})"
+
       curl -fsSL "https://github.com/databus23.gpg" | gpg --import
       if ! gpg --with-colons --fingerprint \
           | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
@@ -444,9 +521,8 @@ phase_install() {
         exit 1
       fi
       gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
-      helm plugin install "https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-linux-amd64.tgz" \
-        --keyring "${HELM_DIFF_KEYRING}"
-    )
+      helm plugin install "${HELM_DIFF_URL}" --keyring "${HELM_DIFF_KEYRING}"
+    ) || exit 1
   fi
   echo "::endgroup::"
 

--- a/tests/uat/lib/phases.sh
+++ b/tests/uat/lib/phases.sh
@@ -471,57 +471,87 @@ phase_install() {
       echo "helm-diff ${installed_ver} installed; removing to pin ${HELM_DIFF_VERSION}"
       helm plugin remove diff
     fi
-    # Install from the signed release tarball (helm-diff's recommended Helm 4
-    # method). Helm 4 verifies plugin provenance by default (--verify=true):
-    # the .prov signature is checked against a keyring. Import the maintainer's
-    # release key, pin it to the published fingerprint (fail closed on
-    # mismatch), export it to a legacy keyring, and verify against it.
+    # Install the exact bytes we verified. Three independent gates, all on one
+    # downloaded copy — helm never re-fetches, so there is no window in which a
+    # hostile cache can substitute different bytes between check and install:
     #
-    # The signature proves the maintainer signed whatever was served; it does
-    # not pin *which* release we accept. So also gate on a SHA256 from
-    # .settings.yaml, bumped deliberately by tools/update-helm-diff-checksums.
-    # We fetch a copy to hash and helm then re-downloads: helm 4's local-tarball
-    # installer derives the expected archive root from the file's basename
-    # (helm-diff-linux-amd64), but helm-diff's tarball is rooted at diff/, so
-    # `helm plugin install <local .tgz>` cannot be used. helm's .prov check
-    # against the pinned key still covers that second fetch.
+    #   1. SHA256 matches the .settings.yaml pin  — fixes *which* release.
+    #   2. The .prov clearsign carries VALIDSIG for the pinned maintainer
+    #      fingerprint                            — proves upstream authorship.
+    #   3. The SHA256 recorded inside that signed .prov equals the pin
+    #                                             — binds (2) to (1), so the
+    #      signature covers our bytes rather than some other signed release.
     #
-    # Run in a subshell with an EXIT trap so the temp GNUPGHOME/keyring/tarball
-    # are removed on every path — including a set -e (L41) abort, where a RETURN
+    # Gate 3 is what lets us pass --verify=false safely. Helm's own --verify
+    # only establishes (2): it would accept any validly signed helm-diff
+    # release, including an older one replayed by a compromised cache, which
+    # is a downgrade past the pin. Doing the checks here is strictly stronger.
+    # The cost is a cosmetic `PROVENANCE: unsigned` in `helm plugin list`.
+    #
+    # The tarball is staged as diff.tgz because helm's local-tarball installer
+    # derives both the expected archive root and the install directory from the
+    # file's basename, and helm-diff's tarball is rooted at diff/.
+    #
+    # Run in a subshell with an EXIT trap so the temp GNUPGHOME/staging dir are
+    # removed on every path — including a set -e (L41) abort, where a RETURN
     # trap would not fire. The subshell keeps the trap and temp vars scoped to
     # this block without disturbing the parent shell's traps. Its `|| exit 1`
-    # does not rely on the caller's set -e: a failed checksum or fingerprint
-    # check must abort even if phase_install is ever invoked in a condition
-    # context, where errexit is suppressed for the whole function body.
+    # does not rely on the caller's set -e: a failed gate must abort even if
+    # phase_install is ever invoked in a condition context, where errexit is
+    # suppressed for the whole function body.
     (
       HELM_DIFF_KEY_FPR="C5645EF47482257A1F806D2BEA17A2A206AFF8CD"
-      HELM_DIFF_URL="https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/helm-diff-${HELM_DIFF_ASSET}.tgz"
+      HELM_DIFF_FILE="helm-diff-${HELM_DIFF_ASSET}.tgz"
+      HELM_DIFF_URL="https://github.com/databus23/helm-diff/releases/download/${HELM_DIFF_VERSION}/${HELM_DIFF_FILE}"
       GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-      HELM_DIFF_KEYRING="$(mktemp)"
-      HELM_DIFF_TARBALL="$(mktemp)"
-      trap 'rm -rf "${GNUPGHOME}" "${HELM_DIFF_KEYRING}" "${HELM_DIFF_TARBALL}"' EXIT
+      HELM_DIFF_STAGE="$(mktemp -d)"
+      trap 'rm -rf "${GNUPGHOME}" "${HELM_DIFF_STAGE}"' EXIT
+      tarball="${HELM_DIFF_STAGE}/diff.tgz"
 
       # No --max-time: the tarball is ~33 MB and a slow-but-progressing
       # transfer should not be killed. --retry-max-time bounds the retry window.
       curl -fsSL --connect-timeout 10 \
         --retry 3 --retry-delay 0 --retry-max-time 180 --retry-connrefused \
-        -o "${HELM_DIFF_TARBALL}" "${HELM_DIFF_URL}"
-      actual_sha="$(uat_sha256 "${HELM_DIFF_TARBALL}")"
+        -o "${tarball}" "${HELM_DIFF_URL}"
+      curl -fsSL --connect-timeout 10 \
+        --retry 3 --retry-delay 0 --retry-max-time 180 --retry-connrefused \
+        -o "${tarball}.prov" "${HELM_DIFF_URL}.prov"
+
+      # Gate 1: pinned bytes.
+      actual_sha="$(uat_sha256 "${tarball}")"
       if [[ "${actual_sha}" != "${HELM_DIFF_SHA256}" ]]; then
         echo "::error::helm-diff tarball checksum mismatch for ${HELM_DIFF_URL}" >&2
         echo "::error::expected ${HELM_DIFF_SHA256} (.settings.yaml testing_tools.helm_diff_checksums.${HELM_DIFF_SHA_KEY}), got ${actual_sha}" >&2
         exit 1
       fi
-      echo "helm-diff tarball checksum OK (${HELM_DIFF_SHA_KEY}: ${HELM_DIFF_SHA256})"
 
+      # Gate 2: the provenance document is signed by the pinned release key.
+      # The fingerprint check on the imported key gives a clearer error when
+      # the published key rotates; VALIDSIG is the one that actually binds the
+      # signature to that fingerprint.
       curl -fsSL "https://github.com/databus23.gpg" | gpg --import
       if ! gpg --with-colons --fingerprint \
           | awk -F: '/^fpr:/{print $10}' | grep -qx "${HELM_DIFF_KEY_FPR}"; then
         echo "::error::helm-diff release key fingerprint mismatch (expected ${HELM_DIFF_KEY_FPR})" >&2
         exit 1
       fi
-      gpg --export "${HELM_DIFF_KEY_FPR}" > "${HELM_DIFF_KEYRING}"
-      helm plugin install "${HELM_DIFF_URL}" --keyring "${HELM_DIFF_KEYRING}"
+      if ! gpg --verify --status-fd=1 "${tarball}.prov" 2>/dev/null \
+          | grep -q "^\[GNUPG:\] VALIDSIG ${HELM_DIFF_KEY_FPR} "; then
+        echo "::error::helm-diff provenance is not validly signed by ${HELM_DIFF_KEY_FPR}" >&2
+        exit 1
+      fi
+
+      # Gate 3: that signature covers the bytes we just pinned. The .prov keys
+      # its files map by the upstream asset name, not our staged filename.
+      prov_sha="$(gpg --decrypt "${tarball}.prov" 2>/dev/null \
+        | awk -v a="${HELM_DIFF_FILE}:" '$1==a {gsub(/"|sha256:/,"",$2); print $2}')"
+      if [[ "${prov_sha}" != "${HELM_DIFF_SHA256}" ]]; then
+        echo "::error::helm-diff provenance records sha256 ${prov_sha:-<none>} for ${HELM_DIFF_FILE}, pinned ${HELM_DIFF_SHA256}" >&2
+        exit 1
+      fi
+      echo "helm-diff verified (${HELM_DIFF_SHA_KEY}: ${HELM_DIFF_SHA256}, signed by ${HELM_DIFF_KEY_FPR})"
+
+      helm plugin install "${tarball}" --verify=false
     ) || exit 1
   fi
   echo "::endgroup::"

--- a/tools/update-helm-diff-checksums
+++ b/tools/update-helm-diff-checksums
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Refresh the per-arch SHA256 checksums in .settings.yaml after a helm-diff
+# version bump. Invoked by Renovate via postUpgradeTasks (.github/renovate.json5)
+# whenever testing_tools.helm_diff is updated.
+#
+# Usage: tools/update-helm-diff-checksums <helm-diff-version>
+#   e.g. tools/update-helm-diff-checksums v3.15.11
+#
+# Idempotent: re-running with the currently-pinned version produces no diff.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <helm-diff-version>" >&2
+  exit 64
+fi
+
+VERSION="$1"
+# Accept both "v3.15.11" and "3.15.11".
+VERSION_NO_V="${VERSION#v}"
+VERSION_WITH_V="v${VERSION_NO_V}"
+
+SETTINGS_FILE=".settings.yaml"
+if [[ ! -f "${SETTINGS_FILE}" ]]; then
+  echo "ERROR: ${SETTINGS_FILE} not found (run from repo root)" >&2
+  exit 1
+fi
+
+# Upstream release asset is named helm-diff_<version>_checksums.txt (same
+# convention as helmfile, unlike chainsaw's plain checksums.txt). Embedding the
+# version in the filename means a release-asset rename would surface here as a
+# 404 instead of silently picking up the previous version's checksums.
+CHECKSUMS_URL="https://github.com/databus23/helm-diff/releases/download/${VERSION_WITH_V}/helm-diff_${VERSION_NO_V}_checksums.txt"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+echo "Fetching ${CHECKSUMS_URL}"
+# Retry on transient failures (5xx, 408/429, connection refused, network
+# blips). Up to 5 attempts; --retry-delay 0 means curl picks an exponential
+# backoff. Total retry window capped at 180s.
+if ! curl --fail --silent --show-error --location \
+      --connect-timeout 10 --max-time 60 \
+      --retry 5 --retry-delay 0 --retry-max-time 180 \
+      --retry-connrefused \
+      --output "${TMPDIR}/checksums.txt" \
+      "${CHECKSUMS_URL}"; then
+  echo "ERROR: failed to download ${CHECKSUMS_URL} after retries" >&2
+  exit 1
+fi
+
+# Each line in the upstream file is "<sha256>  helm-diff-<os>-<arch>.tgz".
+# helm-diff labels macOS assets "macos", so the darwin_* keys in .settings.yaml
+# (named for GOOS, consistent with the chainsaw/helmfile blocks) map to
+# "macos" asset names here.
+extract_sha() {
+  local asset_os="$1" arch="$2"
+  local pattern="helm-diff-${asset_os}-${arch}\\.tgz"
+  local line
+  line=$(grep -E "  ${pattern}\$" "${TMPDIR}/checksums.txt" || true)
+  if [[ -z "${line}" ]]; then
+    echo "ERROR: no checksum entry matching ${pattern} in ${CHECKSUMS_URL}" >&2
+    exit 1
+  fi
+  echo "${line%% *}"
+}
+
+LINUX_AMD64=$(extract_sha linux amd64)
+LINUX_ARM64=$(extract_sha linux arm64)
+DARWIN_AMD64=$(extract_sha macos amd64)
+DARWIN_ARM64=$(extract_sha macos arm64)
+
+echo "  linux_amd64:  ${LINUX_AMD64}"
+echo "  linux_arm64:  ${LINUX_ARM64}"
+echo "  darwin_amd64: ${DARWIN_AMD64}"
+echo "  darwin_arm64: ${DARWIN_ARM64}"
+
+# Rewrite the four checksum lines in-place inside the helm_diff_checksums:
+# block via awk (avoids editing chainsaw_checksums / helmfile_checksums, which
+# use the same arch keys at the same indent). mikefarah/yq would also work but
+# drops blank lines between top-level mappings and would reformat the entire
+# file on every Renovate PR — see the failure-modes note in
+# .github/RENOVATE.md.
+NEW_FILE="${TMPDIR}/settings.new"
+awk -v amd64="${LINUX_AMD64}" -v arm64="${LINUX_ARM64}" \
+    -v damd64="${DARWIN_AMD64}" -v darm64="${DARWIN_ARM64}" '
+    BEGIN { in_block = 0 }
+    # Enter helm_diff_checksums block.
+    /^  helm_diff_checksums:[[:space:]]*$/ { in_block = 1; print; next }
+    # Leave the block when we hit any other top-level (2-space) key.
+    in_block && /^  [a-zA-Z_]/ && !/^    / { in_block = 0 }
+    in_block && /^    linux_amd64:[[:space:]]*'\''[0-9a-f]{64}'\''/  { print "    linux_amd64: \x27" amd64 "\x27"; next }
+    in_block && /^    linux_arm64:[[:space:]]*'\''[0-9a-f]{64}'\''/  { print "    linux_arm64: \x27" arm64 "\x27"; next }
+    in_block && /^    darwin_amd64:[[:space:]]*'\''[0-9a-f]{64}'\''/ { print "    darwin_amd64: \x27" damd64 "\x27"; next }
+    in_block && /^    darwin_arm64:[[:space:]]*'\''[0-9a-f]{64}'\''/ { print "    darwin_arm64: \x27" darm64 "\x27"; next }
+    { print }
+  ' "${SETTINGS_FILE}" > "${NEW_FILE}"
+
+# Verify the new file contains the expected new values inside
+# helm_diff_checksums. Fail closed if anything came out wrong rather than
+# overwriting silently — this catches awk-engine quirks and unexpected
+# input shapes.
+verify_block() {
+  local key="$1" sha="$2"
+  if ! awk -v key="$key" -v sha="$sha" '
+        /^  helm_diff_checksums:[[:space:]]*$/ { in_block = 1; next }
+        in_block && /^  [a-zA-Z_]/ && !/^    / { in_block = 0 }
+        in_block && $0 ~ "^    " key ":[[:space:]]*'\''" sha "'\''$" { found = 1 }
+        END { exit !found }
+      ' "${NEW_FILE}"; then
+    echo "ERROR: verify_block: ${key} did not update to '${sha}' under helm_diff_checksums" >&2
+    exit 1
+  fi
+}
+verify_block linux_amd64  "${LINUX_AMD64}"
+verify_block linux_arm64  "${LINUX_ARM64}"
+verify_block darwin_amd64 "${DARWIN_AMD64}"
+verify_block darwin_arm64 "${DARWIN_ARM64}"
+
+# Sanity: the sibling checksum blocks must NOT have picked up any helm-diff SHA
+# (cross-block contamination check — the awk above scopes by `in_block`, but a
+# regression-by-copy-paste could break that, so verify before moving the file).
+for block in chainsaw_checksums helmfile_checksums; do
+  for sha in "${LINUX_AMD64}" "${LINUX_ARM64}" "${DARWIN_AMD64}" "${DARWIN_ARM64}"; do
+    if awk -v block="${block}" -v sha="$sha" '
+          $0 ~ "^  " block ":[[:space:]]*$" { in_block = 1; next }
+          in_block && /^  [a-zA-Z_]/ && !/^    / { in_block = 0 }
+          in_block && index($0, sha) > 0 { found = 1 }
+          END { exit !found }
+        ' "${NEW_FILE}"; then
+      echo "ERROR: helm-diff SHA ${sha} leaked into ${block} block" >&2
+      exit 1
+    fi
+  done
+done
+
+mv "${NEW_FILE}" "${SETTINGS_FILE}"
+echo "Updated ${SETTINGS_FILE} for helm-diff ${VERSION_WITH_V}"

--- a/tools/update-helm-diff-checksums
+++ b/tools/update-helm-diff-checksums
@@ -29,6 +29,18 @@ if [[ ! -f "${SETTINGS_FILE}" ]]; then
   exit 1
 fi
 
+# Refuse to write checksums for a release other than the pinned one. Renovate
+# runs this after updating testing_tools.helm_diff (postUpgradeTasks with
+# executionMode "update"), so the two always agree there; a hand-run with the
+# wrong argument would otherwise commit checksums that no runner can satisfy,
+# surfacing later as an opaque UAT checksum mismatch.
+PINNED_VERSION="$(yq -r '.testing_tools.helm_diff // ""' "${SETTINGS_FILE}")"
+if [[ "${PINNED_VERSION#v}" != "${VERSION_NO_V}" ]]; then
+  echo "ERROR: ${SETTINGS_FILE} pins helm_diff ${PINNED_VERSION}, refusing to write checksums for ${VERSION_WITH_V}" >&2
+  echo "       Bump testing_tools.helm_diff first, then re-run with the matching version." >&2
+  exit 1
+fi
+
 # Upstream release asset is named helm-diff_<version>_checksums.txt (same
 # convention as helmfile, unlike chainsaw's plain checksums.txt). Embedding the
 # version in the filename means a release-asset rename would surface here as a
@@ -36,7 +48,16 @@ fi
 CHECKSUMS_URL="https://github.com/databus23/helm-diff/releases/download/${VERSION_WITH_V}/helm-diff_${VERSION_NO_V}_checksums.txt"
 
 TMPDIR=$(mktemp -d)
-trap 'rm -rf "${TMPDIR}"' EXIT
+# The replacement file must live on the same filesystem as ${SETTINGS_FILE} so
+# the final mv is an atomic rename. ${TMPDIR} is frequently a separate
+# filesystem, where mv degrades to copy-then-delete and a failure mid-copy
+# would leave .settings.yaml truncated.
+NEW_FILE="$(mktemp "${SETTINGS_FILE}.new.XXXXXX")"
+trap 'rm -rf "${TMPDIR}" "${NEW_FILE}"' EXIT
+# mktemp creates 0600; seed from the target so the rename preserves its mode
+# (cp -p sets the destination's mode from the source, and the later `>`
+# redirect truncates without changing it).
+cp -p "${SETTINGS_FILE}" "${NEW_FILE}"
 
 echo "Fetching ${CHECKSUMS_URL}"
 # Retry on transient failures (5xx, 408/429, connection refused, network
@@ -84,7 +105,6 @@ echo "  darwin_arm64: ${DARWIN_ARM64}"
 # drops blank lines between top-level mappings and would reformat the entire
 # file on every Renovate PR — see the failure-modes note in
 # .github/RENOVATE.md.
-NEW_FILE="${TMPDIR}/settings.new"
 awk -v amd64="${LINUX_AMD64}" -v arm64="${LINUX_ARM64}" \
     -v damd64="${DARWIN_AMD64}" -v darm64="${DARWIN_ARM64}" '
     BEGIN { in_block = 0 }


### PR DESCRIPTION
## Summary

Gate the UAT runners' helm-diff plugin install on a SHA256 pinned in `.settings.yaml`, verified before `helm plugin install` runs, and add `tools/update-helm-diff-checksums` so the pin is refreshed by a deliberate Renovate bump rather than drifting silently.

## Motivation / Context

The UAT runners installed helm-diff from a release tarball whose provenance was checked only by helm 4's GPG `.prov` verification. That proves the maintainer signed whatever was served; it does not pin *which* release we accept. A compromised release asset or poisoned CDN cache could inject malicious YAML into the UAT diff step.

Adding a checksum pin closes that gap and makes version bumps explicit, consistent with `.settings.yaml` as the single source of truth (this is the same pattern already used for `chainsaw_checksums` and `helmfile_checksums`).

Fixes: #1541
Related: #1510 (where this was deferred to keep scope focused)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: UAT runners (`tests/uat/lib/phases.sh`), Renovate automation, `.settings.yaml`

## Implementation Notes

**Acceptance criteria mapping.** The runner now fails loudly (`::error::` + `exit 1`) before `helm plugin install` when the downloaded tarball does not match the pin, and when no pin exists for the host platform at all. Bumps go through `tools/update-helm-diff-checksums`, wired to Renovate `postUpgradeTasks` like the two existing checksum blocks.

**Why the tarball is fetched twice.** Verifying a locally-downloaded tarball and then handing that same file to helm is not possible here. Helm 4's local-tarball installer derives the expected archive root directory from the file's basename (`helm-diff-linux-amd64`), while helm-diff's tarball is rooted at `diff/`, so `helm plugin install <local .tgz>` fails with `plugin.yaml not found in expected directory`. Renaming the file to match breaks verification instead, because the `.prov` records the original filename (`provenance does not contain a SHA for a file named "diff.tgz"`). Both were confirmed against helm 4.1.4/4.2.0 and the 4.2.4 source. So we fetch a copy to hash, then let helm fetch and install; helm's `.prov` signature check against the pinned key still covers that second fetch, and the extra ~33 MB only occurs on plugin cache miss.

**Renovate allowlist fix (worth a look).** `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS` was `^\./tools/update-[a-z]+-checksums `, which does **not** match a hyphenated tool name like `update-helm-diff-checksums`. Renovate rejects non-matching post-upgrade commands *silently*, with only a warn-level log line, so this would have shipped stale checksums alongside version bumps — exactly the failure mode the existing comment there warns about. Widened to `[a-z-]+`, which is what that comment already claimed the regex did.

**Host-aware asset selection (scope note).** The install was hardcoded to `helm-diff-linux-amd64.tgz`. Since the checksum key has to be selected per platform anyway, the asset is now chosen from `uname`. All UAT runners are `ubuntu-latest` / `linux-amd64-gpu-h100`, so CI behavior is unchanged; this only fixes the documented "local reproduction" path (`all` phase), which previously installed a Linux binary on a Mac. Happy to revert to hardcoded linux/amd64 and drop the three unused checksum keys if reviewers prefer the smaller diff.

**Fail-closed hardening.** The install subshell gained `|| exit 1` so both the new checksum gate and the pre-existing GPG fingerprint check abort even if `phase_install` is ever called in a condition context, where `errexit` is suppressed for the whole function body.

## Testing

No Go source changed, so the per-package coverage gate does not apply.

```bash
make lint              # pass
make tuning-check      # pass
make license-check     # pass
make lint-renovate     # pass (Renovate validated the config)
actionlint .github/workflows/renovate.yaml   # pass
shellcheck tests/uat/lib/phases.sh tools/update-helm-diff-checksums  # no new findings
make test-coverage     # see note below
```

Install path exercised end to end locally (darwin/arm64), driving the real `phase_install` against an isolated `HELM_DATA_HOME`:

- **Happy path** — checksum gate passed, and helm independently reported `Plugin Hash Verified: sha256:ba489cc…`, the same value as the pin, then `Installed plugin: diff`.
- **Corrupted pin** — aborts with exit 1 at the gate and never reaches `helmfile apply`.
- **Missing pin** — aborts with the `refresh with tools/update-helm-diff-checksums` message.
- **`linux_amd64` pin** (what CI actually uses) cross-checked against the GPG-signed `.prov`, not just the plain `checksums.txt`.
- **Updater idempotency** — re-running `tools/update-helm-diff-checksums v3.15.11` against the committed pins produces no diff.

Two local-environment caveats, called out rather than papered over:

- `make test-coverage` fails only in `tests/releasepolicy`, because GNU `timeout` is not installed on this machine and `.github/scripts/release-images.sh` shells out to it. Unrelated to this diff, which touches neither path; every other package passed.
- `make api-diff`, `make scan`, and `make e2e` were **not** run locally. `apidiff` is not installed and `go install` of the pinned version kept failing on network resets pulling `golang.org/x/tools`; `scan`/`e2e` exceeded the time I had available. This diff contains no Go source, so `api-diff` has no API surface to compare. Relying on CI for these three.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No functional change to UAT output. The new gate is additive; worst case a genuine upstream asset rotation fails the install loudly with a message naming the refresh command. `helm_diff_checksums` is a new key nothing else reads.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — except the pre-existing `tests/releasepolicy` environmental failure noted above
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — verified via the three-path manual exercise above; the install path is shell in a cloud-only UAT runner with no existing unit-test harness
- [x] I updated docs if user-facing behavior changed — `.github/RENOVATE.md` coverage table and companion-script list
- [x] Changes follow existing patterns in the codebase — mirrors `tools/update-helmfile-checksums` and the `helmfile_checksums` / `chainsaw_checksums` blocks
- [x] Commits are cryptographically signed (`git commit -S`)
