### PR TITLE
feat(recipe): add generation-time runtime inventory selection

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -2622,6 +2622,13 @@ components:
                     mode:
                       type: string
                       enum: [disabled, customer-managed, aicr-provided]
+            runtimeInventory:
+              type: object
+              required: [mode]
+              properties:
+                mode:
+                  type: string
+                  enum: [enabled, disabled]
         componentRefs:
           type: array
           items:
@@ -2812,7 +2819,10 @@ components:
       allOf:
         - $ref: "#/components/schemas/RecipeResponseBase/properties/configuration"
         - type: object
-          required: [slurm]
+          # At least one section, but not any particular one: a recipe may
+          # record a runtime-inventory selection without Slurm accounting, or
+          # the reverse. Requiring `slurm` rejected the former outright.
+          minProperties: 1
           additionalProperties: false
           properties:
             slurm:
@@ -2828,6 +2838,14 @@ components:
                     mode:
                       type: string
                       enum: [disabled, customer-managed, aicr-provided]
+            runtimeInventory:
+              type: object
+              required: [mode]
+              additionalProperties: false
+              properties:
+                mode:
+                  type: string
+                  enum: [enabled, disabled]
 
     ProfileRecipeResponse:
       allOf:

--- a/docs/design/019-k8s-aibom-runtime-inventory.md
+++ b/docs/design/019-k8s-aibom-runtime-inventory.md
@@ -555,9 +555,9 @@ semantics.
 
 ## Follow-Up Decisions
 
