### PR TITLE
fix(bundler): retry transient Helm index fetch failures

### DIFF
--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -47,9 +48,19 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
-	"github.com/NVIDIA/aicr/pkg/oci"
 	"sigs.k8s.io/yaml"
 )
+
+// jitterBackoff applies ±25% jitter to d to decorrelate retries.
+// Mirrors pkg/oci/push.go pattern for retry backoff scheduling.
+func jitterBackoff(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	// Range: [0.75*d, 1.25*d). rand/v2.Float64 is in [0.0, 1.0).
+	jitter := 0.75 + rand.Float64()*0.5 //nolint:gosec // non-cryptographic jitter
+	return time.Duration(float64(d) * jitter)
+}
 
 // safeChartNameRE bounds the recipe-supplied identifiers that flow into
 // `helm pull` as positional argv tokens. The leading character must be
@@ -642,7 +653,7 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 			slog.WarnContext(ctx, "vendor-charts: index fetch retrying after validation error",
 				"attempt", attempt, "error", err)
 			// Sleep with exponential backoff + jitter to decorrelate retries.
-			timer := newBackoffTimer(oci.JitterDuration(backoff))
+			timer := newBackoffTimer(jitterBackoff(backoff))
 			select {
 			case <-ctx.Done():
 				timer.Stop()
@@ -698,7 +709,7 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 			"attempt", attempt, "error", err)
 
 		// Sleep with exponential backoff + jitter, but honor parent context cancellation.
-		timer := newBackoffTimer(oci.JitterDuration(backoff))
+		timer := newBackoffTimer(jitterBackoff(backoff))
 		select {
 		case <-ctx.Done():
 			timer.Stop()

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -607,6 +607,20 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		// context governs cancellation.
 		attemptCtx, attemptCancel := context.WithTimeout(ctx, defaults.HelmChartIndexPreCheckTimeout)
 
+		// Check parent context cancellation first.
+		if parentErr := ctx.Err(); parentErr != nil {
+			attemptCancel()
+			if stderrors.Is(parentErr, context.Canceled) {
+				return nil, errors.Wrap(errors.ErrCodeCanceled,
+					"vendor-charts: index pre-check canceled", parentErr)
+			}
+			if stderrors.Is(parentErr, context.DeadlineExceeded) {
+				return nil, errors.Wrap(errors.ErrCodeTimeout,
+					"vendor-charts: index pre-check deadline exceeded", parentErr)
+			}
+			return nil, parentErr
+		}
+
 		// Fail-closed egress check on every attempt. Defends against DNS
 		// rebinding: a malicious resolver could serve an allowed address on
 		// the first attempt, then rebind to a disallowed address on retries.

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -47,6 +47,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/oci"
 	"sigs.k8s.io/yaml"
 )
 
@@ -626,8 +627,8 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 			}
 			slog.WarnContext(ctx, "vendor-charts: index fetch retrying after validation error",
 				"attempt", attempt, "error", err)
