### PR TITLE
docs: add NCCL_SOCKET_IFNAME to the AKS example, select workers by label

### DIFF
--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -295,7 +295,9 @@ socket fallback:
 
 ```shell
 # Select workers by label rather than guessing the generated pod name.
-kubectl logs -n <namespace> -c node \
+# --tail=-1 is required: with a selector, kubectl defaults to the last 10 lines
+# and would omit the transport banner, which NCCL prints during init.
+kubectl logs -n <namespace> -c node --tail=-1 \
   -l jobset.sigs.k8s.io/jobset-name=<trainjob-name>,jobset.sigs.k8s.io/replicatedjob-name=node \
   | grep -i 'NCCL INFO.*Using network'
 ```

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -255,7 +255,14 @@ Also TrainJob-expressible. AICR fixes the resource name and the value is always
       value: "0"
     - name: NCCL_NET_PLUGIN
       value: none
+    - name: NCCL_SOCKET_IFNAME
+      value: eth0
 ```
+
+`NCCL_SOCKET_IFNAME` pins NCCL's bootstrap and out-of-band traffic to the
+primary interface. AICR's tested AKS runtime sets it, as does the EKS one — on
+a multi-NIC node, leaving NCCL to guess can send rendezvous traffic down an
+interface that cannot carry it.
 
 The same repeat-every-resource caveat applies.
 
@@ -287,7 +294,10 @@ suppressed — so grepping an ordinary run finds nothing, which is not evidence 
 socket fallback:
 
 ```shell
-kubectl logs <worker-pod> -c node | grep -i 'NCCL INFO.*Using network'
+# Select workers by label rather than guessing the generated pod name.
+kubectl logs -n <namespace> -c node \
+  -l jobset.sigs.k8s.io/jobset-name=<trainjob-name>,jobset.sigs.k8s.io/replicatedjob-name=node \
+  | grep -i 'NCCL INFO.*Using network'
 ```
 
 Expect the plugin name — `FasTrak` for TCPXO, `AWS Libfabric` for EFA, `IB` for


### PR DESCRIPTION
## Summary

Closes the two partials from #2306's review, both of which @njhensley approved-with and I left open deliberately.

## Motivation / Context

Follow-up to #2306. Part of #2217.

**`NCCL_SOCKET_IFNAME` was missing from the AKS example.** AICR's tested AKS runtime pins it (`validators/performance/testdata/h100/aks/runtime.yaml:134`), as does the EKS one. The EFA section covered it; AKS did not. On a multi-NIC node, leaving NCCL to guess can send bootstrap and out-of-band traffic down an interface that cannot carry it.

**The verify step used a bare `<worker-pod>` placeholder**, which asks the reader to guess a generated pod name.

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

For the verify step I did not document Trainer's `<trainjob>-node-<idx>-0` name convention, which was the original suggestion. **Selecting by label is better and is what AICR's own validator does** — `nccl_all_reduce_bw_constraint.go:1759` builds `jobset.sigs.k8s.io/jobset-name=…,jobset.sigs.k8s.io/replicatedjob-name=node`.

A name pattern is an implementation detail that can drift; a label selector cannot, and it returns every worker rather than one guessed pod, which is what you want when checking whether the fabric engaged.

## Testing

Doc-only; no Go source touched. Ran the doc gates:

- `check-docs-filenames`, `check-docs-mdx`, `check-docs-mdx-parse` — OK
- `lint-yaml` — OK
- All four YAML blocks validated with `yq`

Full `make qualify` not run: it adds Go tests, e2e, vulnerability and license scans, none of which a markdown change can affect.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A. Two additions to one page: an env entry in the AKS example, and a label-selector form for the verify command.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes; doc gates run instead
- [x] Linter passes (`make lint`) — doc-relevant targets run
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, documentation
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed and signed off (`git commit -S -s`)