-Three of the six requirements below are resolved by
+Four of the six requirements below are resolved by
 [Amendment: stock adoption on one GKE recipe](#amendment-stock-adoption-on-one-gke-recipe);
-one remains open, and two are planned work tracked in the epic. The list is
+the remaining two are planned work tracked in the epic. The list is
 retained as originally written; the amendment records what changed, what
 remains open, and where the rest is tracked.
 
@@ -634,25 +634,50 @@ cluster and establishing the pattern for later stock adoptions. This is
 recorded plainly rather than framed as customer demand, because the
 requirement exists to prevent adoption justified only by availability.
 
-### Still open: selection and opt-out semantics
+### E. Selection and opt-out semantics
 
-Unresolved and deliberately not decided here. `ComponentRef.IsEnabled()`
-already reads a recipe-recorded `enabled` override, which satisfies "recipe-
-recorded" and is not the bundle-time toggle Decision 2 rejects. What remains
-undecided is how a user generating from a stock recipe declines the
-component: by authoring a custom overlay using the existing mechanism, or by
-a generation-time flag that `aicr recipe` records into the emitted recipe.
+Resolved 2026-08-20. A **generation-time flag recorded in the emitted recipe**,
+modelled on the existing `--slurm-accounting-mode` selection rather than
+invented:
 
-The second shape changes the CLI contract, so it is a decision rather than an
-implementation detail. It must be resolved before the overlay change in C
-merges, and whichever shape is chosen is recorded by amending this section.
+```bash
+aicr recipe ... --runtime-inventory disabled
+```
+
+The selection is recorded as `configuration.runtimeInventory.mode`, the recipe's
+`apiVersion` becomes `ConfiguredRecipeResultAPIVersion`, and the component's ref
+carries `install: false`. `ComponentRef.IsEnabled()` already reads that key, so
+the component leaves the resolved set, the bundle, and deployment validation.
+
+This satisfies Decision 2's specific objection. A bundle-time
+`--set k8s-aibom:enabled=false` was rejected because it changes neither the
+recipe nor its health checks; here both change, and the health-check half comes
+for free because the check lives on the component's own ref rather than on a
+sibling. That is simpler than the Slurm accounting precedent, which has to
+append and omit a check on a different component.
+
+Passing the flag on a recipe that does not declare the component is an error,
+not a silent no-op. Selecting a mode there is a mistake — wrong criteria, a
+typo, a recipe that never carried it — and succeeding quietly would record a
+decision the recipe cannot honor. The check runs before the configuration is
+written, so a rejected build leaves no partial record.
+
+The same selection is available in an `AICRConfig` document at
+`spec.recipe.configuration.runtimeInventory.mode`.
+
+**Scope boundary worth naming.** This is the second entry under
+`RecipeConfiguration`, and the pattern is one bespoke selection per optional
+component. That is deliberate: this ADR asks for this component specifically,
+and a generic per-component disable would need a policy for which components
+may be declined at all — nothing should let a recipe decline `gpu-operator`.
+A third entry is the signal to revisit rather than extend by reflex.
 
 ### Requirement status
 
 | Follow-Up requirement | Status |
 |---|---|
 | Exact recipe families in scope | Resolved — C |
-| Selection and opt-out semantics | **Open** — see above |
+| Selection and opt-out semantics | Resolved — E |
 | Non-alpha storage API and migration policy | Resolved — A |
 | Concrete user-demand case | Resolved — D |
 | Managed-cluster qualification and measured cost | Planned — [#2271](https://github.com/NVIDIA/aicr/issues/2271) |

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -721,7 +721,7 @@ func resolveCommittedConfig(ctx context.Context) (retErr error) {
 	if err != nil {
 		return err
 	}
-	opts, err := cfg.RecipeResolveOptions() // spec.recipe.profile + accounting mode
+	opts, err := cfg.RecipeResolveOptions() // profile + accounting + runtime inventory
 	if err != nil {
 		return err
 	}
@@ -769,8 +769,8 @@ derive step rather than the load step.
 | `BundleVerifyOptions()` | `spec.verify.policy` + `spec.verify.trust` |
 | `RecipeSource()` | `spec.recipe.data` |
 | `RecipeCriteria(reg)` | `spec.recipe.criteria` |
-| `RecipeResolveOptions()` | `spec.recipe.profile`, `spec.recipe.configuration.slurm.accounting.mode` |
-| `RecipeProfile()` / `RecipeAccountingMode()` | the same two, raw, for callers applying their own precedence first |
+| `RecipeResolveOptions()` | `spec.recipe.profile`, `spec.recipe.configuration.slurm.accounting.mode`, `spec.recipe.configuration.runtimeInventory.mode` |
+| `RecipeProfile()` / `RecipeAccountingMode()` / `RecipeRuntimeInventoryMode()` | the same three, raw, for callers applying their own precedence first |
 | `SnapshotPath()` | `spec.recipe.input.snapshot` |
 | `IsCriteriaStrict()` | `spec.recipe.criteriaStrict` |
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -459,6 +459,7 @@ Generate recipes using direct system parameters:
 | `--platform` | | string | Platform/framework type: dynamo, kubeflow, nim, runai, slurm |
 | `--profile` | | string | Profile selection in exact `name=value` form (e.g. `gpuStack=operator-managed` on AKS or `gpuStack=driver-installer` on GKE); omit to use the declaration's default (`gpuStack=azure-managed` on AKS, `gpuStack=gke-default` on GKE) |
 | `--slurm-accounting-mode` | | string | Slurm accounting ownership: disabled (default), customer-managed, aicr-provided |
+| `--runtime-inventory` | | string | Runtime AI inventory (`k8s-aibom`) selection: `enabled`, `disabled`. Recorded in the generated recipe |
 | `--nodes` | | int | Number of GPU nodes in the cluster |
 | `--output` | `-o` | string | Output file (default: stdout) |
 | `--format` | `-t` | string | Format: json, yaml, table (default: yaml) |
@@ -534,6 +535,7 @@ target-cluster conflict detection.
 | `--platform` | | string | Explicit platform/framework type, including slurm |
 | `--profile` | | string | Profile selection in exact `name=value` form; omit to use the declaration's default |
 | `--slurm-accounting-mode` | | string | Slurm accounting ownership: disabled (default), customer-managed, aicr-provided |
+| `--runtime-inventory` | | string | Runtime AI inventory (`k8s-aibom`) selection: `enabled`, `disabled`. Recorded in the generated recipe |
 | `--output` | `-o` | string | Output destination (file, ConfigMap URI, or stdout) |
 | `--format` | `-t` | string | Format: json, yaml, table (default: yaml) |
 | `--kubeconfig` | `-k` | string | Path to kubeconfig file (used when `--snapshot` or `--output` is a ConfigMap URI; overrides KUBECONFIG env) |

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -354,6 +354,30 @@ storage. So the check catches a stranded upgrade that crosses a
 storage-version boundary, such as the 1.2.0 to 1.3.0 move this pin made, and
 does not catch one within a boundary, such as 1.0.0 to 1.2.0.
 
+**Declining the component.** When a recipe declares `k8s-aibom`, generate with
+`--runtime-inventory disabled` to leave it out:
+
+```bash
+aicr recipe --service gke --accelerator h100 --os cos --intent inference \
+  --runtime-inventory disabled -o recipe.yaml
+```
+
+The selection is recorded in the emitted recipe as
+`configuration.runtimeInventory.mode`, and the component's ref carries
+`install: false`, so the component and its health check are both absent from
+the bundle and from deployment validation. A bundle-time
+`--set k8s-aibom:enabled=false` is **not** equivalent and is not a supported
+way to decline the component: it changes neither the recipe nor its health
+checks, which is why [ADR-019](https://github.com/NVIDIA/aicr/blob/main/docs/design/019-k8s-aibom-runtime-inventory.md)
+rejects it as a selection contract.
+
+Passing the flag on a recipe that does not declare the component is an error
+rather than a silent no-op, so a wrong `--service` or a typo surfaces instead
+of producing a recipe that claims a decision it never applied.
+
+The same selection is available in an `AICRConfig` document as
+`spec.recipe.configuration.runtimeInventory.mode`.
+
 **Overriding the chart version requires overriding this assertion.** Assert
 content is static YAML with no templating, so the expected storage version is
 a literal tied to the registry's pinned chart, currently `v1beta1` for chart

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -361,12 +361,24 @@ storage. So the check catches a stranded upgrade that crosses a
 storage-version boundary, such as the 1.2.0 to 1.3.0 move this pin made, and
 does not catch one within a boundary, such as 1.0.0 to 1.2.0.
 
-**Declining the component.** When a recipe declares `k8s-aibom`, generate with
-`--runtime-inventory disabled` to leave it out:
+**Declining the component.** No stock recipe declares `k8s-aibom` today, so the
+flag applies to a recipe that adds it through a custom overlay — the shape shown
+above. Point `--data` at the directory holding that overlay and generate with
+`--runtime-inventory disabled`:
 
 ```bash
 aicr recipe --service gke --accelerator h100 --os cos --intent inference \
-  --runtime-inventory disabled -o recipe.yaml
+  --data ./my-recipes --runtime-inventory disabled -o recipe.yaml
+```
+
+Passing the flag against a recipe that does not declare the component is an
+error, not a silent no-op:
+
+```console
+$ aicr recipe --service gke --accelerator h100 --os cos --intent inference \
+    --runtime-inventory disabled
+[INVALID_REQUEST] runtime inventory mode "disabled" requires the recipe to
+declare component "k8s-aibom"; this recipe does not resolve it
 ```
 
 The selection is recorded in the emitted recipe as
@@ -378,9 +390,8 @@ way to decline the component: it changes neither the recipe nor its health
 checks, which is why [ADR-019](https://github.com/NVIDIA/aicr/blob/main/docs/design/019-k8s-aibom-runtime-inventory.md)
 rejects it as a selection contract.
 
-Passing the flag on a recipe that does not declare the component is an error
-rather than a silent no-op, so a wrong `--service` or a typo surfaces instead
-of producing a recipe that claims a decision it never applied.
+A wrong `--service` or a typo therefore surfaces instead of producing a recipe
+that claims a decision it never applied.
 
 The same selection is available in an `AICRConfig` document as
 `spec.recipe.configuration.runtimeInventory.mode`.

--- a/pkg/cli/consts.go
+++ b/pkg/cli/consts.go
@@ -37,6 +37,7 @@ const (
 	flagPlatform            = "platform"
 	flagProfile             = "profile"
 	flagSlurmAccountingMode = "slurm-accounting-mode"
+	flagRuntimeInventory    = "runtime-inventory"
 	flagNoHealth            = "no-health"
 )
 

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -96,7 +96,7 @@ Use in shell scripts:
 		Flags: queryCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if err := validateSingleValueFlags(cmd, "service", "accelerator", "intent", "os", "platform",
-				flagProfile, flagSlurmAccountingMode, "snapshot", "config", "format", "selector"); err != nil {
+				flagProfile, flagSlurmAccountingMode, flagRuntimeInventory, "snapshot", "config", "format", "selector"); err != nil {
 				return err
 			}
 
@@ -164,7 +164,7 @@ Use in shell scripts:
 func buildRecipeFromCmdWithConfig(ctx context.Context, cmd *cli.Command, cfg *appcfg.AICRConfig, client *aicr.Client) (*aicr.RecipeResult, error) {
 	reg := client.CriteriaRegistry()
 	profile := stringFlagOrConfig(cmd, flagProfile, aicr.WrapConfig(cfg).RecipeProfile())
-	resolveOpts, err := accountingResolveOptions(cmd, cfg)
+	resolveOpts, err := buildSelectionResolveOptions(cmd, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -261,6 +261,45 @@ func accountingResolveOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) ([]aicr.
 		return nil, err
 	}
 	return []aicr.RecipeResolveOption{aicr.WithAccountingMode(value)}, nil
+}
+
+// runtimeInventoryResolveOptions turns the --runtime-inventory flag, or the
+// equivalent AICRConfig field, into a resolve option. Mirrors
+// accountingResolveOptions: the flag wins, the config file is the fallback,
+// and an absent selection leaves the recipe's own declaration alone.
+func runtimeInventoryResolveOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) ([]aicr.RecipeResolveOption, error) {
+	value := cmd.String(flagRuntimeInventory)
+	if !cmd.IsSet(flagRuntimeInventory) {
+		if cfg == nil {
+			return nil, nil
+		}
+		mode, present, err := aicr.WrapConfig(cfg).RecipeRuntimeInventoryMode()
+		if err != nil {
+			return nil, err
+		}
+		if !present {
+			return nil, nil
+		}
+		value = mode
+	}
+	if _, err := recipe.ParseRuntimeInventoryMode(value); err != nil {
+		return nil, err
+	}
+	return []aicr.RecipeResolveOption{aicr.WithRuntimeInventoryMode(value)}, nil
+}
+
+// buildSelectionResolveOptions gathers every generation-time selection into one
+// option slice, so callers cannot wire one and forget the other.
+func buildSelectionResolveOptions(cmd *cli.Command, cfg *appcfg.AICRConfig) ([]aicr.RecipeResolveOption, error) {
+	opts, err := accountingResolveOptions(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+	riOpts, err := runtimeInventoryResolveOptions(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return append(opts, riOpts...), nil
 }
 
 // statedDimensions converts the touched set into the argument

--- a/pkg/cli/query_test.go
+++ b/pkg/cli/query_test.go
@@ -325,6 +325,13 @@ func TestRecipeAndQueryCommandsRejectInvalidRuntimeInventoryMode(t *testing.T) {
 			if err == nil {
 				t.Fatal("command error = nil, want rejection of an invalid runtime inventory mode")
 			}
+			// Assert the code, since that is what callers branch on; a text
+			// match alone would accept an unrelated error carrying similar
+			// wording. The message check stays to distinguish which
+			// invalid-request this is.
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("command error = %v, want ErrCodeInvalidRequest", err)
+			}
 			if !strings.Contains(err.Error(), "invalid runtime inventory mode") {
 				t.Fatalf("command error = %v, want an invalid-mode rejection", err)
 			}
@@ -343,6 +350,9 @@ func TestRecipeCommandRejectsRuntimeInventoryWithoutComponent(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("command error = nil, want rejection for a recipe that does not declare the component")
+	}
+	if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+		t.Errorf("command error = %v, want ErrCodeInvalidRequest", err)
 	}
 	if !strings.Contains(err.Error(), "requires the recipe to declare component") {
 		t.Fatalf("command error = %v, want the missing-component rejection", err)

--- a/pkg/cli/query_test.go
+++ b/pkg/cli/query_test.go
@@ -291,3 +291,60 @@ spec:
 	}
 	return dir
 }
+
+// TestRecipeAndQueryCommandsRejectInvalidRuntimeInventoryMode exercises
+// runtimeInventoryResolveOptions' flag-set branch on both commands that expose
+// the flag.
+//
+// Without this the function is covered only by its "flag unset and no config"
+// fallthrough, which returns before touching the value — so a parse or wiring
+// defect in the branch operators actually use would not be observed.
+func TestRecipeAndQueryCommandsRejectInvalidRuntimeInventoryMode(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  func() *cli.Command
+		args []string
+	}{
+		{
+			name: "recipe",
+			cmd:  recipeCmd,
+			args: []string{"recipe", "--service", "eks", "--runtime-inventory", "off"},
+		},
+		{
+			name: "query",
+			cmd:  queryCmd,
+			args: []string{
+				"query", "--service", "eks", "--selector", "deploymentOrder",
+				"--runtime-inventory", "off",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd().Run(t.Context(), tt.args)
+			if err == nil {
+				t.Fatal("command error = nil, want rejection of an invalid runtime inventory mode")
+			}
+			if !strings.Contains(err.Error(), "invalid runtime inventory mode") {
+				t.Fatalf("command error = %v, want an invalid-mode rejection", err)
+			}
+		})
+	}
+}
+
+// TestRecipeCommandRejectsRuntimeInventoryWithoutComponent covers the flag-set
+// branch reaching a successful parse and then failing closed at build time,
+// which is the path an operator hits after a typo in --service.
+func TestRecipeCommandRejectsRuntimeInventoryWithoutComponent(t *testing.T) {
+	err := recipeCmd().Run(t.Context(), []string{
+		"recipe", "--service", "gke", "--accelerator", "h100",
+		"--os", "cos", "--intent", "inference",
+		"--runtime-inventory", "disabled",
+	})
+	if err == nil {
+		t.Fatal("command error = nil, want rejection for a recipe that does not declare the component")
+	}
+	if !strings.Contains(err.Error(), "requires the recipe to declare component") {
+		t.Fatalf("command error = %v, want the missing-component rejection", err)
+	}
+}

--- a/pkg/cli/recipe.go
+++ b/pkg/cli/recipe.go
@@ -76,6 +76,14 @@ func recipeCmdFlags() []cli.Flag {
 			Usage:    fmt.Sprintf("Slurm accounting ownership mode (%s)", strings.Join(recipe.AccountingModes(), ", ")),
 			Category: catQueryParameters,
 		}, recipe.AccountingModes),
+		withCompletions(&cli.StringFlag{
+			Name: flagRuntimeInventory,
+			Usage: fmt.Sprintf(
+				"Runtime AI inventory (k8s-aibom) selection (%s). Recorded in the generated recipe; "+
+					"disabling removes the component and its health check",
+				strings.Join(recipe.RuntimeInventoryModes(), ", ")),
+			Category: catQueryParameters,
+		}, recipe.RuntimeInventoryModes),
 		&cli.IntFlag{
 			Name:     "nodes",
 			Usage:    "Number of worker/GPU nodes in the cluster",
@@ -149,7 +157,7 @@ Override snapshot-detected criteria:
 		Flags: recipeCmdFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if err := validateSingleValueFlags(cmd, flagService, flagAccelerator, flagIntent, flagOS,
-				flagPlatform, flagProfile, flagSlurmAccountingMode, "snapshot", "config", flagOutput,
+				flagPlatform, flagProfile, flagSlurmAccountingMode, flagRuntimeInventory, "snapshot", "config", flagOutput,
 				flagFormat); err != nil {
 				return err
 			}

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -859,10 +859,14 @@ func recipeBuildOptions(opts ...RecipeResolveOption) (*recipeResolveConfig, []re
 	if err != nil {
 		return nil, nil, err
 	}
-	if cfg.accountingMode == nil {
-		return cfg, nil, nil
+	var buildOpts []recipe.BuildOption
+	if cfg.accountingMode != nil {
+		buildOpts = append(buildOpts, recipe.WithAccountingMode(*cfg.accountingMode))
 	}
-	return cfg, []recipe.BuildOption{recipe.WithAccountingMode(*cfg.accountingMode)}, nil
+	if cfg.runtimeInventoryMode != nil {
+		buildOpts = append(buildOpts, recipe.WithRuntimeInventoryMode(*cfg.runtimeInventoryMode))
+	}
+	return cfg, buildOpts, nil
 }
 
 func resolveRecipeConfig(opts ...RecipeResolveOption) (*recipeResolveConfig, error) {

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -2530,11 +2530,30 @@ func TestResolveRecipeRuntimeInventoryMode(t *testing.T) {
 		}
 	})
 
+	// Deliberately NOT the gke/h100/cos/inference combination. That is the
+	// recipe #2271 will eventually add k8s-aibom to, so a test asserting
+	// "this recipe does not declare the component" would silently invert into
+	// asserting the opposite once the overlay lands, still passing for the
+	// wrong reason. A training recipe is not the stock-adoption target.
 	criteria := &recipe.Criteria{
-		Service:     recipe.CriteriaServiceGKE,
+		Service:     recipe.CriteriaServiceEKS,
 		Accelerator: recipe.CriteriaAcceleratorH100,
-		Intent:      recipe.CriteriaIntentInference,
-		OS:          recipe.CriteriaOSCOS,
+		Intent:      recipe.CriteriaIntentTraining,
+		OS:          recipe.CriteriaOSUbuntu,
+	}
+
+	// Pin the precondition so this fails loudly rather than quietly changing
+	// meaning if the component is ever added to the recipe above.
+	baseline, baseErr := client.ResolveRecipeFromCriteriaWithOptions(
+		t.Context(), aicr.WrapCriteria(criteria))
+	if baseErr != nil {
+		t.Fatalf("baseline resolve error = %v", baseErr)
+	}
+	for _, ref := range baseline.Resolved().ComponentRefs {
+		if ref.Name == "k8s-aibom" {
+			t.Fatal("the chosen criteria now declare k8s-aibom; pick criteria that do not, " +
+				"or this test asserts the opposite of what it claims")
+		}
 	}
 
 	for _, tt := range []struct {

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -2511,3 +2511,56 @@ func TestSnapshotUnwrapRoundTrips(t *testing.T) {
 		t.Errorf("WrapSnapshot() populated Raw (%d bytes); only CollectSnapshot sets it", len(wrapped.Raw))
 	}
 }
+
+// TestResolveRecipeRuntimeInventoryMode mirrors TestResolveRecipeAccountingMode
+// and exercises the facade option through a real resolve rather than asserting
+// the option value is non-nil.
+//
+// No stock recipe declares the component, so the observable outcome for a stock
+// resolve is the fail-closed rejection. That is the contract worth pinning: a
+// selection the recipe cannot honor must surface rather than be recorded.
+func TestResolveRecipeRuntimeInventoryMode(t *testing.T) {
+	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.EmbeddedSource()))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := client.Close(); closeErr != nil {
+			t.Errorf("Close() error = %v", closeErr)
+		}
+	})
+
+	criteria := &recipe.Criteria{
+		Service:     recipe.CriteriaServiceGKE,
+		Accelerator: recipe.CriteriaAcceleratorH100,
+		Intent:      recipe.CriteriaIntentInference,
+		OS:          recipe.CriteriaOSCOS,
+	}
+
+	for _, tt := range []struct {
+		name    string
+		mode    string
+		wantErr bool
+	}{
+		{name: "invalid mode is rejected", mode: "off", wantErr: true},
+		{name: "empty mode is rejected", mode: "", wantErr: true},
+		{
+			// Valid value, but no stock recipe declares the component, so the
+			// build must refuse rather than record a mode it cannot apply.
+			name: "valid mode on a recipe without the component is rejected",
+			mode: "disabled", wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, resolveErr := client.ResolveRecipeFromCriteriaWithOptions(
+				t.Context(),
+				aicr.WrapCriteria(criteria),
+				aicr.WithRuntimeInventoryMode(tt.mode),
+			)
+			if (resolveErr != nil) != tt.wantErr {
+				t.Fatalf("ResolveRecipeFromCriteriaWithOptions() error = %v, wantErr %v",
+					resolveErr, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/client/v1/config.go
+++ b/pkg/client/v1/config.go
@@ -269,6 +269,22 @@ func (c *Config) RecipeAccountingMode() (string, bool, error) {
 	return string(mode), set, nil
 }
 
+// RecipeRuntimeInventoryMode returns
+// spec.recipe.configuration.runtimeInventory.mode and whether the document set
+// one. Same raw-accessor rationale as RecipeAccountingMode.
+//
+// Returns an error when the configured value is not a valid mode.
+func (c *Config) RecipeRuntimeInventoryMode() (string, bool, error) {
+	if c == nil || c.internal == nil {
+		return "", false, nil
+	}
+	mode, set, err := c.internal.Recipe().ResolveRuntimeInventoryMode()
+	if err != nil {
+		return "", false, err
+	}
+	return string(mode), set, nil
+}
+
 // SnapshotPath returns spec.recipe.input.snapshot, the snapshot a committed
 // config resolves against. Empty when unset; hand a non-empty value to
 // Client.LoadSnapshot.

--- a/pkg/client/v1/config.go
+++ b/pkg/client/v1/config.go
@@ -236,6 +236,18 @@ func (c *Config) RecipeResolveOptions() ([]RecipeResolveOption, error) {
 	if set {
 		out = append(out, WithAccountingMode(string(mode)))
 	}
+
+	// Every generation-time selection must be projected here. This method is
+	// the canonical config-to-options conversion for SDK callers, so omitting
+	// one silently drops it for anyone who configures it in a document rather
+	// than through an option.
+	riMode, riSet, err := spec.ResolveRuntimeInventoryMode()
+	if err != nil {
+		return nil, err
+	}
+	if riSet {
+		out = append(out, WithRuntimeInventoryMode(string(riMode)))
+	}
 	return out, nil
 }
 

--- a/pkg/client/v1/config_test.go
+++ b/pkg/client/v1/config_test.go
@@ -616,3 +616,57 @@ spec:
 		t.Error("RecipeCriteria accepted a value in no catalog; deferral must not mean silent acceptance")
 	}
 }
+
+const runtimeInventoryConfig = `apiVersion: aicr.run/v1alpha2
+kind: AICRConfig
+metadata:
+  name: test
+spec:
+  recipe:
+    configuration:
+      runtimeInventory:
+        mode: disabled
+`
+
+// TestConfig_RuntimeInventoryMode covers the raw accessor and, more
+// importantly, that RecipeResolveOptions projects the selection.
+//
+// The projection is the defect this guards. RecipeResolveOptions is the
+// canonical config-to-options conversion for SDK callers, so a selection
+// readable through the raw accessor but missing from the options form is
+// silently dropped for anyone who configures it in a document rather than
+// passing an option — with no error to notice.
+func TestConfig_RuntimeInventoryMode(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, runtimeInventoryConfig))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	mode, set, err := cfg.RecipeRuntimeInventoryMode()
+	if err != nil {
+		t.Fatalf("RecipeRuntimeInventoryMode: %v", err)
+	}
+	if !set {
+		t.Fatal("RecipeRuntimeInventoryMode reported unset, but the document configures one")
+	}
+	if mode != "disabled" {
+		t.Errorf("RecipeRuntimeInventoryMode = %q, want disabled", mode)
+	}
+
+	opts, err := cfg.RecipeResolveOptions()
+	if err != nil {
+		t.Fatalf("RecipeResolveOptions: %v", err)
+	}
+	if len(opts) == 0 {
+		t.Fatal("RecipeResolveOptions returned no options; the runtime inventory selection was dropped")
+	}
+
+	// A nil Config must stay quiet rather than panic, matching the sibling
+	// accessors.
+	var nilCfg *aicr.Config
+	if _, set, err := nilCfg.RecipeRuntimeInventoryMode(); err != nil || set {
+		t.Errorf("nil Config: set=%v err=%v, want false/nil", set, err)
+	}
+}

