### PR TITLE
docs: describe how a training workload attaches to the cluster fabric

### DIFF
--- a/demos/workloads/training/gke-nccl-test-tcpxo.yaml
+++ b/demos/workloads/training/gke-nccl-test-tcpxo.yaml
@@ -127,7 +127,7 @@ spec:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -150,7 +150,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.14
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -242,7 +242,7 @@ spec:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -265,7 +265,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.14
       imagePullPolicy: Always
       command:
         - /bin/sh

--- a/demos/workloads/training/gke-nccl-test-tcpxo.yaml
+++ b/demos/workloads/training/gke-nccl-test-tcpxo.yaml
@@ -127,7 +127,7 @@ spec:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -150,7 +150,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.14
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -242,7 +242,7 @@ spec:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -265,7 +265,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.14
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
       imagePullPolicy: Always
       command:
         - /bin/sh

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -28,6 +28,8 @@ navigation:
         path: user/cli-reference.md
       - page: Generating Bundles
         path: user/bundling.md
+      - page: Fabric-Attached Training
+        path: user/fabric-attached-training.md
       - page: CLI Configuration File
         path: user/cli-config.md
       - page: Artifact Verification

--- a/docs/integrator/gke-tcpxo-networking.md
+++ b/docs/integrator/gke-tcpxo-networking.md
@@ -257,6 +257,8 @@ NRI profile (recommended, no `hostNetwork`):
 
 ```shell
 kubectl create ns nccl-test
+# Note: this manifest is pinned to the earlier v1.0.14 / v1.0.20 pair.
+# Update both images to your cluster's pair before applying.
 kubectl apply -f demos/workloads/training/gke-nccl-test-tcpxo.yaml -n nccl-test
 
 # Wait for pods to be 2/2 Running

--- a/docs/integrator/gke-tcpxo-networking.md
+++ b/docs/integrator/gke-tcpxo-networking.md
@@ -132,7 +132,7 @@ spec:
   hostNetwork: false
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.20
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
       securityContext:
         capabilities:
           add: [NET_ADMIN, NET_BIND_SERVICE]
@@ -175,18 +175,38 @@ Key properties:
 - NRI annotations inject GPU devices and multi-NIC interfaces
 - Requires NRI device injector DaemonSet deployed on GPU nodes
 
+Running a **Kubeflow TrainJob** rather than a bare Pod? A TrainJob cannot add
+the `tcpxo-daemon` sidecar, so the wiring must live in a `TrainingRuntime` — see
+[Attaching a Training Workload to the Cluster Fabric](../user/fabric-attached-training.md).
+
 See [`demos/workloads/training/gke-nccl-test-tcpxo.yaml`](https://github.com/NVIDIA/aicr/blob/main/demos/workloads/training/gke-nccl-test-tcpxo.yaml) for a complete 2-node NCCL benchmark example.
 
 ## NCCL Plugin Version Matching
 
-The NCCL test container image must match the cluster's installed TCPXO plugin version. Check with:
+Google publishes the plugin installer and the `tcpxo-daemon` sidecar as a
+**coupled release pair**. Running a mismatched pair is unsupported. The pair
+AICR currently ships is:
+
+| Component | Image | Version |
+|---|---|---|
+| Plugin installer (DaemonSet, cluster-side) | `nccl-plugin-gpudirecttcpx-dev` | `v1.0.15` |
+| Sidecar (workload-side) | `tcpgpudmarxd-dev` | `v1.0.21` |
+
+Check what your cluster actually runs:
 
 ```shell
 kubectl get ds nccl-tcpxo-installer -n kube-system \
   -o jsonpath='{.spec.template.spec.containers[?(@.name=="nccl-tcpxo-installer")].image}'
 ```
 
-Update the `nccl-plugin-gpudirecttcpx-dev` image tag in your workload to match.
+Then set your workload's `tcpxo-daemon` image to the daemon version paired with
+it, per [Google's release notes][tcpxo-releases].
+
+**Upgrade ordering is directional:** upgrade the plugin installer *before* the
+daemon. A plugin newer than its paired daemon is the supported transitional
+state; the reverse is not.
+
+[tcpxo-releases]: https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/gpudirect-tcpxo/README.md
 
 ## Running the NCCL Benchmark
 

--- a/docs/integrator/gke-tcpxo-networking.md
+++ b/docs/integrator/gke-tcpxo-networking.md
@@ -179,7 +179,7 @@ Running a **Kubeflow TrainJob** rather than a bare Pod? A TrainJob cannot add
 the `tcpxo-daemon` sidecar, so the wiring must live in a `TrainingRuntime` — see
 [Attaching a Training Workload to the Cluster Fabric](../user/fabric-attached-training.md).
 
-See [`demos/workloads/training/gke-nccl-test-tcpxo.yaml`](https://github.com/NVIDIA/aicr/blob/main/demos/workloads/training/gke-nccl-test-tcpxo.yaml) for a complete 2-node NCCL benchmark example.
+See [`demos/workloads/training/gke-nccl-test-tcpxo.yaml`](https://github.com/NVIDIA/aicr/blob/main/demos/workloads/training/gke-nccl-test-tcpxo.yaml) for a complete 2-node NCCL benchmark example. (pinned to an earlier coupled pair, plugin `v1.0.14` with daemon `v1.0.20`)
 
 ## NCCL Plugin Version Matching
 

--- a/docs/integrator/gke-tcpxo-networking.md
+++ b/docs/integrator/gke-tcpxo-networking.md
@@ -196,15 +196,16 @@ Check what your cluster actually runs:
 
 ```shell
 kubectl get ds nccl-tcpxo-installer -n kube-system \
