### PR TITLE
fix(evidence): clarify operator SKIP, pin Trainer namespace split

### DIFF
--- a/pkg/evidence/cncf/scripts/collect-evidence.sh
+++ b/pkg/evidence/cncf/scripts/collect-evidence.sh
@@ -2542,8 +2542,20 @@ collect_operator() {
     EVIDENCE_FILE="${EVIDENCE_DIR}/robust-operator.md"
     log_info "Collecting Robust AI Operator evidence → ${EVIDENCE_FILE}"
 
-    # Detect which AI operator is present and route to the appropriate collector.
-    # Priority: Dynamo > NIM Operator > Kubeflow Trainer
+    # Detect which AI operator the recipe/bundle deployed and route to the
+    # appropriate collector. Priority: Dynamo > NIM Operator > Kubeflow Trainer.
+    #
+    # Each probe is pinned to the namespace the AICR recipe deploys that operator
+    # into (recipes/registry.yaml `defaultNamespace`); for Kubeflow Trainer that is
+    # `kubeflow`, the upstream chart's own default. This is deliberate and must not
+    # be relaxed into a cluster-wide search: the performance validator installs its
+    # own temporary Kubeflow Trainer into `kubeflow-system`
+    # (validators/performance/trainer_lifecycle.go) purely to run the NCCL
+    # benchmark, and tears it down again at the end of the run. That installation is
+    # scaffolding, not something the bundle deploys, so counting it here would make
+    # signed conformance evidence claim an operator the recipe never shipped.
+    # A SKIP while the validator's self-install happens to be live is the correct
+    # answer, not a false negative. See issue #2223.
     if kubectl get deploy -n dynamo-system dynamo-platform-dynamo-operator-controller-manager --no-headers 2>/dev/null | grep -q .; then
         collect_operator_dynamo
     elif kubectl get deploy -n nvidia-nim -l app.kubernetes.io/name=k8s-nim-operator --no-headers 2>/dev/null | grep -q .; then
@@ -2552,8 +2564,8 @@ collect_operator() {
         collect_operator_kubeflow
     else
         write_section_header "Robust AI Operator"
-        echo "**Result: SKIP (prerequisite absent)** — no supported Dynamo, NIM, or Kubeflow Trainer operator is installed." >> "${EVIDENCE_FILE}"
-        log_info "Robust operator evidence collection skipped — no supported operator found."
+        echo "**Result: SKIP (prerequisite absent)** — the recipe/bundle deployed no supported AI operator: no Dynamo operator in \`dynamo-system\`, no NIM operator in \`nvidia-nim\`, and no Kubeflow Trainer in \`kubeflow\`. A Kubeflow Trainer that the performance validator self-installed into \`kubeflow-system\` for the NCCL benchmark is deliberately not counted here — it is torn down at the end of the run and is not part of the deployed bundle." >> "${EVIDENCE_FILE}"
+        log_info "Robust operator evidence collection skipped — no supported operator deployed by the recipe/bundle."
         return
     fi
 }

--- a/pkg/evidence/cncf/scripts/collect-evidence.sh
+++ b/pkg/evidence/cncf/scripts/collect-evidence.sh
@@ -2564,7 +2564,9 @@ collect_operator() {
         collect_operator_kubeflow
     else
         write_section_header "Robust AI Operator"
-        echo "**Result: SKIP (prerequisite absent)** — the recipe/bundle deployed no supported AI operator: no Dynamo operator in \`dynamo-system\`, no NIM operator in \`nvidia-nim\`, and no Kubeflow Trainer in \`kubeflow\`. A Kubeflow Trainer that the performance validator self-installed into \`kubeflow-system\` for the NCCL benchmark is deliberately not counted here — it is torn down at the end of the run and is not part of the deployed bundle." >> "${EVIDENCE_FILE}"
+        echo "**Result: SKIP (prerequisite absent)** — the recipe/bundle deployed no supported AI operator: no Dynamo operator in \`dynamo-system\`, no NIM operator in \`nvidia-nim\`, and no Kubeflow Trainer in \`kubeflow\`." >> "${EVIDENCE_FILE}"
+        echo "" >> "${EVIDENCE_FILE}"
+        echo "A Kubeflow Trainer that the performance validator self-installed into \`kubeflow-system\` for the NCCL benchmark is deliberately not counted here: it is torn down at the end of the run and is not part of the deployed bundle." >> "${EVIDENCE_FILE}"
         log_info "Robust operator evidence collection skipped — no supported operator deployed by the recipe/bundle."
         return
     fi

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -76,6 +76,21 @@ const (
 	// NOT the only layout: the kubeflow-trainer Helm chart the recipes deploy pins
 	// defaultNamespace: kubeflow (recipes/registry.yaml). The probe therefore
 	// discovers the live namespace rather than assuming this one.
+	//
+	// Differing from the chart's namespace is load-bearing, not accidental drift to
+	// be tidied away later (issue #2223). Two things depend on it:
+	//
+	//   - The CNCF evidence collector distinguishes "the bundle deployed Kubeflow
+	//     Trainer" from "the validator self-installed one to run the NCCL
+	//     benchmark" solely by namespace. Sharing one namespace would let this
+	//     temporary install be collected as recipe-deployed, so signed conformance
+	//     evidence would claim an operator the bundle never shipped.
+	//   - The conflict guard in ensureTrainerInstalled compares the discovered
+	//     installation's namespace against this one to refuse installing over a
+	//     Trainer this validator does not own. Sharing a namespace makes that
+	//     comparison always false, and applyTrainerResources would then overwrite
+	//     the recipe's Helm-managed objects in place via
+	//     updateExistingTrainerResource, with nothing restoring them afterwards.
 	trainerNamespace = "kubeflow-system"
 
 	// trainerValidatingWebhookConfig and trainerMutatingWebhookConfig are the


### PR DESCRIPTION
## Summary

Corrects the Section 6 SKIP wording in the CNCF evidence collector so it says which namespaces were probed and why a validator self-installed Kubeflow Trainer is not counted, and records on both sides why the recipe's `kubeflow` namespace and the performance validator's `kubeflow-system` namespace must stay different.

## Motivation / Context

Section 6 (Robust AI Operator) emitted:

> **Result: SKIP (prerequisite absent)** — no supported Dynamo, NIM, or Kubeflow Trainer operator is installed.

On a cluster where the performance validator's temporary Trainer self-install was live in `kubeflow-system`, that reads as a false negative — a Trainer was plainly running and healthy at collection time.

**The probe is correct; only the wording was wrong.** Section 6 attests what the recipe/bundle deployed. The validator's self-install is scaffolding for the NCCL benchmark and is torn down at the end of the run, so counting it would make signed conformance evidence claim an operator the bundle never shipped. A SKIP in that situation is the right answer, stated badly.

Fixes: #2223
Related: #2133, #2222

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`) — `validators/performance` (comment only)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/evidence/cncf` (CNCF evidence collector)

## Implementation Notes

**What changed.** The emitted SKIP line now names the namespace each operator was looked for in (`dynamo-system`, `nvidia-nim`, `kubeflow`) and states that a Trainer self-installed into `kubeflow-system` by the performance validator is deliberately not counted. The detection block and `trainerNamespace` both carry a comment explaining the split. No detection logic changed.

**Why not align the two namespaces.** The issue as originally filed also considered moving the validator's self-install onto the chart's `kubeflow` namespace for consistency. That divergence turns out to be load-bearing, and collapsing it breaks two things:

- **The evidence collector would over-claim.** Namespace is the only signal separating "the bundle deployed Kubeflow Trainer" from "the validator installed one to run NCCL." Sharing a namespace makes the temporary install collectable as recipe-deployed, converting today's conservative SKIP into a false PASS in a signed artifact — the strictly worse direction, and it defeats the fix in this PR.
- **The conflict guard would go dead.** `ensureTrainerInstalled` (`trainer_lifecycle.go:443`) compares the discovered installation's namespace against `trainerNamespace` to refuse installing over a Trainer it does not own. With one namespace that comparison is always false, so an incomplete recipe install would fall through to `applyTrainerResources`, whose `IsAlreadyExists` branch calls `updateExistingTrainerResource` and overwrites the recipe's Helm-managed Deployment/Service/ConfigMap in place with the vendored upstream kustomize spec. Those objects are not added to the rollback set, so nothing restores them after cleanup.

Documenting the invariant on both sides is what stops it being tidied away later.

## Testing

Scoped checks rather than a full green `make qualify` locally, because the diff is comments plus one emitted message string — no logic, no exported surface, no registry/chart/values change:

```bash
go build ./validators/...                                         # ok
go test -race ./validators/performance/... ./pkg/evidence/...     # ok (all packages)
golangci-lint run -c .golangci.yaml ./validators/performance/...  # 0 issues
bash -n pkg/evidence/cncf/scripts/collect-evidence.sh             # syntax ok
shellcheck -S warning pkg/evidence/cncf/scripts/collect-evidence.sh
```

`shellcheck` reports two warnings, both pre-existing and untouched by this diff: `SC2034` at line 37 (`DEPLOY_TIMEOUT` unused) and `SC2069` at line 2341 (redirection order). No new findings.

**On the local `make qualify` run.** It aborted at `lint-go` reporting 87 issues, none of them in this branch — every path resolved into unrelated sibling worktrees on the same machine. Re-running the identical full-module lint with an isolated `GOCACHE` and `GOLANGCI_LINT_CACHE` returns `0 issues`, confirming those diagnostics were replayed from a shared build cache rather than produced by this code. The linter is v2.12.2, matching the `.settings.yaml` pin. Because the abort happened at the lint stage, the later local stages (tuning-check, e2e, scan, license-check, api-diff) did not run — CI covers them, and the full Merge Gate is green.

CI on `338d5085f`: 29 checks pass, 0 fail. That includes `tests / Lint`, `tests / Test`, `tests / E2E`, `tests / CLI E2E`, `tests / Security Scan`, `analyze`, `grype`, `malware-scan`, and the three GPU lanes (H100 training, H100 inference, L40G smoke). An earlier attempt of `tests / Lint` was cancelled after hanging ~9 minutes on an Ubuntu apt mirror before golangci-lint started; it passed on re-run.

Coverage: no logic changed, and `validators/` is excluded from the coverage floor per `.settings.yaml`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** No behavior change in operator detection, so previously-collected evidence stays valid. Only the SKIP sentence differs in newly collected artifacts. Committed evidence under `docs/conformance/` is a historical record of real runs and is deliberately left untouched.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, no behavior change; no test asserts the SKIP string
- [ ] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