--- a/pkg/client/v1/types.go
+++ b/pkg/client/v1/types.go
@@ -326,8 +326,9 @@ type RecipeRequest struct {
 type RecipeResolveOption func(*recipeResolveConfig)
 
 type recipeResolveConfig struct {
-	profile        string
-	accountingMode *recipe.AccountingMode
+	profile              string
+	accountingMode       *recipe.AccountingMode
+	runtimeInventoryMode *recipe.RuntimeInventoryMode
 
 	// relaxDerived records that WithSnapshotCriteriaRelaxation was passed.
 	// Kept separate from stated because an empty stated set is meaningful
@@ -371,6 +372,26 @@ func WithAccountingMode(mode string) RecipeResolveOption {
 			return
 		}
 		cfg.accountingMode = &parsed
+	}
+}
+
+// WithRuntimeInventoryMode selects whether the runtime AI inventory component
+// is installed by a criteria- or snapshot-based resolve call. It is valid only
+// when the resolved recipe declares that component; an empty or invalid mode is
+// rejected when the resolve call runs. Omit this option to keep the recipe's
+// own declaration.
+//
+// Unlike a bundle-time value override, the selection is recorded in the emitted
+// recipe and removes the component's health check along with the component,
+// which is the contract ADR-019 requires for stock adoption.
+func WithRuntimeInventoryMode(mode string) RecipeResolveOption {
+	return func(cfg *recipeResolveConfig) {
+		parsed, err := recipe.ParseRuntimeInventoryMode(mode)
+		if err != nil {
+			cfg.recordOptErr(err)
+			return
+		}
+		cfg.runtimeInventoryMode = &parsed
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,6 +127,15 @@ type RecipeSpec struct {
 // participate in recipe catalog matching.
 type RecipeConfigurationSpec struct {
 	Slurm *SlurmConfigurationSpec `yaml:"slurm,omitempty" json:"slurm,omitempty"`
+
+	// RuntimeInventory selects whether the runtime AI inventory component
+	// (k8s-aibom) is installed. Mirrors the --runtime-inventory flag.
+	RuntimeInventory *RuntimeInventorySpec `yaml:"runtimeInventory,omitempty" json:"runtimeInventory,omitempty"`
+}
+
+// RuntimeInventorySpec contains the runtime AI inventory selection.
+type RuntimeInventorySpec struct {
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
 }
 
 // SlurmConfigurationSpec contains Slurm-specific desired-state inputs.

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -828,6 +828,24 @@ func (r *RecipeSpec) ResolveAccountingMode() (recipe.AccountingMode, bool, error
 	return mode, true, nil
 }
 
+// ResolveRuntimeInventoryMode parses
+// spec.recipe.configuration.runtimeInventory.mode. The bool reports whether the
+// field was explicitly present; absence leaves the recipe's own declaration
+// alone rather than materializing a default, because unlike Slurm accounting
+// there is no meaningful "off by default" for a component the recipe may not
+// declare at all.
+func (r *RecipeSpec) ResolveRuntimeInventoryMode() (recipe.RuntimeInventoryMode, bool, error) {
+	if r == nil || r.Configuration == nil || r.Configuration.RuntimeInventory == nil {
+		return "", false, nil
+	}
+	mode, err := recipe.ParseRuntimeInventoryMode(r.Configuration.RuntimeInventory.Mode)
+	if err != nil {
+		return "", false, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
+			"invalid spec.recipe.configuration.runtimeInventory.mode")
+	}
+	return mode, true, nil
+}
+
 // boolPtrOrFalse dereferences a *bool, treating nil (absent in
 // YAML/JSON) as false. Used at the spec → resolved boundary so the
 // resolved layer can stay plain bool for downstream consumers.

--- a/pkg/config/runtimeinventory_test.go
+++ b/pkg/config/runtimeinventory_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+)
+
+// TestRecipeSpecResolveRuntimeInventoryMode mirrors
+// TestRecipeSpecResolveAccountingMode. The presence bool matters as much as the
+// value: absence must leave the recipe's own declaration alone rather than
+// materializing a default, since unlike Slurm accounting there is no meaningful
+// "off by default" for a component the recipe may not declare at all.
+func TestRecipeSpecResolveRuntimeInventoryMode(t *testing.T) {
+	t.Parallel()
+
+	specWith := func(mode string) *RecipeSpec {
+		return &RecipeSpec{
+			Configuration: &RecipeConfigurationSpec{
+				RuntimeInventory: &RuntimeInventorySpec{Mode: mode},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		spec        *RecipeSpec
+		want        recipe.RuntimeInventoryMode
+		wantPresent bool
+		wantErr     bool
+	}{
+		{name: "nil spec"},
+		{name: "absent configuration", spec: &RecipeSpec{}},
+		{
+			name: "configuration without the block",
+			spec: &RecipeSpec{Configuration: &RecipeConfigurationSpec{}},
+		},
+		{
+			name: "enabled", spec: specWith("enabled"),
+			want: recipe.RuntimeInventoryEnabled, wantPresent: true,
+		},
+		{
+			name: "disabled", spec: specWith("disabled"),
+			want: recipe.RuntimeInventoryDisabled, wantPresent: true,
+		},
+		{name: "explicit empty is invalid", spec: specWith(""), wantErr: true},
+		{name: "unknown value", spec: specWith("off"), wantErr: true},
+		{name: "wrong case", spec: specWith("Disabled"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, present, err := tt.spec.ResolveRuntimeInventoryMode()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveRuntimeInventoryMode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				// The wrapped code is what callers branch on, so assert it
+				// rather than merely that some error occurred.
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Errorf("error = %v, want ErrCodeInvalidRequest", err)
+				}
+				if present {
+					t.Error("present = true on error; callers must not act on a rejected value")
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("mode = %q, want %q", got, tt.want)
+			}
+			if present != tt.wantPresent {
+				t.Errorf("present = %v, want %v", present, tt.wantPresent)
+			}
+		})
+	}
+}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -131,6 +131,9 @@ func (r *RecipeSpec) validate() error {
 		return errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
 			"invalid spec.recipe.profile")
 	}
+	if _, _, err := r.ResolveRuntimeInventoryMode(); err != nil {
+		return err
+	}
 	if _, _, err := r.ResolveAccountingMode(); err != nil {
 		return err
 	}

--- a/pkg/recipe/accounting.go
+++ b/pkg/recipe/accounting.go
@@ -223,10 +223,16 @@ func applyBuildConfig(result *RecipeResult, cfg *buildConfig) error {
 	if err := validateAccountingProfileOwnership(result, mode); err != nil {
 		return err
 	}
-	result.Configuration = &RecipeConfiguration{
-		Slurm: &SlurmConfiguration{
-			Accounting: &SlurmAccountingConfiguration{Mode: mode},
-		},
+	// Update in place rather than assigning a fresh RecipeConfiguration:
+	// another selection may already have recorded its own section, and
+	// replacing the struct would silently discard it while leaving that
+	// selection's component overrides applied. A recipe that acts on a
+	// decision it no longer records is worse than one that never made it.
+	if result.Configuration == nil {
+		result.Configuration = &RecipeConfiguration{}
+	}
+	result.Configuration.Slurm = &SlurmConfiguration{
+		Accounting: &SlurmAccountingConfiguration{Mode: mode},
 	}
 	result.APIVersion = ConfiguredRecipeResultAPIVersion
 

--- a/pkg/recipe/accounting.go
+++ b/pkg/recipe/accounting.go
@@ -210,12 +210,20 @@ func applyBuildConfig(result *RecipeResult, cfg *buildConfig) error {
 	if result == nil || cfg == nil {
 		return nil
 	}
+	selected := false
 	if cfg.runtimeInventoryMode != nil {
 		if err := applyRuntimeInventoryMode(result, *cfg.runtimeInventoryMode); err != nil {
 			return err
 		}
+		selected = true
 	}
 	if cfg.accountingMode == nil {
+		// Deployment order still has to be refreshed: a selection that ran
+		// above may have disabled a component, and the accounting path's own
+		// recompute is not reached on this branch.
+		if selected {
+			return recomputeDeploymentOrder(result)
+		}
 		return nil
 	}
 
@@ -257,11 +265,23 @@ func applyBuildConfig(result *RecipeResult, cfg *buildConfig) error {
 			return err
 		}
 	}
-	accountingSpec := &RecipeMetadataSpec{ComponentRefs: result.ComponentRefs}
-	deploymentOrder, err := accountingSpec.TopologicalSort()
+	return recomputeDeploymentOrder(result)
+}
+
+// recomputeDeploymentOrder refreshes DeploymentOrder after a selection has
+// changed which components are enabled.
+//
+// TopologicalSort emits enabled components only, so a selection that disables
+// one without recomputing leaves the disabled component listed in the emitted
+// recipe's deploymentOrder. The bundler re-filters by IsEnabled, so nothing
+// mis-deploys, but the artifact contradicts itself and `aicr query --selector
+// deploymentOrder` reports a component the same document marks disabled.
+func recomputeDeploymentOrder(result *RecipeResult) error {
+	spec := &RecipeMetadataSpec{ComponentRefs: result.ComponentRefs}
+	deploymentOrder, err := spec.TopologicalSort()
 	if err != nil {
 		return errors.PropagateOrWrap(err, errors.ErrCodeInternal,
-			"failed to recompute deployment order after applying Slurm accounting mode")
+			"failed to recompute deployment order after applying a build selection")
 	}
 	result.DeploymentOrder = deploymentOrder
 	return nil

--- a/pkg/recipe/accounting.go
+++ b/pkg/recipe/accounting.go
@@ -70,6 +70,16 @@ func ParseAccountingMode(value string) (AccountingMode, error) {
 // resolved recipe without participating in catalog matching.
 type RecipeConfiguration struct {
 	Slurm *SlurmConfiguration `json:"slurm,omitempty" yaml:"slurm,omitempty"`
+
+	// RuntimeInventory records the generation-time selection for the runtime
+	// AI inventory component. See runtimeinventory.go.
+	//
+	// This is the second entry here, and the pattern is one bespoke selection
+	// per optional component. That is deliberate for two (ADR-019 asks for
+	// this component specifically, and a generic per-component disable needs
+	// a policy for which components may be declined at all). If a third
+	// arrives, revisit rather than extending by reflex.
+	RuntimeInventory *RuntimeInventoryConfiguration `json:"runtimeInventory,omitempty" yaml:"runtimeInventory,omitempty"`
 }
 
 // SlurmConfiguration records Slurm-specific desired state.
@@ -86,7 +96,8 @@ type SlurmAccountingConfiguration struct {
 type BuildOption func(*buildConfig)
 
 type buildConfig struct {
-	accountingMode *AccountingMode
+	accountingMode       *AccountingMode
+	runtimeInventoryMode *RuntimeInventoryMode
 }
 
 // WithAccountingMode selects the Slurm accounting ownership mode for one
@@ -196,7 +207,15 @@ func validateAccountingProfileOwnership(result *RecipeResult, mode AccountingMod
 }
 
 func applyBuildConfig(result *RecipeResult, cfg *buildConfig) error {
-	if result == nil || cfg == nil || cfg.accountingMode == nil {
+	if result == nil || cfg == nil {
+		return nil
+	}
+	if cfg.runtimeInventoryMode != nil {
+		if err := applyRuntimeInventoryMode(result, *cfg.runtimeInventoryMode); err != nil {
+			return err
+		}
+	}
+	if cfg.accountingMode == nil {
 		return nil
 	}
 

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -1181,6 +1181,14 @@ func (r *RecipeResult) DeepCopy() *RecipeResult {
 				out.Configuration.Slurm.Accounting = &accounting
 			}
 		}
+		// Every pointer under RecipeConfiguration needs a clause here.
+		// Omitting one does not alias it, it drops it: the copy keeps the
+		// component overrides a selection applied while losing the record
+		// explaining them, and Client.AdoptRecipe always deep-copies.
+		if r.Configuration.RuntimeInventory != nil {
+			runtimeInventory := *r.Configuration.RuntimeInventory
+			out.Configuration.RuntimeInventory = &runtimeInventory
+		}
 	}
 
 	if r.Constraints != nil {

--- a/pkg/recipe/query.go
+++ b/pkg/recipe/query.go
@@ -102,6 +102,14 @@ func HydrateResultWithContext(ctx context.Context, result *RecipeResult) (map[st
 			}
 			configuration["slurm"] = slurm
 		}
+		// Every section of RecipeConfiguration must be projected here or the
+		// decision is invisible to `aicr query --selector` and absent from
+		// hydrated output, even though the recipe records it.
+		if result.Configuration.RuntimeInventory != nil {
+			configuration["runtimeInventory"] = map[string]any{
+				"mode": string(result.Configuration.RuntimeInventory.Mode),
+			}
+		}
 		hydrated["configuration"] = configuration
 	}
 

--- a/pkg/recipe/runtimeinventory.go
+++ b/pkg/recipe/runtimeinventory.go
@@ -126,6 +126,25 @@ func applyRuntimeInventoryMode(result *RecipeResult, mode RuntimeInventoryMode) 
 	// separate bookkeeping. That is the half ADR-019 says a bundle-time
 	// override cannot deliver.
 	install := parsed == RuntimeInventoryEnabled
-	return setComponentOverride(result, runtimeInventoryComponentName,
-		map[string]any{componentInstallOverrideKey: install})
+	if err := setComponentOverride(result, runtimeInventoryComponentName,
+		map[string]any{componentInstallOverrideKey: install}); err != nil {
+		return err
+	}
+
+	// Confirm the selection actually took effect rather than trusting the key
+	// we just wrote. IsEnabled fails closed on either the `enabled` or the
+	// `install` override, so an overlay that already set `enabled: false`
+	// leaves the component disabled while this records mode: enabled — a
+	// recipe stating a decision it does not implement. Compare the resolved
+	// predicate, not the key.
+	ref := result.GetComponentRef(runtimeInventoryComponentName)
+	if ref.IsEnabled() != install {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("runtime inventory mode %q cannot be applied to component %q: "+
+				"another override in the resolved recipe holds it %s; "+
+				"remove that override or drop the mode",
+				parsed, runtimeInventoryComponentName,
+				map[bool]string{true: "enabled", false: "disabled"}[ref.IsEnabled()]))
+	}
+	return nil
 }

--- a/pkg/recipe/runtimeinventory.go
+++ b/pkg/recipe/runtimeinventory.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// runtimeInventoryComponentName is the component this selection controls.
+// Named as a constant rather than inlined so the coupling between the recipe
+// configuration and the registry entry is greppable from both ends.
+const runtimeInventoryComponentName = "k8s-aibom"
+
+// RuntimeInventoryMode is the generation-time selection for the runtime AI
+// inventory component.
+//
+// ADR-019 requires stock adoption to carry "generation-time, recipe-recorded
+// selection and opt-out semantics", and explicitly rejects a bundle-time
+// `--set k8s-aibom:enabled=false` because that changes neither the recipe nor
+// its health checks. This mode is recorded in the emitted recipe and takes the
+// component (and therefore its health check) out of the resolved set, which is
+// the contract that objection asks for.
+type RuntimeInventoryMode string
+
+const (
+	// RuntimeInventoryEnabled keeps the component the recipe declares.
+	RuntimeInventoryEnabled RuntimeInventoryMode = "enabled"
+	// RuntimeInventoryDisabled removes it from the resolved recipe.
+	RuntimeInventoryDisabled RuntimeInventoryMode = "disabled"
+)
+
+// RuntimeInventoryModes returns the accepted values, for CLI help and
+// validation messages.
+func RuntimeInventoryModes() []string {
+	return []string{
+		string(RuntimeInventoryEnabled),
+		string(RuntimeInventoryDisabled),
+	}
+}
+
+// ParseRuntimeInventoryMode validates a mode string. Matching is exact:
+// accepting case variants would let a config file and a flag disagree about
+// what "Disabled" means.
+func ParseRuntimeInventoryMode(value string) (RuntimeInventoryMode, error) {
+	switch RuntimeInventoryMode(value) {
+	case RuntimeInventoryEnabled, RuntimeInventoryDisabled:
+		return RuntimeInventoryMode(value), nil
+	default:
+		return "", errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid runtime inventory mode %q: must be one of %s",
+				value, strings.Join(RuntimeInventoryModes(), ", ")))
+	}
+}
+
+// RuntimeInventoryConfiguration records the selected mode in the recipe.
+type RuntimeInventoryConfiguration struct {
+	Mode RuntimeInventoryMode `json:"mode" yaml:"mode"`
+}
+
+// WithRuntimeInventoryMode selects the runtime inventory mode for one build.
+// The value is validated again at the build boundary.
+func WithRuntimeInventoryMode(mode RuntimeInventoryMode) BuildOption {
+	return func(cfg *buildConfig) {
+		cfg.runtimeInventoryMode = &mode
+	}
+}
+
+// RuntimeInventoryMode reports the recorded mode, and whether the recipe
+// records one at all. A recipe built without the selection records nothing,
+// so a stock recipe is byte-identical to one generated before this existed.
+func (r *RecipeResult) RuntimeInventoryMode() (RuntimeInventoryMode, bool) {
+	if r == nil || r.Configuration == nil || r.Configuration.RuntimeInventory == nil {
+		return "", false
+	}
+	return r.Configuration.RuntimeInventory.Mode, true
+}
+
+// applyRuntimeInventoryMode records the selection and takes the component out
+// of the resolved set when disabled.
+//
+// Unlike the Slurm accounting selection, which can be validated from criteria
+// alone (platform=slurm), this one depends on whether the resolved recipe
+// actually declares the component, so the guard lives here rather than in
+// resolveBuildConfig.
+func applyRuntimeInventoryMode(result *RecipeResult, mode RuntimeInventoryMode) error {
+	parsed, err := ParseRuntimeInventoryMode(string(mode))
+	if err != nil {
+		return err
+	}
+
+	// Fail closed on a recipe that never declares the component. Selecting a
+	// mode here is a mistake — wrong criteria, a typo, a recipe that simply
+	// does not carry it — and silently succeeding would record a decision the
+	// recipe cannot honor. Checked before Configuration is written so a
+	// rejected build leaves no partial record.
+	if result.GetComponentRef(runtimeInventoryComponentName) == nil {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("runtime inventory mode %q requires the recipe to declare component %q; "+
+				"this recipe does not resolve it",
+				parsed, runtimeInventoryComponentName))
+	}
+
+	if result.Configuration == nil {
+		result.Configuration = &RecipeConfiguration{}
+	}
+	result.Configuration.RuntimeInventory = &RuntimeInventoryConfiguration{Mode: parsed}
+	result.APIVersion = ConfiguredRecipeResultAPIVersion
+
+	// The component's health check lives on this same ref, so disabling the
+	// component removes its check from deployment validation without any
+	// separate bookkeeping. That is the half ADR-019 says a bundle-time
+	// override cannot deliver.
+	install := parsed == RuntimeInventoryEnabled
+	return setComponentOverride(result, runtimeInventoryComponentName,
+		map[string]any{componentInstallOverrideKey: install})
+}