-  -o jsonpath='{.spec.template.spec.containers[?(@.name=="nccl-tcpxo-installer")].image}'
+  -o jsonpath='{.spec.template.spec.initContainers[?(@.name=="nccl-tcpxo-installer")].image}'
 ```
 
 Then set your workload's `tcpxo-daemon` image to the daemon version paired with
 it, per [Google's release notes][tcpxo-releases].
 
-**Upgrade ordering is directional:** upgrade the plugin installer *before* the
-daemon. A plugin newer than its paired daemon is the supported transitional
-state; the reverse is not.
+**Upgrade in order:** upgrade the plugin installer first, then the workload's
+daemon. Google also advises that workloads should not be running while the
+installer is upgraded. This is a sequence, not a statement that a mismatched
+pair is supported to run.
 
 [tcpxo-releases]: https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/gpudirect-tcpxo/README.md
 

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -1,0 +1,304 @@
+# Attaching a Training Workload to the Cluster Fabric
+
+AICR recipes deliver the cluster-side prerequisites for high-speed inter-node
+networking — the NCCL plugin, device injection, node labels and taints. What
+they do not do is attach your *workload* to that fabric. This page describes
+what a training workload must declare, per platform.
+
+Without this wiring a multi-node job still runs: NCCL falls back to TCP over
+the primary interface. Intra-node NVLink is unaffected, so nothing errors and
+the job completes — just far slower than the hardware allows. Check for it
+rather than assuming it.
+
+## Which layer owns what
+
+Kubeflow Trainer splits a workload across two objects, and the split determines
+where fabric wiring can live.
+
+A **TrainJob** can supply:
+
+- pod annotations and labels, via `PodTemplatePatch.Metadata`
+- volumes, via `PodSpecPatch.Volumes`
+- per-container `env`, `volumeMounts` and `securityContext`, via `ContainerPatch`
+- `image`, `command`, `args` and `resourcesPerNode` for the trainer container
+
+A **TrainJob cannot add a container.** `ContainerPatch` carries only `name`,
+`env`, `volumeMounts` and `securityContext` — no `image`, no `command` — and
+the runtime rejects a patch naming a container it does not already define.
+
+That single limitation decides everything below. Fabrics needing only resource
+requests and environment are fully TrainJob-expressible. Fabrics needing a
+sidecar require a **Runtime** — either one AICR ships, or one you author.
+
+| Fabric | Platform | Needs a sidecar? | Where the wiring goes |
+|---|---|---|---|
+| GPUDirect TCPXO | GKE, A3 Mega | yes (`tcpxo-daemon`) | a `TrainingRuntime` you author |
+| EFA | EKS | no | your `TrainJob` |
+| InfiniBand / RDMA | AKS | no | your `TrainJob` |
+
+## GKE — GPUDirect TCPXO
+
+TCPXO needs a `tcpxo-daemon` sidecar, so the wiring lives in a Runtime.
+`TrainingRuntime` is an ordinary namespaced resource: create one in your own
+namespace and reference it from your TrainJob.
+
+### Before you start
+
+Confirm the cluster prerequisites are in place — see
+[GKE TCPXO Networking Prerequisites](../integrator/gke-tcpxo-networking.md).
+You need the eight GPU NIC `Network` objects bound to the GPU node pool:
+
+```shell
+kubectl get networks.networking.gke.io -o name | grep gpu-nic
+```
+
+**Use the names your cluster actually has.** AICR requires only that each name
+contain `gpu-nic`; the rest is chosen by whoever provisioned the cluster, so
+prefixed forms such as `aicr-demo2-gpu-nic-0` are common. Substitute them into
+the `networking.gke.io/interfaces` annotation below — the examples use
+`gpu-nic0`–`gpu-nic7`.
+
+Match the sidecar image to the plugin your cluster runs — see
+[NCCL Plugin Version Matching](../integrator/gke-tcpxo-networking.md#nccl-plugin-version-matching).
+
+### The TrainingRuntime
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: torch-tcpxo
+  namespace: my-team          # your namespace
+  labels:
+    trainer.kubeflow.org/framework: torch
+spec:
+  mlPolicy:
+    numNodes: 2               # override per job with spec.trainer.numNodes
+    torch: {}
+  template:
+    spec:
+      replicatedJobs:
+      - name: node
+        template:
+          spec:
+            template:
+              metadata:
+                annotations:
+                  # Expose GPU and DMA devices to the sidecar via NRI, so it
+                  # does not need privileged mode. One entry per GPU, plus the
+                  # three control devices.
+                  devices.gke.io/container.tcpxo-daemon: |
+                    - path: /dev/nvidia0
+                    - path: /dev/nvidia1
+                    - path: /dev/nvidia2
+                    - path: /dev/nvidia3
+                    - path: /dev/nvidia4
+                    - path: /dev/nvidia5
+                    - path: /dev/nvidia6
+                    - path: /dev/nvidia7
+                    - path: /dev/nvidiactl
+                    - path: /dev/nvidia-uvm
+                    - path: /dev/dmabuf_import_helper
+                  networking.gke.io/default-interface: eth0
+                  # Substitute your cluster's Network names.
+                  networking.gke.io/interfaces: |
+                    [
+                      {"interfaceName":"eth0","network":"default"},
+                      {"interfaceName":"eth1","network":"gpu-nic0"},
+                      {"interfaceName":"eth2","network":"gpu-nic1"},
+                      {"interfaceName":"eth3","network":"gpu-nic2"},
+                      {"interfaceName":"eth4","network":"gpu-nic3"},
+                      {"interfaceName":"eth5","network":"gpu-nic4"},
+                      {"interfaceName":"eth6","network":"gpu-nic5"},
+                      {"interfaceName":"eth7","network":"gpu-nic6"},
+                      {"interfaceName":"eth8","network":"gpu-nic7"}
+                    ]
+              spec:
+                initContainers:
+                # Native sidecar: an initContainer with restartPolicy: Always
+                # runs alongside the worker for the pod's lifetime.
+                - name: tcpxo-daemon
+                  image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+                  restartPolicy: Always
+                  command: ["/bin/sh", "-c"]
+                  args:
+                  - |
+                    set -ex
+                    chmod 755 /fts/entrypoint_rxdm_container.sh
+                    /fts/entrypoint_rxdm_container.sh --num_hops=2
+                  securityContext:
+                    capabilities:
+                      add: ["NET_ADMIN", "NET_BIND_SERVICE"]
+                  volumeMounts:
+                  - {name: tcpxo-libraries, mountPath: /usr/local/nvidia, readOnly: true}
+                  - {name: tcpxo-sys, mountPath: /hostsysfs}
+                  - {name: tcpxo-proc-sys, mountPath: /hostprocsysfs}
+                  env:
+                  - name: LD_LIBRARY_PATH
+                    value: /usr/local/nvidia/lib64
+                containers:
+                - name: node
+                  # Your training image. It must be ABI-compatible with the
+                  # host-installed plugin libraries mounted below; it does not
+                  # need the plugin baked in.
+                  image: nvcr.io/nvidia/pytorch:25.06-py3
+                  resources:
+                    limits:
+                      nvidia.com/gpu: 8      # TCPXO requires all 8 GPUs
+                    requests:
+                      nvidia.com/gpu: 8
+                  securityContext:
+                    capabilities:
+                      add: ["IPC_LOCK"]
+                  volumeMounts:
+                  - {name: dshm, mountPath: /dev/shm}
+                  - {name: tcpxo-libraries, mountPath: /usr/local/nvidia, readOnly: true}
+                  - {name: tcpxo-aperture-devices, mountPath: /dev/aperture_devices}
+                volumes:
+                - name: dshm
+                  emptyDir: {medium: Memory}
+                - name: tcpxo-libraries
+                  hostPath: {path: /home/kubernetes/bin/nvidia}
+                - name: tcpxo-sys
+                  hostPath: {path: /sys}
+                - name: tcpxo-proc-sys
+                  hostPath: {path: /proc/sys}
+                - name: tcpxo-aperture-devices
+                  hostPath: {path: /dev/aperture_devices}
+```
+
+### Sourcing the NCCL configuration
+
+The annotations and sidecar attach the NICs; they do not configure NCCL. The
+plugin installer stages a profile script on each node, and your entrypoint must
+source it before launching training:
+
+```shell
+NCCL_LIB_DIR=/usr/local/nvidia/lib64 . /usr/local/nvidia/lib64/nccl-env-profile.sh
+```
+
+That sets the complete versioned variable set for your plugin release —
+`NCCL_FASTRAK_*` and also `NCCL_SOCKET_IFNAME`, `NCCL_CROSS_NIC`, protocol and
+tuner paths, and `LD_LIBRARY_PATH`. Setting only the `NCCL_FASTRAK_*` variables
+by hand is not equivalent, and the set changes between plugin releases.
+
+### The TrainJob
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: my-training-job
+  namespace: my-team
+spec:
+  runtimeRef:
+    name: torch-tcpxo
+    apiGroup: trainer.kubeflow.org
+    kind: TrainingRuntime
+  trainer:
+    numNodes: 2
+    image: my-registry/my-trainer:latest
+    command: ["sh", "-c"]
+    args:
+    - |
+      NCCL_LIB_DIR=/usr/local/nvidia/lib64 . /usr/local/nvidia/lib64/nccl-env-profile.sh
+      torchrun --nnodes=$PET_NNODES --nproc-per-node=8 train.py
+```
+
+**Do not set `resourcesPerNode` here.** On the pinned Kubeflow Trainer version
+a `resourcesPerNode` carrying limits or requests **replaces** the worker's
+entire resource requirements — so a job requesting only CPU or memory silently
+loses the runtime's `nvidia.com/gpu: 8`, and TCPXO stops working. Let the
+runtime own the resource shape. If you must set it, repeat *every* resource,
+including the GPU request.
+
+## EKS — EFA
+
+EFA needs no sidecar, so a TrainJob can attach to it directly against a generic
+runtime such as the `torch-distributed` runtime AICR ships.
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: my-training-job
+spec:
+  runtimeRef:
+    name: torch-distributed
+    apiGroup: trainer.kubeflow.org
+    kind: ClusterTrainingRuntime
+  trainer:
+    numNodes: 2
+    image: my-registry/my-trainer:latest
+    resourcesPerNode:
+      limits:
+        nvidia.com/gpu: 8
+        vpc.amazonaws.com/efa: 32     # see below — varies by instance type
+      requests:
+        nvidia.com/gpu: 8
+        vpc.amazonaws.com/efa: 32
+    env:
+    - name: FI_PROVIDER
+      value: efa
+    - name: FI_EFA_USE_DEVICE_RDMA
+      value: "1"
+    - name: LD_LIBRARY_PATH
+      value: /opt/amazon/ofi-nccl/lib:/opt/amazon/efa/lib:/usr/local/nvidia/lib64
+```
+
+**Repeat the GPU request.** `resourcesPerNode` replaces the whole resource
+block, so listing EFA without `nvidia.com/gpu` yields a pod with no GPUs.
+
+**Determine the EFA count from the node, not from a table.** It varies by
+instance type — 4 on p4d, 32 on p5, and on g7e by size, with some sizes having
+none:
+
+```shell
+kubectl get nodes -l nvidia.com/gpu.present=true \
+  -o jsonpath='{.items[0].status.allocatable.vpc\.amazonaws\.com/efa}'
+```
+
+## AKS — InfiniBand / RDMA
+
+Also TrainJob-expressible. AICR fixes the resource name, and the value is
+always `1`:
+
+```yaml
+  trainer:
+    numNodes: 2
+    image: my-registry/my-trainer:latest
+    resourcesPerNode:
+      limits:
+        nvidia.com/gpu: 8
+        rdma/hca_shared_devices_a: 1
+      requests:
+        nvidia.com/gpu: 8
+        rdma/hca_shared_devices_a: 1
+    env:
+    - name: NCCL_IB_DISABLE
+      value: "0"
+    - name: NCCL_NET_PLUGIN
+      value: none
+```
+
+The same GPU-request caveat applies.
+
+## Verifying the fabric is in use
+
+Run a short job with NCCL debug enabled and check which transport it selected:
+
+```shell
+kubectl logs <worker-pod> | grep -i 'NCCL INFO Using network'
+```
+
+Expect the plugin name — `FasTrak` for TCPXO, `AWS Libfabric` for EFA, `IB` for
+InfiniBand. **`Socket` means the fabric is not in use** and the job is running
+over TCP.
+
+Enabling `NCCL_DEBUG=INFO` is verbose. Prefer a short dedicated run for the
+check rather than leaving it on for a full training job.
+
+## Related
+
+- [GKE TCPXO Networking Prerequisites](../integrator/gke-tcpxo-networking.md) — cluster-side setup
+- [AKS GPU Setup](../integrator/aks-gpu-setup.md) — RDMA prerequisites

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -47,8 +47,8 @@ namespace and reference it from `runtimeRef`.
 - four hostPath volumes, and `IPC_LOCK` on the worker
 - the NCCL configuration for your plugin release
 
