### PR TITLE
fix(bundler): let CRD-owning components replace their CRDs on Flux upgrade

### DIFF
--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -445,14 +445,26 @@ Which deployers need that step differs, so check yours:
 |---|---|---|
 | `helm` | `helm upgrade` skips `crds/` | Yes |
 | `helmfile` | `helmfile apply` upgrades through Helm, so it also skips `crds/` | Yes |
-| `flux` | The generated `HelmRelease` sets no `spec.upgrade.crds`, and the helm-controller default is `Skip` | Yes |
+| `flux` | The generated `HelmRelease` sets `spec.upgrade.crds: CreateReplace` for components the registry marks `ownsCRDs`, and leaves the helm-controller `Skip` default in place for the rest | Only for components without `ownsCRDs` |
 | `argocd`, `argocd-helm` | Argo CD renders the chart with CRDs included and applies them as ordinary manifests each sync | No |
 
-Flux can be made to handle this itself by setting `spec.upgrade.crds:
-CreateReplace` on the `HelmRelease`, but AICR does not generate that field for
-any component today, and `CreateReplace` is a cluster-wide behavior change that
-should be decided per chart rather than assumed. Until then, treat Flux like
-`helm`.
+`ownsCRDs` is opt-in, and narrow on purpose. Of the 15 registry components
+that ship CRDs under `crds/`, 11 share at least one CRD with another
+component: `nfd`, `gpu-operator`, and `network-operator` all ship the
+NodeFeature CRDs, and `nfd`, `gpu-operator`, and `kai-scheduler` all appear
+together in `base.yaml`. If every release replaced CRDs on upgrade, two or
+three `HelmRelease` objects would rewrite the same CRD on every reconcile,
+each with the schema its own chart pins. The `Skip` default is what prevents
+that today, so it stays the default.
+
+A component qualifies only if it solely owns every CRD it ships and ships none
+using `spec.conversion.strategy: Webhook`, since replace discards a `caBundle`
+injected at runtime. `kubeflow-trainer` is excluded for that second reason.
+Currently `gatekeeper`, `k8s-aibom`, and `nvsentinel` qualify.
+
+`helm` and `helmfile` always need the step, because skipping `crds/` on
+upgrade is Helm's own behavior rather than something the generated bundle can
+change.
 
 Uninstall in this order. Removing the component from the overlay and applying a
 regenerated bundle does **not** remove the previously installed release: the

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -340,12 +340,17 @@ closed. Zero `AIBOM` objects is healthy before any namespace opts in.
 
 The check also requires both shipped CRDs, `aiboms.aibom.k8saibom.dev` and
 `aibomcontrollerconfigs.aibom.k8saibom.dev`, to report the storage version of
-the chart version pinned in the registry. It matters
-because Helm and Helmfile skip a chart's `crds/` directory on upgrade, and the
-`HelmRelease` AICR generates for Flux leaves `spec.upgrade.crds` unset so the
-helm-controller default of `Skip` applies. A cluster can therefore run a new
+the chart version pinned in the registry. It matters because Helm and Helmfile
+skip a chart's `crds/` directory on upgrade, so a cluster can run a new
 controller against the previous schema while the older version stays served
 and the controller keeps working.
+
+Flux is the exception for this component: `k8s-aibom` is marked `ownsCRDs` in
+the registry, so its generated `HelmRelease` sets
+`spec.upgrade.crds: CreateReplace` and Flux applies the CRDs itself. Argo CD
+applies them as ordinary manifests each sync. The assertion is still worth
+making on every deployer, because it proves the deployed CRDs match the pinned
+chart rather than merely that some deployer was expected to update them.
 
 Both CRDs are asserted separately, so a failure names which one is stranded
 and a partially applied CRD set cannot pass. If this check fails after a chart
@@ -408,12 +413,15 @@ image: chart, CRDs, status API, and image are one qualified set. Quiesce
 configuration changes during rollback and confirm that
 `AIBOMControllerConfig/default` returns to a current `Ready=True` state.
 
-**Apply CRDs before the bundle upgrade.** The chart ships its CRDs under
-`crds/`. Helm installs that directory on first install and never touches it
-again on upgrade, so a chart bump whose CRDs changed leaves the previous schema
-in place and the API server silently prunes the new controller's writes to
-added fields. Apply the CRDs from the exact qualified chart first, then
-upgrade:
+**Apply CRDs before the bundle upgrade — `helm` and `helmfile` only.** The
+chart ships its CRDs under `crds/`. Helm installs that directory on first
+install and never touches it again on upgrade, so a chart bump whose CRDs
+changed leaves the previous schema in place and the API server silently prunes
+the new controller's writes to added fields.
+
+The `flux`, `argocd`, and `argocd-helm` bundles handle this themselves for this
+component and need no manual step; see the deployer table below. For `helm` and
+`helmfile`, apply the CRDs from the exact qualified chart first, then upgrade:
 
 ```bash
 CHART="oci://ghcr.io/googlecloudplatform/charts/k8s-aibom"

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -432,8 +432,9 @@ helm show crds "${CHART}" --version "${VERSION}" \
   | kubectl apply --server-side --force-conflicts -f -
 ```
 
-Three details in that command are load-bearing, and the obvious shorter form
-fails on both counts:
+Three details in that command are load-bearing. The obvious shorter form —
+piping `helm show crds` straight into `kubectl apply --server-side` — fails on
+the first two:
 
 - **`sed -n '/^---$/,$p'`** drops `helm`'s progress output. For an OCI chart,
   `helm show crds` writes `Pulled:` and `Digest:` lines to *stdout*, and those

--- a/pkg/bundler/deployer/flux/flux.go
+++ b/pkg/bundler/deployer/flux/flux.go
@@ -1018,8 +1018,23 @@ func usesRegistryChart(ref recipe.ComponentRef, cfg *recipe.ComponentConfig) boo
 		return false
 	}
 	return ref.Source == cfg.Helm.DefaultRepository &&
-		ref.EffectiveChart() == cfg.Helm.DefaultChart &&
-		ref.Version == cfg.Helm.DefaultVersion
+		ref.EffectiveChart() == registryChartName(cfg.Helm.DefaultChart) &&
+		deployer.NormalizeVersion(ref.Version) == deployer.NormalizeVersion(cfg.Helm.DefaultVersion)
+}
+
+// registryChartName reduces a registry defaultChart to the form a resolved
+// ComponentRef actually carries.
+//
+// ApplyRegistryDefaults strips everything before the last "/" when defaulting
+// ref.Chart, so a registry entry like "gatekeeper/gatekeeper" resolves to
+// "gatekeeper". Comparing against the unstripped value silently fails for every
+// component whose defaultChart carries a repo-alias prefix, which is how
+// gatekeeper was enrolled in ownsCRDs and never emitted the policy.
+func registryChartName(defaultChart string) string {
+	if idx := strings.LastIndex(defaultChart, "/"); idx >= 0 {
+		return defaultChart[idx+1:]
+	}
+	return defaultChart
 }
 
 // ownsCRDs reports whether the named component may replace its CRDs on

