### PR TITLE
feat(recipes): assert k8s-aibom CRD storage version in the health check

### DIFF
--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -327,6 +327,20 @@ cluster-scoped `AIBOMControllerConfig/default` to report a current
 observed the object's current generation. Missing or stale resources fail
 closed. Zero `AIBOM` objects is healthy before any namespace opts in.
 
+The check also requires both shipped CRDs, `aiboms.aibom.k8saibom.dev` and
+`aibomcontrollerconfigs.aibom.k8saibom.dev`, to report the storage version
+that the pinned chart ships. This is positive proof that the deployed CRDs
+match the recipe, not a breakage detector. It matters because Helm, Helmfile,
+and Flux never update an existing CRD on upgrade (only Argo CD applies them),
+so a cluster can otherwise run a new controller against the previous schema
+while the non-storage version stays served and the controller keeps working.
+
+Both CRDs are asserted separately, so a failure names which one is stranded
+and a partially applied CRD set cannot pass. If this check fails after a chart
+bump, the pre-upgrade CRD step in
+[Upgrade, uninstall, and troubleshooting](#upgrade-uninstall-and-troubleshooting)
+is the thing to run.
+
 `readiness.strictConfig` is enabled, so invalid new configuration cannot
 silently replace the controller's last-known-good configuration while the pod
 continues to report ready.

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -328,18 +328,29 @@ observed the object's current generation. Missing or stale resources fail
 closed. Zero `AIBOM` objects is healthy before any namespace opts in.
 
 The check also requires both shipped CRDs, `aiboms.aibom.k8saibom.dev` and
-`aibomcontrollerconfigs.aibom.k8saibom.dev`, to report the storage version
-that the pinned chart ships. This is positive proof that the deployed CRDs
-match the recipe, not a breakage detector. It matters because Helm, Helmfile,
-and Flux never update an existing CRD on upgrade (only Argo CD applies them),
-so a cluster can otherwise run a new controller against the previous schema
-while the non-storage version stays served and the controller keeps working.
+`aibomcontrollerconfigs.aibom.k8saibom.dev`, to report the storage version of
+the chart version pinned in the registry. This is positive proof that the
+deployed CRDs came from that chart, not a breakage detector. It matters
+because Helm and Helmfile skip a chart's `crds/` directory on upgrade, and the
+`HelmRelease` AICR generates for Flux leaves `spec.upgrade.crds` unset so the
+helm-controller default of `Skip` applies. A cluster can therefore run a new
+controller against the previous schema while the older version stays served
+and the controller keeps working.
 
 Both CRDs are asserted separately, so a failure names which one is stranded
 and a partially applied CRD set cannot pass. If this check fails after a chart
 bump, the pre-upgrade CRD step in
 [Upgrade, uninstall, and troubleshooting](#upgrade-uninstall-and-troubleshooting)
 is the thing to run.
+
+**Overriding the chart version requires overriding this assertion.** Assert
+content is static YAML with no templating, so the expected storage version is
+a literal tied to the registry's pinned chart. Chart 1.2.0 declares only
+`v1alpha1`; 1.3.0 adds `v1beta1` and moves storage to it. A recipe that sets
+`version` on the `k8s-aibom` componentRef to a chart with a different storage
+version will therefore fail this step even though the cluster is correct. Such
+a recipe must supply matching inline `healthCheckAsserts` on the componentRef,
+or set `healthCheckSkip: true` to drop the registry check entirely.
 
 `readiness.strictConfig` is enabled, so invalid new configuration cannot
 silently replace the controller's last-known-good configuration while the pod

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -329,8 +329,7 @@ closed. Zero `AIBOM` objects is healthy before any namespace opts in.
 
 The check also requires both shipped CRDs, `aiboms.aibom.k8saibom.dev` and
 `aibomcontrollerconfigs.aibom.k8saibom.dev`, to report the storage version of
-the chart version pinned in the registry. This is positive proof that the
-deployed CRDs came from that chart, not a breakage detector. It matters
+the chart version pinned in the registry. It matters
 because Helm and Helmfile skip a chart's `crds/` directory on upgrade, and the
 `HelmRelease` AICR generates for Flux leaves `spec.upgrade.crds` unset so the
 helm-controller default of `Skip` applies. A cluster can therefore run a new
@@ -342,6 +341,14 @@ and a partially applied CRD set cannot pass. If this check fails after a chart
 bump, the pre-upgrade CRD step in
 [Upgrade, uninstall, and troubleshooting](#upgrade-uninstall-and-troubleshooting)
 is the thing to run.
+
+The assertion establishes that the storage-version contract matches the pinned
+chart. It is not provenance: it reads one field, so it cannot show the CRDs
+originated from that chart, and it cannot tell apart chart versions that share
+a storage version. Charts 1.0.0, 1.1.0, and 1.2.0 all declare `v1alpha1` as
+storage. So the check catches a stranded upgrade that crosses a
+storage-version boundary, such as 1.2.0 to 1.3.0, and does not catch one
+within a boundary, such as 1.0.0 to 1.2.0.
 
 **Overriding the chart version requires overriding this assertion.** Assert
 content is static YAML with no templating, so the expected storage version is

--- a/pkg/chainsaw/k8s_aibom_check_states_test.go
+++ b/pkg/chainsaw/k8s_aibom_check_states_test.go
@@ -210,8 +210,16 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 		},
 		{
 			// A cluster whose CRDs were replaced with a newer chart's while
-			// the recipe still pins v1.2.0. The controller keeps working —
+			// the recipe still pins 1.2.0. The controller keeps working —
 			// v1alpha1 stays served — so nothing else in this check notices.
+			//
+			// This state is also what a *legitimate* 1.3.0 pin looks like,
+			// which is the version-coupling the check documents: the expected
+			// version is a literal tied to the registry's pinned chart, so a
+			// recipe overriding `version` must supply matching inline
+			// healthCheckAsserts or set healthCheckSkip. The assertion cannot
+			// distinguish the two cases, and pinning the strict reading is
+			// the fail-closed direction.
 			name:    "aiboms CRD storage version drift fails closed",
 			desired: new(int64(1)), deploymentGen: 3, status: healthyDeployment,
 			configPresent: true,

--- a/pkg/chainsaw/k8s_aibom_check_states_test.go
+++ b/pkg/chainsaw/k8s_aibom_check_states_test.go
@@ -74,6 +74,13 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 		observedGeneration int64
 		readyGeneration    int64
 		readyStatus        string
+		// CRD inputs. Empty storage version means the qualified default
+		// (v1alpha1, matching the pinned v1.2.0 chart), so existing cases
+		// describe a correctly-applied CRD set without restating it.
+		aibomCRDStorage  string
+		configCRDStorage string
+		omitAIBOMCRD     bool
+		omitConfigCRD    bool
 		// Expectations.
 		wantPass   bool
 		wantOutput string
@@ -201,6 +208,47 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 			generation:    2, observedGeneration: 2, readyGeneration: 2, readyStatus: "False",
 			wantOutput: "AIBOMControllerConfig",
 		},
+		{
+			// A cluster whose CRDs were replaced with a newer chart's while
+			// the recipe still pins v1.2.0. The controller keeps working —
+			// v1alpha1 stays served — so nothing else in this check notices.
+			name:    "aiboms CRD storage version drift fails closed",
+			desired: new(int64(1)), deploymentGen: 3, status: healthyDeployment,
+			configPresent: true,
+			generation:    2, observedGeneration: 2, readyGeneration: 2, readyStatus: "True",
+			aibomCRDStorage: "v1beta1",
+			wantOutput:      "aiboms.aibom.k8saibom.dev",
+		},
+		{
+			// The half-applied CRD set. Upstream's documented
+			// `helm show crds | kubectl apply` migration silently applied only
+			// one of the two CRDs, so this is an observed state rather than a
+			// hypothetical. It is also the case a single-CRD assertion would
+			// miss entirely: aiboms is correct, and only the configuration
+			// CRD moved.
+			name:    "partially applied CRD set fails closed",
+			desired: new(int64(1)), deploymentGen: 3, status: healthyDeployment,
+			configPresent: true,
+			generation:    2, observedGeneration: 2, readyGeneration: 2, readyStatus: "True",
+			configCRDStorage: "v1beta1",
+			wantOutput:       "aibomcontrollerconfigs.aibom.k8saibom.dev",
+		},
+		{
+			name:    "missing aiboms CRD fails closed",
+			desired: new(int64(1)), deploymentGen: 3, status: healthyDeployment,
+			configPresent: true,
+			generation:    2, observedGeneration: 2, readyGeneration: 2, readyStatus: "True",
+			omitAIBOMCRD: true,
+			wantOutput:   "aiboms.aibom.k8saibom.dev",
+		},
+		{
+			name:    "missing aibomcontrollerconfigs CRD fails closed",
+			desired: new(int64(1)), deploymentGen: 3, status: healthyDeployment,
+			configPresent: true,
+			generation:    2, observedGeneration: 2, readyGeneration: 2, readyStatus: "True",
+			omitConfigCRD: true,
+			wantOutput:    "aibomcontrollerconfigs.aibom.k8saibom.dev",
+		},
 	}
 
 	for _, tt := range tests {
@@ -208,6 +256,41 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 			t.Parallel()
 
 			fetcher := newFakeFetcher()
+
+			// addCRD registers a CRD serving both versions with exactly one
+			// marked as storage, matching the shape the upstream chart ships.
+			// The non-storage version stays served, which is why a stranded
+			// CRD does not break the controller and why the storage-version
+			// assertion is the only thing that sees it.
+			addCRD := func(name, storageVersion string) {
+				versions := make([]any, 0, 2)
+				for _, v := range []string{"v1alpha1", "v1beta1"} {
+					versions = append(versions, map[string]any{
+						"name":    v,
+						"served":  true,
+						"storage": v == storageVersion,
+					})
+				}
+				fetcher.addGet("apiextensions.k8s.io/v1", "CustomResourceDefinition", "", name,
+					map[string]any{
+						"apiVersion": "apiextensions.k8s.io/v1",
+						"kind":       "CustomResourceDefinition",
+						"metadata":   map[string]any{"name": name},
+						"spec":       map[string]any{"versions": versions},
+					})
+			}
+			storageOrDefault := func(v string) string {
+				if v == "" {
+					return "v1alpha1"
+				}
+				return v
+			}
+			if !tt.omitAIBOMCRD {
+				addCRD("aiboms.aibom.k8saibom.dev", storageOrDefault(tt.aibomCRDStorage))
+			}
+			if !tt.omitConfigCRD {
+				addCRD("aibomcontrollerconfigs.aibom.k8saibom.dev", storageOrDefault(tt.configCRDStorage))
+			}
 
 			deploymentSpec := map[string]any{}
 			if !tt.omitDeploymentSpec {

--- a/recipes/checks/k8s-aibom/health-check.yaml
+++ b/recipes/checks/k8s-aibom/health-check.yaml
@@ -28,15 +28,31 @@ spec:
     # Asserted before the workload steps so a stranded CRD is named as the
     # cause rather than surfacing later as a confusing controller symptom.
     #
-    # On Helm, Helmfile, and Flux an existing CRD is never updated on upgrade
-    # (only Argo CD applies them), so a cluster can run a new controller
-    # against the previous CRD schema. This assertion is the positive proof
-    # that the deployed CRDs are the ones the pinned chart ships — not a
-    # breakage detector. The controller's own readiness is a separate signal
-    # and not one AICR owns: upstream shipped a start-ordering race from
-    # v1.1.0 through v1.2.0 that produced a false-Ready window in exactly
-    # this state, so a check that depended on their probe would have been
-    # silently wrong for two releases.
+    # Helm and Helmfile skip a chart's crds/ directory on upgrade, and the
+    # HelmRelease AICR generates for Flux sets no spec.upgrade.crds, so the
+    # helm-controller default of Skip applies. (Flux itself can replace CRDs
+    # via spec.upgrade.crds: CreateReplace; AICR does not generate that field
+    # for any component today — see #2264. Argo CD applies CRDs as ordinary
+    # manifests each sync and is unaffected.) A cluster can therefore run a
+    # new controller against the previous CRD schema.
+    #
+    # VERSION-COUPLED BY CONSTRUCTION. Assert content is static YAML; there
+    # is no templating, so the expected version below is a literal tied to
+    # the chart version the registry pins for this component (1.2.0, whose
+    # CRDs declare only v1alpha1). A recipe that overrides `version` on the
+    # componentRef to a chart with a different storage version — 1.3.0 moves
+    # storage to v1beta1 — will fail this step even though the cluster is
+    # correct. That recipe must supply matching inline `healthCheckAsserts`
+    # on the componentRef, or set `healthCheckSkip: true`. Documented in
+    # docs/user/component-catalog.md. Flip this literal, do not generalize
+    # it, when the registry pin moves.
+    #
+    # This is positive proof that the deployed CRDs came from the chart
+    # version the registry pins — not a breakage detector. The controller's
+    # own readiness is a separate signal and not one AICR owns: upstream
+    # shipped a start-ordering race from v1.1.0 through v1.2.0 that produced
+    # a false-Ready window in exactly this state, so a check that depended on
+    # their probe would have been silently wrong for two releases.
     #
     # Assert the storage version, NOT status.storedVersions. Immediately
     # after a storage flip storedVersions legitimately contains both the old
@@ -45,12 +61,10 @@ spec:
     # later v1alpha1 *removal*, not this.
     #
     # Both CRDs are asserted, in separate steps so a failure names which one
-    # is stranded. This is not symmetry for its own sake: upstream's
-    # documented `helm show crds | kubectl apply` migration silently applied
-    # only one of the two CRDs (missing YAML document separators), so a
-    # half-applied CRD set is a state clusters actually reach, and it is
-    # silent. A single-CRD assertion would pass while the other resource
-    # still stored the old version.
+    # is stranded, and so a partially applied CRD set cannot pass. That
+    # second assertion is load-bearing rather than symmetric: removing it
+    # lets the partial-apply case pass, which the tests in
+    # pkg/chainsaw/k8s_aibom_check_states_test.go demonstrate.
     - name: validate-aibom-crd-storage-version
       try:
         - assert:

--- a/recipes/checks/k8s-aibom/health-check.yaml
+++ b/recipes/checks/k8s-aibom/health-check.yaml
@@ -47,12 +47,25 @@ spec:
     # docs/user/component-catalog.md. Flip this literal, do not generalize
     # it, when the registry pin moves.
     #
-    # This is positive proof that the deployed CRDs came from the chart
-    # version the registry pins — not a breakage detector. The controller's
-    # own readiness is a separate signal and not one AICR owns: upstream
-    # shipped a start-ordering race from v1.1.0 through v1.2.0 that produced
-    # a false-Ready window in exactly this state, so a check that depended on
-    # their probe would have been silently wrong for two releases.
+    # WHAT THIS DOES AND DOES NOT ESTABLISH. It asserts that the deployed
+    # CRDs' storage-version contract matches the one the pinned chart
+    # declares. It is not provenance: it reads one field and cannot show the
+    # CRDs originated from that chart, and it cannot discriminate between
+    # chart versions that share a storage version. Charts 1.0.0, 1.1.0, and
+    # 1.2.0 all declare exactly v1alpha1 as storage, so CRDs from any of them
+    # satisfy this step identically.
+    #
+    # The practical consequence: this catches a stranded upgrade across a
+    # storage-version boundary — 1.2.0 to 1.3.0, the case that matters now —
+    # and does not catch a stranded upgrade within one, such as 1.0.0 to
+    # 1.2.0. That is the correct trade for a static assert; do not describe
+    # the step as proving more than it does.
+    #
+    # The controller's own readiness is a separate signal and not one AICR
+    # owns: upstream shipped a start-ordering race from v1.1.0 through v1.2.0
+    # that produced a false-Ready window in exactly this state, so a check
+    # that depended on their probe would have been silently wrong for two
+    # releases.
     #
     # Assert the storage version, NOT status.storedVersions. Immediately
     # after a storage flip storedVersions legitimately contains both the old

--- a/recipes/checks/k8s-aibom/health-check.yaml
+++ b/recipes/checks/k8s-aibom/health-check.yaml
@@ -25,6 +25,50 @@ spec:
   timeouts:
     assert: 2m
   steps:
+    # Asserted before the workload steps so a stranded CRD is named as the
+    # cause rather than surfacing later as a confusing controller symptom.
+    #
+    # On Helm, Helmfile, and Flux an existing CRD is never updated on upgrade
+    # (only Argo CD applies them), so a cluster can run a new controller
+    # against the previous CRD schema. This assertion is the positive proof
+    # that the deployed CRDs are the ones the pinned chart ships — not a
+    # breakage detector. The controller's own readiness is a separate signal
+    # and not one AICR owns: upstream shipped a start-ordering race from
+    # v1.1.0 through v1.2.0 that produced a false-Ready window in exactly
+    # this state, so a check that depended on their probe would have been
+    # silently wrong for two releases.
+    #
+    # Assert the storage version, NOT status.storedVersions. Immediately
+    # after a storage flip storedVersions legitimately contains both the old
+    # and new version until stored objects are rewritten, so asserting on it
+    # would fail every correctly-upgraded cluster. storedVersions gates a
+    # later v1alpha1 *removal*, not this.
+    #
+    # Both CRDs are asserted, in separate steps so a failure names which one
+    # is stranded. This is not symmetry for its own sake: upstream's
+    # documented `helm show crds | kubectl apply` migration silently applied
+    # only one of the two CRDs (missing YAML document separators), so a
+    # half-applied CRD set is a state clusters actually reach, and it is
+    # silent. A single-CRD assertion would pass while the other resource
+    # still stored the old version.
+    - name: validate-aibom-crd-storage-version
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: aiboms.aibom.k8saibom.dev
+              ((spec.versions[?storage == `true`].name | [0]) == 'v1alpha1'): true
+    - name: validate-aibomcontrollerconfig-crd-storage-version
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: aibomcontrollerconfigs.aibom.k8saibom.dev
+              ((spec.versions[?storage == `true`].name | [0]) == 'v1alpha1'): true
     - name: validate-controller-deployment
       try:
         - assert:


### PR DESCRIPTION
## Summary

Adds a storage-version assertion for both `k8s-aibom` CRDs to the component health check, so a cluster whose CRDs were never upgraded fails validation instead of passing quietly.

## Motivation / Context

The check validated the controller Deployment and `AIBOMControllerConfig` but asserted nothing about the CRDs, so it could not tell whether the deployed CRDs are the ones the pinned chart ships.

Helm, Helmfile, and Flux never update an existing CRD on upgrade; only Argo CD applies them (#2264). A cluster can therefore run a new controller against the previous schema while the non-storage version stays served and the controller keeps working.

This is **positive proof that the deployed CRDs match the recipe**, not a breakage detector — which is also why it is worth having independently of how the controller happens to behave when stranded.

Fixes: #2281
Related: #2271, #2282, #2264

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: component health check

## Implementation Notes

**Not gated on the controller's readiness, deliberately.** Upstream shipped a readiness start-ordering race from v1.1.0 through v1.2.0 that produced a false-Ready window in exactly this state, and it took two fix iterations upstream to hold. A check depending on their probe would have been silently wrong for two releases. This assertion depends only on the API server's view of the CRD.

**Asserts the storage version, not `status.storedVersions`.** Immediately after a storage flip, `storedVersions` legitimately contains both versions until stored objects are rewritten, so asserting on it would fail every correctly-upgraded cluster. `storedVersions` gates a later `v1alpha1` removal instead — confirmed with upstream and recorded in the ADR-019 amendment.

**Both CRDs, in separate steps.** So a failure names which resource is stranded, and so a partially applied CRD set cannot pass. This is load-bearing rather than symmetric, and the tests prove it: removing only the second assertion lets `partially_applied_CRD_set_fails_closed` pass the check.

**Pinned to `v1alpha1`**, matching the currently pinned 1.2.0 chart. Both flip to `v1beta1` in #2282.

### One claim I checked and dropped

While writing #2281 I asserted that a partially applied CRD set was reachable through AICR's own documented `helm show crds | kubectl apply` step, based on upstream reporting that bug and on the raw `crds/` files in 1.2.0 lacking a leading `---` on one of two files.

Tested rather than assumed: `helm show crds` inserts separators between files, so the 1.2.0 chart yields three well-formed documents with both CRDs parsing. Identical on 1.3.0. **Our documented command is not affected, and no docs warning was added.** The two-CRD assertion still stands on its own evidence (above), just not on that reasoning. Detail on #2281.

## Testing

```bash
make qualify
```

Test and lint stages pass. `tests/releasepolicy` failed on `failed to enumerate tags for ghcr.io/nvidia/aicr`, a live registry call unrelated to this change; it passes in isolation with `-count=1`. Since `qualify` aborts at `test`, `make lint` was run separately and is clean (0 golangci-lint issues, MDX and doc-filename gates pass).

Four new table cases in `TestK8sAIBOMHealthCheckClusterStates`, each verified to fail without the assertions:

```
--- FAIL: .../aiboms_CRD_storage_version_drift_fails_closed
--- FAIL: .../partially_applied_CRD_set_fails_closed
--- FAIL: .../missing_aiboms_CRD_fails_closed
--- FAIL: .../missing_aibomcontrollerconfigs_CRD_fails_closed
```

All pre-existing cases continue to pass, so the new assertions do not disturb the states the check already covered. Each case pins `wantOutput` to the specific CRD name, so a case cannot pass because the wrong assertion caught the fault.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Additive assertions on one optional component's health check. No stock recipe references `k8s-aibom`, so no stock recipe's validation changes. A cluster with correctly applied CRDs sees no difference.

**Rollout notes:** A cluster that upgraded the chart without applying CRDs will now fail this check where it previously passed. That is the intended detection, and the failure names the stranded CRD and points at the existing pre-upgrade CRD step.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