-**The shape, abridged** — commented-out lines mark what is elided. This shows
-where things go; it is not a working manifest:
+**The shape, abridged** — `"<...>"` marks a value you must fill in. Every key a
+workload needs is shown; this is not a working manifest:
 
 ```yaml
 apiVersion: trainer.kubeflow.org/v1alpha1
@@ -71,22 +71,24 @@ spec:
             template:
               metadata:
                 annotations:
-                  # devices.gke.io/container.tcpxo-daemon: <NRI device list>
+                  devices.gke.io/container.tcpxo-daemon: "<NRI device list — see reference>"
                   networking.gke.io/default-interface: eth0
-                  # networking.gke.io/interfaces: <YOUR 8 network names>
+                  networking.gke.io/interfaces: "<YOUR 8 network names — see below>"
               spec:
-                # nodeSelector / tolerations: carry over from your bundle
+                nodeSelector: "<carry over from your bundle>"
+                tolerations: "<carry over from your bundle>"
                 initContainers:
                 - name: tcpxo-daemon     # native sidecar: restartPolicy: Always
-                  image: <registry>/tcpgpudmarxd-dev:<paired-with-your-plugin>
-                  # + args, capabilities, volumeMounts
+                  image: "<registry>/tcpgpudmarxd-dev:<paired-with-your-plugin>"
+                  args: "<see reference>"                 # + capabilities, volumeMounts
                 containers:
                 - name: node
                   image: <your training image>
                   resources:
                     limits: {nvidia.com/gpu: 8}     # TCPXO needs all 8
-                  # + env, securityContext (IPC_LOCK), volumeMounts
-                # volumes: 4 hostPaths + dshm
+                  env: "<incl. NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY>"
+                  securityContext: "<IPC_LOCK>"          # + volumeMounts
+                volumes: "<4 hostPaths + dshm>"
 ```
 
 Then reference it from the TrainJob, which carries no fabric configuration at all:
@@ -165,19 +167,22 @@ carries **no `resources` block at all**, so `resourcesPerNode` is the only
 source of GPUs here — omitting `nvidia.com/gpu` yields a pod with none:
 
 ```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+spec:
   runtimeRef:
     name: torch-distributed
-    kind: ClusterTrainingRuntime     # note: cluster-scoped, unlike the GKE example
+    kind: ClusterTrainingRuntime     # cluster-scoped, unlike the GKE example
     apiGroup: trainer.kubeflow.org
   trainer:
     numNodes: 2                      # torch-distributed defaults to 1
     resourcesPerNode:
-        limits:
-          nvidia.com/gpu: 8
-          vpc.amazonaws.com/efa: 32   # per node — see below
-        requests:
-          nvidia.com/gpu: 8
-          vpc.amazonaws.com/efa: 32
+      limits:
+        nvidia.com/gpu: 8
+        vpc.amazonaws.com/efa: 32    # per node — see below
+      requests:
+        nvidia.com/gpu: 8
+        vpc.amazonaws.com/efa: 32
 ```
 
 **An image carrying the EFA stack.** AICR installs the device plugin, which

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -37,14 +37,16 @@ That single limitation decides the rest:
 | EFA | EKS | no | your `TrainJob` |
 | InfiniBand / RDMA | AKS | no | your `TrainJob` |
 
-## GKE — GPUDirect TCPXO
+## GKE GPUDirect TCPXO
 
 TCPXO needs the `tcpxo-daemon` sidecar, so the wiring cannot live in a TrainJob.
 `TrainingRuntime` is an ordinary namespaced resource: author one in your
 namespace and reference it from `runtimeRef`.
 