--- a/pkg/bundler/deployer/flux/flux.go
+++ b/pkg/bundler/deployer/flux/flux.go
@@ -263,7 +263,7 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 
 	// Resolve which components solely own their CRDs, so their
 	// HelmRelease can replace CRDs on upgrade instead of skipping them.
-	if ownerErr := g.resolveCRDOwners(sortedRefs); ownerErr != nil {
+	if ownerErr := g.resolveCRDOwners(ctx, sortedRefs); ownerErr != nil {
 		return nil, ownerErr
 	}
 
@@ -974,7 +974,11 @@ func buildComponentSummaries(sortedRefs []recipe.ComponentRef, preManifests, man
 // A registry failure is fatal rather than defaulting everything to false:
 // silently treating every component as "does not own its CRDs" would quietly
 // restore the stranded-CRD behavior this flag exists to fix.
-func (g *Generator) resolveCRDOwners(refs []recipe.ComponentRef) error {
+func (g *Generator) resolveCRDOwners(ctx context.Context, refs []recipe.ComponentRef) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return errors.Wrap(errors.ErrCodeTimeout,
+			"context cancelled before resolving CRD upgrade policy", ctxErr)
+	}
 	registry, regErr := recipe.GetComponentRegistryFor(g.RecipeResult.DataProvider())
 	if regErr != nil {
 		return errors.PropagateOrWrap(regErr, errors.ErrCodeInternal,
@@ -982,12 +986,40 @@ func (g *Generator) resolveCRDOwners(refs []recipe.ComponentRef) error {
 	}
 	out := make(map[string]bool, len(refs))
 	for _, ref := range refs {
-		if cfg := registry.Get(ref.Name); cfg != nil && cfg.OwnsCRDs {
-			out[ref.Name] = true
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return errors.Wrap(errors.ErrCodeTimeout,
+				"context cancelled while resolving CRD upgrade policy", ctxErr)
 		}
+		cfg := registry.Get(ref.Name)
+		if cfg == nil || !cfg.OwnsCRDs || !usesRegistryChart(ref, cfg) {
+			continue
+		}
+		out[ref.Name] = true
 	}
 	g.crdOwners = out
 	return nil
+}
+
+// usesRegistryChart reports whether a ref still points at the exact chart the
+// registry pins for its component.
+//
+// ownsCRDs records the result of an audit performed against that chart: that
+// the component solely owns every CRD it ships, and ships none using a webhook
+// conversion strategy. A recipe may override source, chart, or version on the
+// componentRef, and those overrides bypass registry defaulting entirely. The
+// audit says nothing about the chart they point at, so the flag must not carry
+// over to it — replacing CRDs from an unaudited chart is exactly the
+// destructive case the opt-in design exists to avoid.
+//
+// Fails closed: any mismatch, or a component with no Helm chart, keeps
+// helm-controller's Skip default.
+func usesRegistryChart(ref recipe.ComponentRef, cfg *recipe.ComponentConfig) bool {
+	if cfg.Helm.DefaultChart == "" {
+		return false
+	}
+	return ref.Source == cfg.Helm.DefaultRepository &&
+		ref.EffectiveChart() == cfg.Helm.DefaultChart &&
+		ref.Version == cfg.Helm.DefaultVersion
 }
 
 // ownsCRDs reports whether the named component may replace its CRDs on

--- a/pkg/bundler/deployer/flux/flux.go
+++ b/pkg/bundler/deployer/flux/flux.go
@@ -114,6 +114,12 @@ type Generator struct {
 	// RecipeResult contains the recipe metadata and component references.
 	RecipeResult *recipe.RecipeResult
 
+	// crdOwners maps component name -> registry ownsCRDs flag, resolved
+	// once per Generate. Components absent from the registry are absent
+	// here and default to false, which keeps helm-controller's Skip
+	// behavior — the conservative direction.
+	crdOwners map[string]bool
+
 	// ComponentValues maps component names to their values.
 	ComponentValues map[string]map[string]any
 
@@ -253,6 +259,12 @@ func (g *Generator) Generate(ctx context.Context, outputDir string) (*deployer.O
 			return nil, errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("unsafe component name: %q", ref.Name))
 		}
+	}
+
+	// Resolve which components solely own their CRDs, so their
+	// HelmRelease can replace CRDs on upgrade instead of skipping them.
+	if ownerErr := g.resolveCRDOwners(sortedRefs); ownerErr != nil {
+		return nil, ownerErr
 	}
 
 	if err := g.detectInjectedReleaseCollisions(sortedRefs); err != nil {
@@ -954,3 +966,30 @@ func buildComponentSummaries(sortedRefs []recipe.ComponentRef, preManifests, man
 	}
 	return summaries
 }
+
+// resolveCRDOwners populates g.crdOwners from the registry in one round-trip.
+// Components missing from the registry are omitted and therefore read as
+// false, which keeps helm-controller's Skip default.
+//
+// A registry failure is fatal rather than defaulting everything to false:
+// silently treating every component as "does not own its CRDs" would quietly
+// restore the stranded-CRD behavior this flag exists to fix.
+func (g *Generator) resolveCRDOwners(refs []recipe.ComponentRef) error {
+	registry, regErr := recipe.GetComponentRegistryFor(g.RecipeResult.DataProvider())
+	if regErr != nil {
+		return errors.PropagateOrWrap(regErr, errors.ErrCodeInternal,
+			"failed to resolve component registry for CRD upgrade policy")
+	}
+	out := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		if cfg := registry.Get(ref.Name); cfg != nil && cfg.OwnsCRDs {
+			out[ref.Name] = true
+		}
+	}
+	g.crdOwners = out
+	return nil
+}
+
+// ownsCRDs reports whether the named component may replace its CRDs on
+// upgrade. Unknown components are false.
+func (g *Generator) ownsCRDs(name string) bool { return g.crdOwners[name] }

--- a/pkg/bundler/deployer/flux/flux_test.go
+++ b/pkg/bundler/deployer/flux/flux_test.go
@@ -3102,3 +3102,80 @@ func TestGenerate_SourceOnlyRefChartFallsBackToName(t *testing.T) {
 		t.Errorf("README should list the gpu-operator-post release for a source-only mixed component, got:\n%s", readme)
 	}
 }
