### PR TITLE
feat(recipes): requalify and re-pin k8s-aibom to v1.3.0

### DIFF
--- a/docs/design/019-k8s-aibom-runtime-inventory.md
+++ b/docs/design/019-k8s-aibom-runtime-inventory.md
@@ -662,6 +662,38 @@ Decision 4 is unchanged: chart, image, CRDs, and the public status contract
 remain one versioned set, so the graduation release requires full
 requalification rather than a version bump.
 
+### Requalified artifact set: v1.3.0, 2026-08-20
+
+That requalification was performed. The Status block above records what was
+accepted on 2026-08-19 and is left intact as the dated record; this is the
+set the registry now pins.
+
+| Item | Qualified value |
+|---|---|
+| Source tag | [`v1.3.0`](https://github.com/GoogleCloudPlatform/k8s-aibom/releases/tag/v1.3.0) at `30af41abbe0bed3c41a42289ccf294be8c4779bb` |
+| Image | `ghcr.io/googlecloudplatform/k8s-aibom@sha256:f8e48d4edc44e6ee8e40a2ac6c5f60b190aa18d411a75702dc5798a77a039e8d` |
+| Chart | `oci://ghcr.io/googlecloudplatform/charts/k8s-aibom:1.3.0` at `sha256:4ffa933e272a977e0b60f2eca1c4326176e6196e2ee69e1bf4f72c8b5a511c90` |
+| Attestations | Image SLSA provenance, image CycloneDX SBOM, and chart SLSA provenance all verify, bound to `refs/tags/v1.3.0`, source digest `30af41ab…`, and a GitHub-hosted runner |
+| API | `v1alpha1` and `v1beta1` both served; CRD storage on `v1beta1` |
+| Kubernetes support | Policy rather than fixed range: stable APIs only, no known ceiling, tested floor 1.27, backed by an upstream version-matrix CI job |
+
+Gate findings that changed AICR-visible behavior:
+
+- **Rendered RBAC is byte-identical to 1.2.0.** No permission change accompanies
+  the graduation.
+- **The rendered resource set is unchanged**, and the chart still renders
+  `AIBOMControllerConfig` at `aibom.k8saibom.dev/v1alpha1`. Only CRD *storage*
+  moved to `v1beta1`. The component health check reflects that asymmetry
+  deliberately, asserting `v1beta1` storage on both CRDs while continuing to
+  read the config resource at `v1alpha1`.
+- **The readiness fixes ship in the image, not the chart.** Probe configuration
+  renders identically across the two versions, so the corrected readiness
+  behavior is only obtained by re-pinning the image digest — which is the
+  substantive half of this requalification.
+
+The prior pin's supported-range statement is superseded by the upstream policy
+above; AICR documentation links that policy rather than restating a range.
+
 ## References
 
 - [k8s-aibom repository](https://github.com/GoogleCloudPlatform/k8s-aibom)

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -290,7 +290,7 @@ AICR enforces and surfaces inference-gateway exposure in two places:
 
 ## k8s-aibom Runtime Inventory
 
-AICR qualifies k8s-aibom v1.2.0 as an optional Helm component. It is not in
+AICR qualifies k8s-aibom v1.3.0 as an optional Helm component. It is not in
 the base, a mixin, or any stock overlay. To enable it, add this reference to a
 custom or external overlay and keep that overlay's criteria as narrow as the
 intended rollout:
@@ -310,13 +310,17 @@ that broad reach: its `criteria: intent: any` attaches to every matching intent.
 See [Recipe Development](../integrator/recipe-development.md) for external data
 and criteria composition.
 
-The qualified artifacts are source tag `v1.2.0` at commit
-`4aa7638b08ab9927bfa8df85c46c80234b9996f9`, OCI chart
-`oci://ghcr.io/googlecloudplatform/charts/k8s-aibom:1.2.0`, and the controller
-image pinned by digest in the component values. Upstream documents Kubernetes
-1.27 through 1.35 support. AICR also observed the dedicated integration test
-passing on its Kind 1.36.1 node image; that is qualification evidence, not an
-extension of upstream's support statement.
+The qualified artifacts are source tag `v1.3.0` at commit
+`30af41abbe0bed3c41a42289ccf294be8c4779bb`, OCI chart
+`oci://ghcr.io/googlecloudplatform/charts/k8s-aibom:1.3.0`, and the controller
+image pinned by digest in the component values. v1.3.0 is the API-graduation
+release: both `v1alpha1` and `v1beta1` are served and CRD storage is on
+`v1beta1`, while the chart still renders the `AIBOMControllerConfig` resource
+itself at `v1alpha1`. Upstream states Kubernetes support as a policy rather
+than a fixed range — stable APIs only, no known ceiling, tested floor 1.27 —
+backed by a version-matrix CI job. AICR also observed the dedicated
+integration test passing on its Kind 1.36.1 node image; that is qualification
+evidence, not an extension of upstream's support statement.
 
 ### Health and readiness
 
@@ -347,13 +351,13 @@ chart. It is not provenance: it reads one field, so it cannot show the CRDs
 originated from that chart, and it cannot tell apart chart versions that share
 a storage version. Charts 1.0.0, 1.1.0, and 1.2.0 all declare `v1alpha1` as
 storage. So the check catches a stranded upgrade that crosses a
-storage-version boundary, such as 1.2.0 to 1.3.0, and does not catch one
-within a boundary, such as 1.0.0 to 1.2.0.
+storage-version boundary, such as the 1.2.0 to 1.3.0 move this pin made, and
+does not catch one within a boundary, such as 1.0.0 to 1.2.0.
 
 **Overriding the chart version requires overriding this assertion.** Assert
 content is static YAML with no templating, so the expected storage version is
-a literal tied to the registry's pinned chart. Chart 1.2.0 declares only
-`v1alpha1`; 1.3.0 adds `v1beta1` and moves storage to it. A recipe that sets
+a literal tied to the registry's pinned chart, currently `v1beta1` for chart
+1.3.0. Charts 1.2.0 and earlier declare only `v1alpha1`. A recipe that sets
 `version` on the `k8s-aibom` componentRef to a chart with a different storage
 version will therefore fail this step even though the cluster is correct. Such
 a recipe must supply matching inline `healthCheckAsserts` on the componentRef,

--- a/docs/user/container-images.md
+++ b/docs/user/container-images.md
@@ -45,7 +45,7 @@ _Rendering fidelity:_ `catalog-parity: charts are rendered with the shared recip
 | gpu-operator-ocp | manifest | — | — | 0 |
 | gpu-operator-ocp-olm | manifest | — | — | 0 |
 | grove | helm | grove-charts | v0.1.0-alpha.8 | 1 |
-| k8s-aibom | helm | k8s-aibom | 1.2.0 | 1 |
+| k8s-aibom | helm | k8s-aibom | 1.3.0 | 1 |
 | k8s-ephemeral-storage-metrics | helm | k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics | 1.19.2 | 1 |
 | k8s-nim-operator | helm | k8s-nim-operator | 3.1.0 | 1 |
 | k8s-nim-operator-ocp | helm | k8s-nim-operator | 3.1.0 | 1 |
@@ -138,7 +138,7 @@ _No images extracted._
 
 - `gcr.io/gke-release/nri-device-injector:1.0.25-gke.6@sha256:7704e2bd74b8edbb76b6913c7904cc2362f1fa887c4d4aba7b19778ea353537c`
 - `gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830`
-- `ubuntu:26.04@sha256:6df9e8dd1eac389ebfef692c9648449adeb815d01e16e29cd6f3e50fe64ba9a6`
+- `ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b`
 - `us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15@sha256:4c9f0de3f39455a2ea35e844e0fc92564ca5629f6b03250fde40e8160719dae4`
 
 ### gpu-operator
@@ -173,7 +173,7 @@ _No images extracted._
 
 ### k8s-aibom
 
-- `ghcr.io/googlecloudplatform/k8s-aibom@sha256:b5040d14a20b4e890956d5f47b78445dac6c871eb5799586d9011c48ce71c198`
+- `ghcr.io/googlecloudplatform/k8s-aibom@sha256:f8e48d4edc44e6ee8e40a2ac6c5f60b190aa18d411a75702dc5798a77a039e8d`
 
 ### k8s-ephemeral-storage-metrics
 

--- a/pkg/chainsaw/k8s_aibom_check_states_test.go
+++ b/pkg/chainsaw/k8s_aibom_check_states_test.go
@@ -75,7 +75,7 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 		readyGeneration    int64
 		readyStatus        string
 		// CRD inputs. Empty storage version means the qualified default
-		// (v1alpha1, matching the pinned v1.2.0 chart), so existing cases
+		// (v1beta1, matching the pinned 1.3.0 chart), so existing cases
 		// describe a correctly-applied CRD set without restating it.
 		aibomCRDStorage  string
 		configCRDStorage string
@@ -209,36 +209,43 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 			wantOutput: "AIBOMControllerConfig",
 		},
 		{
-			// A cluster whose CRDs were replaced with a newer chart's while
-			// the recipe still pins 1.2.0. The controller keeps working —
-			// v1alpha1 stays served — so nothing else in this check notices.
+			// The stranded-CRD case the check exists for: the registry now
+			// pins 1.3.0, but this cluster still carries CRDs from 1.2.0 or
+			// earlier, which serve only v1alpha1 and store it. Nothing else
+			// in this check notices, because the controller runs fine against
+			// a served version.
 			//
-			// This state is also what a *legitimate* 1.3.0 pin looks like,
-			// which is the version-coupling the check documents: the expected
-			// version is a literal tied to the registry's pinned chart, so a
-			// recipe overriding `version` must supply matching inline
-			// healthCheckAsserts or set healthCheckSkip. The assertion cannot
-			// distinguish the two cases, and pinning the strict reading is
-			// the fail-closed direction.
+			// This state is also what a *legitimate* pre-1.3.0 pin looks
+			// like, which is the version-coupling the check documents: the
+			// expected version is a literal tied to the registry's pinned
+			// chart, so a recipe overriding `version` must supply matching
+			// inline healthCheckAsserts or set healthCheckSkip. The assertion
+			// cannot distinguish the two cases, and pinning the strict
+			// reading is the fail-closed direction.
 			name:    "aiboms CRD storage version drift fails closed",
 			desired: new(int64(1)), deploymentGen: 3, status: healthyDeployment,
 			configPresent: true,
 			generation:    2, observedGeneration: 2, readyGeneration: 2, readyStatus: "True",
-			aibomCRDStorage: "v1beta1",
+			aibomCRDStorage: "v1alpha1",
 			wantOutput:      "aiboms.aibom.k8saibom.dev",
 		},
 		{
-			// The half-applied CRD set. Upstream's documented
-			// `helm show crds | kubectl apply` migration silently applied only
-			// one of the two CRDs, so this is an observed state rather than a
-			// hypothetical. It is also the case a single-CRD assertion would
-			// miss entirely: aiboms is correct, and only the configuration
-			// CRD moved.
+			// The half-applied CRD set: aiboms upgraded to the pinned chart
+			// while aibomcontrollerconfigs did not. Reachable by a hand-
+			// applied single file, an interrupted apply, or a deployer
+			// syncing a subset. (An earlier version of this comment blamed
+			// AICR's documented `helm show crds | kubectl apply` step; that
+			// was tested and is not affected — helm inserts separators
+			// between crds/ files and both CRDs apply.)
+			//
+			// This is the case a single-CRD assertion would miss entirely,
+			// which is what makes the second assertion load-bearing rather
+			// than symmetric.
 			name:    "partially applied CRD set fails closed",
 			desired: new(int64(1)), deploymentGen: 3, status: healthyDeployment,
 			configPresent: true,
 			generation:    2, observedGeneration: 2, readyGeneration: 2, readyStatus: "True",
-			configCRDStorage: "v1beta1",
+			configCRDStorage: "v1alpha1",
 			wantOutput:       "aibomcontrollerconfigs.aibom.k8saibom.dev",
 		},
 		{
@@ -265,14 +272,25 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 
 			fetcher := newFakeFetcher()
 
-			// addCRD registers a CRD serving both versions with exactly one
-			// marked as storage, matching the shape the upstream chart ships.
-			// The non-storage version stays served, which is why a stranded
-			// CRD does not break the controller and why the storage-version
-			// assertion is the only thing that sees it.
+			// addCRD registers a CRD in the shape the corresponding upstream
+			// chart actually ships, so a "stranded" case models a real
+			// pre-upgrade cluster rather than an invented hybrid:
+			//
+			//   v1beta1 storage -> chart 1.3.0: serves v1alpha1 and v1beta1,
+			//                      storage on v1beta1 (the current pin)
+			//   v1alpha1 storage -> chart 1.2.0 and earlier: serves only
+			//                       v1alpha1, storage on it
+			//
+			// The non-storage version staying served on 1.3.0 is why a
+			// stranded CRD does not break the controller, and why the
+			// storage-version assertion is the only thing that sees it.
 			addCRD := func(name, storageVersion string) {
-				versions := make([]any, 0, 2)
-				for _, v := range []string{"v1alpha1", "v1beta1"} {
+				served := []string{"v1alpha1", "v1beta1"}
+				if storageVersion == "v1alpha1" {
+					served = []string{"v1alpha1"}
+				}
+				versions := make([]any, 0, len(served))
+				for _, v := range served {
 					versions = append(versions, map[string]any{
 						"name":    v,
 						"served":  true,
@@ -289,7 +307,7 @@ func TestK8sAIBOMHealthCheckClusterStates(t *testing.T) {
 			}
 			storageOrDefault := func(v string) string {
 				if v == "" {
-					return "v1alpha1"
+					return "v1beta1"
 				}
 				return v
 			}

--- a/recipes/checks/k8s-aibom/health-check.yaml
+++ b/recipes/checks/k8s-aibom/health-check.yaml
@@ -38,12 +38,13 @@ spec:
     #
     # VERSION-COUPLED BY CONSTRUCTION. Assert content is static YAML; there
     # is no templating, so the expected version below is a literal tied to
-    # the chart version the registry pins for this component (1.2.0, whose
-    # CRDs declare only v1alpha1). A recipe that overrides `version` on the
-    # componentRef to a chart with a different storage version — 1.3.0 moves
-    # storage to v1beta1 — will fail this step even though the cluster is
-    # correct. That recipe must supply matching inline `healthCheckAsserts`
-    # on the componentRef, or set `healthCheckSkip: true`. Documented in
+    # the chart version the registry pins for this component (1.3.0, whose
+    # CRDs serve v1alpha1 and v1beta1 with storage on v1beta1). A recipe that
+    # overrides `version` on the componentRef to a chart with a different
+    # storage version — 1.2.0 and earlier store v1alpha1 — will fail this
+    # step even though the cluster is correct. That recipe must supply
+    # matching inline `healthCheckAsserts` on the componentRef, or set
+    # `healthCheckSkip: true`. Documented in
     # docs/user/component-catalog.md. Flip this literal, do not generalize
     # it, when the registry pin moves.
     #
@@ -53,19 +54,25 @@ spec:
     # CRDs originated from that chart, and it cannot discriminate between
     # chart versions that share a storage version. Charts 1.0.0, 1.1.0, and
     # 1.2.0 all declare exactly v1alpha1 as storage, so CRDs from any of them
-    # satisfy this step identically.
+    # would satisfy an equivalent v1alpha1 assertion identically.
     #
     # The practical consequence: this catches a stranded upgrade across a
-    # storage-version boundary — 1.2.0 to 1.3.0, the case that matters now —
+    # storage-version boundary — the 1.2.0 to 1.3.0 move this pin just made —
     # and does not catch a stranded upgrade within one, such as 1.0.0 to
     # 1.2.0. That is the correct trade for a static assert; do not describe
     # the step as proving more than it does.
+    #
+    # NOTE the asymmetry with the AIBOMControllerConfig step below, which
+    # still reads aibom.k8saibom.dev/v1alpha1. That is deliberate and
+    # verified against the rendered chart: 1.3.0 moves CRD *storage* to
+    # v1beta1 while still rendering the controller config CR itself at
+    # v1alpha1, and both versions stay served. Do not "fix" the two to match.
     #
     # The controller's own readiness is a separate signal and not one AICR
     # owns: upstream shipped a start-ordering race from v1.1.0 through v1.2.0
     # that produced a false-Ready window in exactly this state, so a check
     # that depended on their probe would have been silently wrong for two
-    # releases.
+    # releases. 1.3.0 fixes it, but the assertion stays independent of it.
     #
     # Assert the storage version, NOT status.storedVersions. Immediately
     # after a storage flip storedVersions legitimately contains both the old
@@ -86,7 +93,7 @@ spec:
               kind: CustomResourceDefinition
               metadata:
                 name: aiboms.aibom.k8saibom.dev
-              ((spec.versions[?storage == `true`].name | [0]) == 'v1alpha1'): true
+              ((spec.versions[?storage == `true`].name | [0]) == 'v1beta1'): true
     - name: validate-aibomcontrollerconfig-crd-storage-version
       try:
         - assert:
@@ -95,7 +102,7 @@ spec:
               kind: CustomResourceDefinition
               metadata:
                 name: aibomcontrollerconfigs.aibom.k8saibom.dev
-              ((spec.versions[?storage == `true`].name | [0]) == 'v1alpha1'): true
+              ((spec.versions[?storage == `true`].name | [0]) == 'v1beta1'): true
     - name: validate-controller-deployment
       try:
         - assert:

--- a/recipes/components/k8s-aibom/values.yaml
+++ b/recipes/components/k8s-aibom/values.yaml
@@ -20,7 +20,7 @@
 image:
   repository: ghcr.io/googlecloudplatform/k8s-aibom
   tag: ""
-  digest: sha256:b5040d14a20b4e890956d5f47b78445dac6c871eb5799586d9011c48ce71c198
+  digest: sha256:f8e48d4edc44e6ee8e40a2ac6c5f60b190aa18d411a75702dc5798a77a039e8d
 
 # Make pod readiness reflect the current AIBOMControllerConfig status rather
 # than process liveness alone. Invalid current configuration must fail closed.

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -522,7 +522,7 @@ components:
     helm:
       defaultRepository: oci://ghcr.io/googlecloudplatform/charts
       defaultChart: k8s-aibom
-      defaultVersion: "1.2.0"
+      defaultVersion: "1.3.0"
       defaultNamespace: k8s-aibom-system
     nodeScheduling:
       system:


### PR DESCRIPTION
## Summary

Re-runs all four ADR-019 adoption gates against upstream v1.3.0, the API-graduation release, and moves the registry pin to it.

## Motivation / Context

ADR-019 Decision 4: chart, image, CRDs, and the public status contract are one versioned set, and a CRD change requires requalification rather than a version bump. v1.3.0 adds `v1beta1` alongside `v1alpha1` and moves CRD storage to it, so this is a requalification.

Fixes: #2282
Related: #2271, #2264

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: component health check

## Implementation Notes

### Qualified artifact set

| Item | Value |
|---|---|
| Source | `v1.3.0` at `30af41abbe0bed3c41a42289ccf294be8c4779bb` |
| Image | `ghcr.io/googlecloudplatform/k8s-aibom@sha256:f8e48d4edc44e6ee8e40a2ac6c5f60b190aa18d411a75702dc5798a77a039e8d` |
| Chart | `oci://ghcr.io/googlecloudplatform/charts/k8s-aibom:1.3.0` at `sha256:4ffa933e272a977e0b60f2eca1c4326176e6196e2ee69e1bf4f72c8b5a511c90` |

### Gate 1 — release and supply chain

Three attestations verified with `gh attestation verify --owner GoogleCloudPlatform --deny-self-hosted-runners`, inspected as JSON rather than trusting the exit code:

| Predicate | Subject | Ref | Runner | Source digest |
|---|---|---|---|---|
| `https://slsa.dev/provenance/v1` | image | `refs/tags/v1.3.0` | github-hosted | `30af41ab…` |
| `https://cyclonedx.org/bom` | image | `refs/tags/v1.3.0` | github-hosted | — |
| `https://slsa.dev/provenance/v1` | chart | `refs/tags/v1.3.0` | github-hosted | `30af41ab…` |

Build config resolves to the upstream `release.yaml` workflow in `GoogleCloudPlatform/k8s-aibom`.

### Gate 2 — Helm and Kubernetes lifecycle

Rendered both versions against our `values.yaml`. Resource set is unchanged: ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, AIBOMControllerConfig. The only template differences are `helm.sh/chart` and `app.kubernetes.io/version` labels.

**The chart still renders `AIBOMControllerConfig` at `aibom.k8saibom.dev/v1alpha1`.** Only CRD *storage* moved. This is the finding that shaped the health-check change below — a blanket `v1alpha1` → `v1beta1` replacement would have broken the check against a correctly-deployed cluster.

Also confirmed `readiness.strictConfig: true` still reaches the rendered output as the container arg `--strict-config-readiness`; it is a controller flag, not a CR spec field.

### Gate 3 — security, RBAC, privacy

Rendered RBAC diffed 1.2.0 → 1.3.0: **byte-identical**. No permission change accompanies the graduation.

### Gate 4 — operational safety

**The readiness fixes ship in the image, not the chart.** Probe configuration renders identically across both versions, so the corrected readiness behavior (upstream's start-ordering race fix plus the per-probe informer assertion) is obtained only by re-pinning the image digest. That is the substantive half of this change and the reason a chart-version-only bump would have been wrong.

### Health check

Both CRD storage assertions flip to `v1beta1`; the controller-config step deliberately keeps reading `v1alpha1`, with a comment explaining the asymmetry so it is not "fixed" later.

The test helper now builds each CRD in the shape its chart actually ships — 1.3.0 serves both versions with storage on `v1beta1`, 1.2.0 and earlier serve only `v1alpha1` — so a stranded case models a real pre-upgrade cluster rather than an invented hybrid. The four CRD cases invert accordingly, which is itself evidence they were testing the literal rather than something incidental.

Also corrects a stale comment missed in #2305: the partial-apply case still attributed that state to AICR's documented CRD-apply step, a claim tested and retracted on that PR.

### Deliberately out of scope

Cross-boundary upgrade, rollback, and uninstall evidence on real GKE. That is an ADR-019 **Follow-Up Decisions** requirement governing *stock adoption*, not a Decision 4 requalification requirement — I had over-scoped #2282 by folding it in. It moves to its own issue under #2271, where the real-GKE demo already needs a cluster.

### One unrelated line

The regenerated BOM also picks up an `ubuntu:26.04` digest that #2301 changed in a rendered manifest without regenerating the doc — the same gate gap that broke `TestStockRenderParityGolden` on `main` earlier today. `make bom-docs` regenerates wholesale, so it cannot be excluded without leaving the doc inconsistent.

## Testing

```bash
make qualify
```

`Codebase qualification completed`, no failures.

Verified the storage-version flip is load-bearing: reverting the two literals to `v1alpha1` fails the healthy case and every negative case's `wantOutput` assertion, because the default CRD fixture now models 1.3.0.

Gate commands are reproducible from the tables above; chart renders were compared with `helm template` against the committed `values.yaml`.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

No stock recipe references `k8s-aibom`, so no stock recipe changes. Medium rather than low because existing adopters on a custom recipe move to a new chart and image on their next bundle, and clusters upgrading through Helm, Helmfile, or Flux must apply the new CRDs first — the storage version genuinely changes here, which is precisely what the health check added in #2305 now detects.

**Rollout notes:** Adopters upgrading through Helm, Helmfile, or Flux must run the pre-upgrade CRD step documented in the component catalog. Argo CD applies CRDs each sync and needs nothing. Without it the health check fails naming the stranded CRD, which is the intended behavior.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