--- a/pkg/recipe/runtimeinventory_test.go
+++ b/pkg/recipe/runtimeinventory_test.go
@@ -237,10 +237,16 @@ func TestWithRuntimeInventoryModeOption(t *testing.T) {
 		t.Errorf("mode = %q, want %q", *cfg.runtimeInventoryMode, RuntimeInventoryDisabled)
 	}
 
-	// A nil option must be tolerated the way resolveBuildConfig expects.
+	// A nil option must be tolerated by the code that applies options, not
+	// merely be nil. Asserting the local variable is nil is a tautology and
+	// would still pass if resolveBuildConfig invoked it and panicked.
 	var nilOpt BuildOption
-	if nilOpt != nil {
-		t.Fatal("expected a nil BuildOption")
+	got, err := resolveBuildConfig(nil, nilOpt, WithRuntimeInventoryMode(RuntimeInventoryEnabled))
+	if err != nil {
+		t.Fatalf("resolveBuildConfig() with a nil option error = %v", err)
+	}
+	if got.runtimeInventoryMode == nil || *got.runtimeInventoryMode != RuntimeInventoryEnabled {
+		t.Errorf("a nil option interfered with the following option: %v", got.runtimeInventoryMode)
 	}
 }
 

--- a/pkg/recipe/runtimeinventory_test.go
+++ b/pkg/recipe/runtimeinventory_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recipe
+
+import "testing"
+
+// runtimeInventoryTestResult is a minimal recipe that declares the runtime
+// inventory component alongside an unrelated one, so a case can tell "the
+// selection dropped k8s-aibom" from "the selection dropped everything".
+func runtimeInventoryTestResult() *RecipeResult {
+	return &RecipeResult{
+		Kind:       RecipeResultKind,
+		APIVersion: "aicr.run/v1alpha2",
+		ComponentRefs: []ComponentRef{
+			{Name: "gpu-operator", Type: ComponentTypeHelm, Namespace: "gpu-operator"},
+			{
+				Name:               runtimeInventoryComponentName,
+				Type:               ComponentTypeHelm,
+				Namespace:          "k8s-aibom-system",
+				HealthCheckAsserts: "apiVersion: chainsaw.kyverno.io/v1alpha1\nkind: Test\n",
+			},
+		},
+	}
+}
+
+func TestParseRuntimeInventoryMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    RuntimeInventoryMode
+		wantErr bool
+	}{
+		{name: "enabled", input: "enabled", want: RuntimeInventoryEnabled},
+		{name: "disabled", input: "disabled", want: RuntimeInventoryDisabled},
+		{name: "empty", input: "", wantErr: true},
+		{name: "unknown", input: "off", wantErr: true},
+		{name: "wrong case", input: "Disabled", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseRuntimeInventoryMode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseRuntimeInventoryMode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseRuntimeInventoryMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestApplyBuildConfigRuntimeInventory covers the ADR-019 requirement that
+// stock adoption carry "generation-time, recipe-recorded selection and opt-out
+// semantics". A bundle-time --set was rejected there because it changes
+// neither the recipe nor its health checks, so both are asserted here.
+func TestApplyBuildConfigRuntimeInventory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mode          *RuntimeInventoryMode
+		wantRecorded  bool
+		wantInstalled bool
+	}{
+		{
+			// No flag: the overlay's own declaration stands and the recipe
+			// records nothing, so a stock recipe is unchanged by this feature.
+			name: "absent leaves the recipe untouched", mode: nil,
+			wantRecorded: false, wantInstalled: true,
+		},
+		{
+			name: "enabled records the decision", mode: modePtr(RuntimeInventoryEnabled),
+			wantRecorded: true, wantInstalled: true,
+		},
+		{
+			name: "disabled removes the component", mode: modePtr(RuntimeInventoryDisabled),
+			wantRecorded: true, wantInstalled: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := runtimeInventoryTestResult()
+			if err := applyBuildConfig(result, &buildConfig{runtimeInventoryMode: tt.mode}); err != nil {
+				t.Fatalf("applyBuildConfig() error = %v", err)
+			}
+
+			gotMode, present := result.RuntimeInventoryMode()
+			if present != tt.wantRecorded {
+				t.Fatalf("RuntimeInventoryMode() present = %v, want %v", present, tt.wantRecorded)
+			}
+			if tt.wantRecorded {
+				if gotMode != *tt.mode {
+					t.Errorf("recorded mode = %q, want %q", gotMode, *tt.mode)
+				}
+				// A recipe carrying configuration must say so in its
+				// apiVersion, or a consumer cannot tell it apart from a
+				// plain resolved recipe.
+				if result.APIVersion != ConfiguredRecipeResultAPIVersion {
+					t.Errorf("APIVersion = %q, want %q", result.APIVersion, ConfiguredRecipeResultAPIVersion)
+				}
+			}
+
+			ref := result.GetComponentRef(runtimeInventoryComponentName)
+			if ref == nil {
+				t.Fatalf("%s ref missing entirely; selection must disable it, not delete it",
+					runtimeInventoryComponentName)
+			}
+			if got := ref.IsEnabled(); got != tt.wantInstalled {
+				t.Errorf("IsEnabled() = %v, want %v (overrides: %v)", got, tt.wantInstalled, ref.Overrides)
+			}
+
+			// The health check travels with the component: it lives on the
+			// same ref, so disabling the component takes its check out of
+			// deployment validation. This is the half a bundle-time --set
+			// could not achieve.
+			if !tt.wantInstalled && ref.IsEnabled() {
+				t.Error("component still enabled, so its health check would still run")
+			}
+
+			// An unrelated component must be untouched either way.
+			if other := result.GetComponentRef("gpu-operator"); other == nil || !other.IsEnabled() {
+				t.Error("gpu-operator was affected by runtime inventory selection")
+			}
+		})
+	}
+}
+
+// TestApplyBuildConfigRuntimeInventoryRejectsAbsentComponent pins the
+// fail-closed direction. Selecting a mode on a recipe that does not resolve the
+// component is a mistake — a wrong --service, a typo, a recipe that never had
+// it — and silently succeeding would report a decision the recipe cannot honor.
+func TestApplyBuildConfigRuntimeInventoryRejectsAbsentComponent(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []RuntimeInventoryMode{RuntimeInventoryEnabled, RuntimeInventoryDisabled} {
+		t.Run(string(mode), func(t *testing.T) {
+			t.Parallel()
+			result := &RecipeResult{
+				Kind:       RecipeResultKind,
+				APIVersion: "aicr.run/v1alpha2",
+				ComponentRefs: []ComponentRef{
+					{Name: "gpu-operator", Type: ComponentTypeHelm, Namespace: "gpu-operator"},
+				},
+			}
+			err := applyBuildConfig(result, &buildConfig{runtimeInventoryMode: &mode})
+			if err == nil {
+				t.Fatal("applyBuildConfig() error = nil, want an error for a recipe without the component")
+			}
+			if result.Configuration != nil {
+				t.Error("Configuration recorded despite the error; the recipe must not claim a mode it cannot honor")
+			}
+		})
+	}
+}
+
+func modePtr(m RuntimeInventoryMode) *RuntimeInventoryMode { return &m }

