### PR TITLE
fix(sdk): address OCI source follow-up feedback

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -375,6 +375,10 @@ and extraction are bounded, content digests are checked while streaming, and
 archive traversal, links, devices, oversized content, and malformed catalogs
 fail closed before the provider is activated.
 
+OCI sources use credentials from the standard Docker configuration
+(`~/.docker/config.json` or `$DOCKER_CONFIG`) and may invoke the configured
+credential helper for the selected registry host.
+
 Use `NewClientContext` so caller cancellation and tighter deadlines
 propagate through registry authentication, download, extraction, and catalog
 validation:
@@ -443,7 +447,9 @@ client, err := aicr.NewClient(
   to `WithAllowLists`.
 - **`WithOCISourceTempDir(parent string)`** selects an existing writable
   parent for an OCI-backed Client's private workspace. It is rejected for
-  embedded and filesystem sources.
+  embedded and filesystem sources. Budget capacity for up to a 64 MiB staged
+  compressed layer plus a 128 MiB extracted tree, along with filesystem and
+  manifest overhead.
 
 `AllowLists` is a facade-owned struct whose `Accelerators`, `Services`,
 `Intents`, and `OSTypes` fields are plain `[]string` slices, so callers

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -152,9 +152,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/distribution/reference"
-	"github.com/opencontainers/go-digest"
-
 	"github.com/NVIDIA/aicr/pkg/bundler"
 	"github.com/NVIDIA/aicr/pkg/bundler/validations"
 	"github.com/NVIDIA/aicr/pkg/constraints"
@@ -368,10 +365,18 @@ func validateSourceConfiguration(c *Client) error {
 		return nil
 	}
 
-	if err := validateOCIRepository(c.source.registry); err != nil {
-		return err
+	pullOptions := oci.RecipePullOptions{
+		Repository: c.source.registry,
+		Selector:   c.source.selector,
 	}
-	digestSelector, err := validateOCISelector(c.source.selector)
+	if c.ociSource.tempDir != nil {
+		if *c.ociSource.tempDir == "" {
+			return errors.New(errors.ErrCodeInvalidRequest,
+				"OCI source temporary-directory parent must be non-empty")
+		}
+		pullOptions.TempDir = *c.ociSource.tempDir
+	}
+	digestSelector, err := oci.ValidateRecipePullOptions(pullOptions)
 	if err != nil {
 		return err
 	}
@@ -387,65 +392,7 @@ func validateSourceConfiguration(c *Client) error {
 	return nil
 }
 
-func validateOCIRepository(repository string) error {
-	if repository == "" || strings.TrimSpace(repository) != repository {
-		return errors.New(errors.ErrCodeInvalidRequest,
-			"OCI recipe repository must be non-empty and contain no surrounding whitespace")
-	}
-	if strings.HasPrefix(repository, "oci://") {
-		repository = strings.TrimPrefix(repository, "oci://")
-	} else if strings.Contains(repository, "://") {
-		return errors.New(errors.ErrCodeInvalidRequest,
-			"OCI recipe repository supports only the optional oci:// scheme")
-	}
-
-	named, err := reference.ParseNormalizedNamed(repository)
-	if err != nil {
-		return errors.Wrap(errors.ErrCodeInvalidRequest, "invalid OCI recipe repository", err)
-	}
-	if !reference.IsNameOnly(named) {
-		return errors.New(errors.ErrCodeInvalidRequest,
-			"OCI recipe repository must not contain a tag or digest; pass it as the selector")
-	}
-	return nil
-}
-
-// validateOCISelector returns true when selector is an immutable sha256 digest.
-func validateOCISelector(selector string) (bool, error) {
-	if selector == "" || strings.TrimSpace(selector) != selector {
-		return false, errors.New(errors.ErrCodeInvalidRequest,
-			"OCI recipe selector is required and must contain no surrounding whitespace")
-	}
-	if strings.Contains(selector, ":") {
-		parsed := digest.Digest(selector)
-		if parsed.Algorithm() != digest.SHA256 {
-			return false, errors.New(errors.ErrCodeInvalidRequest,
-				"OCI recipe digest selector must use sha256")
-		}
-		if err := parsed.Validate(); err != nil {
-			return false, errors.Wrap(errors.ErrCodeInvalidRequest,
-				"invalid OCI recipe digest selector", err)
-		}
-		return true, nil
-	}
-
-	named, err := reference.WithName("example.invalid/aicr-recipes")
-	if err != nil {
-		return false, errors.Wrap(errors.ErrCodeInternal,
-			"construct OCI recipe selector validator", err)
-	}
-	if _, err := reference.WithTag(named, selector); err != nil {
-		return false, errors.Wrap(errors.ErrCodeInvalidRequest,
-			"invalid OCI recipe tag selector", err)
-	}
-	return false, nil
-}
-
 func validateOCITempDir(parent string) error {
-	if parent == "" || strings.TrimSpace(parent) != parent {
-		return errors.New(errors.ErrCodeInvalidRequest,
-			"OCI source temporary-directory parent must be non-empty and contain no surrounding whitespace")
-	}
 	abs, err := filepath.Abs(parent)
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInvalidRequest,

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -178,22 +178,31 @@ func TestNewClientRejectsMissingFilesystemDir(t *testing.T) {
 func TestNewClientRejectsInvalidOCISourceConfiguration(t *testing.T) {
 	t.Parallel()
 
+	digestSelector := "sha256:" + strings.Repeat("a", 64)
 	tests := []struct {
 		name       string
 		repository string
 		selector   string
+		tempDir    string
+		setTempDir bool
 	}{
 		{name: "empty repository", selector: "v1"},
 		{name: "tag selector", repository: "ghcr.io/nvidia/aicr-recipes", selector: "v1"},
 		{name: "invalid digest", repository: "ghcr.io/nvidia/aicr-recipes", selector: "sha256:short"},
-		{name: "ambiguous repository tag", repository: "ghcr.io/nvidia/aicr-recipes:v1", selector: "sha256:" + strings.Repeat("a", 64)},
+		{name: "ambiguous repository tag", repository: "ghcr.io/nvidia/aicr-recipes:v1", selector: digestSelector},
+		{name: "empty temp directory", repository: "ghcr.io/nvidia/aicr-recipes", selector: digestSelector, setTempDir: true},
+		{name: "temp directory whitespace", repository: "ghcr.io/nvidia/aicr-recipes", selector: digestSelector, tempDir: " /tmp", setTempDir: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := aicr.NewClient(
+			opts := []aicr.Option{
 				aicr.WithRecipeSource(aicr.OCISource(tt.repository, tt.selector)),
-			)
+			}
+			if tt.setTempDir {
+				opts = append(opts, aicr.WithOCISourceTempDir(tt.tempDir))
+			}
+			_, err := aicr.NewClient(opts...)
 			if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
 				t.Errorf("NewClient() error = %v, want ErrCodeInvalidRequest", err)
 			}

--- a/pkg/oci/recipe_pull.go
+++ b/pkg/oci/recipe_pull.go
@@ -25,6 +25,7 @@ import (
 	stderrors "errors"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"path"
@@ -67,6 +68,25 @@ type RecipePullOptions struct {
 	Repository string
 	Selector   string
 	TempDir    string
+}
+
+type recipePullValidation struct {
+	normalized     string
+	registry       string
+	repository     string
+	selectorDigest digest.Digest
+}
+
+// ValidateRecipePullOptions performs the I/O-free structural validation used
+// before staging and reports whether Selector is an immutable sha256 digest.
+// An empty TempDir selects os.TempDir; a nonempty value is syntax-checked here,
+// while StageRecipeArtifact verifies that it can create the private child.
+func ValidateRecipePullOptions(opts RecipePullOptions) (bool, error) {
+	validated, err := validateRecipePullOptions(opts)
+	if err != nil {
+		return false, err
+	}
+	return validated.selectorDigest != "", nil
 }
 
 // StagedRecipeArtifact owns the private OCI content and, after an explicit
@@ -351,7 +371,7 @@ func stageRecipeArtifactWithDependencies(
 	deps recipePullDependencies,
 ) (_ *StagedRecipeArtifact, retErr error) {
 
-	normalized, registry, repository, digestSelector, err := validateRecipePullOptions(opts)
+	validated, err := validateRecipePullOptions(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +400,7 @@ func stageRecipeArtifactWithDependencies(
 		return nil, apperrors.PropagateOrWrap(err, apperrors.ErrCodeInternal,
 			"failed to create private OCI recipe content store")
 	}
-	repo, err := deps.newRepository(ctx, normalized)
+	repo, err := deps.newRepository(ctx, validated.normalized)
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +412,7 @@ func stageRecipeArtifactWithDependencies(
 	}()
 
 	descriptor, manifest, err := pullRecipeGraphWithRetry(
-		ctx, repo, store, opts.Selector, digestSelector, deps)
+		ctx, repo, store, opts.Selector, validated.selectorDigest, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -410,10 +430,10 @@ func stageRecipeArtifactWithDependencies(
 		remote:       repo,
 		descriptor:   immutableDescriptor(descriptor),
 		manifest:     cloneRecipeManifest(manifest),
-		selectorHash: digestSelector,
-		reference:    normalized + "@" + descriptor.Digest.String(),
-		registry:     registry,
-		repository:   repository,
+		selectorHash: validated.selectorDigest,
+		reference:    validated.normalized + "@" + descriptor.Digest.String(),
+		registry:     validated.registry,
+		repository:   validated.repository,
 		extract:      deps.extract,
 	}
 	keepLayout = true
@@ -475,6 +495,13 @@ func pullRecipeGraphWithRetry(
 		if attempt == attempts {
 			break
 		}
+		slog.Debug("retrying OCI recipe pull after transient failure",
+			"attempt", attempt,
+			"nextAttempt", attempt+1,
+			"maxAttempts", attempts,
+			"backoff", backoff,
+			"error", lastErr,
+		)
 		if err := deps.waitBackoff(ctx, backoff); err != nil {
 			return ociv1.Descriptor{}, ociv1.Manifest{}, err
 		}
@@ -715,55 +742,57 @@ func validateRecipeRetryTraffic(size int64, traffic *recipeDownloadBudget) error
 
 func validateRecipePullOptions(
 	opts RecipePullOptions,
-) (normalized, registry, repository string, selectorDigest digest.Digest, retErr error) {
+) (recipePullValidation, error) {
 
+	validated := recipePullValidation{}
 	input := opts.Repository
 	if input == "" || strings.TrimSpace(input) != input {
-		return "", "", "", "", apperrors.New(apperrors.ErrCodeInvalidRequest,
+		return validated, apperrors.New(apperrors.ErrCodeInvalidRequest,
 			"OCI recipe repository must be non-empty and contain no surrounding whitespace")
 	}
 	if strings.HasPrefix(input, "oci://") {
 		input = strings.TrimPrefix(input, "oci://")
 	} else if strings.Contains(input, "://") {
-		return "", "", "", "", apperrors.New(apperrors.ErrCodeInvalidRequest,
+		return validated, apperrors.New(apperrors.ErrCodeInvalidRequest,
 			"OCI recipe repository supports only the optional oci:// scheme")
 	}
 	named, err := reference.ParseNormalizedNamed(input)
 	if err != nil {
-		return "", "", "", "", apperrors.Wrap(apperrors.ErrCodeInvalidRequest,
+		return validated, apperrors.Wrap(apperrors.ErrCodeInvalidRequest,
 			"invalid OCI recipe repository", err)
 	}
 	if !reference.IsNameOnly(named) {
-		return "", "", "", "", apperrors.New(apperrors.ErrCodeInvalidRequest,
+		return validated, apperrors.New(apperrors.ErrCodeInvalidRequest,
 			"OCI recipe repository must not contain a tag or digest")
 	}
-	registry = reference.Domain(named)
-	repository = reference.Path(named)
-	if err := validateRegistryReference(registry, repository); err != nil {
-		return "", "", "", "", err
+	validated.registry = reference.Domain(named)
+	validated.repository = reference.Path(named)
+	if err := validateRegistryReference(validated.registry, validated.repository); err != nil {
+		return recipePullValidation{}, err
 	}
 	if opts.Selector == "" || strings.TrimSpace(opts.Selector) != opts.Selector {
-		return "", "", "", "", apperrors.New(apperrors.ErrCodeInvalidRequest,
+		return recipePullValidation{}, apperrors.New(apperrors.ErrCodeInvalidRequest,
 			"OCI recipe selector is required and must contain no surrounding whitespace")
 	}
 	if strings.Contains(opts.Selector, ":") {
-		selectorDigest = digest.Digest(opts.Selector)
-		if selectorDigest.Algorithm() != digest.SHA256 {
-			return "", "", "", "", apperrors.New(apperrors.ErrCodeInvalidRequest,
+		validated.selectorDigest = digest.Digest(opts.Selector)
+		if validated.selectorDigest.Algorithm() != digest.SHA256 {
+			return recipePullValidation{}, apperrors.New(apperrors.ErrCodeInvalidRequest,
 				"OCI recipe digest selector must use sha256")
 		}
-		if err := selectorDigest.Validate(); err != nil {
-			return "", "", "", "", apperrors.Wrap(apperrors.ErrCodeInvalidRequest,
+		if err := validated.selectorDigest.Validate(); err != nil {
+			return recipePullValidation{}, apperrors.Wrap(apperrors.ErrCodeInvalidRequest,
 				"invalid OCI recipe digest selector", err)
 		}
 	} else if err := validateDistributionTag(opts.Selector); err != nil {
-		return "", "", "", "", err
+		return recipePullValidation{}, err
 	}
 	if opts.TempDir != "" && strings.TrimSpace(opts.TempDir) != opts.TempDir {
-		return "", "", "", "", apperrors.New(apperrors.ErrCodeInvalidRequest,
+		return recipePullValidation{}, apperrors.New(apperrors.ErrCodeInvalidRequest,
 			"OCI recipe temporary-directory parent must contain no surrounding whitespace")
 	}
-	return registry + "/" + repository, registry, repository, selectorDigest, nil
+	validated.normalized = validated.registry + "/" + validated.repository
+	return validated, nil
 }
 
 func validateRecipeManifestDescriptor(desc ociv1.Descriptor, selector digest.Digest) error {

--- a/pkg/oci/recipe_pull_test.go
+++ b/pkg/oci/recipe_pull_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -122,6 +123,11 @@ func TestStageRecipeArtifactAcceptsPackageOutput(t *testing.T) {
 }
 
 func TestStageRecipeArtifactFreezesResolvedTagAcrossRetry(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
 	artifact := newTestRecipeArtifact(t, []testArchiveEntry{{
 		header:  tar.Header{Name: "registry.yaml", Mode: 0o644, Typeflag: tar.TypeReg},
 		content: []byte("components: []\n"),
@@ -160,6 +166,18 @@ func TestStageRecipeArtifactFreezesResolvedTagAcrossRetry(t *testing.T) {
 	}
 	if len(waits) != 1 || waits[0] != 2*time.Millisecond {
 		t.Errorf("backoff waits = %v, want [2ms]", waits)
+	}
+	logOutput := logs.String()
+	for _, want := range []string{
+		"retrying OCI recipe pull after transient failure",
+		"attempt=1",
+		"nextAttempt=2",
+		"maxAttempts=3",
+		"backoff=2ms",
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Errorf("retry log = %q, want field %q", logOutput, want)
+		}
 	}
 }
 
@@ -612,13 +630,58 @@ func TestValidateRecipePullOptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, _, gotDigest, err := validateRecipePullOptions(tt.opts)
+			got, err := validateRecipePullOptions(tt.opts)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("validateRecipePullOptions() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if got != tt.wantRepo || gotDigest != tt.wantDigest {
+			if got.normalized != tt.wantRepo || got.selectorDigest != tt.wantDigest {
 				t.Errorf("validateRecipePullOptions() = (%q, %q), want (%q, %q)",
-					got, gotDigest, tt.wantRepo, tt.wantDigest)
+					got.normalized, got.selectorDigest, tt.wantRepo, tt.wantDigest)
+			}
+		})
+	}
+}
+
+func TestValidateRecipePullOptionsReportsDigestSelector(t *testing.T) {
+	digestSelector := "sha256:" + strings.Repeat("a", 64)
+	tests := []struct {
+		name       string
+		opts       RecipePullOptions
+		wantDigest bool
+		wantErr    bool
+	}{
+		{
+			name: "digest",
+			opts: RecipePullOptions{
+				Repository: "ghcr.io/nvidia/aicr-recipes",
+				Selector:   digestSelector,
+			},
+			wantDigest: true,
+		},
+		{
+			name: "tag",
+			opts: RecipePullOptions{
+				Repository: "ghcr.io/nvidia/aicr-recipes",
+				Selector:   "v1",
+			},
+		},
+		{
+			name: "invalid",
+			opts: RecipePullOptions{
+				Repository: "https://ghcr.io/nvidia/aicr-recipes",
+				Selector:   digestSelector,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDigest, err := ValidateRecipePullOptions(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateRecipePullOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if gotDigest != tt.wantDigest {
+				t.Errorf("ValidateRecipePullOptions() digest = %t, want %t", gotDigest, tt.wantDigest)
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up to #2212 addressing post-merge review feedback.

## Summary

- centralize OCI recipe pull option validation
- add debug breadcrumbs for transient pull retries
- document Docker credential-helper behavior and temporary workspace sizing

## Validation

- `go test -race ./pkg/oci ./pkg/client/v1`
- `golangci-lint -c .golangci.yaml run ./pkg/oci/... ./pkg/client/v1/...` (`0 issues`)
- `make check-docs-mdx check-docs-mdx-parse`

The full local qualification run reached only the unrelated Sigstore TUF integration checks, where this environment receives HTTP 403 from the public CDN; GitHub CI will re-run the complete gate.