-**What that runtime must carry**, all of it documented in
-[Workload Pod Configuration](../integrator/gke-tcpxo-networking.md#workload-pod-configuration-nri-profile):
+**What that runtime must carry.** The annotations and sidecar are specified in
+[Workload Pod Configuration](../integrator/gke-tcpxo-networking.md#workload-pod-configuration-nri-profile);
+the `dshm` volume, worker `IPC_LOCK`, daemon `args` and NCCL settings are not in
+that section — take them from AICR's validator runtime, cited below.
 
 - the `networking.gke.io/interfaces` and `devices.gke.io/container.tcpxo-daemon`
   annotations, on the pod template metadata
@@ -52,7 +54,11 @@ namespace and reference it from `runtimeRef`.
   cluster runs
 - four hostPath volumes plus a memory-backed `dshm` at `/dev/shm`, and `IPC_LOCK`
   on the worker
-- the NCCL configuration for your plugin release
+- the NCCL configuration for your plugin release. The ~40 `NCCL_FASTRAK_*`
+  tuning variables ship as `/usr/local/nvidia/lib64/nccl-env-profile.sh`, laid
+  down by the plugin installer and version-matched to it. Source that file in
+  your container's startup rather than transcribing the variables — a job that
+  skips it still attaches to the fabric, but runs well under its bandwidth
 
 **A placement sketch** — `"<...>"` marks a value you must fill in. It shows
 where each piece goes; it is not a manifest, abridged or otherwise, and the
@@ -81,7 +87,7 @@ spec:
                 annotations:
                   devices.gke.io/container.tcpxo-daemon: "<NRI device list — see reference>"
                   networking.gke.io/default-interface: eth0
-                  networking.gke.io/interfaces: "<YOUR 8 network names — see below>"
+                  networking.gke.io/interfaces: "<JSON array, 9 entries — see reference>"
               spec:
                 nodeSelector: "<carry over from your bundle>"
                 tolerations: "<carry over from your bundle>"
@@ -174,7 +180,7 @@ which prefers the TrainJob's value and can yield `PET_NPROC_PER_NODE=1`.
 
 If you must set it, repeat *every* resource in it, including the GPU request.
 
-## EKS — EFA
+## EKS EFA
 
 EFA needs no sidecar, so a TrainJob can attach to it against a generic runtime
 such as the `torch-distributed` runtime AICR ships. It needs three things:
@@ -196,10 +202,10 @@ spec:
     resourcesPerNode:
       limits:
         nvidia.com/gpu: 8
-        vpc.amazonaws.com/efa: <EFA_COUNT>    # per node — read it, see below
+        vpc.amazonaws.com/efa: "<EFA_COUNT>"    # per node — read it, see below
       requests:
         nvidia.com/gpu: 8
-        vpc.amazonaws.com/efa: <EFA_COUNT>
+        vpc.amazonaws.com/efa: "<EFA_COUNT>"
 ```
 
 **`IPC_LOCK` and `FI_EFA_FORK_SAFE=1`.** `torch-distributed` grants neither —
@@ -208,6 +214,11 @@ other `FI_*` variables in `spec.trainer.env`, and `IPC_LOCK` via a
 `runtimePatches` entry setting `securityContext` on the `node` container
 (`securityContext` is patchable there even though `env` is not). Without
 `IPC_LOCK`, NCCL may fail to register pinned buffers.
+
+**`NCCL_SOCKET_IFNAME=eth0`.** AICR's tested EFA and InfiniBand runtimes both pin
+this so NCCL's bootstrap uses the control interface. On a multi-NIC node — p5
+carries several EFA ENIs — NCCL may otherwise pick a secondary, non-routable NIC
+for rendezvous and hang during initialization, before any transport is chosen.
 
 **An image carrying the EFA stack.** AICR installs the device plugin, which
 exposes the devices — it does not put `libfabric` or `aws-ofi-nccl` into your
@@ -226,7 +237,7 @@ kubectl get nodes -l <your-gpu-pool-selector> \
   -o custom-columns='NODE:.metadata.name,EFA:.status.allocatable.vpc\.amazonaws\.com/efa'
 ```
 
-## AKS — InfiniBand / RDMA
+## AKS InfiniBand and RDMA
 
 Also TrainJob-expressible. AICR fixes the resource name and the value is always
 `1`:
@@ -255,6 +266,12 @@ the device is allocated, which reads as an NCCL bug rather than a missing
 capability. Add it the same way as for EFA: a `runtimePatches` entry setting
 `securityContext` on the `node` container.
 
+**An image carrying the IB verbs stack.** As with EFA, allocating the device is
+not enough: NCCL's IB transport dlopens `libibverbs` and the rest of rdma-core at
+runtime. An image without them logs `NET/IB : No device found` and falls back to
+sockets — the job still completes, just over TCP. Build from a base that carries
+rdma-core, or install it in the image.
+
 **A memory-backed `/dev/shm` is also expected.** AICR's tested runtime mounts a
 `dshm` volume (`emptyDir: {medium: Memory}`) there; the default 64 MiB `/dev/shm`
 is small for multi-process NCCL.
@@ -264,7 +281,10 @@ prerequisites.
 
 ## Verifying the fabric is in use
 
-Run a short job with `NCCL_DEBUG=INFO` and check which transport NCCL selected:
+Run a short job with `NCCL_DEBUG=INFO` and check which transport NCCL selected.
+Every runtime AICR ships sets `NCCL_DEBUG=WARN`, at which this line is
+suppressed — so grepping an ordinary run finds nothing, which is not evidence of
+socket fallback:
 
 ```shell
 kubectl logs <worker-pod> -c node | grep -i 'NCCL INFO.*Using network'

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -47,8 +47,9 @@ namespace and reference it from `runtimeRef`.
 - four hostPath volumes, and `IPC_LOCK` on the worker
 - the NCCL configuration for your plugin release
 
-**The shape, abridged** — `"<...>"` marks a value you must fill in. Every key a
-workload needs is shown; this is not a working manifest:
+**A placement sketch** — `"<...>"` marks a value you must fill in. It shows
+where each piece goes; it is not a manifest, abridged or otherwise, and the
+authoritative field list is the integrator page linked below:
 
 ```yaml
 apiVersion: trainer.kubeflow.org/v1alpha1
@@ -106,12 +107,18 @@ spec:
     image: my-registry/my-trainer:latest
 ```
 
-**For a complete, working reference**, see the runtime AICR's own performance
-validator applies:
-[`validators/performance/testdata/h100/gke/runtime.yaml`](https://github.com/NVIDIA/aicr/blob/main/validators/performance/testdata/h100/gke/runtime.yaml).
-It is an MPI benchmark rather than a training job, so the launcher differs — but
-the fabric wiring is exactly what a workload needs, and it is kept current
-against the recipe.
+**The authoritative wiring** is
+[Workload Pod Configuration](../integrator/gke-tcpxo-networking.md#workload-pod-configuration-nri-profile)
+together with the version table in
+[NCCL Plugin Version Matching](../integrator/gke-tcpxo-networking.md#nccl-plugin-version-matching).
+Take the annotation, sidecar, volume and capability requirements from there.
+
+AICR's performance validator applies a runtime with the same wiring
+([`validators/performance/testdata/h100/gke/runtime.yaml`](https://github.com/NVIDIA/aicr/blob/main/validators/performance/testdata/h100/gke/runtime.yaml)),
+which is useful to read for shape. It is **not** a template to copy: it is an
+MPI benchmark rather than a training job, it carries validator-only
+placeholders substituted at apply time, and its own image pins are not
+guaranteed to match the pair the recipe currently ships.
 
 Two details are easy to miss because they are not in the pod spec:
 

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -202,15 +202,17 @@ spec:
     args:
     - |
       NCCL_LIB_DIR=/usr/local/nvidia/lib64 . /usr/local/nvidia/lib64/nccl-env-profile.sh
-      torchrun --nnodes=$PET_NNODES --nproc-per-node=8 train.py
+      torchrun --nnodes=$PET_NNODES --nproc-per-node=$PET_NPROC_PER_NODE train.py
 ```
 
 **Do not set `resourcesPerNode` here.** On the pinned Kubeflow Trainer version
-a `resourcesPerNode` carrying limits or requests **replaces** the worker's
-entire resource requirements — so a job requesting only CPU or memory silently
-loses the runtime's `nvidia.com/gpu: 8`, and TCPXO stops working. Let the
-runtime own the resource shape. If you must set it, repeat *every* resource,
-including the GPU request.
+**any** non-nil `resourcesPerNode` — including an empty `{}`, or one carrying
+only `limits.cpu` — **replaces** the worker's entire resource requirements. A
+job that sets it to ask for memory silently loses the runtime's
+`nvidia.com/gpu: 8`, and TCPXO stops working.
+
+Let the runtime own the resource shape. If you must set `resourcesPerNode`,
+repeat *every* resource in it, including the GPU request.
 
 ## EKS — EFA
 
@@ -246,8 +248,9 @@ spec:
       value: /opt/amazon/ofi-nccl/lib:/opt/amazon/efa/lib:/usr/local/nvidia/lib64
 ```
 
-**Repeat the GPU request.** `resourcesPerNode` replaces the whole resource
-block, so listing EFA without `nvidia.com/gpu` yields a pod with no GPUs.
+**Repeat the GPU request.** Any non-nil `resourcesPerNode` replaces the whole
+resource block — it is not merged — so listing EFA without `nvidia.com/gpu`
+yields a pod with no GPUs.
 
 **Determine the EFA count from the node, not from a table.** It varies by
 instance type — 4 on p4d, 32 on p5, and on g7e by size, with some sizes having
@@ -281,7 +284,8 @@ always `1`:
       value: none
 ```
 
-The same GPU-request caveat applies.
+The same GPU-request caveat applies: any non-nil `resourcesPerNode` replaces
+the whole block, so `nvidia.com/gpu` must be repeated.
 
 ## Verifying the fabric is in use
 

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -15,9 +15,15 @@ assuming it.
 Kubeflow Trainer splits a workload across two objects, and the split decides
 where fabric wiring can live.
 
-A **TrainJob** can supply pod annotations and labels (`PodTemplatePatch.Metadata`),
-volumes (`PodSpecPatch.Volumes`), and per-container `env`, `volumeMounts` and
-`securityContext` (`ContainerPatch`).
+A **TrainJob** can supply pod annotations and labels (`PodTemplatePatch.Metadata`)
+and volumes (`PodSpecPatch.Volumes`) through `spec.runtimePatches`, plus
+`image`, `command`, `args`, `env` and `resourcesPerNode` for the trainer
+through `spec.trainer`.
+
+Note where worker **environment** goes: `ContainerPatch.env` is rejected for the
+`node`, `dataset-initializer` and `model-initializer` containers, so worker
+variables belong in `spec.trainer.env`, not in a runtime patch. `ContainerPatch`
+can still set `volumeMounts` and `securityContext` on `node`.
 
 A **TrainJob cannot add a container.** `ContainerPatch` carries only `name`,
 `env`, `volumeMounts` and `securityContext` — no `image`, no `command` — and the
@@ -79,7 +85,9 @@ spec:
                 nodeSelector: "<carry over from your bundle>"
                 tolerations: "<carry over from your bundle>"
                 initContainers:
-                - name: tcpxo-daemon     # native sidecar: restartPolicy: Always
+                - name: tcpxo-daemon
+                  restartPolicy: Always    # native sidecar — without this the
+                                           # pod stalls in initialization
                   image: "<registry>/tcpgpudmarxd-dev:<paired-with-your-plugin>"
                   args: "<see reference>"                 # + capabilities, volumeMounts
                 containers:
@@ -154,8 +162,9 @@ to list them; ask whoever provisions the cluster for the eight names, or for the
 
 ### Do not set `resourcesPerNode`
 
-Let the runtime own the resource shape. `resourcesPerNode` on a TrainJob is not
-merged into the runtime's — a value carrying `limits` or `requests` **replaces**
+Let the runtime own the resource shape. On the pinned Kubeflow Trainer
+**v2.2.0**, `resourcesPerNode` on a TrainJob is not merged into the runtime's —
+a value carrying `limits` or `requests` **replaces**
 the worker's resource requirements outright, so a job that sets it to ask for
 memory silently loses the runtime's `nvidia.com/gpu: 8` and TCPXO stops working.
 
@@ -186,11 +195,18 @@ spec:
     resourcesPerNode:
       limits:
         nvidia.com/gpu: 8
-        vpc.amazonaws.com/efa: 32    # per node — see below
+        vpc.amazonaws.com/efa: <EFA_COUNT>    # per node — read it, see below
       requests:
         nvidia.com/gpu: 8
-        vpc.amazonaws.com/efa: 32
+        vpc.amazonaws.com/efa: <EFA_COUNT>
 ```
+
+**`IPC_LOCK` and `FI_EFA_FORK_SAFE=1`.** `torch-distributed` grants neither —
+AICR's tested EFA runtime sets both. Add `FI_EFA_FORK_SAFE=1` alongside the
+other `FI_*` variables in `spec.trainer.env`, and `IPC_LOCK` via a
+`runtimePatches` entry setting `securityContext` on the `node` container
+(`securityContext` is patchable there even though `env` is not). Without
+`IPC_LOCK`, NCCL may fail to register pinned buffers.
 
 **An image carrying the EFA stack.** AICR installs the device plugin, which
 exposes the devices — it does not put `libfabric` or `aws-ofi-nccl` into your
@@ -238,7 +254,7 @@ prerequisites.
 Run a short job with `NCCL_DEBUG=INFO` and check which transport NCCL selected:
 
 ```shell
-kubectl logs <worker-pod> | grep -i 'NCCL INFO.*Using network'
+kubectl logs <worker-pod> -c node | grep -i 'NCCL INFO.*Using network'
 ```
 
 Expect the plugin name — `FasTrak` for TCPXO, `AWS Libfabric` for EFA, `IB` for

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -50,7 +50,8 @@ namespace and reference it from `runtimeRef`.
   annotations, on the pod template metadata
 - the `tcpxo-daemon` native sidecar, at the version paired with the plugin your
   cluster runs
-- four hostPath volumes, and `IPC_LOCK` on the worker
+- four hostPath volumes plus a memory-backed `dshm` at `/dev/shm`, and `IPC_LOCK`
+  on the worker
 - the NCCL configuration for your plugin release
 
 **A placement sketch** — `"<...>"` marks a value you must fill in. It shows
@@ -245,8 +246,20 @@ Also TrainJob-expressible. AICR fixes the resource name and the value is always
       value: none
 ```
 
-The same repeat-every-resource caveat applies. See
-[AKS GPU Setup](../integrator/aks-gpu-setup.md) for the cluster-side
+The same repeat-every-resource caveat applies.
+
+**`IPC_LOCK` is required here too, and allocating the RDMA device does not grant
+it.** NCCL's IB transport registers pinned (memlocked) buffers via ibverbs, and
+`IPC_LOCK` is what lifts `RLIMIT_MEMLOCK` — without it the job can fail *after*
+the device is allocated, which reads as an NCCL bug rather than a missing
+capability. Add it the same way as for EFA: a `runtimePatches` entry setting
+`securityContext` on the `node` container.
+
+**A memory-backed `/dev/shm` is also expected.** AICR's tested runtime mounts a
+`dshm` volume (`emptyDir: {medium: Memory}`) there; the default 64 MiB `/dev/shm`
+is small for multi-process NCCL.
+
+See [AKS GPU Setup](../integrator/aks-gpu-setup.md) for the cluster-side
 prerequisites.
 
 ## Verifying the fabric is in use

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -47,8 +47,8 @@ namespace and reference it from `runtimeRef`.
 - four hostPath volumes, and `IPC_LOCK` on the worker
 - the NCCL configuration for your plugin release
 
-**The shape, abridged** — elisions marked `...`; this is to show where things
-go, not to copy verbatim:
+**The shape, abridged** — commented-out lines mark what is elided. This shows
+where things go; it is not a working manifest:
 
 ```yaml
 apiVersion: trainer.kubeflow.org/v1alpha1
@@ -71,23 +71,22 @@ spec:
             template:
               metadata:
                 annotations:
-                  devices.gke.io/container.tcpxo-daemon: ...         # NRI device list
+                  # devices.gke.io/container.tcpxo-daemon: <NRI device list>
                   networking.gke.io/default-interface: eth0
-                  networking.gke.io/interfaces: ...                  # YOUR 8 network names
+                  # networking.gke.io/interfaces: <YOUR 8 network names>
               spec:
-                nodeSelector: ...        # carry over from your bundle
-                tolerations: ...
+                # nodeSelector / tolerations: carry over from your bundle
                 initContainers:
                 - name: tcpxo-daemon     # native sidecar: restartPolicy: Always
-                  image: .../tcpgpudmarxd-dev:<paired-with-your-plugin>
-                  ...
+                  image: <registry>/tcpgpudmarxd-dev:<paired-with-your-plugin>
+                  # + args, capabilities, volumeMounts
                 containers:
                 - name: node
                   image: <your training image>
                   resources:
                     limits: {nvidia.com/gpu: 8}     # TCPXO needs all 8
-                  ...
-                volumes: ...             # 4 hostPaths + dshm
+                  # + env, securityContext (IPC_LOCK), volumeMounts
+                # volumes: 4 hostPaths + dshm
 ```
 
 Then reference it from the TrainJob, which carries no fabric configuration at all:
@@ -161,18 +160,24 @@ If you must set it, repeat *every* resource in it, including the GPU request.
 EFA needs no sidecar, so a TrainJob can attach to it against a generic runtime
 such as the `torch-distributed` runtime AICR ships. It needs three things:
 
-**The device request**, alongside every other resource — `resourcesPerNode`
-replaces rather than merges, so omitting `nvidia.com/gpu` here yields a pod with
-no GPUs:
+**The device request**, alongside every other resource. `torch-distributed`
+carries **no `resources` block at all**, so `resourcesPerNode` is the only
+source of GPUs here — omitting `nvidia.com/gpu` yields a pod with none:
 
 ```yaml
+  runtimeRef:
+    name: torch-distributed
+    kind: ClusterTrainingRuntime     # note: cluster-scoped, unlike the GKE example
+    apiGroup: trainer.kubeflow.org
+  trainer:
+    numNodes: 2                      # torch-distributed defaults to 1
     resourcesPerNode:
-      limits:
-        nvidia.com/gpu: 8
-        vpc.amazonaws.com/efa: 32     # per node — see below
-      requests:
-        nvidia.com/gpu: 8
-        vpc.amazonaws.com/efa: 32
+        limits:
+          nvidia.com/gpu: 8
+          vpc.amazonaws.com/efa: 32   # per node — see below
+        requests:
+          nvidia.com/gpu: 8
+          vpc.amazonaws.com/efa: 32
 ```
 
 **An image carrying the EFA stack.** AICR installs the device plugin, which

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -1,34 +1,29 @@
 # Attaching a Training Workload to the Cluster Fabric
 
-AICR recipes deliver the cluster-side prerequisites for high-speed inter-node
-networking — the NCCL plugin, device injection, node labels and taints. What
-they do not do is attach your *workload* to that fabric. This page describes
-what a training workload must declare, per platform.
+AICR recipes deliver the cluster side of high-speed inter-node networking — the
+NCCL plugin, device injection, node labels and taints. They do **not** attach
+your workload to it. That part is yours, and this page describes what it
+involves.
 
-Without this wiring a multi-node job still runs: NCCL falls back to TCP over
-the primary interface. Intra-node NVLink is unaffected, so nothing errors and
-the job completes — just far slower than the hardware allows. Check for it
-rather than assuming it.
+Without it a multi-node job still runs: NCCL falls back to TCP over the primary
+interface. Intra-node NVLink is unaffected, so nothing errors and the job
+completes — just far slower than the hardware allows. Check for it rather than
+assuming it.
 
 ## Which layer owns what
 
-Kubeflow Trainer splits a workload across two objects, and the split determines
+Kubeflow Trainer splits a workload across two objects, and the split decides
 where fabric wiring can live.
 
-A **TrainJob** can supply:
-
-- pod annotations and labels, via `PodTemplatePatch.Metadata`
-- volumes, via `PodSpecPatch.Volumes`
-- per-container `env`, `volumeMounts` and `securityContext`, via `ContainerPatch`
-- `image`, `command`, `args` and `resourcesPerNode` for the trainer container
+A **TrainJob** can supply pod annotations and labels (`PodTemplatePatch.Metadata`),
+volumes (`PodSpecPatch.Volumes`), and per-container `env`, `volumeMounts` and
+`securityContext` (`ContainerPatch`).
 
 A **TrainJob cannot add a container.** `ContainerPatch` carries only `name`,
-`env`, `volumeMounts` and `securityContext` — no `image`, no `command` — and
-the runtime rejects a patch naming a container it does not already define.
+`env`, `volumeMounts` and `securityContext` — no `image`, no `command` — and the
+runtime rejects a patch naming a container it does not already define.
 
-That single limitation decides everything below. Fabrics needing only resource
-requests and environment are fully TrainJob-expressible. Fabrics needing a
-sidecar require a **Runtime** — either one AICR ships, or one you author.
+That single limitation decides the rest:
 
 | Fabric | Platform | Needs a sidecar? | Where the wiring goes |
 |---|---|---|---|
@@ -38,238 +33,171 @@ sidecar require a **Runtime** — either one AICR ships, or one you author.
 
 ## GKE — GPUDirect TCPXO
 
-TCPXO needs a `tcpxo-daemon` sidecar, so the wiring lives in a Runtime.
-`TrainingRuntime` is an ordinary namespaced resource: create one in your own
-namespace and reference it from your TrainJob.
+TCPXO needs the `tcpxo-daemon` sidecar, so the wiring cannot live in a TrainJob.
+`TrainingRuntime` is an ordinary namespaced resource: author one in your
+namespace and reference it from `runtimeRef`.
 
-### Before you start
+**What that runtime must carry**, all of it documented in
+[Workload Pod Configuration](../integrator/gke-tcpxo-networking.md#workload-pod-configuration-nri-profile):
 
-Confirm the cluster prerequisites are in place — see
-[GKE TCPXO Networking Prerequisites](../integrator/gke-tcpxo-networking.md).
-You need the eight GPU NIC `Network` objects bound to the GPU node pool:
+- the `networking.gke.io/interfaces` and `devices.gke.io/container.tcpxo-daemon`
+  annotations, on the pod template metadata
+- the `tcpxo-daemon` native sidecar, at the version paired with the plugin your
+  cluster runs
+- four hostPath volumes, and `IPC_LOCK` on the worker
+- the NCCL configuration for your plugin release
 
-```shell
-kubectl get networks.networking.gke.io -o name | grep gpu-nic
-```
-
-**Use the names your cluster actually has.** AICR requires only that each name
-contain `gpu-nic`; the rest is chosen by whoever provisioned the cluster, so
-prefixed forms such as `aicr-demo2-gpu-nic-0` are common. Substitute them into
-the `networking.gke.io/interfaces` annotation below — the examples use
-`gpu-nic0`–`gpu-nic7`.
-
-Match the sidecar image to the plugin your cluster runs — see
-[NCCL Plugin Version Matching](../integrator/gke-tcpxo-networking.md#nccl-plugin-version-matching).
-
-### The TrainingRuntime
+**The shape, abridged** — elisions marked `...`; this is to show where things
+go, not to copy verbatim:
 
 ```yaml
 apiVersion: trainer.kubeflow.org/v1alpha1
-kind: TrainingRuntime
+kind: TrainingRuntime          # namespaced — yours to create
 metadata:
   name: torch-tcpxo
-  namespace: my-team          # your namespace
   labels:
     trainer.kubeflow.org/framework: torch
 spec:
-  mlPolicy:
-    numNodes: 2               # override per job with spec.trainer.numNodes
-    torch: {}
+  mlPolicy: {numNodes: 2, torch: {}}
   template:
     spec:
       replicatedJobs:
       - name: node
         template:
+          metadata:
+            labels:
+              trainer.kubeflow.org/trainjob-ancestor-step: trainer   # required
           spec:
             template:
               metadata:
                 annotations:
-                  # Expose GPU and DMA devices to the sidecar via NRI, so it
-                  # does not need privileged mode. One entry per GPU, plus the
-                  # three control devices.
-                  devices.gke.io/container.tcpxo-daemon: |
-                    - path: /dev/nvidia0
-                    - path: /dev/nvidia1
-                    - path: /dev/nvidia2
-                    - path: /dev/nvidia3
-                    - path: /dev/nvidia4
-                    - path: /dev/nvidia5
-                    - path: /dev/nvidia6
-                    - path: /dev/nvidia7
-                    - path: /dev/nvidiactl
-                    - path: /dev/nvidia-uvm
-                    - path: /dev/dmabuf_import_helper
+                  devices.gke.io/container.tcpxo-daemon: ...         # NRI device list
                   networking.gke.io/default-interface: eth0
-                  # Substitute your cluster's Network names.
-                  networking.gke.io/interfaces: |
-                    [
-                      {"interfaceName":"eth0","network":"default"},
-                      {"interfaceName":"eth1","network":"gpu-nic0"},
-                      {"interfaceName":"eth2","network":"gpu-nic1"},
-                      {"interfaceName":"eth3","network":"gpu-nic2"},
-                      {"interfaceName":"eth4","network":"gpu-nic3"},
-                      {"interfaceName":"eth5","network":"gpu-nic4"},
-                      {"interfaceName":"eth6","network":"gpu-nic5"},
-                      {"interfaceName":"eth7","network":"gpu-nic6"},
-                      {"interfaceName":"eth8","network":"gpu-nic7"}
-                    ]
+                  networking.gke.io/interfaces: ...                  # YOUR 8 network names
               spec:
+                nodeSelector: ...        # carry over from your bundle
+                tolerations: ...
                 initContainers:
-                # Native sidecar: an initContainer with restartPolicy: Always
-                # runs alongside the worker for the pod's lifetime.
-                - name: tcpxo-daemon
-                  image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
-                  restartPolicy: Always
-                  command: ["/bin/sh", "-c"]
-                  args:
-                  - |
-                    set -ex
-                    chmod 755 /fts/entrypoint_rxdm_container.sh
-                    /fts/entrypoint_rxdm_container.sh --num_hops=2
-                  securityContext:
-                    capabilities:
-                      add: ["NET_ADMIN", "NET_BIND_SERVICE"]
-                  volumeMounts:
-                  - {name: tcpxo-libraries, mountPath: /usr/local/nvidia, readOnly: true}
-                  - {name: tcpxo-sys, mountPath: /hostsysfs}
-                  - {name: tcpxo-proc-sys, mountPath: /hostprocsysfs}
-                  env:
-                  - name: LD_LIBRARY_PATH
-                    value: /usr/local/nvidia/lib64
+                - name: tcpxo-daemon     # native sidecar: restartPolicy: Always
+                  image: .../tcpgpudmarxd-dev:<paired-with-your-plugin>
+                  ...
                 containers:
                 - name: node
-                  # Your training image. It must be ABI-compatible with the
-                  # host-installed plugin libraries mounted below; it does not
-                  # need the plugin baked in.
-                  image: nvcr.io/nvidia/pytorch:25.06-py3
+                  image: <your training image>
                   resources:
-                    limits:
-                      nvidia.com/gpu: 8      # TCPXO requires all 8 GPUs
-                    requests:
-                      nvidia.com/gpu: 8
-                  securityContext:
-                    capabilities:
-                      add: ["IPC_LOCK"]
-                  volumeMounts:
-                  - {name: dshm, mountPath: /dev/shm}
-                  - {name: tcpxo-libraries, mountPath: /usr/local/nvidia, readOnly: true}
-                  - {name: tcpxo-aperture-devices, mountPath: /dev/aperture_devices}
-                volumes:
-                - name: dshm
-                  emptyDir: {medium: Memory}
-                - name: tcpxo-libraries
-                  hostPath: {path: /home/kubernetes/bin/nvidia}
-                - name: tcpxo-sys
-                  hostPath: {path: /sys}
-                - name: tcpxo-proc-sys
-                  hostPath: {path: /proc/sys}
-                - name: tcpxo-aperture-devices
-                  hostPath: {path: /dev/aperture_devices}
+                    limits: {nvidia.com/gpu: 8}     # TCPXO needs all 8
+                  ...
+                volumes: ...             # 4 hostPaths + dshm
 ```
 
-### Sourcing the NCCL configuration
-
-The annotations and sidecar attach the NICs; they do not configure NCCL. The
-plugin installer stages a profile script on each node, and your entrypoint must
-source it before launching training:
-
-```shell
-NCCL_LIB_DIR=/usr/local/nvidia/lib64 . /usr/local/nvidia/lib64/nccl-env-profile.sh
-```
-
-That sets the complete versioned variable set for your plugin release —
-`NCCL_FASTRAK_*` and also `NCCL_SOCKET_IFNAME`, `NCCL_CROSS_NIC`, protocol and
-tuner paths, and `LD_LIBRARY_PATH`. Setting only the `NCCL_FASTRAK_*` variables
-by hand is not equivalent, and the set changes between plugin releases.
-
-### The TrainJob
+Then reference it from the TrainJob, which carries no fabric configuration at all:
 
 ```yaml
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: TrainJob
-metadata:
-  name: my-training-job
-  namespace: my-team
 spec:
   runtimeRef:
     name: torch-tcpxo
-    apiGroup: trainer.kubeflow.org
     kind: TrainingRuntime
+    apiGroup: trainer.kubeflow.org
   trainer:
     numNodes: 2
     image: my-registry/my-trainer:latest
-    command: ["sh", "-c"]
-    args:
-    - |
-      NCCL_LIB_DIR=/usr/local/nvidia/lib64 . /usr/local/nvidia/lib64/nccl-env-profile.sh
-      torchrun --nnodes=$PET_NNODES --nproc-per-node=$PET_NPROC_PER_NODE train.py
 ```
 
-**Do not set `resourcesPerNode` here.** On the pinned Kubeflow Trainer version
-**any** non-nil `resourcesPerNode` — including an empty `{}`, or one carrying
-only `limits.cpu` — **replaces** the worker's entire resource requirements. A
-job that sets it to ask for memory silently loses the runtime's
-`nvidia.com/gpu: 8`, and TCPXO stops working.
+**For a complete, working reference**, see the runtime AICR's own performance
+validator applies:
+[`validators/performance/testdata/h100/gke/runtime.yaml`](https://github.com/NVIDIA/aicr/blob/main/validators/performance/testdata/h100/gke/runtime.yaml).
+It is an MPI benchmark rather than a training job, so the launcher differs — but
+the fabric wiring is exactly what a workload needs, and it is kept current
+against the recipe.
 
-Let the runtime own the resource shape. If you must set `resourcesPerNode`,
-repeat *every* resource in it, including the GPU request.
+Two details are easy to miss because they are not in the pod spec:
+
+- Your runtime's `node` replicated job needs the label
+  `trainer.kubeflow.org/trainjob-ancestor-step: trainer`. Without it Trainer
+  applies none of the TrainJob's `trainer` block — image, command, `numNodes`,
+  or the `PET_*` rendezvous variables.
+- AICR's bundler injects `nodeSelector` and `tolerations` into the runtime it
+  ships, from `--accelerated-node-selector` and `--accelerated-node-toleration`.
+  **A runtime you author inherits nothing**, so carry your bundle's resolved
+  values across or the job may stay Pending — or land on another 8-GPU pool
+  without TCPXO.
+
+### The network names are yours to supply
+
+This is the part no example can fill in for you. The
+`networking.gke.io/interfaces` annotation must name the eight GPU NIC `Network`
+objects **as they exist on your cluster**. AICR requires only that each name
+contain `gpu-nic`; the rest is chosen by whoever provisioned it, so prefixed
+forms such as `aicr-demo2-gpu-nic-0` are common.
+
+```shell
+kubectl get networks.networking.gke.io \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep gpu-nic
+```
+
+That prints bare names, which is what the annotation takes. `-o name` would
+prefix them with `network.networking.gke.io/` — not the form to paste.
+
+`Network` is cluster-scoped. If your role is namespace-only you will not be able
+to list them; ask whoever provisions the cluster for the eight names, or for the
+`GKENetworkParamSet` mapping.
+
+### Do not set `resourcesPerNode`
+
+Let the runtime own the resource shape. `resourcesPerNode` on a TrainJob is not
+merged into the runtime's — a value carrying `limits` or `requests` **replaces**
+the worker's resource requirements outright, so a job that sets it to ask for
+memory silently loses the runtime's `nvidia.com/gpu: 8` and TCPXO stops working.
+
+Setting it at all — even to `{}` — also feeds Torch's process-count inference,
+which prefers the TrainJob's value and can yield `PET_NPROC_PER_NODE=1`.
+
+If you must set it, repeat *every* resource in it, including the GPU request.
 
 ## EKS — EFA
 
-EFA needs no sidecar, so a TrainJob can attach to it directly against a generic
-runtime such as the `torch-distributed` runtime AICR ships.
+EFA needs no sidecar, so a TrainJob can attach to it against a generic runtime
+such as the `torch-distributed` runtime AICR ships. It needs three things:
+
+**The device request**, alongside every other resource — `resourcesPerNode`
+replaces rather than merges, so omitting `nvidia.com/gpu` here yields a pod with
+no GPUs:
 
 ```yaml
-apiVersion: trainer.kubeflow.org/v1alpha1
-kind: TrainJob
-metadata:
-  name: my-training-job
-spec:
-  runtimeRef:
-    name: torch-distributed
-    apiGroup: trainer.kubeflow.org
-    kind: ClusterTrainingRuntime
-  trainer:
-    numNodes: 2
-    image: my-registry/my-trainer:latest
     resourcesPerNode:
       limits:
         nvidia.com/gpu: 8
-        vpc.amazonaws.com/efa: 32     # see below — varies by instance type
+        vpc.amazonaws.com/efa: 32     # per node — see below
       requests:
         nvidia.com/gpu: 8
         vpc.amazonaws.com/efa: 32
-    env:
-    - name: FI_PROVIDER
-      value: efa
-    - name: FI_EFA_USE_DEVICE_RDMA
-      value: "1"
-    - name: LD_LIBRARY_PATH
-      value: /opt/amazon/ofi-nccl/lib:/opt/amazon/efa/lib:/usr/local/nvidia/lib64
 ```
 
-**Repeat the GPU request.** Any non-nil `resourcesPerNode` replaces the whole
-resource block — it is not merged — so listing EFA without `nvidia.com/gpu`
-yields a pod with no GPUs.
+**An image carrying the EFA stack.** AICR installs the device plugin, which
+exposes the devices — it does not put `libfabric` or `aws-ofi-nccl` into your
+training image. An ordinary PyTorch image will fall back to sockets no matter
+what `LD_LIBRARY_PATH` says. Build from a base that includes them, and point
+`LD_LIBRARY_PATH` at wherever *that image* installs the plugin; AICR's tested
+image uses `/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu`.
 
-**Determine the EFA count from the node, not from a table.** It varies by
+**The count, read from the nodes you will actually run on.** It varies by
 instance type — 4 on p4d, 32 on p5, and on g7e by size, with some sizes having
-none:
+none. Check every eligible node and fail if they disagree, rather than trusting
+the first one:
 
 ```shell
-kubectl get nodes -l nvidia.com/gpu.present=true \
-  -o jsonpath='{.items[0].status.allocatable.vpc\.amazonaws\.com/efa}'
+kubectl get nodes -l <your-gpu-pool-selector> \
+  -o custom-columns='NODE:.metadata.name,EFA:.status.allocatable.vpc\.amazonaws\.com/efa'
 ```
 
 ## AKS — InfiniBand / RDMA
 
-Also TrainJob-expressible. AICR fixes the resource name, and the value is
-always `1`:
+Also TrainJob-expressible. AICR fixes the resource name and the value is always
+`1`:
 
 ```yaml
-  trainer:
-    numNodes: 2
-    image: my-registry/my-trainer:latest
     resourcesPerNode:
       limits:
         nvidia.com/gpu: 8
@@ -284,25 +212,26 @@ always `1`:
       value: none
 ```
 
-The same GPU-request caveat applies: any non-nil `resourcesPerNode` replaces
-the whole block, so `nvidia.com/gpu` must be repeated.
+The same repeat-every-resource caveat applies. See
+[AKS GPU Setup](../integrator/aks-gpu-setup.md) for the cluster-side
+prerequisites.
 
 ## Verifying the fabric is in use
 
-Run a short job with NCCL debug enabled and check which transport it selected:
+Run a short job with `NCCL_DEBUG=INFO` and check which transport NCCL selected:
 
 ```shell
-kubectl logs <worker-pod> | grep -i 'NCCL INFO Using network'
+kubectl logs <worker-pod> | grep -i 'NCCL INFO.*Using network'
 ```
 
 Expect the plugin name — `FasTrak` for TCPXO, `AWS Libfabric` for EFA, `IB` for
 InfiniBand. **`Socket` means the fabric is not in use** and the job is running
 over TCP.
 
-Enabling `NCCL_DEBUG=INFO` is verbose. Prefer a short dedicated run for the
-check rather than leaving it on for a full training job.
+`NCCL_DEBUG=INFO` is verbose. Prefer a short dedicated run for the check rather
+than leaving it on for a full training job.
 
 ## Related
 
-- [GKE TCPXO Networking Prerequisites](../integrator/gke-tcpxo-networking.md) — cluster-side setup
+- [GKE TCPXO Networking Prerequisites](../integrator/gke-tcpxo-networking.md) — cluster-side setup and the full pod-level wiring
 - [AKS GPU Setup](../integrator/aks-gpu-setup.md) — RDMA prerequisites


### PR DESCRIPTION
## Summary

Adds `docs/user/fabric-attached-training.md` — what a training workload must declare to use high-speed inter-node networking, covering GKE TCPXO, EKS EFA and AKS RDMA. Also corrects the stale `tcpxo-daemon` pin in the integrator doc.

## Motivation / Context

Fixes #2295. Part of #2217.

AICR recipes already deliver the cluster-side prerequisites — the NCCL plugin installer, NRI device injection, node labels and taints. Nothing documents what a *workload* must declare to use them.

There is no `TrainingRuntime` or `TrainJob` example anywhere in the repo. `docs/integrator/gke-tcpxo-networking.md` publishes the pod-level wiring, but only as a raw `kind: Pod`, and `demos/workloads/training/gke-nccl-test-tcpxo.yaml` stops there too. A user running Kubeflow Trainer must transpose that snippet into `spec.template.spec.replicatedJobs[].template.spec.template` themselves and derive several facts nobody wrote down.

Without the wiring a multi-node job still runs — NCCL falls back to TCP, intra-node NVLink is unaffected, nothing errors, and the job is simply far slower than the hardware allows.

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**Scoped to awareness, not a copy-pasteable runtime.** An earlier draft carried a full worked `TrainingRuntime`. Review found seven correctness gaps in it — a missing `trainer.kubeflow.org/trainjob-ancestor-step` label, a missing `NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY`, no node scheduling, and more. All were real, and together they showed the shape was wrong: a runtime presented as copy-pasteable makes every field a claim this page must then keep current against the recipe.

The page now answers what a reader actually needs: **a workload must wire itself**, which layer can carry which part, and that the eight GPU NIC network names are cluster-specific and theirs to supply. The example is a **placement sketch** — it shows where each piece goes, and the authoritative field list stays with `docs/integrator/gke-tcpxo-networking.md`, which owns that content. The validator's runtime (`validators/performance/testdata/h100/gke/runtime.yaml`) is offered as useful to read for shape, explicitly **not** as a template: it carries validator-only placeholders substituted at apply time, it is an MPI benchmark rather than a training job, and its own image pins are maintained against the validator rather than the recipe — it still pins the daemon version this PR corrects.

**The layer boundary is the load-bearing fact.** A `TrainJob` *can* supply pod annotations (`PodTemplatePatch.Metadata`), volumes (`PodSpecPatch.Volumes`) and per-container `env`/`volumeMounts`/`securityContext`. It *cannot* add a container — `ContainerPatch` has no `image` or `command`. That is why TCPXO needs a Runtime and EFA/RDMA do not.

**Traps documented because each fails silently:**

- The `networking.gke.io/interfaces` annotation must name the cluster's *actual* `Network` objects. The lookup uses a jsonpath range, not `-o name`, which prefixes results with `network.networking.gke.io/` — not the form the annotation takes. Namespace-only readers are told to ask their provisioner, since `Network` is cluster-scoped.
- A hand-authored runtime inherits neither the trainer-ancestor label nor the `nodeSelector`/`tolerations` AICR's bundler injects into the runtime it ships.
- `resourcesPerNode` replaces rather than merges when it carries `limits` or `requests`; separately, any non-nil value feeds Torch's process-count inference.
- EFA needs an image carrying `libfabric` and `aws-ofi-nccl`. The device plugin exposes devices; it does not install libraries, so `LD_LIBRARY_PATH` alone cannot help.
- The EFA count is read across every eligible node rather than the first, since mixed pools and partial plugin rollout are reachable.

**Version pin correction.** The integrator doc pinned `tcpgpudmarxd-dev:v1.0.20`, the daemon Google pairs with plugin **v1.0.14**. The recipe ships plugin **v1.0.15**, whose pair is **v1.0.21**. The version-matching section now states the coupled pair and Google's documented upgrade **sequence** — installer first, and not while workloads are running — without asserting that a mismatched pair runs correctly. The lookup command is also corrected to query `initContainers`: AICR deploys the installer there, so the documented query returned an empty string on every AICR GKE cluster, which reads as "no installer" rather than "broken query". The linked demo is still on the earlier pair; that bump belongs to #2296, so the link now says which pair it uses rather than widening this docs-only change into `demos/`.

## Testing

Doc-only change; no Go source touched, so `make test` and `lint-go` cannot regress. Ran the doc-relevant gates:

- `make check-docs-filenames` — OK
- `make check-docs-mdx` — OK
- `make check-docs-mdx-parse` — OK, 54 doc files parse as MDX (CI-blocking gate)
- `make lint-yaml` — OK (`docs/index.yml` nav entry)
- All four YAML examples validated with `yq`
- All relative links and anchors in the new page resolve against their targets

Full `make qualify` was not run: it adds Go tests, e2e, vulnerability and license scans, none of which a markdown-and-nav change can affect. The lychee link check runs in CI on `docs/**` PRs.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A. New page plus one nav entry. Changes to existing content, all in `docs/integrator/gke-tcpxo-networking.md`: the daemon pin; the rewritten version-matching section, including the corrected `initContainers` lookup command; a cross-link pointing Kubeflow readers at the new page, with a note on which pair the linked demo carries; and the same note above the `kubectl apply -f demos/...` step under *Manual standalone benchmark*, since that one is actionable.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes; doc gates run instead (see Testing)
- [x] Linter passes (`make lint`) — doc-relevant targets run; `lint-go` unaffected
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, documentation
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed and signed off (`git commit -S -s`); author matches the `Signed-off-by` trailer