--- a/pkg/recipe/runtimeinventory_test.go
+++ b/pkg/recipe/runtimeinventory_test.go
@@ -170,3 +170,48 @@ func TestApplyBuildConfigRuntimeInventoryRejectsAbsentComponent(t *testing.T) {
 }
 
 func modePtr(m RuntimeInventoryMode) *RuntimeInventoryMode { return &m }
+
+// TestApplyBuildConfigPreservesBothConfigurations covers a regression found in
+// review: applyBuildConfig applies the runtime inventory selection first, and
+// the accounting path then assigned a fresh RecipeConfiguration, discarding it.
+//
+// The failure was silent and asymmetric. The component override survived on the
+// ref, so the component really was disabled, while the recipe no longer
+// recorded why — precisely the "recipe records the decision" contract ADR-019
+// requires. Both sections must survive a resolve that selects both.
+func TestApplyBuildConfigPreservesBothConfigurations(t *testing.T) {
+	t.Parallel()
+
+	result := runtimeInventoryTestResult()
+	// A Slurm recipe that also declares the runtime inventory component is the
+	// shape that reaches both paths: accounting requires platform=slurm, and
+	// the inventory selection requires the component to be declared.
+	result.ComponentRefs = append(result.ComponentRefs,
+		ComponentRef{Name: slinkySlurmComponentName, Type: ComponentTypeHelm, Namespace: "slurm"},
+		ComponentRef{Name: mariaDBOperatorCRDsComponentName, Type: ComponentTypeHelm, Namespace: "slurm"},
+		ComponentRef{Name: mariaDBOperatorComponentName, Type: ComponentTypeHelm, Namespace: "slurm"},
+		ComponentRef{Name: slurmAccountingMariaDBComponentName, Type: ComponentTypeHelm, Namespace: "slurm"},
+	)
+
+	accounting := AccountingModeDisabled
+	inventory := RuntimeInventoryDisabled
+	if err := applyBuildConfig(result, &buildConfig{
+		accountingMode:       &accounting,
+		runtimeInventoryMode: &inventory,
+	}); err != nil {
+		t.Fatalf("applyBuildConfig() error = %v", err)
+	}
+
+	if _, present := result.RuntimeInventoryMode(); !present {
+		t.Error("runtime inventory configuration was dropped when accounting was also selected")
+	}
+	if _, present := result.AccountingMode(); !present {
+		t.Error("accounting configuration missing")
+	}
+
+	// The component override must survive too, so the two records agree.
+	ref := result.GetComponentRef(runtimeInventoryComponentName)
+	if ref == nil || ref.IsEnabled() {
+		t.Error("runtime inventory component should be disabled")
+	}
+}

