### PR TITLE
docs: link upstream Kubernetes support policy and fix the CRD-apply command

### DIFF
--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -317,10 +317,17 @@ image pinned by digest in the component values. v1.3.0 is the API-graduation
 release: both `v1alpha1` and `v1beta1` are served and CRD storage is on
 `v1beta1`, while the chart still renders the `AIBOMControllerConfig` resource
 itself at `v1alpha1`. Upstream states Kubernetes support as a policy rather
-than a fixed range — stable APIs only, no known ceiling, tested floor 1.27 —
-backed by a version-matrix CI job. AICR also observed the dedicated
-integration test passing on its Kind 1.36.1 node image; that is qualification
-evidence, not an extension of upstream's support statement.
+than a fixed range: stable APIs only, no known version ceiling, tested floor
+1.27, backed by a weekly CI matrix. The authoritative statement is
+[upstream's compatibility policy](https://github.com/GoogleCloudPlatform/k8s-aibom/blob/main/docs/compatibility.md),
+which is linked rather than restated here so it cannot drift out of date on
+our side. That link deliberately tracks `main`: the point is the current
+policy, not a snapshot of it, which is the opposite of how this page cites
+qualified artifacts.
+
+AICR also observed the dedicated integration test passing on its Kind 1.36.1
+node image; that is qualification evidence, not an extension of upstream's
+support statement.
 
 ### Health and readiness
 
@@ -409,12 +416,28 @@ added fields. Apply the CRDs from the exact qualified chart first, then
 upgrade:
 
 ```bash
-helm show crds oci://ghcr.io/googlecloudplatform/charts/k8s-aibom \
-  --version <qualified-version> | kubectl apply --server-side -f -
+CHART="oci://ghcr.io/googlecloudplatform/charts/k8s-aibom"
+VERSION="1.3.0"   # replace with the version you are upgrading to
+
+helm show crds "${CHART}" --version "${VERSION}" \
+  | sed -n '/^---$/,$p' \
+  | kubectl apply --server-side --force-conflicts -f -
 ```
 
-Use `--server-side` because the CRDs exceed the annotation size limit that
-client-side apply depends on.
+Three details in that command are load-bearing, and the obvious shorter form
+fails on both counts:
+
+- **`sed -n '/^---$/,$p'`** drops `helm`'s progress output. For an OCI chart,
+  `helm show crds` writes `Pulled:` and `Digest:` lines to *stdout*, and those
+  two lines parse as a valid YAML mapping, so `kubectl` rejects the stream with
+  `error validating data: [apiVersion not set, kind not set]`.
+- **`--force-conflicts`** is required because Helm created these CRDs on
+  install and owns their fields. Without it, server-side apply refuses with a
+  field-manager conflict.
+- **`--server-side`** is required because the CRDs exceed the annotation size
+  limit that client-side apply depends on.
+
+Verified against a live GKE cluster across a 1.2.0 to 1.3.0 upgrade.
 
 Which deployers need that step differs, so check yours:
 


### PR DESCRIPTION
## Summary

Two corrections to the `k8s-aibom` section of the component catalog: link upstream's Kubernetes support policy instead of restating it, and fix the pre-upgrade CRD command, which did not work.

## Motivation / Context

#2283 asked for the fixed 1.27-1.35 range to be replaced by a pointer to upstream's policy. #2309 already removed the fixed range and described the policy, but never linked it — so the description could still drift.

The second fix was found while capturing cross-boundary upgrade evidence for #2311 on a live GKE cluster: running the documented command verbatim fails.

Fixes: #2283
Related: #2311

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

### 1. Kubernetes support policy

Now links [upstream's compatibility policy](https://github.com/GoogleCloudPlatform/k8s-aibom/blob/main/docs/compatibility.md).

**The link intentionally tracks `main` rather than a pinned commit,** and the page now says so inline. The purpose of #2283 is to stop restating a support statement that can change; pinning would reintroduce exactly the drift it removes. That is the opposite of how this page cites *qualified artifacts*, where pinning is correct, so the distinction is written down rather than left for someone to "fix" later.

### 2. The CRD-apply command was broken

Previously documented:

```bash
helm show crds oci://ghcr.io/googlecloudplatform/charts/k8s-aibom \
  --version <qualified-version> | kubectl apply --server-side -f -
```

Run against the chart we ship, it fails twice over:

**`helm show crds` pollutes stdout for OCI charts.** The first two lines are progress, not YAML:

```
Pulled: ghcr.io/googlecloudplatform/charts/k8s-aibom:1.3.0
Digest: sha256:4ffa933e272a977e0b60f2eca1c4326176e6196e2ee69e1bf4f72c8b5a511c90
```

Those parse as a valid YAML mapping, so they become a document `kubectl` rejects:

```
error: error validating "STDIN": error validating data: [apiVersion not set, kind not set]
```

**Server-side apply conflicts with Helm's field ownership.** Helm created the CRDs on install and owns their fields, so even with clean input the apply refuses without `--force-conflicts`.

Corrected form, with each flag carrying the reason it is there so the shorter version is not restored later:

```bash
CHART="oci://ghcr.io/googlecloudplatform/charts/k8s-aibom"
VERSION="1.3.0"   # replace with the version you are upgrading to

helm show crds "${CHART}" --version "${VERSION}" \
  | sed -n '/^---$/,$p' \
  | kubectl apply --server-side --force-conflicts -f -
```

Also uses the quoted-assignment placeholder form rather than a bare `<qualified-version>`, so the block is inert to the shell rather than a syntax error — the form #2266 specifies.

## Testing

`make lint` clean, including the MDX and doc-filename gates. Docs-only change, so no Go tests are affected.

**The corrected command was executed verbatim against a live GKE cluster** (`v1.35.6-gke`, 2 × H100), not verified by inspection:

```
customresourcedefinition.apiextensions.k8s.io/aibomcontrollerconfigs.aibom.k8saibom.dev serverside-applied
customresourcedefinition.apiextensions.k8s.io/aiboms.aibom.k8saibom.dev serverside-applied
```

Both failure modes above were reproduced first with the old command on that same cluster, so the fix addresses observed behavior rather than a suspected problem.

## How this was missed earlier

CodeRabbit raised this command on #2312 and I dismissed the concern after verifying that both CRDs *parse* out of `helm show crds` — which they do. I never piped the output to `kubectl apply`, which is where it fails. Testing a proxy for the operation instead of the operation is what let a broken command stay documented.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Documentation only, one file. The command it replaces did not work, so there is no working behavior to regress.

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, docs only
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