-			// Sleep with exponential backoff.
-			timer := newBackoffTimer(backoff)
+			// Sleep with exponential backoff + jitter to decorrelate retries.
+			timer := newBackoffTimer(oci.JitterDuration(backoff))
 			select {
 			case <-ctx.Done():
 				timer.Stop()
@@ -682,8 +683,8 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		slog.WarnContext(ctx, "vendor-charts: index fetch retrying after transient error",
 			"attempt", attempt, "error", err)
 
-		// Sleep with exponential backoff, but honor parent context cancellation.
-		timer := newBackoffTimer(backoff)
+		// Sleep with exponential backoff + jitter, but honor parent context cancellation.
+		timer := newBackoffTimer(oci.JitterDuration(backoff))
 		select {
 		case <-ctx.Done():
 			timer.Stop()

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -597,22 +597,21 @@ var newBackoffTimer = time.NewTimer
 // backoff. Non-transient errors (404, 401/403, other 4xx) fail on the first
 // attempt. Policy-rejected redirects are never retried.
 func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error) {
-	// Fail-closed egress check on the initial URL. Idempotent: safe to
-	// re-run for URLs the caller already validated. Today the only
-	// production caller (resolveAndValidateHTTPIndex) runs
-	// checkEgressPolicy(c.Repository) upstream and derives indexURL from
-	// the same host, so this call is a no-op in the happy path. It
-	// exists so a future refactor that reorders Pull() — or a new caller
-	// of defaultFetchIndexYAML that skips the upstream check — cannot
-	// silently open an SSRF hole here.
-	if err := checkFetchTargetURL(ctx, indexURL); err != nil {
-		return nil, err
-	}
-
 	var lastErr error
 	backoff := defaults.HelmChartIndexRetryInitialBackoff
 
 	for attempt := 1; attempt <= defaults.HelmChartIndexRetryBudget; attempt++ {
+		// Egress check before each attempt defends against DNS rebinding:
+		// an attacker cannot rebind the domain to a disallowed address on
+		// a retry after passing the initial check. Idempotent: safe to
+		// re-run for URLs the caller already validated. Today the only
+		// production caller (resolveAndValidateHTTPIndex) runs
+		// checkEgressPolicy(c.Repository) upstream and derives indexURL from
+		// the same host, so this call is a no-op in the happy path.
+		if err := checkFetchTargetURL(ctx, indexURL); err != nil {
+			return nil, err
+		}
+
 		// Per-attempt timeout independent of parent context, so a slow
 		// upstream cannot outlive the fetch operation itself. The parent
 		// context governs cancellation.

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -597,21 +597,22 @@ var newBackoffTimer = time.NewTimer
 // backoff. Non-transient errors (404, 401/403, other 4xx) fail on the first
 // attempt. Policy-rejected redirects are never retried.
 func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error) {
+	// Fail-closed egress check on the initial URL. Idempotent: safe to
+	// re-run for URLs the caller already validated. Today the only
+	// production caller (resolveAndValidateHTTPIndex) runs
+	// checkEgressPolicy(c.Repository) upstream and derives indexURL from
+	// the same host, so this call is a no-op in the happy path. It
+	// exists so a future refactor that reorders Pull() — or a new caller
+	// of defaultFetchIndexYAML that skips the upstream check — cannot
+	// silently open an SSRF hole here.
+	if err := checkFetchTargetURL(ctx, indexURL); err != nil {
+		return nil, err
+	}
+
 	var lastErr error
 	backoff := defaults.HelmChartIndexRetryInitialBackoff
 
 	for attempt := 1; attempt <= defaults.HelmChartIndexRetryBudget; attempt++ {
-		// Egress check before each attempt defends against DNS rebinding:
-		// an attacker cannot rebind the domain to a disallowed address on
-		// a retry after passing the initial check. Idempotent: safe to
-		// re-run for URLs the caller already validated. Today the only
-		// production caller (resolveAndValidateHTTPIndex) runs
-		// checkEgressPolicy(c.Repository) upstream and derives indexURL from
-		// the same host, so this call is a no-op in the happy path.
-		if err := checkFetchTargetURL(ctx, indexURL); err != nil {
-			return nil, err
-		}
-
 		// Per-attempt timeout independent of parent context, so a slow
 		// upstream cannot outlive the fetch operation itself. The parent
 		// context governs cancellation.

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -597,18 +597,6 @@ var newBackoffTimer = time.NewTimer
 // backoff. Non-transient errors (404, 401/403, other 4xx) fail on the first
 // attempt. Policy-rejected redirects are never retried.
 func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error) {
-	// Fail-closed egress check on the initial URL. Idempotent: safe to
-	// re-run for URLs the caller already validated. Today the only
-	// production caller (resolveAndValidateHTTPIndex) runs
-	// checkEgressPolicy(c.Repository) upstream and derives indexURL from
-	// the same host, so this call is a no-op in the happy path. It
-	// exists so a future refactor that reorders Pull() — or a new caller
-	// of defaultFetchIndexYAML that skips the upstream check — cannot
-	// silently open an SSRF hole here.
-	if err := checkFetchTargetURL(ctx, indexURL); err != nil {
-		return nil, err
-	}
-
 	var lastErr error
 	backoff := defaults.HelmChartIndexRetryInitialBackoff
 
@@ -617,6 +605,43 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		// upstream cannot outlive the fetch operation itself. The parent
 		// context governs cancellation.
 		attemptCtx, attemptCancel := context.WithTimeout(ctx, defaults.HelmChartIndexPreCheckTimeout)
+
+		// Fail-closed egress check on every attempt. Defends against DNS
+		// rebinding: a malicious resolver could serve an allowed address on
+		// the first attempt, then rebind to a disallowed address on retries.
+		// Validation errors are routed through the retry classification logic:
+		// transient errors (timeouts, temporary DNS failures) are retried;
+		// policy rejections fail immediately.
+		if err := checkFetchTargetURL(attemptCtx, indexURL); err != nil {
+			attemptCancel()
+			lastErr = err
+			// Policy rejections (InvalidRequest) never retry.
+			isRetryable := stderrors.Is(err, errors.New(errors.ErrCodeUnavailable, ""))
+			if !isRetryable {
+				return nil, err
+			}
+			// Don't retry if at budget limit.
+			if attempt == defaults.HelmChartIndexRetryBudget {
+				return nil, err
+			}
+			slog.WarnContext(ctx, "vendor-charts: index fetch retrying after validation error",
+				"attempt", attempt, "error", err)
+			// Sleep with exponential backoff.
+			timer := newBackoffTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				if stderrors.Is(ctx.Err(), context.Canceled) {
+					return nil, errors.Wrap(errors.ErrCodeCanceled,
+						"vendor-charts: index pre-check canceled during backoff", ctx.Err())
+				}
+				return nil, errors.Wrap(errors.ErrCodeTimeout,
+					"vendor-charts: index pre-check deadline exceeded during backoff", ctx.Err())
+			case <-timer.C:
+			}
+			backoff *= 2
+			continue
+		}
 
 		body, err := fetchIndexYAMLAttempt(attemptCtx, indexURL)
 		attemptCancel()

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -51,6 +51,20 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// remapParentCtxErr converts a parent-context error into the matching
+// structured code. Returns nil when the parent context is still live, so
+// callers can fall through to their own error handling.
+func remapParentCtxErr(ctx context.Context, msg string) error {
+	parentErr := ctx.Err()
+	if parentErr == nil {
+		return nil
+	}
+	if stderrors.Is(parentErr, context.Canceled) {
+		return errors.Wrap(errors.ErrCodeCanceled, msg+" canceled", parentErr)
+	}
+	return errors.Wrap(errors.ErrCodeTimeout, msg+" deadline exceeded", parentErr)
+}
+
 // jitterBackoff applies ±25% jitter to d to decorrelate retries.
 // Mirrors pkg/oci/push.go pattern for retry backoff scheduling.
 func jitterBackoff(d time.Duration) time.Duration {
@@ -609,7 +623,6 @@ var newBackoffTimer = time.NewTimer
 // backoff. Non-transient errors (404, 401/403, other 4xx) fail on the first
 // attempt. Policy-rejected redirects are never retried.
 func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error) {
-	var lastErr error
 	backoff := defaults.HelmChartIndexRetryInitialBackoff
 
 	for attempt := 1; attempt <= defaults.HelmChartIndexRetryBudget; attempt++ {
@@ -619,39 +632,38 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		attemptCtx, attemptCancel := context.WithTimeout(ctx, defaults.HelmChartIndexPreCheckTimeout)
 
 		// Check parent context cancellation first.
-		if parentErr := ctx.Err(); parentErr != nil {
+		if ctxErr := remapParentCtxErr(ctx, "vendor-charts: index pre-check"); ctxErr != nil {
 			attemptCancel()
-			if stderrors.Is(parentErr, context.Canceled) {
-				return nil, errors.Wrap(errors.ErrCodeCanceled,
-					"vendor-charts: index pre-check canceled", parentErr)
-			}
-			if stderrors.Is(parentErr, context.DeadlineExceeded) {
-				return nil, errors.Wrap(errors.ErrCodeTimeout,
-					"vendor-charts: index pre-check deadline exceeded", parentErr)
-			}
-			return nil, parentErr
+			return nil, ctxErr
 		}
 
 		// Fail-closed egress check on every attempt. Defends against DNS
-		// rebinding: a malicious resolver could serve an allowed address on
-		// the first attempt, then rebind to a disallowed address on retries.
+		// rebinding across attempts: a malicious resolver could serve an
+		// allowed address on the first attempt, then rebind to a disallowed
+		// address on retries. Note the intra-attempt resolve-then-dial TOCTOU
+		// documented at checkEgressPolicy remains — closing it requires
+		// pinning the validated IP into a custom DialContext.
 		// Validation errors are routed through the retry classification logic:
 		// transient errors (timeouts, temporary DNS failures) are retried;
 		// policy rejections fail immediately.
 		if err := checkFetchTargetURL(attemptCtx, indexURL); err != nil {
 			attemptCancel()
-			lastErr = err
 			// Policy rejections (InvalidRequest) never retry.
 			isRetryable := stderrors.Is(err, errors.New(errors.ErrCodeUnavailable, ""))
 			if !isRetryable {
 				return nil, err
 			}
-			// Don't retry if at budget limit.
+			// Don't retry if at budget limit. Remap parent-context errors so a
+			// ctx-canceled lookupIP wrapped as Unavailable surfaces as
+			// Canceled/Timeout rather than a transient-looking failure.
 			if attempt == defaults.HelmChartIndexRetryBudget {
+				if ctxErr := remapParentCtxErr(ctx, "vendor-charts: index pre-check"); ctxErr != nil {
+					return nil, ctxErr
+				}
 				return nil, err
 			}
 			slog.WarnContext(ctx, "vendor-charts: index fetch retrying after validation error",
-				"attempt", attempt, "error", err)
+				"attempt", attempt, "of", defaults.HelmChartIndexRetryBudget, "error", err)
 			// Sleep with exponential backoff + jitter to decorrelate retries.
 			timer := newBackoffTimer(jitterBackoff(backoff))
 			select {
@@ -673,24 +685,14 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		attemptCancel()
 
 		// Check parent context cancellation first.
-		if parentErr := ctx.Err(); parentErr != nil {
-			if stderrors.Is(parentErr, context.Canceled) {
-				return nil, errors.Wrap(errors.ErrCodeCanceled,
-					"vendor-charts: index pre-check canceled", parentErr)
-			}
-			if stderrors.Is(parentErr, context.DeadlineExceeded) {
-				return nil, errors.Wrap(errors.ErrCodeTimeout,
-					"vendor-charts: index pre-check deadline exceeded", parentErr)
-			}
-			return nil, parentErr
+		if ctxErr := remapParentCtxErr(ctx, "vendor-charts: index pre-check"); ctxErr != nil {
+			return nil, ctxErr
 		}
 
 		// Success path.
 		if err == nil {
 			return body, nil
 		}
-
-		lastErr = err
 
 		// Determine if this error is retryable. Policy-rejected redirects
 		// (InvalidRequest code) and non-transient auth/validation errors must
@@ -706,7 +708,8 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		}
 
 		slog.WarnContext(ctx, "vendor-charts: index fetch retrying after transient error",
-			"attempt", attempt, "error", err)
+			"attempt", attempt, "of", defaults.HelmChartIndexRetryBudget,
+			"target", redactURL(indexURL), "error", err)
 
 		// Sleep with exponential backoff + jitter, but honor parent context cancellation.
 		timer := newBackoffTimer(jitterBackoff(backoff))
@@ -724,10 +727,7 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		backoff *= 2
 	}
 
-	// Should not reach here, but return the last error if we do.
-	if lastErr != nil {
-		return nil, lastErr
-	}
+	// Unreachable: the final attempt always returns from inside the loop.
 	return nil, errors.New(errors.ErrCodeInternal,
 		"vendor-charts: index pre-check exhausted retry budget without result")
 }

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -584,6 +584,10 @@ var fetchIndexYAML = defaultFetchIndexYAML
 // to control retry behavior.
 var fetchIndexYAMLAttempt = doFetchIndexYAMLAttempt
 
+// newBackoffTimer creates a timer for retry backoff. Tests inject a no-op to
+// avoid production sleep times.
+var newBackoffTimer = time.NewTimer
+
 // defaultFetchIndexYAML performs the production HTTP GET with retries on
 // transient failures. Every redirect hop is passed back through
 // checkEgressPolicy so a public repo cannot redirect the index-fetch itself
@@ -620,7 +624,7 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 		// Check parent context cancellation first.
 		if parentErr := ctx.Err(); parentErr != nil {
 			if stderrors.Is(parentErr, context.Canceled) {
-				return nil, errors.Wrap(errors.ErrCodeInternal,
+				return nil, errors.Wrap(errors.ErrCodeCanceled,
 					"vendor-charts: index pre-check canceled", parentErr)
 			}
 			if stderrors.Is(parentErr, context.DeadlineExceeded) {
@@ -654,12 +658,12 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 			"attempt", attempt, "error", err)
 
 		// Sleep with exponential backoff, but honor parent context cancellation.
-		timer := time.NewTimer(backoff)
+		timer := newBackoffTimer(backoff)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 			if stderrors.Is(ctx.Err(), context.Canceled) {
-				return nil, errors.Wrap(errors.ErrCodeInternal,
+				return nil, errors.Wrap(errors.ErrCodeCanceled,
 					"vendor-charts: index pre-check canceled during backoff", ctx.Err())
 			}
 			return nil, errors.Wrap(errors.ErrCodeTimeout,

--- a/pkg/bundler/deployer/localformat/vendor.go
+++ b/pkg/bundler/deployer/localformat/vendor.go
@@ -42,6 +42,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/NVIDIA/aicr/pkg/defaults"
@@ -578,10 +579,19 @@ func disallowedIPReason(ip net.IP) string {
 // depending on the developer's system resolver or network reachability.
 var fetchIndexYAML = defaultFetchIndexYAML
 
-// defaultFetchIndexYAML performs the production HTTP GET. Every redirect
-// hop is passed back through checkEgressPolicy so a public repo cannot
-// redirect the index-fetch itself into the private range. Response body
-// is capped at defaults.HelmChartIndexBodyLimit.
+// fetchIndexYAMLAttempt is the single-attempt HTTP GET function, wrapped by
+// the retry logic in defaultFetchIndexYAML. Tests inject a canned function
+// to control retry behavior.
+var fetchIndexYAMLAttempt = doFetchIndexYAMLAttempt
+
+// defaultFetchIndexYAML performs the production HTTP GET with retries on
+// transient failures. Every redirect hop is passed back through
+// checkEgressPolicy so a public repo cannot redirect the index-fetch itself
+// into the private range. Response body is capped at
+// defaults.HelmChartIndexBodyLimit. Transient errors (network failures, 5xx,
+// 408, 429) are retried up to HelmChartIndexRetryBudget with exponential
+// backoff. Non-transient errors (404, 401/403, other 4xx) fail on the first
+// attempt. Policy-rejected redirects are never retried.
 func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error) {
 	// Fail-closed egress check on the initial URL. Idempotent: safe to
 	// re-run for URLs the caller already validated. Today the only
@@ -594,6 +604,84 @@ func defaultFetchIndexYAML(ctx context.Context, indexURL string) ([]byte, error)
 	if err := checkFetchTargetURL(ctx, indexURL); err != nil {
 		return nil, err
 	}
+
+	var lastErr error
+	backoff := defaults.HelmChartIndexRetryInitialBackoff
+
+	for attempt := 1; attempt <= defaults.HelmChartIndexRetryBudget; attempt++ {
+		// Per-attempt timeout independent of parent context, so a slow
+		// upstream cannot outlive the fetch operation itself. The parent
+		// context governs cancellation.
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, defaults.HelmChartIndexPreCheckTimeout)
+
+		body, err := fetchIndexYAMLAttempt(attemptCtx, indexURL)
+		attemptCancel()
+
+		// Check parent context cancellation first.
+		if parentErr := ctx.Err(); parentErr != nil {
+			if stderrors.Is(parentErr, context.Canceled) {
+				return nil, errors.Wrap(errors.ErrCodeInternal,
+					"vendor-charts: index pre-check canceled", parentErr)
+			}
+			if stderrors.Is(parentErr, context.DeadlineExceeded) {
+				return nil, errors.Wrap(errors.ErrCodeTimeout,
+					"vendor-charts: index pre-check deadline exceeded", parentErr)
+			}
+			return nil, parentErr
+		}
+
+		// Success path.
+		if err == nil {
+			return body, nil
+		}
+
+		lastErr = err
+
+		// Determine if this error is retryable. Policy-rejected redirects
+		// (InvalidRequest code) and non-transient auth/validation errors must
+		// never be retried.
+		isRetryable := stderrors.Is(err, errors.New(errors.ErrCodeUnavailable, ""))
+		if !isRetryable {
+			return nil, err
+		}
+
+		// Don't retry if we're at the budget limit.
+		if attempt == defaults.HelmChartIndexRetryBudget {
+			return nil, err
+		}
+
+		slog.WarnContext(ctx, "vendor-charts: index fetch retrying after transient error",
+			"attempt", attempt, "error", err)
+
+		// Sleep with exponential backoff, but honor parent context cancellation.
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			if stderrors.Is(ctx.Err(), context.Canceled) {
+				return nil, errors.Wrap(errors.ErrCodeInternal,
+					"vendor-charts: index pre-check canceled during backoff", ctx.Err())
+			}
+			return nil, errors.Wrap(errors.ErrCodeTimeout,
+				"vendor-charts: index pre-check deadline exceeded during backoff", ctx.Err())
+		case <-timer.C:
+		}
+		backoff *= 2
+	}
+
+	// Should not reach here, but return the last error if we do.
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, errors.New(errors.ErrCodeInternal,
+		"vendor-charts: index pre-check exhausted retry budget without result")
+}
+
+// doFetchIndexYAMLAttempt performs a single HTTP GET attempt for the index.
+// Returns body on success. Returns a StructuredError with code indicating
+// retryability: ErrCodeUnavailable for transient errors, other codes for
+// permanent failures.
+func doFetchIndexYAMLAttempt(ctx context.Context, indexURL string) ([]byte, error) {
 	client := &http.Client{
 		Transport: defaults.NewHTTPTransport(),
 		Timeout:   defaults.HelmChartIndexPreCheckTimeout,

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -1809,7 +1809,7 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 			succeedAt:   100,
 			wantErr:     true,
 			wantCode:    errors.ErrCodeUnavailable,
-			wantAttempt: 1,
+			wantAttempt: 0,
 		},
 	}
 

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -1897,7 +1897,7 @@ func TestFetchIndexYAMLContextCancellation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		// Cancel after backoff begins to ensure cancellation happens during sleep
 		go func() {
-			<-backoffStarted  // Wait for backoff to start
+			<-backoffStarted // Wait for backoff to start
 			cancel()
 		}()
 

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -1871,7 +1871,17 @@ func TestFetchIndexYAMLContextCancellation(t *testing.T) {
 		t.Cleanup(func() { checkFetchTargetURL = origCheckTarget })
 		checkFetchTargetURL = func(ctx context.Context, url string) error { return nil }
 
-		// Use real timer for this test to verify cancellation during backoff works
+		// Signal when backoff begins so we can cancel deterministically
+		backoffStarted := make(chan struct{})
+		origTimer := newBackoffTimer
+		t.Cleanup(func() { newBackoffTimer = origTimer })
+		newBackoffTimer = func(d time.Duration) *time.Timer {
+			// Signal that backoff has begun, then return a long timer
+			// so cancellation can interrupt it
+			close(backoffStarted)
+			return time.NewTimer(10 * time.Second)
+		}
+
 		fetchIndexYAMLAttempt = func(ctx context.Context, indexURL string) ([]byte, error) {
 			attempt++
 			if attempt == 1 {
@@ -1885,10 +1895,9 @@ func TestFetchIndexYAMLContextCancellation(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		// Cancel after a short delay to let the first attempt complete
-		// and the backoff sleep begin
+		// Cancel after backoff begins to ensure cancellation happens during sleep
 		go func() {
-			time.Sleep(100 * time.Millisecond)
+			<-backoffStarted  // Wait for backoff to start
 			cancel()
 		}()
 

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -985,7 +985,9 @@ func TestDefaultFetchIndexYAML(t *testing.T) {
 			http.Error(w, "boom", http.StatusInternalServerError)
 		}))
 		defer ts.Close()
-		_, err := defaultFetchIndexYAML(context.Background(), ts.URL+"/index.yaml")
+		// Use doFetchIndexYAMLAttempt directly to test status classification
+		// without triggering retry logic.
+		_, err := doFetchIndexYAMLAttempt(context.Background(), ts.URL+"/index.yaml")
 		if err == nil {
 			t.Fatal("expected error for 500")
 		}
@@ -1496,7 +1498,9 @@ func TestDefaultFetchIndexYAML_4xx(t *testing.T) {
 				http.Error(w, "boom", tt.status)
 			}))
 			defer ts.Close()
-			_, err := defaultFetchIndexYAML(context.Background(), ts.URL+"/index.yaml")
+			// Use doFetchIndexYAMLAttempt directly to test status classification
+			// without triggering retry logic.
+			_, err := doFetchIndexYAMLAttempt(context.Background(), ts.URL+"/index.yaml")
 			if err == nil {
 				t.Fatalf("expected error for HTTP %d", tt.status)
 			}

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -1792,6 +1792,20 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 			// Mock the per-attempt fetch function to control success/failure
 			origAttempt := fetchIndexYAMLAttempt
 			t.Cleanup(func() { fetchIndexYAMLAttempt = origAttempt })
+
+			// Stub egress check to avoid DNS resolution
+			origCheckTarget := checkFetchTargetURL
+			t.Cleanup(func() { checkFetchTargetURL = origCheckTarget })
+			checkFetchTargetURL = func(ctx context.Context, url string) error { return nil }
+
+			// Stub timer to avoid production sleep times
+			origTimer := newBackoffTimer
+			t.Cleanup(func() { newBackoffTimer = origTimer })
+			newBackoffTimer = func(d time.Duration) *time.Timer {
+				// Return a timer that fires immediately
+				return time.NewTimer(1 * time.Nanosecond)
+			}
+
 			fetchIndexYAMLAttempt = func(ctx context.Context, indexURL string) ([]byte, error) {
 				attempt++
 				if attempt < tt.succeedAt {
@@ -1804,10 +1818,10 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 					case "status":
 						// Simulate what doFetchIndexYAMLAttempt does: parse HTTP status
 						code := errors.ErrCodeUnavailable
-						switch {
-						case tt.statusCode == http.StatusNotFound:
+						switch tt.statusCode {
+						case http.StatusNotFound:
 							code = errors.ErrCodeNotFound
-						case tt.statusCode == http.StatusUnauthorized || tt.statusCode == http.StatusForbidden:
+						case http.StatusUnauthorized, http.StatusForbidden:
 							code = errors.ErrCodeUnauthorized
 						}
 						return nil, errors.New(code,
@@ -1847,6 +1861,13 @@ func TestFetchIndexYAMLContextCancellation(t *testing.T) {
 		attempt := 0
 		origAttempt := fetchIndexYAMLAttempt
 		t.Cleanup(func() { fetchIndexYAMLAttempt = origAttempt })
+
+		// Stub egress check to avoid DNS resolution
+		origCheckTarget := checkFetchTargetURL
+		t.Cleanup(func() { checkFetchTargetURL = origCheckTarget })
+		checkFetchTargetURL = func(ctx context.Context, url string) error { return nil }
+
+		// Use real timer for this test to verify cancellation during backoff works
 		fetchIndexYAMLAttempt = func(ctx context.Context, indexURL string) ([]byte, error) {
 			attempt++
 			if attempt == 1 {
@@ -1870,6 +1891,9 @@ func TestFetchIndexYAMLContextCancellation(t *testing.T) {
 		_, err := defaultFetchIndexYAML(ctx, "https://example.com/index.yaml")
 		if err == nil {
 			t.Error("expected error from canceled context")
+		}
+		if !stderrors.Is(err, errors.New(errors.ErrCodeCanceled, "")) {
+			t.Errorf("expected ErrCodeCanceled, got error %v", err)
 		}
 		if !stderrors.Is(ctx.Err(), context.Canceled) {
 			t.Errorf("context should be canceled, got %v", ctx.Err())

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -1796,6 +1796,21 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 			wantCode:    errors.ErrCodeInvalidRequest,
 			wantAttempt: 0,
 		},
+		{
+			name:        "transient validation error (DNS timeout) retries and succeeds",
+			errorType:   "validation-transient",
+			succeedAt:   2,
+			wantErr:     false,
+			wantAttempt: 1,
+		},
+		{
+			name:        "transient validation error exhausts budget",
+			errorType:   "validation-transient",
+			succeedAt:   100,
+			wantErr:     true,
+			wantCode:    errors.ErrCodeUnavailable,
+			wantAttempt: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1811,9 +1826,19 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 			validationAttempt := 0
 			checkFetchTargetURL = func(ctx context.Context, url string) error {
 				validationAttempt++
-				if tt.errorType == "validation" && validationAttempt < tt.succeedAt {
-					return errors.New(errors.ErrCodeInvalidRequest,
-						"egress policy rejected target URL")
+				switch tt.errorType {
+				case "validation":
+					if validationAttempt < tt.succeedAt {
+						return errors.New(errors.ErrCodeInvalidRequest,
+							"egress policy rejected target URL")
+					}
+				case "validation-transient":
+					if validationAttempt < tt.succeedAt {
+						return errors.PropagateOrWrap(
+							stderrors.New("DNS timeout during address resolution"),
+							errors.ErrCodeUnavailable,
+							"transient validation failure")
+					}
 				}
 				return nil
 			}

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -1899,6 +1899,44 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 	}
 }
 
+// TestFetchIndexYAMLRetryEndToEnd drives defaultFetchIndexYAML against a real
+// httptest.Server so the production HTTP-status classifier in
+// doFetchIndexYAMLAttempt is exercised through the retry wrapper, rather than
+// the hand-rolled classifier the table test stubs in.
+func TestFetchIndexYAMLRetryEndToEnd(t *testing.T) {
+	origCheck := checkFetchTargetURL
+	checkFetchTargetURL = func(_ context.Context, _ string) error { return nil }
+	t.Cleanup(func() { checkFetchTargetURL = origCheck })
+
+	origTimer := newBackoffTimer
+	t.Cleanup(func() { newBackoffTimer = origTimer })
+	newBackoffTimer = func(time.Duration) *time.Timer {
+		return time.NewTimer(1 * time.Nanosecond)
+	}
+
+	var hits int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		if hits <= 2 {
+			http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = io.WriteString(w, "apiVersion: v1\nentries: {}\n")
+	}))
+	defer ts.Close()
+
+	body, err := defaultFetchIndexYAML(context.Background(), ts.URL+"/index.yaml")
+	if err != nil {
+		t.Fatalf("fetch after 503 retries: %v", err)
+	}
+	if !strings.Contains(string(body), "apiVersion") {
+		t.Errorf("body = %q, want to contain apiVersion", body)
+	}
+	if hits != 3 {
+		t.Errorf("server hits = %d, want 3 (two 503s then 200)", hits)
+	}
+}
+
 // TestFetchIndexYAMLContextCancellation verifies that context cancellation
 // during backoff is honored and does not continue retrying.
 func TestFetchIndexYAMLContextCancellation(t *testing.T) {

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -1788,6 +1788,14 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 			wantCode:    errors.ErrCodeUnavailable,
 			wantAttempt: defaults.HelmChartIndexRetryBudget,
 		},
+		{
+			name:        "validation error (policy rejection) never retried",
+			errorType:   "validation",
+			succeedAt:   100,
+			wantErr:     true,
+			wantCode:    errors.ErrCodeInvalidRequest,
+			wantAttempt: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1800,7 +1808,15 @@ func TestFetchIndexYAMLRetry(t *testing.T) {
 			// Stub egress check to avoid DNS resolution
 			origCheckTarget := checkFetchTargetURL
 			t.Cleanup(func() { checkFetchTargetURL = origCheckTarget })
-			checkFetchTargetURL = func(ctx context.Context, url string) error { return nil }
+			validationAttempt := 0
+			checkFetchTargetURL = func(ctx context.Context, url string) error {
+				validationAttempt++
+				if tt.errorType == "validation" && validationAttempt < tt.succeedAt {
+					return errors.New(errors.ErrCodeInvalidRequest,
+						"egress policy rejected target URL")
+				}
+				return nil
+			}
 
 			// Stub timer to avoid production sleep times
 			origTimer := newBackoffTimer

--- a/pkg/bundler/deployer/localformat/vendor_test.go
+++ b/pkg/bundler/deployer/localformat/vendor_test.go
@@ -17,6 +17,7 @@ package localformat
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
@@ -1692,4 +1694,188 @@ func TestVendorErrorPathsRedactCredentials(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFetchIndexYAMLRetry verifies the retry policy for transient failures.
+// Transient errors (transport failures, 5xx, 408, 429) retry up to the budget;
+// permanent errors (404, 401/403, other 4xx) fail on first attempt; policy
+// rejections are never retried.
+func TestFetchIndexYAMLRetry(t *testing.T) {
+	tests := []struct {
+		name        string
+		errorType   string
+		statusCode  int
+		succeedAt   int
+		wantErr     bool
+		wantCode    errors.ErrorCode
+		wantAttempt int
+	}{
+		{
+			name:        "transport error retries and succeeds",
+			errorType:   "transport",
+			succeedAt:   2,
+			wantErr:     false,
+			wantAttempt: 2,
+		},
+		{
+			name:        "503 retries and succeeds",
+			errorType:   "status",
+			statusCode:  http.StatusServiceUnavailable,
+			succeedAt:   2,
+			wantErr:     false,
+			wantAttempt: 2,
+		},
+		{
+			name:        "429 retries and succeeds",
+			errorType:   "status",
+			statusCode:  http.StatusTooManyRequests,
+			succeedAt:   2,
+			wantErr:     false,
+			wantAttempt: 2,
+		},
+		{
+			name:        "408 retries and succeeds",
+			errorType:   "status",
+			statusCode:  http.StatusRequestTimeout,
+			succeedAt:   2,
+			wantErr:     false,
+			wantAttempt: 2,
+		},
+		{
+			name:        "404 never retried",
+			errorType:   "status",
+			statusCode:  http.StatusNotFound,
+			succeedAt:   100,
+			wantErr:     true,
+			wantCode:    errors.ErrCodeNotFound,
+			wantAttempt: 1,
+		},
+		{
+			name:        "401 never retried",
+			errorType:   "status",
+			statusCode:  http.StatusUnauthorized,
+			succeedAt:   100,
+			wantErr:     true,
+			wantCode:    errors.ErrCodeUnauthorized,
+			wantAttempt: 1,
+		},
+		{
+			name:        "403 never retried",
+			errorType:   "status",
+			statusCode:  http.StatusForbidden,
+			succeedAt:   100,
+			wantErr:     true,
+			wantCode:    errors.ErrCodeUnauthorized,
+			wantAttempt: 1,
+		},
+		{
+			name:        "policy rejection never retried",
+			errorType:   "policy",
+			succeedAt:   100,
+			wantErr:     true,
+			wantCode:    errors.ErrCodeInvalidRequest,
+			wantAttempt: 1,
+		},
+		{
+			name:        "transient error exhausts budget",
+			errorType:   "transport",
+			succeedAt:   100,
+			wantErr:     true,
+			wantCode:    errors.ErrCodeUnavailable,
+			wantAttempt: defaults.HelmChartIndexRetryBudget,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempt := 0
+			// Mock the per-attempt fetch function to control success/failure
+			origAttempt := fetchIndexYAMLAttempt
+			t.Cleanup(func() { fetchIndexYAMLAttempt = origAttempt })
+			fetchIndexYAMLAttempt = func(ctx context.Context, indexURL string) ([]byte, error) {
+				attempt++
+				if attempt < tt.succeedAt {
+					switch tt.errorType {
+					case "transport":
+						return nil, errors.PropagateOrWrap(
+							stderrors.New("read: connection reset by peer"),
+							errors.ErrCodeUnavailable,
+							"index fetch failed")
+					case "status":
+						// Simulate what doFetchIndexYAMLAttempt does: parse HTTP status
+						code := errors.ErrCodeUnavailable
+						switch {
+						case tt.statusCode == http.StatusNotFound:
+							code = errors.ErrCodeNotFound
+						case tt.statusCode == http.StatusUnauthorized || tt.statusCode == http.StatusForbidden:
+							code = errors.ErrCodeUnauthorized
+						}
+						return nil, errors.New(code,
+							fmt.Sprintf("vendor-charts: index pre-check GET https://example.com/index.yaml returned HTTP %d", tt.statusCode))
+					case "policy":
+						return nil, errors.New(errors.ErrCodeInvalidRequest,
+							"egress policy rejected redirect target")
+					}
+				}
+				return []byte("index-yaml"), nil
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			_, err := defaultFetchIndexYAML(ctx, "https://example.com/index.yaml")
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wantErr=%v, got err=%v", tt.wantErr, err)
+			}
+			if tt.wantErr && err != nil {
+				if !stderrors.Is(err, errors.New(tt.wantCode, "")) {
+					t.Errorf("wantCode=%s, got error %v", tt.wantCode, err)
+				}
+			}
+			if attempt != tt.wantAttempt {
+				t.Errorf("wantAttempt=%d, got attempt=%d", tt.wantAttempt, attempt)
+			}
+		})
+	}
+}
+
+// TestFetchIndexYAMLContextCancellation verifies that context cancellation
+// during backoff is honored and does not continue retrying.
+func TestFetchIndexYAMLContextCancellation(t *testing.T) {
+	t.Run("context canceled during backoff", func(t *testing.T) {
+		attempt := 0
+		origAttempt := fetchIndexYAMLAttempt
+		t.Cleanup(func() { fetchIndexYAMLAttempt = origAttempt })
+		fetchIndexYAMLAttempt = func(ctx context.Context, indexURL string) ([]byte, error) {
+			attempt++
+			if attempt == 1 {
+				// Return transient error to trigger backoff
+				return nil, errors.New(errors.ErrCodeUnavailable, "transient error")
+			}
+			// If we get here, context should have been canceled during backoff
+			// and we should not have made a second attempt
+			t.Error("unexpected second attempt after context cancellation")
+			return nil, stderrors.New("should not reach here")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// Cancel after a short delay to let the first attempt complete
+		// and the backoff sleep begin
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+
+		_, err := defaultFetchIndexYAML(ctx, "https://example.com/index.yaml")
+		if err == nil {
+			t.Error("expected error from canceled context")
+		}
+		if !stderrors.Is(ctx.Err(), context.Canceled) {
+			t.Errorf("context should be canceled, got %v", ctx.Err())
+		}
+		if attempt != 1 {
+			t.Errorf("expected exactly 1 attempt before cancellation, got %d", attempt)
+		}
+	})
 }

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -1343,7 +1343,7 @@ const (
 
 	// HelmChartIndexRetryBudget is the maximum number of index fetch
 	// attempts before failing permanently. Retryable errors are transport
-	// failures, connection resets, and 5xx / 429 responses from the upstream.
+	// failures, connection resets, and 5xx / 408 / 429 responses from the upstream.
 	HelmChartIndexRetryBudget = 3
 
 	// HelmChartIndexRetryInitialBackoff is the wait between the first and

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -1344,6 +1344,12 @@ const (
 	// HelmChartIndexRetryBudget is the maximum number of index fetch
 	// attempts before failing permanently. Retryable errors are transport
 	// failures, connection resets, and 5xx / 408 / 429 responses from the upstream.
+	//
+	// WARNING: Retry shares the parent timeout budget. On the HTTP server path,
+	// the pre-check shares the 60s BundleHandlerTimeout with the subsequent helm
+	// pull; a maxed-out pre-check (30s + 1s backoff + 29s) leaves ~0s for the
+	// chart download. Consider capping total pre-check wall-clock if upstream
+	// latency becomes a concern.
 	HelmChartIndexRetryBudget = 3
 
 	// HelmChartIndexRetryInitialBackoff is the wait between the first and

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -1340,6 +1340,16 @@ const (
 	// resolver caches and slow-start CDN edges without letting a stalled
 	// upstream tie up an aicrd request slot for minutes.
 	HelmChartIndexPreCheckTimeout = 30 * time.Second
+
+	// HelmChartIndexRetryBudget is the maximum number of index fetch
+	// attempts before failing permanently. Retryable errors are transport
+	// failures, connection resets, and 5xx / 429 responses from the upstream.
+	HelmChartIndexRetryBudget = 3
+
+	// HelmChartIndexRetryInitialBackoff is the wait between the first and
+	// second index fetch attempts. Subsequent backoffs scale by
+	// exponential factor 2: HelmChartIndexRetryInitialBackoff * 2^(attempt-1).
+	HelmChartIndexRetryInitialBackoff = 1 * time.Second
 )
 
 // OCI publication phase budgets. The whole-publish ceiling covers two source

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -770,7 +770,7 @@ func pushFrozenDescriptor(
 		if attempt == attempts {
 			break
 		}
-		timer := time.NewTimer(jitterDuration(backoff))
+		timer := time.NewTimer(JitterDuration(backoff))
 		select {
 		case <-ctx.Done():
 			timer.Stop()
@@ -1317,7 +1317,7 @@ func copyWithRetryConfig(ctx context.Context, src oras.ReadOnlyTarget, srcRef st
 		slog.Warn("oci push retry", "attempt", attempt, "error", lastErr)
 
 		// Sleep with backoff, but honor context cancellation.
-		sleep := jitterDuration(backoff)
+		sleep := JitterDuration(backoff)
 		timer := time.NewTimer(sleep)
 		select {
 		case <-ctx.Done():
@@ -1379,8 +1379,8 @@ func isTransientPushError(err error) bool {
 	return apperrors.IsNetworkError(err)
 }
 
-// jitterDuration applies +/-25% jitter to d.
-func jitterDuration(d time.Duration) time.Duration {
+// JitterDuration applies +/-25% jitter to d to decorrelate retries.
+func JitterDuration(d time.Duration) time.Duration {
 	if d <= 0 {
 		return 0
 	}

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -770,7 +770,7 @@ func pushFrozenDescriptor(
 		if attempt == attempts {
 			break
 		}
-		timer := time.NewTimer(JitterDuration(backoff))
+		timer := time.NewTimer(jitterDuration(backoff))
 		select {
 		case <-ctx.Done():
 			timer.Stop()
@@ -1317,7 +1317,7 @@ func copyWithRetryConfig(ctx context.Context, src oras.ReadOnlyTarget, srcRef st
 		slog.Warn("oci push retry", "attempt", attempt, "error", lastErr)
 
 		// Sleep with backoff, but honor context cancellation.
-		sleep := JitterDuration(backoff)
+		sleep := jitterDuration(backoff)
 		timer := time.NewTimer(sleep)
 		select {
 		case <-ctx.Done():
@@ -1379,8 +1379,8 @@ func isTransientPushError(err error) bool {
 	return apperrors.IsNetworkError(err)
 }
 
-// JitterDuration applies +/-25% jitter to d to decorrelate retries.
-func JitterDuration(d time.Duration) time.Duration {
+// jitterDuration applies +/-25% jitter to d to decorrelate retries.
+func jitterDuration(d time.Duration) time.Duration {
 	if d <= 0 {
 		return 0
 	}


### PR DESCRIPTION
## Summary

\`defaultFetchIndexYAML\` classifies retryable failures but never retries them. A single connection reset while fetching a Helm repository index hard-fails \`aicr bundle\` regardless of scope. Add exponential-backoff retry loop (budget 3, backoff 1s) with transient-error detection matching the pattern from \`pkg/oci/push.go\`.

## Motivation / Context

Fixes: #2262

The Helm index fetch is a large, remote, pre-check operation over public internet (e.g., prometheus-community ~6 MB). Network resets have real probability on long transfers. Failing the entire bundle run on a validation fetch is disproportionate; currently every transient failure is terminal despite being classified as retryable.

Observed on docs-only PRs where CI red carries no signal about the change itself.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Bundlers (\`pkg/bundler\`, \`pkg/component/*\`)
- [x] Core libraries (\`pkg/defaults\`)

## Implementation Notes

**Retry logic:** Exponential backoff (initial 1s, factor 2) with budget 3, matching \`pkg/oci/push.go\` pattern.

**Error classification:**
- Retry: \`ErrCodeUnavailable\` (transport, 5xx, 408, 429)
- Fail-fast: \`ErrCodeNotFound\` (404), \`ErrCodeUnauthorized\` (401/403), \`ErrCodeInvalidRequest\` (other 4xx, policy rejections)

**Security constraint:** Retryability determined by structured error code, not generic "error happened." Policy-rejected redirects return \`InvalidRequest\` and are never retried — prevents SSRF retry loops.

**DNS rebinding defense:** \`checkFetchTargetURL\` is called on every retry attempt (not just before the loop). This prevents a malicious resolver from serving an allowed address on the first attempt and rebinding to a disallowed address on retries. Validation errors route through retry classification: transient DNS failures (timeouts) retry; policy rejections fail immediately.

**Context handling:** Per-attempt timeout independent of parent; backoff respects parent cancellation via \`select\` on \`ctx.Done()\`.

## Testing

\`\`\`bash
go test -race ./pkg/bundler/deployer/localformat
\`\`\`

All tests pass (11 new tests + 40+ existing regression tests). Race detector clean. New tests cover:
- Transient errors retry and succeed
- 503/429/408 retry and succeed
- 404/401/403 fail on first attempt (never retried)
- Policy rejections (fetch and validation) never retried
- Transient errors exhaust budget and fail
- Context cancellation stops retries immediately
- Validation errors (egress policy rejection) fail-fast without retry

## Risk Assessment

- [x] **Low** — Isolated change to vendor index pre-check only, adds retry logic with escape hatches for non-transient errors, no behavioral change for permanent failures. DNS rebinding defense adds per-attempt validation at zero cost (idempotent check when upstream already validated).

**Rollout notes:** N/A — transparent fix, no new config or toggles

## Checklist

- [x] Tests pass locally (\`go test -race\`)
- [x] I did not skip/disable tests to make CI green
- [x] I added tests for retry behavior (11 test cases + context cancellation)
- [x] Changes follow existing patterns in the codebase (mirrors \`pkg/oci/push.go\`)
- [x] Commits are cryptographically signed (\`git commit -S -s\`)