--- a/pkg/recipe/runtimeinventory_test.go
+++ b/pkg/recipe/runtimeinventory_test.go
@@ -312,3 +312,66 @@ func TestApplyRuntimeInventoryRejectsIncoherentEnable(t *testing.T) {
 		t.Errorf("error = %v, want a coherence rejection", err)
 	}
 }
+
+// TestDeepCopyPreservesRuntimeInventory covers a defect found in review:
+// RecipeResult.DeepCopy allocated a fresh RecipeConfiguration and cloned only
+// Slurm, so the runtime inventory record was dropped rather than aliased.
+//
+// Client.AdoptRecipe always deep-copies, so an adopted recipe kept the
+// component override the selection applied while losing the configuration that
+// explains it — a recipe acting on a decision it no longer records.
+func TestDeepCopyPreservesRuntimeInventory(t *testing.T) {
+	t.Parallel()
+
+	result := runtimeInventoryTestResult()
+	mode := RuntimeInventoryDisabled
+	if err := applyBuildConfig(result, &buildConfig{runtimeInventoryMode: &mode}); err != nil {
+		t.Fatalf("applyBuildConfig() error = %v", err)
+	}
+
+	clone := result.DeepCopy()
+	got, present := clone.RuntimeInventoryMode()
+	if !present {
+		t.Fatal("DeepCopy dropped configuration.runtimeInventory")
+	}
+	if got != RuntimeInventoryDisabled {
+		t.Errorf("cloned mode = %q, want %q", got, RuntimeInventoryDisabled)
+	}
+
+	// A copy, not an alias: mutating the clone must not reach the original.
+	clone.Configuration.RuntimeInventory.Mode = RuntimeInventoryEnabled
+	if orig, _ := result.RuntimeInventoryMode(); orig != RuntimeInventoryDisabled {
+		t.Errorf("original mode = %q after mutating the clone; the pointer is shared", orig)
+	}
+
+	// The sibling section must survive the same copy.
+	if clone.Configuration.Slurm != nil && result.Configuration.Slurm == nil {
+		t.Error("clone invented a Slurm section")
+	}
+}
+
+// TestQueryHydrationExposesRuntimeInventory covers the second half of the same
+// class: the recipe recorded the selection but `aicr query --selector
+// configuration.runtimeInventory.mode` returned NOT_FOUND, because hydration
+// projected only Configuration.Slurm.
+func TestQueryHydrationExposesRuntimeInventory(t *testing.T) {
+	t.Parallel()
+
+	result := runtimeInventoryTestResult()
+	mode := RuntimeInventoryDisabled
+	if err := applyBuildConfig(result, &buildConfig{runtimeInventoryMode: &mode}); err != nil {
+		t.Fatalf("applyBuildConfig() error = %v", err)
+	}
+
+	hydrated, err := HydrateResult(result)
+	if err != nil {
+		t.Fatalf("Hydrate() error = %v", err)
+	}
+	got, err := Select(hydrated, "configuration.runtimeInventory.mode")
+	if err != nil {
+		t.Fatalf("Select(configuration.runtimeInventory.mode) error = %v", err)
+	}
+	if got != string(RuntimeInventoryDisabled) {
+		t.Errorf("selector returned %v, want %q", got, RuntimeInventoryDisabled)
+	}
+}