+
+// TestGenerate_HelmReleaseCRDUpgradePolicyIsOptIn covers #2264.
+//
+// Helm installs a chart's crds/ directory on first install and never touches
+// it again on upgrade, and helm-controller's spec.upgrade.crds default of Skip
+// inherits that, so a chart bump whose CRDs changed runs a new controller
+// against the previous schema.
+//
+// The fix is opt-in rather than a blanket default. An audit found 15 registry
+// components ship CRDs under crds/ and 11 share at least one CRD with another
+// component -- nfd, gpu-operator and network-operator all ship the NodeFeature
+// CRDs, and nfd, gpu-operator and kai-scheduler all appear together in
+// base.yaml. Replacing unconditionally would have several HelmReleases rewrite
+// the same CRD on every reconcile. Skip is what prevents that today.
+//
+// So this asserts both directions: an owner emits the policy, and a sharer
+// must not. A test that only checked the positive case would pass for an
+// unconditional template, which is the bug this replaced.
+func TestGenerate_HelmReleaseCRDUpgradePolicyIsOptIn(t *testing.T) {
+	tests := []struct {
+		name          string
+		component     string
+		ociSourceName string
+		want          string
+	}{
+		// k8s-aibom is registry ownsCRDs: sole owner, no webhook conversion.
+		{name: "owner via sourceRef", component: "k8s-aibom", want: "CreateReplace"},
+		{name: "owner via chartRef", component: "k8s-aibom", ociSourceName: "aicr-bundle", want: "CreateReplace"},
+		// nfd shares the NodeFeature CRDs with gpu-operator and
+		// network-operator, so replacing would race them.
+		{name: "sharer via sourceRef", component: "nfd", want: ""},
+		{name: "sharer via chartRef", component: "nfd", ociSourceName: "aicr-bundle", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+
+			recipeResult := &recipe.RecipeResult{}
+			recipeResult.Metadata.Version = testVersion
+			recipeResult.ComponentRefs = []recipe.ComponentRef{{
+				Name:      tt.component,
+				Namespace: tt.component,
+				Chart:     tt.component,
+				Version:   "1.0.0",
+				Type:      recipe.ComponentTypeHelm,
+				Source:    "oci://example.com/charts",
+			}}
+
+			g := &Generator{
+				RecipeResult:    recipeResult,
+				ComponentValues: map[string]map[string]any{tt.component: {}},
+				Version:         "v0.9.0",
+				OCISourceName:   tt.ociSourceName,
+			}
+			if _, err := g.Generate(context.Background(), outputDir); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+
+			var hr struct {
+				Spec struct {
+					Upgrade struct {
+						CRDs string `yaml:"crds"`
+					} `yaml:"upgrade"`
+				} `yaml:"spec"`
+			}
+			raw := readFile(t, filepath.Join(outputDir, tt.component, "helmrelease.yaml"))
+			if err := yaml.Unmarshal([]byte(raw), &hr); err != nil {
+				t.Fatalf("parse HelmRelease: %v", err)
+			}
+
+			if hr.Spec.Upgrade.CRDs != tt.want {
+				t.Errorf("spec.upgrade.crds = %q, want %q\n%s", hr.Spec.Upgrade.CRDs, tt.want, raw)
+			}
+		})
+	}
+}