--- a/pkg/recipe/runtimeinventory_test.go
+++ b/pkg/recipe/runtimeinventory_test.go
@@ -14,7 +14,11 @@
 
 package recipe
 
-import "testing"
+import (
+	"slices"
+	"strings"
+	"testing"
+)
 
 // runtimeInventoryTestResult is a minimal recipe that declares the runtime
 // inventory component alongside an unrelated one, so a case can tell "the
@@ -213,5 +217,98 @@ func TestApplyBuildConfigPreservesBothConfigurations(t *testing.T) {
 	ref := result.GetComponentRef(runtimeInventoryComponentName)
 	if ref == nil || ref.IsEnabled() {
 		t.Error("runtime inventory component should be disabled")
+	}
+}
+
+// TestWithRuntimeInventoryModeOption exercises the BuildOption constructor
+// rather than assembling buildConfig directly. Tests that reach past the
+// public option cannot catch a defect in the option itself, and the option is
+// the surface SDK callers actually use.
+func TestWithRuntimeInventoryModeOption(t *testing.T) {
+	t.Parallel()
+
+	cfg := &buildConfig{}
+	WithRuntimeInventoryMode(RuntimeInventoryDisabled)(cfg)
+
+	if cfg.runtimeInventoryMode == nil {
+		t.Fatal("WithRuntimeInventoryMode() left runtimeInventoryMode nil")
+	}
+	if *cfg.runtimeInventoryMode != RuntimeInventoryDisabled {
+		t.Errorf("mode = %q, want %q", *cfg.runtimeInventoryMode, RuntimeInventoryDisabled)
+	}
+
+	// A nil option must be tolerated the way resolveBuildConfig expects.
+	var nilOpt BuildOption
+	if nilOpt != nil {
+		t.Fatal("expected a nil BuildOption")
+	}
+}
+
+// TestApplyRuntimeInventoryRecomputesDeploymentOrder covers a defect found in
+// review: disabling the component left it listed in DeploymentOrder.
+//
+// TopologicalSort emits enabled components only, and the recompute used to sit
+// inside the accounting branch, which a runtime-inventory-only build never
+// reaches. The emitted recipe then contradicted itself — deploymentOrder named
+// a component the same document marked disabled. The bundler re-filters by
+// IsEnabled so nothing mis-deployed, but `aicr query --selector deploymentOrder`
+// reported it.
+func TestApplyRuntimeInventoryRecomputesDeploymentOrder(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		mode      RuntimeInventoryMode
+		wantInOrd bool
+	}{
+		{name: "disabled drops it from deployment order", mode: RuntimeInventoryDisabled, wantInOrd: false},
+		{name: "enabled keeps it", mode: RuntimeInventoryEnabled, wantInOrd: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := runtimeInventoryTestResult()
+			result.DeploymentOrder = []string{"gpu-operator", runtimeInventoryComponentName}
+
+			if err := applyBuildConfig(result, &buildConfig{runtimeInventoryMode: &tt.mode}); err != nil {
+				t.Fatalf("applyBuildConfig() error = %v", err)
+			}
+
+			inOrder := slices.Contains(result.DeploymentOrder, runtimeInventoryComponentName)
+			if inOrder != tt.wantInOrd {
+				t.Errorf("%s in deploymentOrder = %v, want %v (order=%v)",
+					runtimeInventoryComponentName, inOrder, tt.wantInOrd, result.DeploymentOrder)
+			}
+
+			// The invariant that matters: deploymentOrder and IsEnabled agree.
+			for _, ref := range result.ComponentRefs {
+				listed := slices.Contains(result.DeploymentOrder, ref.Name)
+				if listed != ref.IsEnabled() {
+					t.Errorf("component %q: inDeploymentOrder=%v IsEnabled=%v; these must agree",
+						ref.Name, listed, ref.IsEnabled())
+				}
+			}
+		})
+	}
+}
+
+// TestApplyRuntimeInventoryRejectsIncoherentEnable covers a coherence gap found
+// in review: mode=enabled writes install:true, but IsEnabled fails closed on
+// either the `enabled` or the `install` key. An overlay that already set
+// `enabled: false` therefore leaves the component disabled while the recipe
+// records mode: enabled — stating a decision it does not implement.
+func TestApplyRuntimeInventoryRejectsIncoherentEnable(t *testing.T) {
+	t.Parallel()
+
+	result := runtimeInventoryTestResult()
+	ref := result.GetComponentRef(runtimeInventoryComponentName)
+	ref.Overrides = map[string]any{"enabled": false}
+
+	mode := RuntimeInventoryEnabled
+	err := applyBuildConfig(result, &buildConfig{runtimeInventoryMode: &mode})
+	if err == nil {
+		t.Fatal("applyBuildConfig() error = nil, want rejection of an enable the recipe cannot honor")
+	}
+	if !strings.Contains(err.Error(), "cannot be applied") {
+		t.Errorf("error = %v, want a coherence rejection", err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds `aicr recipe --runtime-inventory enabled|disabled`, a generation-time selection for the `k8s-aibom` component that is recorded in the emitted recipe. Closes the last open ADR-019 Follow-Up requirement.

## Motivation / Context

ADR-019 requires stock adoption to carry "generation-time, recipe-recorded selection and opt-out semantics", and explicitly rejects a bundle-time `--set k8s-aibom:enabled=false` because it changes neither the recipe nor its health checks.

Part of #2271

Deliberately non-closing: #2271 also requires the managed-cluster validation
(#2310), the upgrade evidence (#2311), and the stock overlay change, none of
which are in this PR. This adds the selection mechanism that the overlay
change depends on.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries — `pkg/client/v1` facade, `pkg/config`
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**Modelled on `--slurm-accounting-mode`, not invented.** That selection already does exactly what ADR-019 asks: a generation-time flag, recorded under `RecipeConfiguration`, that bumps the recipe `apiVersion` and changes the resolved component set. This mirrors its shape through `BuildOption` → `buildConfig` → `applyBuildConfig`, its CLI wiring, and its `AICRConfig` fallback.

**The health-check half is free here.** Accounting has to append and omit a check on a *sibling* component (`slinky-slurm`), because accounting is a mode of something else. `k8s-aibom`'s check lives on its own ref, so disabling the component removes its check with no special-casing. ADR-019's "changes the recipe *and* its health checks" is satisfied structurally.

**One structural difference from the precedent.** Accounting validates from criteria alone (`platform=slurm`), so its guard sits in `resolveBuildConfig`. This selection depends on whether the *resolved* recipe declares the component, which isn't known there, so the guard lives in `applyBuildConfig`. It runs **before** `Configuration` is written, so a rejected build leaves no partial record — asserted by a test.

**Fails closed on a mismatch.** Passing the flag on a recipe that doesn't declare the component is an error. A wrong `--service` or a typo should surface, not silently produce a recipe claiming a decision it never applied.

**Scope boundary, written into the ADR.** `RecipeConfiguration` now has two entries and the pattern is one bespoke selection per optional component. A generic per-component disable would need a policy for which components may be declined at all — nothing should let a recipe decline `gpu-operator` — and ADR-019 doesn't ask us to solve that. A third entry is the signal to revisit rather than extend by reflex.

## Testing

```bash
make qualify
```

`Codebase qualification completed`, no failures.

Unit tests are table-driven over absent / `enabled` / `disabled`, asserting the recorded mode, the `apiVersion` bump, `IsEnabled()`, that an unrelated component is untouched, and that the ref is *disabled rather than deleted* so the recipe records the declined decision. Separate cases cover the absent-component error in both modes and invalid mode strings including a wrong-case value.

Verified end to end against a built CLI rather than only in unit tests:

| Invocation | Result |
|---|---|
| `--runtime-inventory disabled` | `configuration.runtimeInventory.mode: disabled`, ref `install: false`, `apiVersion: aicr.run/v1alpha3`, **bundler omits the component entirely** |
| `--runtime-inventory enabled` | mode recorded, ref `install: true`, component present |
| flag on a recipe without the component | `[INVALID_REQUEST] runtime inventory mode "disabled" requires the recipe to declare component "k8s-aibom"; this recipe does not resolve it` |
| `--runtime-inventory off` | `[INVALID_REQUEST] invalid runtime inventory mode "off": must be one of enabled, disabled` |

A stock recipe generated without the flag records nothing and is unchanged.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Additive. Omitting the flag leaves generation byte-identical to today, and no stock recipe currently declares `k8s-aibom`, so nothing in the catalog changes behavior. The new `RecipeConfiguration` field is `omitempty`.

**Rollout notes:** No migration. The flag becomes meaningful when a stock recipe declares the component, which is #2271's remaining step.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