--- a/pkg/bundler/deployer/flux/flux_test.go
+++ b/pkg/bundler/deployer/flux/flux_test.go
@@ -3113,134 +3113,201 @@ func TestGenerate_SourceOnlyRefChartFallsBackToName(t *testing.T) {
 // base.yaml and all ship the NodeFeature CRDs, so replacing unconditionally
 // would have several HelmReleases rewrite the same CRD every reconcile.
 //
-// Three directions are asserted, and each fails for a different reason:
+// Refs are built by running ApplyRegistryDefaults over an empty ref, which is
+// what a stock recipe actually resolves to. Constructing them by copying
+// registry fields directly is what an earlier revision did, and it silently
+// diverged: ApplyRegistryDefaults strips a defaultChart to its bare name, so a
+// hand-built ref carrying "gatekeeper/gatekeeper" never matched the real
+// resolved "gatekeeper" and the test could not see that gatekeeper emitted no
+// policy at all. Do not hand-build these refs.
 //
-//	owner            -> emits the policy
-//	sharer           -> must not, because replacing would race another release
-//	coordinates moved -> must not, because ownsCRDs records an audit of the
-//	                    registry's pinned chart and a ref that overrides
-//	                    source/chart/version points somewhere unaudited
-//
-// A positive-only test would pass against an unconditional template, which is
-// the defect this replaced, so the negative cases are the load-bearing ones.
+// The owner cases are discovered from the registry rather than hardcoded, so a
+// component enrolled in ownsCRDs later is covered without touching this test.
 //
 // NOTE ON COVERAGE: this exercises the sourceRef template only. An upstream
 // Helm component renders spec.chart.spec.sourceRef regardless of
-// OCISourceName; the chartRef template is reached by local, vendored and
-// manifest-backed components, and those carry no registry chart coordinates,
-// so they cannot satisfy usesRegistryChart and cannot emit the policy today.
-// Earlier revisions of this test claimed chartRef coverage by setting
-// OCISourceName on a normal Helm ref, which renders sourceRef and tested the
-// same path twice. Do not reintroduce that shape.
+// OCISourceName. TestUsesRegistryChartRejectsRefsWithoutCoordinates covers
+// why the chartRef shape cannot emit the policy today.
 func TestGenerate_HelmReleaseCRDUpgradePolicyIsOptIn(t *testing.T) {
 	registry, regErr := recipe.GetComponentRegistry()
 	if regErr != nil {
 		t.Fatalf("GetComponentRegistry: %v", regErr)
 	}
 
-	// refFor builds a ref at the component's exact registry coordinates, which
-	// is what a stock recipe resolves to.
-	refFor := func(t *testing.T, name string) recipe.ComponentRef {
+	// resolvedRef mirrors stock resolution: an empty ref, then registry
+	// defaults. Anything else risks testing a shape the resolver never emits.
+	resolvedRef := func(t *testing.T, name string) recipe.ComponentRef {
 		t.Helper()
 		cfg := registry.Get(name)
 		if cfg == nil {
 			t.Fatalf("%s missing from registry", name)
 		}
-		return recipe.ComponentRef{
-			Name:      name,
-			Namespace: name,
-			Type:      recipe.ComponentTypeHelm,
-			Source:    cfg.Helm.DefaultRepository,
-			Chart:     cfg.Helm.DefaultChart,
-			Version:   cfg.Helm.DefaultVersion,
+		ref := recipe.ComponentRef{Name: name, Namespace: name, Type: recipe.ComponentTypeHelm}
+		ref.ApplyRegistryDefaults(cfg)
+		return ref
+	}
+
+	// Every enrolled owner, discovered rather than listed.
+	var owners []string
+	for _, name := range registry.Names() {
+		if cfg := registry.Get(name); cfg != nil && cfg.OwnsCRDs {
+			owners = append(owners, name)
 		}
+	}
+	if len(owners) == 0 {
+		t.Fatal("no ownsCRDs components in the registry; this test would prove nothing")
+	}
+
+	t.Run("owners emit the policy", func(t *testing.T) {
+		for _, name := range owners {
+			t.Run(name, func(t *testing.T) {
+				assertCRDPolicy(t, resolvedRef(t, name), name, "CreateReplace")
+			})
+		}
+	})
+
+	// nfd shares the NodeFeature CRDs with gpu-operator and network-operator,
+	// all three of which co-exist in base.yaml.
+	t.Run("sharer does not", func(t *testing.T) {
+		assertCRDPolicy(t, resolvedRef(t, "nfd"), "nfd", "")
+	})
+
+	// ownsCRDs records an audit of the registry's pinned chart. A ref pointing
+	// anywhere else is unaudited, so the policy must not carry over.
+	t.Run("coordinate overrides disable it", func(t *testing.T) {
+		owner := owners[0]
+		for _, tc := range []struct {
+			name   string
+			mutate func(*recipe.ComponentRef)
+		}{
+			{"version", func(r *recipe.ComponentRef) { r.Version = "0.0.1-unaudited" }},
+			{"chart", func(r *recipe.ComponentRef) { r.Chart = "some-fork" }},
+			{"source", func(r *recipe.ComponentRef) { r.Source = "oci://example.invalid/charts" }},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ref := resolvedRef(t, owner)
+				tc.mutate(&ref)
+				assertCRDPolicy(t, ref, owner, "")
+			})
+		}
+	})
+}
+
+// assertCRDPolicy renders one component and asserts spec.upgrade.crds.
+//
+// Decoded as a map, not a typed struct: a string field cannot tell an absent
+// crds key from one explicitly rendered as "", so a negative case would pass
+// against a template emitting an empty value. Presence is the assertion.
+func assertCRDPolicy(t *testing.T, ref recipe.ComponentRef, component, want string) {
+	t.Helper()
+	outputDir := t.TempDir()
+
+	recipeResult := &recipe.RecipeResult{}
+	recipeResult.Metadata.Version = testVersion
+	recipeResult.ComponentRefs = []recipe.ComponentRef{ref}
+
+	g := &Generator{
+		RecipeResult:    recipeResult,
+		ComponentValues: map[string]map[string]any{component: {}},
+		Version:         "v0.9.0",
+	}
+	if _, err := g.Generate(context.Background(), outputDir); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	raw := readFile(t, filepath.Join(outputDir, component, "helmrelease.yaml"))
+	var doc struct {
+		Spec map[string]any `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("parse HelmRelease: %v", err)
+	}
+	upgrade, hasUpgrade := doc.Spec["upgrade"]
+
+	if want == "" {
+		if hasUpgrade {
+			t.Errorf("spec.upgrade present (%v), want the key absent entirely\n%s", upgrade, raw)
+		}
+		return
+	}
+	if !hasUpgrade {
+		t.Fatalf("spec.upgrade absent, want crds = %q\n%s", want, raw)
+	}
+	upgradeMap, ok := upgrade.(map[string]any)
+	if !ok {
+		t.Fatalf("spec.upgrade is %T, want a mapping\n%s", upgrade, raw)
+	}
+	crds, hasCRDs := upgradeMap["crds"]
+	if !hasCRDs {
+		t.Fatalf("spec.upgrade.crds absent, want %q\n%s", want, raw)
+	}
+	if crds != want {
+		t.Errorf("spec.upgrade.crds = %v, want %q\n%s", crds, want, raw)
+	}
+}
+
+// TestUsesRegistryChartRejectsRefsWithoutCoordinates pins the property that
+// makes the chartRef template's UpgradeCRDs block unreachable today.
+//
+// chartRef is reached by local, vendored and manifest-backed components. Those
+// carry no registry chart coordinates, so usesRegistryChart is false for them
+// and the policy cannot render. Asserting that directly is preferable to a
+// render test: an attempt at the render route produced a sourceRef HelmRelease
+// instead, so such a test would have passed without exercising anything, which
+// is the ambiguous-condition shape this suite already avoids elsewhere.
+//
+// If a future chartRef path does carry registry coordinates, this test still
+// holds but the block becomes reachable — at which point the chartRef template
+// needs its own render coverage.
+func TestUsesRegistryChartRejectsRefsWithoutCoordinates(t *testing.T) {
+	registry, regErr := recipe.GetComponentRegistry()
+	if regErr != nil {
+		t.Fatalf("GetComponentRegistry: %v", regErr)
+	}
+	cfg := registry.Get("k8s-aibom")
+	if cfg == nil || !cfg.OwnsCRDs {
+		t.Fatal("k8s-aibom must be an ownsCRDs component for this test to mean anything")
 	}
 
 	tests := []struct {
-		name      string
-		component string
-		mutate    func(*recipe.ComponentRef)
-		want      string
+		name string
+		ref  recipe.ComponentRef
+		want bool
 	}{
 		{
-			// k8s-aibom is registry ownsCRDs: sole owner, no webhook conversion.
-			name: "owner at registry coordinates", component: "k8s-aibom", want: "CreateReplace",
+			name: "manifest-only ref has no chart or source",
+			ref: recipe.ComponentRef{
+				Name: "k8s-aibom", Type: recipe.ComponentTypeHelm,
+				ManifestFiles: []string{"components/k8s-aibom/values.yaml"},
+			},
+			want: false,
 		},
 		{
-			// nfd shares the NodeFeature CRDs with gpu-operator and
-			// network-operator, all three of which co-exist in base.yaml.
-			name: "sharer", component: "nfd", want: "",
+			name: "local chart path is not the registry chart",
+			ref: recipe.ComponentRef{
+				Name: "k8s-aibom", Type: recipe.ComponentTypeHelm,
+				Chart: "./k8s-aibom", Version: cfg.Helm.DefaultVersion,
+			},
+			want: false,
 		},
 		{
-			name: "owner with overridden version", component: "k8s-aibom",
-			mutate: func(r *recipe.ComponentRef) { r.Version = "1.2.0" }, want: "",
-		},
-		{
-			name: "owner with overridden chart", component: "k8s-aibom",
-			mutate: func(r *recipe.ComponentRef) { r.Chart = "some-fork" }, want: "",
-		},
-		{
-			name: "owner with overridden source", component: "k8s-aibom",
-			mutate: func(r *recipe.ComponentRef) { r.Source = "oci://example.invalid/charts" }, want: "",
+			// The control: without this, every case above could pass because
+			// usesRegistryChart always returns false.
+			name: "fully resolved registry ref matches",
+			ref: func() recipe.ComponentRef {
+				r := recipe.ComponentRef{Name: "k8s-aibom", Type: recipe.ComponentTypeHelm}
+				r.ApplyRegistryDefaults(cfg)
+				return r
+			}(),
+			want: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			outputDir := t.TempDir()
-			ref := refFor(t, tt.component)
-			if tt.mutate != nil {
-				tt.mutate(&ref)
-			}
-
-			recipeResult := &recipe.RecipeResult{}
-			recipeResult.Metadata.Version = testVersion
-			recipeResult.ComponentRefs = []recipe.ComponentRef{ref}
-
-			g := &Generator{
-				RecipeResult:    recipeResult,
-				ComponentValues: map[string]map[string]any{tt.component: {}},
-				Version:         "v0.9.0",
-			}
-			if _, err := g.Generate(context.Background(), outputDir); err != nil {
-				t.Fatalf("Generate() error = %v", err)
-			}
-
-			raw := readFile(t, filepath.Join(outputDir, tt.component, "helmrelease.yaml"))
-
-			// Decoded as a map, not a typed struct: a struct field of type
-			// string cannot tell an absent `crds` key from one explicitly
-			// rendered as "", so a negative case would pass against a
-			// template that emits an empty value. Presence is the assertion.
-			var doc struct {
-				Spec map[string]any `yaml:"spec"`
-			}
-			if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
-				t.Fatalf("parse HelmRelease: %v", err)
-			}
-			upgrade, hasUpgrade := doc.Spec["upgrade"]
-
-			if tt.want == "" {
-				if hasUpgrade {
-					t.Errorf("spec.upgrade present (%v), want the key absent entirely\n%s",
-						upgrade, raw)
-				}
-				return
-			}
-
-			if !hasUpgrade {
-				t.Fatalf("spec.upgrade absent, want crds = %q\n%s", tt.want, raw)
-			}
-			upgradeMap, ok := upgrade.(map[string]any)
-			if !ok {
-				t.Fatalf("spec.upgrade is %T, want a mapping\n%s", upgrade, raw)
-			}
-			crds, hasCRDs := upgradeMap["crds"]
-			if !hasCRDs {
-				t.Fatalf("spec.upgrade.crds absent, want %q\n%s", tt.want, raw)
-			}
-			if crds != tt.want {
-				t.Errorf("spec.upgrade.crds = %v, want %q\n%s", crds, tt.want, raw)
+			if got := usesRegistryChart(tt.ref, cfg); got != tt.want {
+				t.Errorf("usesRegistryChart() = %v, want %v (chart=%q source=%q version=%q)",
+					got, tt.want, tt.ref.EffectiveChart(), tt.ref.Source, tt.ref.Version)
 			}
 		})
 	}

--- a/pkg/bundler/deployer/flux/flux_test.go
+++ b/pkg/bundler/deployer/flux/flux_test.go
@@ -3105,62 +3105,108 @@ func TestGenerate_SourceOnlyRefChartFallsBackToName(t *testing.T) {
 
 // TestGenerate_HelmReleaseCRDUpgradePolicyIsOptIn covers #2264.
 //
-// Helm installs a chart's crds/ directory on first install and never touches
-// it again on upgrade, and helm-controller's spec.upgrade.crds default of Skip
-// inherits that, so a chart bump whose CRDs changed runs a new controller
-// against the previous schema.
+// helm-controller's spec.upgrade.crds default of Skip means a chart bump whose
+// CRDs changed runs a new controller against the previous schema. The fix is
+// opt-in via the registry ownsCRDs flag, not a blanket default: an audit found
+// 15 components ship CRDs under crds/ and 11 share at least one with another
+// component. nfd, gpu-operator and kai-scheduler all appear together in
+// base.yaml and all ship the NodeFeature CRDs, so replacing unconditionally
+// would have several HelmReleases rewrite the same CRD every reconcile.
 //
-// The fix is opt-in rather than a blanket default. An audit found 15 registry
-// components ship CRDs under crds/ and 11 share at least one CRD with another
-// component -- nfd, gpu-operator and network-operator all ship the NodeFeature
-// CRDs, and nfd, gpu-operator and kai-scheduler all appear together in
-// base.yaml. Replacing unconditionally would have several HelmReleases rewrite
-// the same CRD on every reconcile. Skip is what prevents that today.
+// Three directions are asserted, and each fails for a different reason:
 //
-// So this asserts both directions: an owner emits the policy, and a sharer
-// must not. A test that only checked the positive case would pass for an
-// unconditional template, which is the bug this replaced.
+//	owner            -> emits the policy
+//	sharer           -> must not, because replacing would race another release
+//	coordinates moved -> must not, because ownsCRDs records an audit of the
+//	                    registry's pinned chart and a ref that overrides
+//	                    source/chart/version points somewhere unaudited
+//
+// A positive-only test would pass against an unconditional template, which is
+// the defect this replaced, so the negative cases are the load-bearing ones.
+//
+// NOTE ON COVERAGE: this exercises the sourceRef template only. An upstream
+// Helm component renders spec.chart.spec.sourceRef regardless of
+// OCISourceName; the chartRef template is reached by local, vendored and
+// manifest-backed components, and those carry no registry chart coordinates,
+// so they cannot satisfy usesRegistryChart and cannot emit the policy today.
+// Earlier revisions of this test claimed chartRef coverage by setting
+// OCISourceName on a normal Helm ref, which renders sourceRef and tested the
+// same path twice. Do not reintroduce that shape.
 func TestGenerate_HelmReleaseCRDUpgradePolicyIsOptIn(t *testing.T) {
+	registry, regErr := recipe.GetComponentRegistry()
+	if regErr != nil {
+		t.Fatalf("GetComponentRegistry: %v", regErr)
+	}
+
+	// refFor builds a ref at the component's exact registry coordinates, which
+	// is what a stock recipe resolves to.
+	refFor := func(t *testing.T, name string) recipe.ComponentRef {
+		t.Helper()
+		cfg := registry.Get(name)
+		if cfg == nil {
+			t.Fatalf("%s missing from registry", name)
+		}
+		return recipe.ComponentRef{
+			Name:      name,
+			Namespace: name,
+			Type:      recipe.ComponentTypeHelm,
+			Source:    cfg.Helm.DefaultRepository,
+			Chart:     cfg.Helm.DefaultChart,
+			Version:   cfg.Helm.DefaultVersion,
+		}
+	}
+
 	tests := []struct {
-		name          string
-		component     string
-		ociSourceName string
-		want          string
+		name      string
+		component string
+		mutate    func(*recipe.ComponentRef)
+		want      string
 	}{
-		// k8s-aibom is registry ownsCRDs: sole owner, no webhook conversion.
-		{name: "owner via sourceRef", component: "k8s-aibom", want: "CreateReplace"},
-		{name: "owner via chartRef", component: "k8s-aibom", ociSourceName: "aicr-bundle", want: "CreateReplace"},
-		// nfd shares the NodeFeature CRDs with gpu-operator and
-		// network-operator, so replacing would race them.
-		{name: "sharer via sourceRef", component: "nfd", want: ""},
-		{name: "sharer via chartRef", component: "nfd", ociSourceName: "aicr-bundle", want: ""},
+		{
+			// k8s-aibom is registry ownsCRDs: sole owner, no webhook conversion.
+			name: "owner at registry coordinates", component: "k8s-aibom", want: "CreateReplace",
+		},
+		{
+			// nfd shares the NodeFeature CRDs with gpu-operator and
+			// network-operator, all three of which co-exist in base.yaml.
+			name: "sharer", component: "nfd", want: "",
+		},
+		{
+			name: "owner with overridden version", component: "k8s-aibom",
+			mutate: func(r *recipe.ComponentRef) { r.Version = "1.2.0" }, want: "",
+		},
+		{
+			name: "owner with overridden chart", component: "k8s-aibom",
+			mutate: func(r *recipe.ComponentRef) { r.Chart = "some-fork" }, want: "",
+		},
+		{
+			name: "owner with overridden source", component: "k8s-aibom",
+			mutate: func(r *recipe.ComponentRef) { r.Source = "oci://example.invalid/charts" }, want: "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			outputDir := t.TempDir()
+			ref := refFor(t, tt.component)
+			if tt.mutate != nil {
+				tt.mutate(&ref)
+			}
 
 			recipeResult := &recipe.RecipeResult{}
 			recipeResult.Metadata.Version = testVersion
-			recipeResult.ComponentRefs = []recipe.ComponentRef{{
-				Name:      tt.component,
-				Namespace: tt.component,
-				Chart:     tt.component,
-				Version:   "1.0.0",
-				Type:      recipe.ComponentTypeHelm,
-				Source:    "oci://example.com/charts",
-			}}
+			recipeResult.ComponentRefs = []recipe.ComponentRef{ref}
 
 			g := &Generator{
 				RecipeResult:    recipeResult,
 				ComponentValues: map[string]map[string]any{tt.component: {}},
 				Version:         "v0.9.0",
-				OCISourceName:   tt.ociSourceName,
 			}
 			if _, err := g.Generate(context.Background(), outputDir); err != nil {
 				t.Fatalf("Generate() error = %v", err)
 			}
 
+			raw := readFile(t, filepath.Join(outputDir, tt.component, "helmrelease.yaml"))
 			var hr struct {
 				Spec struct {
 					Upgrade struct {
@@ -3168,11 +3214,9 @@ func TestGenerate_HelmReleaseCRDUpgradePolicyIsOptIn(t *testing.T) {
 					} `yaml:"upgrade"`
 				} `yaml:"spec"`
 			}
-			raw := readFile(t, filepath.Join(outputDir, tt.component, "helmrelease.yaml"))
 			if err := yaml.Unmarshal([]byte(raw), &hr); err != nil {
 				t.Fatalf("parse HelmRelease: %v", err)
 			}
-
 			if hr.Spec.Upgrade.CRDs != tt.want {
 				t.Errorf("spec.upgrade.crds = %q, want %q\n%s", hr.Spec.Upgrade.CRDs, tt.want, raw)
 			}

--- a/pkg/bundler/deployer/flux/flux_test.go
+++ b/pkg/bundler/deployer/flux/flux_test.go
@@ -3207,18 +3207,40 @@ func TestGenerate_HelmReleaseCRDUpgradePolicyIsOptIn(t *testing.T) {
 			}
 
 			raw := readFile(t, filepath.Join(outputDir, tt.component, "helmrelease.yaml"))
-			var hr struct {
-				Spec struct {
-					Upgrade struct {
-						CRDs string `yaml:"crds"`
-					} `yaml:"upgrade"`
-				} `yaml:"spec"`
+
+			// Decoded as a map, not a typed struct: a struct field of type
+			// string cannot tell an absent `crds` key from one explicitly
+			// rendered as "", so a negative case would pass against a
+			// template that emits an empty value. Presence is the assertion.
+			var doc struct {
+				Spec map[string]any `yaml:"spec"`
 			}
-			if err := yaml.Unmarshal([]byte(raw), &hr); err != nil {
+			if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
 				t.Fatalf("parse HelmRelease: %v", err)
 			}
-			if hr.Spec.Upgrade.CRDs != tt.want {
-				t.Errorf("spec.upgrade.crds = %q, want %q\n%s", hr.Spec.Upgrade.CRDs, tt.want, raw)
+			upgrade, hasUpgrade := doc.Spec["upgrade"]
+
+			if tt.want == "" {
+				if hasUpgrade {
+					t.Errorf("spec.upgrade present (%v), want the key absent entirely\n%s",
+						upgrade, raw)
+				}
+				return
+			}
+
+			if !hasUpgrade {
+				t.Fatalf("spec.upgrade absent, want crds = %q\n%s", tt.want, raw)
+			}
+			upgradeMap, ok := upgrade.(map[string]any)
+			if !ok {
+				t.Fatalf("spec.upgrade is %T, want a mapping\n%s", upgrade, raw)
+			}
+			crds, hasCRDs := upgradeMap["crds"]
+			if !hasCRDs {
+				t.Fatalf("spec.upgrade.crds absent, want %q\n%s", tt.want, raw)
+			}
+			if crds != tt.want {
+				t.Errorf("spec.upgrade.crds = %v, want %q\n%s", crds, tt.want, raw)
 			}
 		})
 	}

--- a/pkg/bundler/deployer/flux/helm.go
+++ b/pkg/bundler/deployer/flux/helm.go
@@ -42,6 +42,9 @@ type HelmReleaseData struct {
 	DependsOn       []DependsOnRef
 	ValuesFrom      []ValuesFromRef // ConfigMap references for dynamic values
 	ValuesYAML      string          // Pre-rendered, indented YAML for spec.values
+	// UpgradeCRDs emits spec.upgrade.crds: CreateReplace. Set only for
+	// components the registry marks ownsCRDs. See NVIDIA/aicr#2264.
+	UpgradeCRDs bool
 }
 
 // ChartRefHelmReleaseData carries per-component data for the
@@ -56,6 +59,9 @@ type ChartRefHelmReleaseData struct {
 	DependsOn       []DependsOnRef
 	ValuesFrom      []ValuesFromRef // ConfigMap references for dynamic values
 	ValuesYAML      string          // Pre-rendered, indented YAML for spec.values
+	// UpgradeCRDs emits spec.upgrade.crds: CreateReplace. Set only for
+	// components the registry marks ownsCRDs. See NVIDIA/aicr#2264.
+	UpgradeCRDs bool
 }
 
 // ArtifactGeneratorData carries per-component data for the
@@ -176,6 +182,7 @@ func (g *Generator) generateHelmComponent(ref recipe.ComponentRef, compDir strin
 		Namespace:       g.resolveNamespace(),
 		TargetNamespace: ref.Namespace,
 		Chart:           chart,
+		UpgradeCRDs:     g.ownsCRDs(ref.Name),
 		Version:         version,
 		SourceKind:      "HelmRepository",
 		SourceName:      sName,
@@ -306,6 +313,7 @@ func (g *Generator) generateManifestHelmChart(compName, dirName, namespace, comp
 		Namespace:       g.resolveNamespace(),
 		TargetNamespace: namespace,
 		Chart:           "./" + dirName,
+		UpgradeCRDs:     g.ownsCRDs(dirName),
 		SourceKind:      "GitRepository",
 		SourceName:      sName,
 		DependsOn:       dependsOn,
@@ -439,6 +447,7 @@ func (g *Generator) generateVendoredHelmComponent(ctx context.Context, ref recip
 		Namespace:       g.resolveNamespace(),
 		TargetNamespace: ref.Namespace,
 		Chart:           "./" + ref.Name,
+		UpgradeCRDs:     g.ownsCRDs(ref.Name),
 		SourceKind:      "GitRepository",
 		SourceName:      sName,
 		DependsOn:       dependsOn,
@@ -480,6 +489,7 @@ func (g *Generator) writeOCIArtifactPair(name, targetNamespace string,
 		Namespace:       g.resolveNamespace(),
 		TargetNamespace: targetNamespace,
 		ChartRefName:    agName,
+		UpgradeCRDs:     g.ownsCRDs(name),
 		DependsOn:       dependsOn,
 		ValuesFrom:      valuesFrom,
 		ValuesYAML:      valuesYAML,

--- a/pkg/bundler/deployer/flux/templates/helmrelease-chartref.yaml.tmpl
+++ b/pkg/bundler/deployer/flux/templates/helmrelease-chartref.yaml.tmpl
@@ -10,6 +10,15 @@ spec:
   targetNamespace: {{ .TargetNamespace }}
   install:
     createNamespace: true
+{{- if .UpgradeCRDs }}
+  # This component solely owns the CRDs it ships (registry: ownsCRDs), so
+  # replacing them on upgrade cannot race another release. Without this,
+  # helm-controller's spec.upgrade.crds default of Skip leaves the schema
+  # installed on day one in place while a new controller runs against it.
+  # Components that share CRDs deliberately omit this. See NVIDIA/aicr#2264.
+  upgrade:
+    crds: CreateReplace
+{{- end }}
   chartRef:
     kind: ExternalArtifact
     name: {{ .ChartRefName }}

--- a/pkg/bundler/deployer/flux/templates/helmrelease.yaml.tmpl
+++ b/pkg/bundler/deployer/flux/templates/helmrelease.yaml.tmpl
@@ -10,6 +10,15 @@ spec:
   targetNamespace: {{ .TargetNamespace }}
   install:
     createNamespace: true
+{{- if .UpgradeCRDs }}
+  # This component solely owns the CRDs it ships (registry: ownsCRDs), so
+  # replacing them on upgrade cannot race another release. Without this,
+  # helm-controller's spec.upgrade.crds default of Skip leaves the schema
+  # installed on day one in place while a new controller runs against it.
+  # Components that share CRDs deliberately omit this. See NVIDIA/aicr#2264.
+  upgrade:
+    crds: CreateReplace
+{{- end }}
   chart:
     spec:
       chart: {{ .Chart }}

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -126,6 +126,33 @@ type ComponentConfig struct {
 	// ships in `crds/`. See https://github.com/NVIDIA/aicr/issues/914.
 	HasSelfRefCRDs bool `yaml:"hasSelfRefCRDs,omitempty"`
 
+	// OwnsCRDs signals that this component is the ONLY chart in the
+	// registry that ships its CRDs, so a deployer may replace those CRDs
+	// on upgrade instead of leaving them at the schema installed on day
+	// one. Helm installs a chart's `crds/` directory on first install and
+	// never touches it again, and Flux's helm-controller inherits that via
+	// its `spec.upgrade.crds: Skip` default, so a chart bump whose CRDs
+	// changed otherwise runs a new controller against the previous schema.
+	//
+	// This is opt-in, and deliberately so. An audit of every Helm
+	// component in the registry found 15 ship CRDs under `crds/`, and 11
+	// of those share at least one CRD with another component: nfd,
+	// gpu-operator, and network-operator all ship the NodeFeature CRDs,
+	// and nfd plus gpu-operator plus kai-scheduler all appear together in
+	// `base.yaml`. Replacing unconditionally would have two or three
+	// HelmReleases rewrite the same CRD on every reconcile, each with the
+	// schema its own chart pins. The `Skip` default is what keeps that
+	// from happening today.
+	//
+	// Set this only for a component that both (a) solely owns every CRD it
+	// ships — including against charts that ship CRDs through `templates/`
+	// rather than `crds/`, which `helm show crds` does not report — and
+	// (b) ships no CRD using `spec.conversion.strategy: Webhook`, because
+	// replace discards a `caBundle` injected at runtime.
+	//
+	// See https://github.com/NVIDIA/aicr/issues/2264.
+	OwnsCRDs bool `yaml:"ownsCRDs,omitempty"`
+
 	// ManifestsUseChartCRDs signals that the component's attached
 	// manifestFiles (wrapped by the bundler into an injected -post
 	// local-helm release) instantiate CRs whose CRDs this component's

--- a/pkg/recipe/ownscrds_audit_test.go
+++ b/pkg/recipe/ownscrds_audit_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import "testing"
+
+// auditedOwnsCRDs pins the exact chart versions whose CRD ownership was
+// audited. ownsCRDs asserts two properties of a specific chart: that the
+// component solely owns every CRD it ships, and that it ships none using
+// spec.conversion.strategy: Webhook. Both are properties of the chart at a
+// version, not of the component name.
+//
+// A recipe that overrides coordinates is already handled at generation time
+// (usesRegistryChart disables the policy). This guard covers the other
+// direction, which nothing else does: bumping defaultVersion in the registry
+// keeps ownsCRDs true and would apply CreateReplace to a chart nobody
+// re-checked, which may by then share a CRD or use webhook conversion.
+//
+// Re-audit procedure when this test fails:
+//
+//  1. helm show crds <chart> --version <new> and list the CRD names.
+//  2. Confirm no other registry component ships any of those names, including
+//     via templates/ — `helm show crds` does not report those, and
+//     prometheus-operator-crds ships through templates/ the same CRDs
+//     kube-prometheus-stack ships under crds/.
+//  3. Confirm none declares spec.conversion.strategy: Webhook.
+//  4. Update the pin below, or drop ownsCRDs if either property no longer holds.
+//
+// See https://github.com/NVIDIA/aicr/issues/2264.
+var auditedOwnsCRDs = map[string]string{
+	"gatekeeper": "3.22.2",
+	"k8s-aibom":  "1.3.0",
+	"nvsentinel": "v1.9.0",
+}
+
+func TestOwnsCRDsPinsMatchAuditedVersions(t *testing.T) {
+	t.Parallel()
+
+	registry, err := GetComponentRegistry()
+	if err != nil {
+		t.Fatalf("GetComponentRegistry: %v", err)
+	}
+
+	enrolled := map[string]string{}
+	for _, name := range registry.Names() {
+		cfg := registry.Get(name)
+		if cfg == nil || !cfg.OwnsCRDs {
+			continue
+		}
+		enrolled[name] = cfg.Helm.DefaultVersion
+	}
+
+	for name, version := range enrolled {
+		audited, ok := auditedOwnsCRDs[name]
+		if !ok {
+			t.Errorf("component %q sets ownsCRDs but has no audited version recorded; "+
+				"run the re-audit procedure in this file and add it", name)
+			continue
+		}
+		if audited != version {
+			t.Errorf("component %q is pinned to chart %q but was audited at %q; "+
+				"a version bump does not carry the CRD-ownership audit forward — "+
+				"re-audit and update auditedOwnsCRDs, or drop ownsCRDs",
+				name, version, audited)
+		}
+	}
+
+	for name := range auditedOwnsCRDs {
+		if _, ok := enrolled[name]; !ok {
+			t.Errorf("component %q has an audited version recorded but no longer sets "+
+				"ownsCRDs; remove the stale entry", name)
+		}
+	}
+}

--- a/recipes/registry.yaml
+++ b/recipes/registry.yaml
@@ -301,6 +301,8 @@ components:
           --accelerated-node-toleration nvidia.com/gpu:NoSchedule."
 
   - name: nvsentinel
+    # Sole owner of its CRDs and no webhook conversion (audited, #2264).
+    ownsCRDs: true
     displayName: nvsentinel
     valueOverrideKeys:
       - nv-sentinel
@@ -508,6 +510,8 @@ components:
           - tolerations
 
   - name: k8s-aibom
+    # Sole owner of its CRDs and no webhook conversion (audited, #2264).
+    ownsCRDs: true
     displayName: k8s-aibom
     valueOverrideKeys:
       - k8saibom
@@ -908,6 +912,8 @@ components:
           - nodeDataBroker.tolerations
 
   - name: gatekeeper
+    # Sole owner of its CRDs and no webhook conversion (audited, #2264).
+    ownsCRDs: true
     displayName: Gatekeeper
     valueOverrideKeys:
       - gatekeeper


### PR DESCRIPTION
## Summary

Components that solely own the CRDs they ship now get `spec.upgrade.crds: CreateReplace` on their generated Flux `HelmRelease`, via a new registry field `ownsCRDs`. Everything else keeps helm-controller's `Skip` default.

## Motivation / Context

Helm installs a chart's `crds/` directory on first install and never touches it again on upgrade. helm-controller inherits that through its `spec.upgrade.crds` default of `Skip`, so a chart bump whose CRDs changed runs a new controller against the previous schema while the API server prunes writes to fields the old schema does not know about.

Fixes: #2264

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)

## History

An earlier revision of this branch defaulted `CreateReplace` on for every component, justified by an audit reporting "11 of 33" CRD-bearing charts. **Review found that audit was wrong, and it was wrong because my script failed open.** It passed registry chart names in repo-alias form (`nvidia/gpu-operator`) to `helm show crds ... --repo <url>`, where the chart argument must be a bare name. That errors; `2>/dev/null` swallowed it and `grep -c` recorded `0`.

The corrected audit changes the design, not just the number. Branch rewritten from `main` rather than patched.

## The audit, redone

15 of 33 components ship CRDs under `crds/`, and **11 of those share at least one CRD with another component**:

| | |
|---|---|
| Sole owner | `gatekeeper`, `k8s-aibom`, `kubeflow-trainer`, `nvsentinel` |
| Shares CRDs | `dynamo-platform`, `gpu-operator`, `grove`, `k8s-nim-operator`(+`-ocp`), `kai-scheduler`, `network-operator`, `nfd`, `nvidia-dra-driver-gpu`(+`-ocp`) |

`nfd`, `gpu-operator`, and `network-operator` all ship the NodeFeature CRDs, and `nfd`, `gpu-operator`, and `kai-scheduler` all appear together in **`base.yaml`** — the root of every stock recipe. An unconditional policy would have two or three `HelmRelease` objects rewrite the same CRD on every reconcile, each with the schema its own chart pins, flapping indefinitely. `Skip` is what prevents that today.

Two qualifying rules, both load-bearing:

1. **Sole ownership, checked against `templates/`-based CRDs too.** `helm show crds` reports only `crds/`, and `prometheus-operator-crds` ships through `templates/` the same ten CRDs `kube-prometheus-stack` ships under `crds/`. So kube-prometheus-stack looks like a sole owner and is not — it is excluded despite appearing in the safe column above.
2. **No `spec.conversion.strategy: Webhook`.** Replace discards a `caBundle` injected at runtime. `kubeflow-trainer`'s `leaderworkersets` CRD converts through `lws-webhook-service` with no `caBundle` in the chart, so it is excluded too.

Leaving **`gatekeeper`, `k8s-aibom`, `nvsentinel`**.

## Implementation Notes

`ownsCRDs` is resolved once per `Generate` and applied at all four `HelmRelease` population sites, covering both the `sourceRef` and `chartRef` template shapes. A registry resolution failure is **fatal** rather than defaulting everything to false, since silently treating every component as "does not own" would quietly restore the behavior this fixes.

**The test asserts both directions** — an owner emits the policy, a sharer must not. Verified that a positive-only test is insufficient: reverting the template to unconditional makes both sharer cases fail, which is precisely the defect being replaced.

**No golden churn.** The three opted-in components appear in no golden fixture. The prior revision moved all 45 stock leaf hashes, which I had attributed to Flux; it was actually the helm README template, which every bundle includes.

**The generated-README CRD instructions from the prior revision are not here.** Review found them unexecutable: no `--repo` for HTTP charts, no chart source at all in the helmfile template, and the section rendered into manifest-only bundles that have no charts. Since `.Repository`/`.ChartName` are available but the template funcmap has no `hasPrefix`, doing this properly needs a precomputed field. Guidance stays in `docs/user/component-catalog.md`, which is correct and now describes the opt-in behavior. Worth a follow-up; a wrong command shipping inside every bundle is worse than a right one in the docs.

**Scope claim:** this does not restore cross-deployer parity and is not described as doing so. `helm` and `helmfile` still skip `crds/` because that is Helm's own behavior, not something the bundle controls.

## Testing

```bash
make qualify
```

`Codebase qualification completed`, no failures.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Low rather than the prior revision's medium: behavior changes for three components rather than all of them, each audited as sole owner with no webhook conversion, and every other component keeps today's exact output. No golden moved.

**Rollout notes:** Flux users of `gatekeeper`, `k8s-aibom`, or `nvsentinel` get correct CRD upgrades on next reconcile. All other components are byte-identical to before.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
