### PR TITLE
fix(validator): decide Trainer lifecycle from recipe, not cluster

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -669,6 +669,13 @@ const (
 	// controller-manager Deployment to have at least one ready replica after installation.
 	TrainerControllerReadyTimeout = 2 * time.Minute
 
+	// TrainerInstallPollInterval is the sleep between checks that a
+	// recipe-declared Kubeflow Trainer installation has become complete. The
+	// benchmark polls rather than failing on the first incomplete read, because a
+	// CRD that is present but not yet Established — or a controller Deployment
+	// that has not appeared — is an ordinary rollout state, not a failed deploy.
+	TrainerInstallPollInterval = 5 * time.Second
+
 	// NCCLTrainJobTimeout is the maximum time to wait for the NCCL all-reduce TrainJob to complete.
 	NCCLTrainJobTimeout = 30 * time.Minute
 

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -478,10 +478,14 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 
 	dynamicClient := ctx.DynamicClient
 
-	// Ensure a usable Kubeflow Trainer. A complete installation already on the
-	// cluster is left alone and reports no resources; anything we install is ours
-	// to clean up after the test completes.
-	installedResources, err := ensureTrainerInstalled(ctx.Ctx, dynamicClient, ctx.Clientset.Discovery())
+	// Ensure a usable Kubeflow Trainer. Whether an incomplete installation is a
+	// failure or something to install over is decided by the recipe, not by what
+	// happens to be on the cluster: a recipe that ships the component must have a
+	// working one, while a recipe that does not gets an ephemeral fixture. Anything
+	// we install is ours to clean up after the test completes.
+	recipeDeclaresTrainer := validators.RecipeDeclares(ctx, kubeflowTrainerComponent)
+	installedResources, err := ensureTrainerInstalled(ctx.Ctx, dynamicClient,
+		ctx.Clientset.Discovery(), recipeDeclaresTrainer)
 	if err != nil {
 		return "", err
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -481,8 +481,9 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// Ensure a usable Kubeflow Trainer. Whether an incomplete installation is a
 	// failure or something to install over is decided by the recipe, not by what
 	// happens to be on the cluster: a recipe that ships the component must have a
-	// working one, while a recipe that does not gets an ephemeral fixture. Anything
-	// we install is ours to clean up after the test completes.
+	// working one, while a recipe that does not reuses whatever is present and
+	// installs an ephemeral fixture only when nothing is. Anything we install is
+	// ours to clean up after the test completes.
 	recipeDeclaresTrainer := validators.RecipeDeclares(ctx, kubeflowTrainerComponent)
 	installedResources, err := ensureTrainerInstalled(ctx.Ctx, dynamicClient,
 		ctx.Clientset.Discovery(), recipeDeclaresTrainer)

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -19,6 +19,7 @@ import (
 	stderrors "errors"
 	"strings"
 	"testing"
+	"time"
 
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -235,44 +236,100 @@ func TestFoldCleanupError_PreservesCleanupCode(t *testing.T) {
 	}
 }
 
-// TestEnsureTrainerInstalled_RecipeDeclaresButMissing verifies the benchmark fails
-// rather than self-installing when the recipe ships Kubeflow Trainer and no complete
-// installation is found.
+// TestEnsureTrainerInstalled_RecipeDrivenLifecycle covers the decision the recipe
+// now drives. The rows that matter are the two where the recipe declares the
+// component: a delivered installation is used as-is, and a missing one fails rather
+// than being installed over — which is the whole point, because self-installing
+// there would report a passing benchmark for a cluster whose delivered Trainer is
+// broken.
 //
-// This is the whole point of keying the decision on the recipe: installing an
-// ephemeral Trainer here would let the benchmark report a passing bandwidth result
-// for a cluster whose delivered Trainer is broken — the deployment failure the
-// recipe's own component promised would be masked by the validator working around
-// it.
-func TestEnsureTrainerInstalled_RecipeDeclaresButMissing(t *testing.T) {
-	// An empty cluster: nothing is installed, which is what a failed deployment of
-	// the kubeflow-trainer component looks like to the probe.
-	client := newTrainerFakeClient()
+// The not-declared + complete row is included because the guard could silently
+// break it: a recipe that never claimed a Trainer must still reuse one that happens
+// to be present, exactly as before.
+//
+// The not-declared + missing row is deliberately absent: it reaches installTrainer,
+// which downloads a release archive, so it belongs in an integration test rather
+// than here.
+func TestEnsureTrainerInstalled_RecipeDrivenLifecycle(t *testing.T) {
+	tests := []struct {
+		name            string
+		declared        bool
+		objects         []runtime.Object
+		wantErr         bool
+		wantErrCode     aicrErrors.ErrorCode
+		wantErrContains string
+	}{
+		{
+			name:     "declared and delivered: used as-is, never claimed for cleanup",
+			declared: true,
+			objects:  completeTrainerInstall(),
+		},
+		{
+			name:            "declared but missing: fails instead of installing over it",
+			declared:        true,
+			objects:         nil,
+			wantErr:         true,
+			wantErrCode:     aicrErrors.ErrCodeNotFound,
+			wantErrContains: kubeflowTrainerComponent,
+		},
+		{
+			name:     "not declared but present: reused, as before",
+			declared: false,
+			objects:  completeTrainerInstall(),
+		},
+		{
+			// Regression guard for a fall-through the linter caught once already:
+			// after the declared wait succeeds, the code must take the readiness
+			// path and stop, not continue into the install path and reinstall over
+			// a Trainer the recipe delivered.
+			name:     "declared and delivered: does not fall through to install",
+			declared: true,
+			objects:  completeTrainerInstall(),
+		},
+	}
 
-	refs, err := ensureTrainerInstalled(context.Background(), client, nil, true)
-	if err == nil {
-		t.Fatal("expected an error when the recipe declares kubeflow-trainer but none is installed")
-	}
-	if len(refs) != 0 {
-		t.Errorf("refs = %d, want 0 (nothing may be installed on the failure path)", len(refs))
-	}
-	if !strings.Contains(err.Error(), kubeflowTrainerComponent) {
-		t.Errorf("error %q does not name the %s component, so an operator cannot tell which "+
-			"component failed to deploy", err, kubeflowTrainerComponent)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer withShortTrainerWait(t)()
+			client := newTrainerFakeClient(tt.objects...)
+
+			refs, err := ensureTrainerInstalled(context.Background(), client, nil, tt.declared)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			// Nothing is ever claimed for cleanup on these rows: a Trainer the
+			// benchmark did not install must not be deleted by it.
+			if len(refs) != 0 {
+				t.Errorf("refs = %d, want 0", len(refs))
+			}
+			if !tt.wantErr {
+				return
+			}
+			// NotFound, not Unavailable: the read succeeded and the answer was "not
+			// deployed". Unavailable is this package's code for a transport failure
+			// (see the decision table on validators.Require), and filing a product
+			// defect under it tells whoever triages the failure to re-run rather than
+			// to fix their deployment.
+			if !stderrors.Is(err, aicrErrors.New(tt.wantErrCode, "")) {
+				t.Errorf("error code = %v, want %s", err, tt.wantErrCode)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Errorf("error %q does not name %q, so an operator cannot tell which "+
+					"component failed to deploy", err, tt.wantErrContains)
+			}
+		})
 	}
 }
 
-// TestEnsureTrainerInstalled_RecipeDeclaresAndPresent verifies the delivered
-// installation is used as-is: it is not reinstalled, and it is not claimed for
-// cleanup, because the recipe owns it rather than the benchmark.
-func TestEnsureTrainerInstalled_RecipeDeclaresAndPresent(t *testing.T) {
-	client := newTrainerFakeClient(completeTrainerInstall()...)
-
-	refs, err := ensureTrainerInstalled(context.Background(), client, nil, true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(refs) != 0 {
-		t.Errorf("refs = %d, want 0 (a recipe-delivered Trainer must never be claimed for cleanup)", len(refs))
+// withShortTrainerWait shrinks the recipe-declared rollout wait for the duration of
+// a test and restores it afterwards.
+func withShortTrainerWait(t *testing.T) func() {
+	t.Helper()
+	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
+	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallPollInterval = time.Millisecond
+	return func() {
+		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
 	}
 }

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -565,3 +565,88 @@ func TestWaitForDeclaredTrainer_LateSuccessDoesNotOutrunTheDeadline(t *testing.T
 		t.Errorf("reason claims nothing was found, but the probe returned complete: %v", err)
 	}
 }
+
+// TestWaitForDeclaredTrainer_ExpiryNamesTheProbeThatJustRan pins the reason reported
+// when the allowance expires on an *incomplete* probe.
+//
+// The recheck before accepting a result runs on every iteration, not only the
+// successful ones. When the probe that just ran came back incomplete, its own
+// finding — the object that is actually missing — is what the operator needs. An
+// earlier revision carried the previous iteration's result into the diagnosis, so
+// the first probe of a wait reported the zero value and the operator got a generic
+// "no complete installation was found" instead of the missing CRD.
+//
+// Stalling the CRD read past the allowance and answering NotFound produces exactly
+// that shape: one probe, incomplete, deadline already gone.
+func TestWaitForDeclaredTrainer_ExpiryNamesTheProbeThatJustRan(t *testing.T) {
+	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
+	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallPollInterval = time.Millisecond
+	defer func() {
+		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
+	}()
+
+	client := newTrainerFakeClient()
+	client.PrependReactor("get", "customresourcedefinitions",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			// Outlive the allowance, then answer NotFound. A missing CRD short-circuits
+			// the probe, so it returns incomplete with no error and the recheck below
+			// is the next thing that runs.
+			time.Sleep(60 * time.Millisecond)
+			return true, nil, apierrors.NewNotFound(
+				schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+				"trainjobs.trainer.kubeflow.org")
+		})
+
+	_, err := waitForDeclaredTrainer(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected an error once the allowance expired with the installation incomplete")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("error code = %v, want ErrCodeNotFound: the deadline expired locally "+
+			"with the parent still live", err)
+	}
+	if !strings.Contains(err.Error(), "CRD trainjobs.trainer.kubeflow.org is missing") {
+		t.Errorf("expiry did not name the object the probe just found missing: %v", err)
+	}
+	if strings.Contains(err.Error(), "no complete installation was found") {
+		t.Errorf("expiry fell back to the generic reason even though the probe that just "+
+			"ran reported a specific missing object: %v", err)
+	}
+}
+
+// TestWaitForDeclaredTrainer_LateSuccessClaimsOnlyWhatWasObserved pins the wording of
+// the late-success reason to what the code can actually know.
+//
+// The recheck learns that the probe returned complete and that the deadline has
+// already passed. It cannot know *when* the installation became complete — only when
+// it was observed to be. Claiming it "became complete after the allowance expired"
+// asserts a transition time nobody measured, and would mislead an operator whose
+// Trainer was healthy all along behind a slow apiserver.
+func TestWaitForDeclaredTrainer_LateSuccessClaimsOnlyWhatWasObserved(t *testing.T) {
+	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
+	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallPollInterval = time.Millisecond
+	defer func() {
+		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
+	}()
+
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+	client.PrependReactor("get", "services",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			time.Sleep(60 * time.Millisecond)
+			return false, nil, nil
+		})
+
+	_, err := waitForDeclaredTrainer(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected an error once the allowance expired")
+	}
+	if strings.Contains(err.Error(), "became complete") {
+		t.Errorf("reason asserts when the installation became complete, which the wait "+
+			"never measured; it only observed completeness after expiry: %v", err)
+	}
+	if !strings.Contains(err.Error(), "observed complete only after the allowance expired") {
+		t.Errorf("reason does not state what was actually observed: %v", err)
+	}
+}

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -320,7 +320,7 @@ func TestEnsureTrainerInstalled_RecipeDrivenLifecycle(t *testing.T) {
 func withShortTrainerWait(t *testing.T) func() {
 	t.Helper()
 	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
-	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallWaitTimeout = 200 * time.Millisecond
 	trainerInstallPollInterval = time.Millisecond
 	return func() {
 		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
@@ -333,15 +333,31 @@ func withShortTrainerWait(t *testing.T) func() {
 // Both expire the poll context, but they mean opposite things: the deadline means
 // the delivered Trainer never became complete, which is the customer's deployment
 // defect this PR exists to surface; cancellation means the run was aborted — a
-// catalog timeout, a canceled phase, a killed Job — which is not. Reporting the
-// second as the first is the same misclassification that made ErrCodeUnavailable
-// wrong for the deadline case.
+// catalog timeout, a canceled phase, a killed Job — which is not.
+//
+// The cancellation has to land *after* a probe completes, not before. Canceling up
+// front is caught by getTrainerObject's own ctx.Err() check on its first read, which
+// returns a "canceled before checking" Timeout through the err path — so the select,
+// and the guard being tested, are never reached. An earlier version of this test did
+// exactly that and passed with the guard deleted.
+//
+// The reactor below makes it deterministic: it cancels and returns NotFound on the
+// first CRD read, and a missing CRD makes isTrainerInstalled return immediately, so
+// that probe is the only one and the next stop is the select.
 func TestWaitForDeclaredTrainer_CanceledRunIsNotADeploymentDefect(t *testing.T) {
 	defer withShortTrainerWait(t)()
-	client := newTrainerFakeClient()
 
+	client := newTrainerFakeClient()
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	defer cancel()
+
+	client.PrependReactor("get", "customresourcedefinitions",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			cancel()
+			return true, nil, apierrors.NewNotFound(
+				schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+				"trainjobs.trainer.kubeflow.org")
+		})
 
 	_, err := waitForDeclaredTrainer(ctx, client)
 	if err == nil {
@@ -353,6 +369,16 @@ func TestWaitForDeclaredTrainer_CanceledRunIsNotADeploymentDefect(t *testing.T) 
 	}
 	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
 		t.Errorf("error code = %v, want ErrCodeTimeout", err)
+	}
+	// Witness that the guard ran rather than getTrainerObject's own pre-read check.
+	// Without this the test passes on the probe-error path and would not notice the
+	// guard being removed — which is how the earlier version of it was vacuous.
+	if strings.Contains(err.Error(), "canceled before checking") {
+		t.Errorf("error %q came from getTrainerObject's pre-read check, not the "+
+			"cancellation guard in the select; this test is not exercising the guard", err)
+	}
+	if !strings.Contains(err.Error(), "canceled while waiting") {
+		t.Errorf("error %q is not the cancellation guard's message", err)
 	}
 }
 
@@ -387,9 +413,11 @@ func TestEnsureTrainerInstalled_DeclaredRolloutDoesNotFallThrough(t *testing.T) 
 		}
 	}
 
-	// A nil discovery client makes installTrainer panic or error immediately, so if
-	// the code falls through to the install path this test fails loudly rather than
-	// silently passing.
+	// A nil discovery client is not what catches a fall-through here: installTrainer
+	// fetches the release archive from GitHub before it touches discovery, so on a
+	// machine with egress a fall-through would download tens of megabytes first. The
+	// assertions below are what catch it — no error, no claimed resources, and a
+	// probe count proving the wait was entered.
 	refs, err := ensureTrainerInstalled(context.Background(), client, nil, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -431,3 +431,41 @@ func TestEnsureTrainerInstalled_DeclaredRolloutDoesNotFallThrough(t *testing.T) 
 			"does not cover the branch it claims to", probes)
 	}
 }
+
+// TestWaitForDeclaredTrainer_SlowProbeCannotOutrunTheDeadline pins the rollout
+// allowance as a bound on the whole wait, not just on the sleeps between probes.
+//
+// An earlier revision probed with the parent context so a deadline landing
+// mid-probe would not surface as a bare timeout. That fixed the classification and
+// removed the bound: each probe makes several sequential reads with their own
+// timeouts, so a slow probe could cross the allowance and still report success if
+// the installation happened to complete meanwhile. The probe runs under pollCtx
+// again, with the expiry classified rather than propagated blind.
+//
+// Here the first read sleeps past the allowance and the installation is complete
+// underneath, so a wait that respects its deadline must fail rather than succeed.
+func TestWaitForDeclaredTrainer_SlowProbeCannotOutrunTheDeadline(t *testing.T) {
+	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
+	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallPollInterval = time.Millisecond
+	defer func() {
+		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
+	}()
+
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+	client.PrependReactor("get", "customresourcedefinitions",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			time.Sleep(60 * time.Millisecond) // outlives the allowance
+			return false, nil, nil            // then let the complete install answer
+		})
+
+	_, err := waitForDeclaredTrainer(context.Background(), client)
+	if err == nil {
+		t.Fatal("wait returned success after its own deadline had passed; the rollout " +
+			"allowance must bound the probe, not only the sleeps between probes")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("error code = %v, want ErrCodeNotFound: the deadline expired locally "+
+			"with the parent still live, which is a deployment that never completed", err)
+	}
+}

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -507,4 +507,17 @@ func TestWaitForDeclaredTrainer_TransportErrorKeepsItsClassification(t *testing.
 			"is not a deployment that never completed, and swallowing that signal sends "+
 			"the operator to fix the wrong thing", err)
 	}
+	// Assert the code positively, not only that it is not NotFound: the negative alone
+	// would pass for any other verdict, including a total loss of classification.
+	//
+	// Note what this does and does not pin. errors.Is walks the chain and Wrap keeps its
+	// Cause, so this matches when Unavailable is anywhere in the chain — it catches the
+	// classification being dropped, not the outermost code being flattened while the
+	// inner error survives. Verified by control: replacing PropagateOrWrap with a plain
+	// Wrap to Internal still passes this. That is the same reach as the sibling
+	// TestEnsureTrainerInstalled_PreservesProbeErrorCode, and the convention in this
+	// file; pinning the outermost code would need a type assertion rather than errors.Is.
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
+		t.Errorf("transport classification lost; want Unavailable, got: %v", err)
+	}
 }

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -464,9 +464,17 @@ func TestWaitForDeclaredTrainer_SlowProbeCannotOutrunTheDeadline(t *testing.T) {
 		t.Fatal("wait returned success after its own deadline had passed; the rollout " +
 			"allowance must bound the probe, not only the sleeps between probes")
 	}
-	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
-		t.Errorf("error code = %v, want ErrCodeNotFound: the deadline expired locally "+
-			"with the parent still live, which is a deployment that never completed", err)
+	// Timeout, not NotFound. The allowance is still enforced — the wait fails — but
+	// nothing here was ever read as missing: the installation underneath is complete
+	// and the only thing that went wrong is a read slower than the budget. Filing
+	// that as NotFound would send an operator to fix a deployment that is fine.
+	if stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("slow read reported as NotFound (%v); no probe observed anything "+
+			"incomplete, so there is no deployment defect to file", err)
+	}
+	var se *aicrErrors.StructuredError
+	if !stderrors.As(err, &se) || se.Code != aicrErrors.ErrCodeTimeout {
+		t.Errorf("reported code = %v, want Timeout", err)
 	}
 }
 
@@ -551,9 +559,15 @@ func TestWaitForDeclaredTrainer_LateSuccessDoesNotOutrunTheDeadline(t *testing.T
 		t.Fatal("wait returned success after its allowance had passed; expiry must be " +
 			"rechecked before accepting a probe's result, not only before issuing it")
 	}
-	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
-		t.Errorf("error code = %v, want ErrCodeNotFound: the deadline expired locally "+
-			"with the parent still live", err)
+	// The probe returned complete, so no incomplete installation was ever observed:
+	// the verdict is the timeout that happened, not a deployment defect.
+	if stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("late success reported as NotFound (%v); the probe found the "+
+			"installation complete, so nothing was missing", err)
+	}
+	var se *aicrErrors.StructuredError
+	if !stderrors.As(err, &se) || se.Code != aicrErrors.ErrCodeTimeout {
+		t.Errorf("reported code = %v, want Timeout", err)
 	}
 	// The reason must describe this probe, not the previous one. The installation is
 	// complete here, so blaming a missing object would point the operator at something
@@ -648,5 +662,51 @@ func TestWaitForDeclaredTrainer_LateSuccessClaimsOnlyWhatWasObserved(t *testing.
 	}
 	if !strings.Contains(err.Error(), "observed complete only after the allowance expired") {
 		t.Errorf("reason does not state what was actually observed: %v", err)
+	}
+}
+
+// TestWaitForDeclaredTrainer_ReadTimeoutsAloneAreNotADeploymentDefect pins the case
+// where the allowance runs out without any probe ever reaching a conclusion.
+//
+// Every read the probe issues is cut short by the poll deadline, so no probe ever
+// observes an incomplete installation — there is nothing on the cluster the wait can
+// point at. Synthesizing NotFound from that empty observation would file a degraded
+// or slow apiserver as a customer deployment defect, which is the same
+// misclassification the NotFound/Unavailable split exists to prevent. With no
+// observation to stand on, the honest verdict is the timeout that actually happened.
+func TestWaitForDeclaredTrainer_ReadTimeoutsAloneAreNotADeploymentDefect(t *testing.T) {
+	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
+	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallPollInterval = time.Millisecond
+	defer func() {
+		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
+	}()
+
+	// Seed only the first CRD the probe reads, and stall that read past the
+	// allowance. The read itself succeeds, so the probe learns nothing incomplete;
+	// the deadline is already gone by the time the second read is issued, and
+	// getTrainerObject's pre-read check turns it into a Timeout. That is the only
+	// thing the wait ever hears back.
+	client := newTrainerFakeClient(establishedCRD(trainerCRDTrainJobs))
+	client.PrependReactor("get", "customresourcedefinitions",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			time.Sleep(60 * time.Millisecond) // outlives the allowance
+			return false, nil, nil            // then let the tracker answer
+		})
+
+	_, err := waitForDeclaredTrainer(context.Background(), client)
+	if err == nil {
+		t.Fatal("wait returned success after its allowance had passed")
+	}
+	if stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("read timeouts reported as NotFound (%v); no probe ever observed an "+
+			"incomplete installation, so there is no deployment defect to file", err)
+	}
+	var se *aicrErrors.StructuredError
+	if !stderrors.As(err, &se) || se.Code != aicrErrors.ErrCodeTimeout {
+		t.Errorf("reported code = %v, want Timeout", err)
+	}
+	if strings.Contains(err.Error(), "no complete installation was found") {
+		t.Errorf("verdict claims nothing was found, but nothing was ever read: %v", err)
 	}
 }

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	stderrors "errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -277,15 +279,6 @@ func TestEnsureTrainerInstalled_RecipeDrivenLifecycle(t *testing.T) {
 			declared: false,
 			objects:  completeTrainerInstall(),
 		},
-		{
-			// Regression guard for a fall-through the linter caught once already:
-			// after the declared wait succeeds, the code must take the readiness
-			// path and stop, not continue into the install path and reinstall over
-			// a Trainer the recipe delivered.
-			name:     "declared and delivered: does not fall through to install",
-			declared: true,
-			objects:  completeTrainerInstall(),
-		},
 	}
 
 	for _, tt := range tests {
@@ -360,5 +353,53 @@ func TestWaitForDeclaredTrainer_CanceledRunIsNotADeploymentDefect(t *testing.T) 
 	}
 	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
 		t.Errorf("error code = %v, want ErrCodeTimeout", err)
+	}
+}
+
+// TestEnsureTrainerInstalled_DeclaredRolloutDoesNotFallThrough pins the branch the
+// fall-through actually lived in.
+//
+// A table row seeded with completeTrainerInstall() cannot reach it: the first probe
+// in ensureTrainerInstalled succeeds, so waitForDeclaredTrainer is never entered and
+// the row exercises the same path as the one above it. The supported rollout state —
+// initially incomplete, complete on a later poll — is the one that enters the wait
+// and then must return rather than continuing into the install path.
+func TestEnsureTrainerInstalled_DeclaredRolloutDoesNotFallThrough(t *testing.T) {
+	defer withShortTrainerWait(t)()
+
+	client := newTrainerFakeClient()
+	var probes int32
+	// Report incomplete on the first probe and complete afterwards, which is what a
+	// chart still landing looks like. The reactor answers only the first read the
+	// probe makes; a NotFound there is enough to make the whole probe incomplete.
+	client.PrependReactor("get", "customresourcedefinitions",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			if atomic.AddInt32(&probes, 1) == 1 {
+				return true, nil, apierrors.NewNotFound(
+					schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+					"trainjobs.trainer.kubeflow.org")
+			}
+			return false, nil, nil // fall through to the tracker
+		})
+	for _, obj := range completeTrainerInstall() {
+		if err := client.Tracker().Add(obj); err != nil {
+			t.Fatalf("seeding fake: %v", err)
+		}
+	}
+
+	// A nil discovery client makes installTrainer panic or error immediately, so if
+	// the code falls through to the install path this test fails loudly rather than
+	// silently passing.
+	refs, err := ensureTrainerInstalled(context.Background(), client, nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0: a Trainer the recipe delivered must never be "+
+			"claimed for cleanup, and a non-empty result means the install path ran", len(refs))
+	}
+	if atomic.LoadInt32(&probes) < 2 {
+		t.Errorf("probes = %d, want >= 2: the wait was never entered, so this test "+
+			"does not cover the branch it claims to", probes)
 	}
 }

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -247,9 +247,9 @@ func TestFoldCleanupError_PreservesCleanupCode(t *testing.T) {
 // break it: a recipe that never claimed a Trainer must still reuse one that happens
 // to be present, exactly as before.
 //
-// The not-declared + missing row is deliberately absent: it reaches installTrainer,
-// which downloads a release archive, so it belongs in an integration test rather
-// than here.
+// The not-declared + missing row is deliberately absent rather than overlooked: it
+// reaches installTrainer, which downloads and kustomize-builds the upstream release
+// archive, so it is covered by e2e rather than being unit-testable here.
 func TestEnsureTrainerInstalled_RecipeDrivenLifecycle(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -331,5 +331,34 @@ func withShortTrainerWait(t *testing.T) func() {
 	trainerInstallPollInterval = time.Millisecond
 	return func() {
 		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
+	}
+}
+
+// TestWaitForDeclaredTrainer_CanceledRunIsNotADeploymentDefect pins the distinction
+// the poll deadline and parent cancellation would otherwise blur.
+//
+// Both expire the poll context, but they mean opposite things: the deadline means
+// the delivered Trainer never became complete, which is the customer's deployment
+// defect this PR exists to surface; cancellation means the run was aborted — a
+// catalog timeout, a canceled phase, a killed Job — which is not. Reporting the
+// second as the first is the same misclassification that made ErrCodeUnavailable
+// wrong for the deadline case.
+func TestWaitForDeclaredTrainer_CanceledRunIsNotADeploymentDefect(t *testing.T) {
+	defer withShortTrainerWait(t)()
+	client := newTrainerFakeClient()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := waitForDeclaredTrainer(ctx, client)
+	if err == nil {
+		t.Fatal("expected an error when the run is canceled")
+	}
+	if stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("canceled run reported as NotFound (%v); an aborted run is not a "+
+			"failed deployment and must not be filed as one", err)
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
+		t.Errorf("error code = %v, want ErrCodeTimeout", err)
 	}
 }

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -33,7 +33,7 @@ import (
 func TestEnsureTrainerInstalled_CompleteInstallIsLeftAlone(t *testing.T) {
 	client := newTrainerFakeClient(completeTrainerInstall()...)
 
-	refs, err := ensureTrainerInstalled(context.Background(), client, nil)
+	refs, err := ensureTrainerInstalled(context.Background(), client, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestEnsureTrainerInstalled_WaitsOnDiscoveredControllerName(t *testing.T) {
 		return false, nil, nil
 	})
 
-	refs, err := ensureTrainerInstalled(ctx, client, nil)
+	refs, err := ensureTrainerInstalled(ctx, client, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error waiting on the discovered controller %q (polled %v): %v",
 			releaseDerivedName, polled, err)
@@ -126,7 +126,7 @@ func TestEnsureTrainerInstalled_WaitsForPreexistingController(t *testing.T) {
 	})
 	defer cancel()
 
-	refs, err := ensureTrainerInstalled(ctx, client, nil)
+	refs, err := ensureTrainerInstalled(ctx, client, nil, false)
 	if err == nil {
 		t.Fatal("expected a not-ready pre-existing controller to fail, got nil error")
 	}
@@ -156,7 +156,7 @@ func TestEnsureTrainerInstalled_RefusesToInstallOverForeignNamespace(t *testing.
 			trainerValidatingWebhookName, "kubeflow"),
 	)
 
-	refs, err := ensureTrainerInstalled(context.Background(), client, nil)
+	refs, err := ensureTrainerInstalled(context.Background(), client, nil, false)
 	if err == nil {
 		t.Fatal("expected the installer to refuse installing over an installation in another namespace")
 	}
@@ -180,7 +180,7 @@ func TestEnsureTrainerInstalled_PreservesProbeErrorCode(t *testing.T) {
 		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
 	})
 
-	_, err := ensureTrainerInstalled(context.Background(), client, nil)
+	_, err := ensureTrainerInstalled(context.Background(), client, nil, false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -232,5 +232,47 @@ func TestFoldCleanupError_PreservesCleanupCode(t *testing.T) {
 	got := foldCleanupError(nil, cleanupErr)
 	if !stderrors.Is(got, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
 		t.Errorf("cleanup error code was flattened: %v", got)
+	}
+}
+
+// TestEnsureTrainerInstalled_RecipeDeclaresButMissing verifies the benchmark fails
+// rather than self-installing when the recipe ships Kubeflow Trainer and no complete
+// installation is found.
+//
+// This is the whole point of keying the decision on the recipe: installing an
+// ephemeral Trainer here would let the benchmark report a passing bandwidth result
+// for a cluster whose delivered Trainer is broken — the deployment failure the
+// recipe's own component promised would be masked by the validator working around
+// it.
+func TestEnsureTrainerInstalled_RecipeDeclaresButMissing(t *testing.T) {
+	// An empty cluster: nothing is installed, which is what a failed deployment of
+	// the kubeflow-trainer component looks like to the probe.
+	client := newTrainerFakeClient()
+
+	refs, err := ensureTrainerInstalled(context.Background(), client, nil, true)
+	if err == nil {
+		t.Fatal("expected an error when the recipe declares kubeflow-trainer but none is installed")
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0 (nothing may be installed on the failure path)", len(refs))
+	}
+	if !strings.Contains(err.Error(), kubeflowTrainerComponent) {
+		t.Errorf("error %q does not name the %s component, so an operator cannot tell which "+
+			"component failed to deploy", err, kubeflowTrainerComponent)
+	}
+}
+
+// TestEnsureTrainerInstalled_RecipeDeclaresAndPresent verifies the delivered
+// installation is used as-is: it is not reinstalled, and it is not claimed for
+// cleanup, because the recipe owns it rather than the benchmark.
+func TestEnsureTrainerInstalled_RecipeDeclaresAndPresent(t *testing.T) {
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+
+	refs, err := ensureTrainerInstalled(context.Background(), client, nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("refs = %d, want 0 (a recipe-delivered Trainer must never be claimed for cleanup)", len(refs))
 	}
 }

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -507,17 +507,52 @@ func TestWaitForDeclaredTrainer_TransportErrorKeepsItsClassification(t *testing.
 			"is not a deployment that never completed, and swallowing that signal sends "+
 			"the operator to fix the wrong thing", err)
 	}
-	// Assert the code positively, not only that it is not NotFound: the negative alone
-	// would pass for any other verdict, including a total loss of classification.
+	// Assert the code a consumer actually reads. ExitCodeFromError resolves the
+	// outermost StructuredError, so that is the value which reaches the exit status —
+	// errors.Is would match Unavailable anywhere in the chain and would still pass if
+	// the verdict were flattened to Internal, which is observable, not cosmetic.
 	//
-	// Note what this does and does not pin. errors.Is walks the chain and Wrap keeps its
-	// Cause, so this matches when Unavailable is anywhere in the chain — it catches the
-	// classification being dropped, not the outermost code being flattened while the
-	// inner error survives. Verified by control: replacing PropagateOrWrap with a plain
-	// Wrap to Internal still passes this. That is the same reach as the sibling
-	// TestEnsureTrainerInstalled_PreservesProbeErrorCode, and the convention in this
-	// file; pinning the outermost code would need a type assertion rather than errors.Is.
-	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
-		t.Errorf("transport classification lost; want Unavailable, got: %v", err)
+	// stderrors.As walks from the outermost and assigns the first match, which is the
+	// same resolution ExitCodeFromError performs. The pattern is already used for this
+	// purpose in pkg/chainsaw's tests.
+	var se *aicrErrors.StructuredError
+	if !stderrors.As(err, &se) || se.Code != aicrErrors.ErrCodeUnavailable {
+		t.Errorf("reported code = %v, want Unavailable: a degraded control plane must not "+
+			"reach the operator as a deployment that never completed", err)
+	}
+}
+
+// TestWaitForDeclaredTrainer_LateSuccessDoesNotOutrunTheDeadline covers the other
+// end of the probe from the slow-first-read case.
+//
+// Delaying the first read makes a later read notice expiry, so the err path catches
+// it. Delaying the *last* read does not: the probe returns ok, and accepting that
+// without rechecking would let a wait return success after its allowance had passed.
+// The bound has to cover the answer, not only the question.
+func TestWaitForDeclaredTrainer_LateSuccessDoesNotOutrunTheDeadline(t *testing.T) {
+	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
+	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallPollInterval = time.Millisecond
+	defer func() {
+		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
+	}()
+
+	client := newTrainerFakeClient(completeTrainerInstall()...)
+	// The Service read is the probe's last step, so stalling it past the allowance
+	// makes the probe succeed with the deadline already gone.
+	client.PrependReactor("get", "services",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			time.Sleep(60 * time.Millisecond)
+			return false, nil, nil // then let the seeded complete install answer
+		})
+
+	_, err := waitForDeclaredTrainer(context.Background(), client)
+	if err == nil {
+		t.Fatal("wait returned success after its allowance had passed; expiry must be " +
+			"rechecked before accepting a probe's result, not only before issuing it")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("error code = %v, want ErrCodeNotFound: the deadline expired locally "+
+			"with the parent still live", err)
 	}
 }

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -469,3 +469,42 @@ func TestWaitForDeclaredTrainer_SlowProbeCannotOutrunTheDeadline(t *testing.T) {
 			"with the parent still live, which is a deployment that never completed", err)
 	}
 }
+
+// TestWaitForDeclaredTrainer_TransportErrorKeepsItsClassification pins the narrow
+// case where the rollout deadline and a real read failure land together.
+//
+// A read that starts before the deadline and fails for a genuine reason after it —
+// an apiserver 503 — must keep its transport classification. Reporting it as "the
+// installation did not become complete" would file a control-plane outage as a
+// customer deployment defect, and it is precisely when the apiserver is degraded
+// that the transport signal is worth the most.
+//
+// Expiry may win only for context-derived errors, which is what the stderrors.Is
+// guard on the probe-error branch enforces.
+func TestWaitForDeclaredTrainer_TransportErrorKeepsItsClassification(t *testing.T) {
+	oldTimeout, oldInterval := trainerInstallWaitTimeout, trainerInstallPollInterval
+	trainerInstallWaitTimeout = 20 * time.Millisecond
+	trainerInstallPollInterval = time.Millisecond
+	defer func() {
+		trainerInstallWaitTimeout, trainerInstallPollInterval = oldTimeout, oldInterval
+	}()
+
+	client := newTrainerFakeClient()
+	client.PrependReactor("get", "customresourcedefinitions",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			// Outlive the allowance, then fail for a real reason rather than a
+			// context one: the deadline has passed by the time this returns.
+			time.Sleep(40 * time.Millisecond)
+			return true, nil, apierrors.NewServiceUnavailable("apiserver is having a bad day")
+		})
+
+	_, err := waitForDeclaredTrainer(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeNotFound, "")) {
+		t.Errorf("transport failure reported as NotFound (%v); a degraded control plane "+
+			"is not a deployment that never completed, and swallowing that signal sends "+
+			"the operator to fix the wrong thing", err)
+	}
+}

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -555,4 +555,13 @@ func TestWaitForDeclaredTrainer_LateSuccessDoesNotOutrunTheDeadline(t *testing.T
 		t.Errorf("error code = %v, want ErrCodeNotFound: the deadline expired locally "+
 			"with the parent still live", err)
 	}
+	// The reason must describe this probe, not the previous one. The installation is
+	// complete here, so blaming a missing object would point the operator at something
+	// that is present; the finding is a rollout slower than its budget.
+	if !strings.Contains(err.Error(), "only after the allowance expired") {
+		t.Errorf("reason contradicts the probe that just succeeded: %v", err)
+	}
+	if strings.Contains(err.Error(), "no complete installation was found") {
+		t.Errorf("reason claims nothing was found, but the probe returned complete: %v", err)
+	}
 }

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -250,8 +250,15 @@ func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (t
 	// makes this work for both the self-install overlay and the Helm chart.
 	install, found, err := discoverTrainerInstall(ctx, dynamicClient,
 		trainerValidatingWebhookGVR, trainerValidatingWebhookConfig, trainerValidatingWebhookName)
-	if err != nil || !found {
+	if err != nil {
 		return trainerInstall{}, false, err
+	}
+	if !found {
+		// Carry discovery's own reason out rather than flattening it to a bare
+		// false: it is the difference between "no admission configuration at all"
+		// and "the configuration is there but names no Service", and the operator
+		// needs to know which to fix.
+		return install, false, nil
 	}
 
 	ok, err := hasTrainerWebhook(ctx, dynamicClient,
@@ -456,8 +463,11 @@ func trainerResourceClient(dynamicClient dynamic.Interface,
 //   - not declared, and absent: install an ephemeral fixture and tear it down, as
 //     before. There is nothing to mask, because nothing was promised.
 //
-// This is deliberately keyed on the recipe rather than on live cluster state, so the
-// same recipe behaves the same way regardless of what happens to be installed.
+// This is deliberately keyed on the recipe rather than on live cluster state: what a
+// missing installation *means* is now a property of the recipe, not of whatever
+// happens to be on the cluster. Execution still differs across the undeclared rows —
+// a pre-existing Trainer is reused, an absent one is installed — which is why the
+// earlier "behaves identically regardless of live state" wording was withdrawn.
 func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface,
 	discoveryClient discovery.DiscoveryInterface, recipeDeclaresTrainer bool) ([]trainerResourceRef, error) {
 

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -111,6 +111,11 @@ const (
 	// overwriting a generically-named admission configuration another operator owns.
 	trainerWebhookSuffix = ".trainer.kubeflow.org"
 
+	// kubeflowTrainerComponent is the registry name of the Kubeflow Trainer
+	// component. A recipe declaring it is promising a Trainer installation, which
+	// is what ensureTrainerInstalled keys its behavior on.
+	kubeflowTrainerComponent = "kubeflow-trainer"
+
 	// jobSetCRDName identifies the JobSet dependency. TrainJobs run as JobSets, so
 	// a Trainer whose JobSet controller never becomes ready fails opaquely later.
 	jobSetCRDName = "jobsets.jobset.x-k8s.io"
@@ -431,8 +436,22 @@ func trainerResourceClient(dynamicClient dynamic.Interface,
 // and returns the resources it created, so the caller can delete them when the run
 // finishes. A complete pre-existing installation is left alone and reported as no
 // resources, so the benchmark never deletes a Trainer it does not own.
+//
+// recipeDeclaresTrainer says whether the recipe under validation ships Kubeflow
+// Trainer as a delivered component, and it decides what an incomplete installation
+// means:
+//
+//   - declared, and present: use the delivered installation.
+//   - declared, but missing or incomplete: fail. Self-installing here would mask a
+//     broken deployment of a component the recipe promised, and the benchmark would
+//     then report a passing result for a cluster that cannot run TrainJobs at all.
+//   - not declared: install an ephemeral fixture and tear it down, as before. The
+//     recipe never claimed a Trainer, so there is nothing to mask.
+//
+// This is deliberately keyed on the recipe rather than on live cluster state, so the
+// same recipe behaves the same way regardless of what happens to be installed.
 func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface,
-	discoveryClient discovery.DiscoveryInterface) ([]trainerResourceRef, error) {
+	discoveryClient discovery.DiscoveryInterface, recipeDeclaresTrainer bool) ([]trainerResourceRef, error) {
 
 	install, installed, err := isTrainerInstalled(ctx, dynamicClient)
 	if err != nil {
@@ -445,6 +464,17 @@ func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface
 	}
 
 	if !installed {
+		// The recipe ships Kubeflow Trainer, so a missing or incomplete installation
+		// is a deployment failure, not something to paper over. Installing our own
+		// here would produce a passing benchmark for a cluster whose delivered
+		// Trainer is broken.
+		if recipeDeclaresTrainer {
+			return nil, aicrErrors.New(aicrErrors.ErrCodeUnavailable, fmt.Sprintf(
+				"the recipe declares the %s component but no complete Kubeflow Trainer "+
+					"installation was found; the benchmark will not self-install over a "+
+					"delivered component that failed to deploy", kubeflowTrainerComponent))
+		}
+
 		// Before applying anything, check for a live installation somewhere else.
 		// Kustomize applies CRDs and RBAC before webhook configurations, so by the
 		// time the admission-config ownership guard could fire, a shared-name

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -269,7 +269,8 @@ func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (t
 	if !ok {
 		slog.Info("Kubeflow Trainer incomplete: admission webhook missing",
 			"configuration", trainerMutatingWebhookConfig, "webhook", trainerMutatingWebhookName)
-		return trainerInstall{Incomplete: "the validating admission webhook configuration is missing"}, false, nil
+		return trainerInstall{Incomplete: fmt.Sprintf(
+			"admission configuration %q is missing", trainerMutatingWebhookConfig)}, false, nil
 	}
 
 	// The controller Deployment is found by label: its name is release-derived on
@@ -313,12 +314,17 @@ func discoverTrainerInstall(ctx context.Context, dynamicClient dynamic.Interface
 	gvr schema.GroupVersionResource, configName, webhookName string) (trainerInstall, bool, error) {
 
 	obj, found, err := getTrainerObject(ctx, dynamicClient, gvr, "", configName)
-	if err != nil || !found {
-		if err == nil {
-			slog.Info("Kubeflow Trainer incomplete: admission configuration missing",
-				"configuration", configName)
-		}
+	if err != nil {
+		// A failed read is not evidence of absence. Propagate it so the caller
+		// classifies it as transport or timeout rather than as a deployment that
+		// never happened.
 		return trainerInstall{}, false, err
+	}
+	if !found {
+		slog.Info("Kubeflow Trainer incomplete: admission configuration missing",
+			"configuration", configName)
+		return trainerInstall{Incomplete: fmt.Sprintf(
+			"admission configuration %q is missing", configName)}, false, nil
 	}
 
 	entries, _, err := unstructured.NestedSlice(obj.Object, "webhooks")
@@ -346,7 +352,9 @@ func discoverTrainerInstall(ctx context.Context, dynamicClient dynamic.Interface
 
 	slog.Info("Kubeflow Trainer incomplete: admission webhook missing",
 		"configuration", configName, "webhook", webhookName)
-	return trainerInstall{Incomplete: "the validating admission webhook configuration is missing"}, false, nil
+	return trainerInstall{Incomplete: fmt.Sprintf(
+		"admission configuration %q exists but does not contain the %q webhook",
+		configName, webhookName)}, false, nil
 }
 
 // getTrainerObject fetches one object. NotFound reports found=false with no
@@ -537,6 +545,42 @@ func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface
 	return nil, awaitTrainerController(ctx, dynamicClient, install)
 }
 
+// classifyPollExpiry turns an expired poll context into the right verdict, or nil
+// when the poll context is still live and the caller should handle its own error.
+//
+// The two expiries mean opposite things. A canceled parent means the run was
+// aborted — catalog timeout, canceled phase, killed Job — which is not a customer
+// deployment defect. A local deadline means the delivered Trainer never became
+// complete, which is.
+//
+// Both paths route through here so the verdict does not depend on whether the clock
+// ran out during a probe or during a sleep: the same cluster state must not produce
+// two different codes.
+func classifyPollExpiry(ctx, pollCtx context.Context, last trainerInstall) error {
+	if ctx.Err() != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
+			"canceled while waiting for the recipe-declared Kubeflow Trainer", ctx.Err())
+	}
+	if pollCtx.Err() == nil {
+		return nil
+	}
+
+	// ErrCodeNotFound, not Unavailable: the read succeeded and the answer was "not
+	// deployed". Unavailable is this package's code for a transport failure — see
+	// the decision table on validators.Require — and using it here would file a
+	// product defect alongside apiserver hiccups, telling whoever triages it to
+	// re-run rather than to fix their deployment.
+	reason := last.Incomplete
+	if reason == "" {
+		reason = "no complete installation was found"
+	}
+	return aicrErrors.New(aicrErrors.ErrCodeNotFound, fmt.Sprintf(
+		"the recipe declares the %s component but its Kubeflow Trainer installation "+
+			"did not become complete within %s: %s. The benchmark will not self-install "+
+			"over a delivered component that failed to deploy",
+		kubeflowTrainerComponent, trainerInstallWaitTimeout, reason))
+}
+
 // awaitTrainerController waits for a Trainer the benchmark does not own to finish
 // starting. The probe confirms every object exists; the controller may still be
 // rolling, and waiting is the alternative to reinstalling over a healthy Trainer.
@@ -573,13 +617,20 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 	defer cancel()
 
 	for {
-		// Probe with the parent context, not pollCtx: getTrainerObject checks
-		// ctx.Err() at the top of every read and returns Timeout, so a deadline
-		// landing mid-probe would surface as a bare timeout instead of the
-		// NotFound-plus-diagnosis this function exists to produce. Letting the
-		// select below own the deadline keeps the two conditions separable.
-		install, ok, err := isTrainerInstalled(ctx, dynamicClient)
+		// Probe under pollCtx so the rollout allowance actually bounds it. Each probe
+		// makes several sequential reads, each with its own DiagnosticTimeout, so a
+		// probe running on the parent context could cross the deadline and still
+		// report success — the allowance would bound only the sleeps.
+		//
+		// The cost is that getTrainerObject checks ctx.Err() at the top of every read
+		// and returns Timeout, so an expiring deadline surfaces here as a probe error
+		// rather than through the select. Classify it below instead of propagating it
+		// blind, so the verdict does not depend on where in the loop the clock ran out.
+		install, ok, err := isTrainerInstalled(pollCtx, dynamicClient)
 		if err != nil {
+			if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
+				return trainerInstall{}, verdict
+			}
 			return trainerInstall{}, aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
 				"failed to check Kubeflow Trainer installation")
 		}
@@ -590,30 +641,11 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 
 		select {
 		case <-pollCtx.Done():
-			// pollCtx expires for two different reasons and they mean opposite
-			// things. A canceled parent means the run was aborted — catalog timeout,
-			// phase cancellation, the Job killed — and reporting that as a customer
-			// deployment defect is the same misclassification the NotFound code
-			// above exists to avoid, one level down.
-			if ctx.Err() != nil {
-				return trainerInstall{}, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
-					"canceled while waiting for the recipe-declared Kubeflow Trainer", ctx.Err())
+			if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
+				return trainerInstall{}, verdict
 			}
-
-			// ErrCodeNotFound, not Unavailable: the read succeeded and the answer was
-			// "not deployed". Unavailable is this package's code for a transport
-			// failure — see the decision table on validators.Require — and using it
-			// here would file a product defect alongside apiserver hiccups, telling
-			// whoever triages it to re-run rather than to fix their deployment.
-			reason := last.Incomplete
-			if reason == "" {
-				reason = "no complete installation was found"
-			}
-			return trainerInstall{}, aicrErrors.New(aicrErrors.ErrCodeNotFound, fmt.Sprintf(
-				"the recipe declares the %s component but its Kubeflow Trainer installation "+
-					"did not become complete within %s: %s. The benchmark will not self-install "+
-					"over a delivered component that failed to deploy",
-				kubeflowTrainerComponent, trainerInstallWaitTimeout, reason))
+			return trainerInstall{}, aicrErrors.New(aicrErrors.ErrCodeInternal,
+				"Kubeflow Trainer wait ended without a verdict")
 		case <-time.After(trainerInstallPollInterval):
 		}
 	}

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -644,6 +644,13 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 			return trainerInstall{}, aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
 				"failed to check Kubeflow Trainer installation")
 		}
+		// Recheck expiry before accepting success. The probe's last read can return
+		// just after the deadline, and taking ok on that read would let the wait
+		// outrun its own allowance — the bound has to cover the answer, not only
+		// the question.
+		if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
+			return trainerInstall{}, verdict
+		}
 		if ok {
 			return install, nil
 		}

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -563,7 +563,12 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 	defer cancel()
 
 	for {
-		install, ok, err := isTrainerInstalled(pollCtx, dynamicClient)
+		// Probe with the parent context, not pollCtx: getTrainerObject checks
+		// ctx.Err() at the top of every read and returns Timeout, so a deadline
+		// landing mid-probe would surface as a bare timeout instead of the
+		// NotFound-plus-diagnosis this function exists to produce. Letting the
+		// select below own the deadline keeps the two conditions separable.
+		install, ok, err := isTrainerInstalled(ctx, dynamicClient)
 		if err != nil {
 			return trainerInstall{}, aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
 				"failed to check Kubeflow Trainer installation")
@@ -575,6 +580,16 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 
 		select {
 		case <-pollCtx.Done():
+			// pollCtx expires for two different reasons and they mean opposite
+			// things. A canceled parent means the run was aborted — catalog timeout,
+			// phase cancellation, the Job killed — and reporting that as a customer
+			// deployment defect is the same misclassification the NotFound code
+			// above exists to avoid, one level down.
+			if ctx.Err() != nil {
+				return trainerInstall{}, aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
+					"canceled while waiting for the recipe-declared Kubeflow Trainer", ctx.Err())
+			}
+
 			// ErrCodeNotFound, not Unavailable: the read succeeded and the answer was
 			// "not deployed". Unavailable is this package's code for a transport
 			// failure — see the decision table on validators.Require — and using it

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -652,11 +652,18 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 		// Report why from *this* probe, not the previous one. When ok is true the
 		// installation is complete, so reusing last would blame a missing object the
 		// probe just found — sending an operator to look for something that is there,
-		// when the real finding is a rollout slower than its budget.
-		expired := last
+		// when the real finding is a rollout slower than its budget. When ok is false
+		// the current probe's own finding is the specific object still missing, which
+		// the previous iteration's result would replace with a staler one — or, on the
+		// first probe, with the zero value's generic fallback.
+		//
+		// The complete case claims only what was observed. The wait never measures when
+		// the installation became complete, only when it saw that it was, so wording it
+		// as a transition would assert a time nobody read.
+		expired := install
 		if ok {
 			expired = trainerInstall{
-				Incomplete: "the installation became complete, but only after the allowance expired",
+				Incomplete: "the installation was observed complete only after the allowance expired",
 			}
 		}
 		if verdict := classifyPollExpiry(ctx, pollCtx, expired); verdict != nil {

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -628,8 +628,18 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 		// blind, so the verdict does not depend on where in the loop the clock ran out.
 		install, ok, err := isTrainerInstalled(pollCtx, dynamicClient)
 		if err != nil {
-			if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
-				return trainerInstall{}, verdict
+			// Let expiry win only for a context-derived error. A read that starts
+			// before the deadline and fails for a real reason after it — an apiserver
+			// 503, say — must keep its transport classification: reporting that as
+			// "the installation did not become complete" files a control-plane outage
+			// as a customer deployment defect, which is the same misclassification
+			// the NotFound/Unavailable distinction exists to prevent. It is also
+			// exactly when the apiserver is degraded that the transport signal is
+			// worth the most.
+			if errors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
+				if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
+					return trainerInstall{}, verdict
+				}
 			}
 			return trainerInstall{}, aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
 				"failed to check Kubeflow Trainer installation")
@@ -644,6 +654,9 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 			if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
 				return trainerInstall{}, verdict
 			}
+			// unreachable: this case fires only once pollCtx is done, and
+			// classifyPollExpiry always returns non-nil then. Kept as a fail-loud
+			// invariant rather than a silent fallthrough.
 			return trainerInstall{}, aicrErrors.New(aicrErrors.ErrCodeInternal,
 				"Kubeflow Trainer wait ended without a verdict")
 		case <-time.After(trainerInstallPollInterval):

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -190,6 +190,12 @@ type trainerInstall struct {
 	Namespace  string
 	Service    string
 	Deployment string
+
+	// Incomplete records which specific object was missing when the probe
+	// reported the installation as incomplete. The probe already determines this
+	// to log it; carrying it out makes the resulting failure self-diagnosing
+	// rather than sending an operator to the logs to find out what to fix.
+	Incomplete string
 }
 
 // trainerResourceRef identifies a Kubernetes resource applied during Trainer installation,
@@ -231,11 +237,11 @@ func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (t
 		}
 		if !found {
 			slog.Info("Kubeflow Trainer incomplete: CRD missing", "crd", crd)
-			return trainerInstall{}, false, nil
+			return trainerInstall{Incomplete: fmt.Sprintf("CRD %s is missing", crd)}, false, nil
 		}
 		if !isCRDEstablished(obj) {
 			slog.Info("Kubeflow Trainer incomplete: CRD not established", "crd", crd)
-			return trainerInstall{}, false, nil
+			return trainerInstall{Incomplete: fmt.Sprintf("CRD %s is not established", crd)}, false, nil
 		}
 	}
 
@@ -256,7 +262,7 @@ func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (t
 	if !ok {
 		slog.Info("Kubeflow Trainer incomplete: admission webhook missing",
 			"configuration", trainerMutatingWebhookConfig, "webhook", trainerMutatingWebhookName)
-		return trainerInstall{}, false, nil
+		return trainerInstall{Incomplete: "the validating admission webhook configuration is missing"}, false, nil
 	}
 
 	// The controller Deployment is found by label: its name is release-derived on
@@ -269,7 +275,7 @@ func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (t
 	if !found {
 		slog.Info("Kubeflow Trainer incomplete: controller Deployment missing",
 			"namespace", install.Namespace)
-		return trainerInstall{}, false, nil
+		return trainerInstall{Incomplete: "the controller Deployment was not found"}, false, nil
 	}
 	install.Deployment = controller
 
@@ -279,7 +285,7 @@ func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (t
 	} else if !found {
 		slog.Info("Kubeflow Trainer incomplete: controller Service missing",
 			"namespace", install.Namespace, "name", install.Service)
-		return trainerInstall{}, false, nil
+		return trainerInstall{Incomplete: "the controller Service was not found"}, false, nil
 	}
 
 	slog.Info("Kubeflow Trainer installation is complete",
@@ -326,14 +332,14 @@ func discoverTrainerInstall(ctx context.Context, dynamicClient dynamic.Interface
 			// rather than guessing a namespace and reinstalling on top of it.
 			slog.Info("Kubeflow Trainer webhook has no Service reference; cannot locate the installation",
 				"configuration", configName, "webhook", webhookName)
-			return trainerInstall{}, false, nil
+			return trainerInstall{Incomplete: "the admission webhook has no Service reference, so the installation namespace cannot be located"}, false, nil
 		}
 		return trainerInstall{Namespace: namespace, Service: service}, true, nil
 	}
 
 	slog.Info("Kubeflow Trainer incomplete: admission webhook missing",
 		"configuration", configName, "webhook", webhookName)
-	return trainerInstall{}, false, nil
+	return trainerInstall{Incomplete: "the validating admission webhook configuration is missing"}, false, nil
 }
 
 // getTrainerObject fetches one object. NotFound reports found=false with no
@@ -445,8 +451,10 @@ func trainerResourceClient(dynamicClient dynamic.Interface,
 //   - declared, but missing or incomplete: fail. Self-installing here would mask a
 //     broken deployment of a component the recipe promised, and the benchmark would
 //     then report a passing result for a cluster that cannot run TrainJobs at all.
-//   - not declared: install an ephemeral fixture and tear it down, as before. The
-//     recipe never claimed a Trainer, so there is nothing to mask.
+//   - not declared, and present: reuse it, unchanged. The recipe never claimed a
+//     Trainer, so a pre-existing one is not evidence of anything to report.
+//   - not declared, and absent: install an ephemeral fixture and tear it down, as
+//     before. There is nothing to mask, because nothing was promised.
 //
 // This is deliberately keyed on the recipe rather than on live cluster state, so the
 // same recipe behaves the same way regardless of what happens to be installed.
@@ -468,11 +476,23 @@ func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface
 		// is a deployment failure, not something to paper over. Installing our own
 		// here would produce a passing benchmark for a cluster whose delivered
 		// Trainer is broken.
+		//
+		// But isTrainerInstalled is an existence probe, not a readiness probe: it
+		// reports incomplete for a CRD that is present but not yet Established, or a
+		// controller Deployment that has not appeared yet. Both are ordinary rollout
+		// states on the bundle-deploy-validate path. Poll before declaring failure,
+		// so a validate that starts while the chart is still landing waits it out
+		// rather than reporting a deployment that has not failed.
 		if recipeDeclaresTrainer {
-			return nil, aicrErrors.New(aicrErrors.ErrCodeUnavailable, fmt.Sprintf(
-				"the recipe declares the %s component but no complete Kubeflow Trainer "+
-					"installation was found; the benchmark will not self-install over a "+
-					"delivered component that failed to deploy", kubeflowTrainerComponent))
+			declared, waitErr := waitForDeclaredTrainer(ctx, dynamicClient)
+			if waitErr != nil {
+				return nil, waitErr
+			}
+			// The delivered installation finished rolling out. Fall through to the
+			// same readiness wait a pre-existing installation gets, and claim no
+			// resources: the recipe owns this Trainer, not the benchmark.
+			install = declared
+			return nil, awaitTrainerController(ctx, dynamicClient, install)
 		}
 
 		// Before applying anything, check for a live installation somewhere else.
@@ -504,15 +524,74 @@ func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface
 		return created, nil
 	}
 
-	// The probe confirms every object exists; the controller may still be rolling.
-	// Wait for it here rather than reinstalling over a healthy Trainer we do not own.
+	return nil, awaitTrainerController(ctx, dynamicClient, install)
+}
+
+// awaitTrainerController waits for a Trainer the benchmark does not own to finish
+// starting. The probe confirms every object exists; the controller may still be
+// rolling, and waiting is the alternative to reinstalling over a healthy Trainer.
+func awaitTrainerController(ctx context.Context, dynamicClient dynamic.Interface, install trainerInstall) error {
 	slog.Info("Kubeflow Trainer already installed, waiting for controller readiness",
 		"namespace", install.Namespace, "deployment", install.Deployment)
 	if readyErr := waitForTrainerReady(ctx, dynamicClient, install.Namespace, install.Deployment); readyErr != nil {
-		return nil, aicrErrors.PropagateOrWrap(readyErr, aicrErrors.ErrCodeTimeout,
+		return aicrErrors.PropagateOrWrap(readyErr, aicrErrors.ErrCodeTimeout,
 			"pre-existing Kubeflow Trainer controller is not ready")
 	}
-	return nil, nil
+	return nil
+}
+
+// trainerInstallWaitTimeout and trainerInstallPollInterval bound the wait for a
+// recipe-declared Trainer to finish rolling out. They are variables rather than
+// constants only so tests can exercise the timeout path without waiting for it.
+var (
+	trainerInstallWaitTimeout  = defaults.TrainerControllerReadyTimeout
+	trainerInstallPollInterval = defaults.TrainerInstallPollInterval
+)
+
+// waitForDeclaredTrainer polls until a recipe-declared Kubeflow Trainer reports a
+// complete installation, or fails with the specific object that never appeared.
+//
+// The distinction it draws is the point of the recipe-driven lifecycle: an
+// installation that is still rolling out is not a failed one, but an installation
+// that never completes is — and the benchmark must not install its own Trainer over
+// a delivered component, because that would report a passing result for a cluster
+// whose Trainer is broken.
+func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface) (trainerInstall, error) {
+	var last trainerInstall
+
+	pollCtx, cancel := context.WithTimeout(ctx, trainerInstallWaitTimeout)
+	defer cancel()
+
+	for {
+		install, ok, err := isTrainerInstalled(pollCtx, dynamicClient)
+		if err != nil {
+			return trainerInstall{}, aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
+				"failed to check Kubeflow Trainer installation")
+		}
+		if ok {
+			return install, nil
+		}
+		last = install
+
+		select {
+		case <-pollCtx.Done():
+			// ErrCodeNotFound, not Unavailable: the read succeeded and the answer was
+			// "not deployed". Unavailable is this package's code for a transport
+			// failure — see the decision table on validators.Require — and using it
+			// here would file a product defect alongside apiserver hiccups, telling
+			// whoever triages it to re-run rather than to fix their deployment.
+			reason := last.Incomplete
+			if reason == "" {
+				reason = "no complete installation was found"
+			}
+			return trainerInstall{}, aicrErrors.New(aicrErrors.ErrCodeNotFound, fmt.Sprintf(
+				"the recipe declares the %s component but its Kubeflow Trainer installation "+
+					"did not become complete within %s: %s. The benchmark will not self-install "+
+					"over a delivered component that failed to deploy",
+				kubeflowTrainerComponent, trainerInstallWaitTimeout, reason))
+		case <-time.After(trainerInstallPollInterval):
+		}
+	}
 }
 
 // foldCleanupError decides the check's verdict when teardown fails. A cleanup

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -261,16 +261,19 @@ func isTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface) (t
 		return install, false, nil
 	}
 
-	ok, err := hasTrainerWebhook(ctx, dynamicClient,
+	reason, ok, err := hasTrainerWebhook(ctx, dynamicClient,
 		trainerMutatingWebhookGVR, trainerMutatingWebhookConfig, trainerMutatingWebhookName)
 	if err != nil {
 		return trainerInstall{}, false, err
 	}
 	if !ok {
-		slog.Info("Kubeflow Trainer incomplete: admission webhook missing",
-			"configuration", trainerMutatingWebhookConfig, "webhook", trainerMutatingWebhookName)
-		return trainerInstall{Incomplete: fmt.Sprintf(
-			"admission configuration %q is missing", trainerMutatingWebhookConfig)}, false, nil
+		// Carry the specific reason out rather than reporting every failure as a
+		// missing configuration: "create it" and "something else owns this name"
+		// are different jobs for whoever reads the verdict.
+		slog.Info("Kubeflow Trainer incomplete: mutating admission webhook unusable",
+			"configuration", trainerMutatingWebhookConfig, "webhook", trainerMutatingWebhookName,
+			"reason", reason)
+		return trainerInstall{Incomplete: reason}, false, nil
 	}
 
 	// The controller Deployment is found by label: its name is release-derived on
@@ -418,17 +421,28 @@ func trainerAPIErrorCode(err error) aicrErrors.ErrorCode {
 // serves the given Trainer webhook. The name check matters because the upstream
 // manifests use generic, unprefixed configuration names that another operator on
 // the cluster may already own.
+//
+// When the answer is no it returns the reason, because the two ways to get there
+// need different remedies: a configuration that is absent has to be created, while
+// one that exists but serves someone else's webhook has to be reconciled with
+// whatever already owns that name. Reporting both as "missing" — which is what
+// flattening this to a bare false did — sends an operator to create an object that
+// is already on the cluster. The validating-webhook path in discoverTrainerInstall
+// draws the same distinction.
 func hasTrainerWebhook(ctx context.Context, dynamicClient dynamic.Interface,
-	gvr schema.GroupVersionResource, configName, webhookName string) (bool, error) {
+	gvr schema.GroupVersionResource, configName, webhookName string) (string, bool, error) {
 
 	obj, found, err := getTrainerObject(ctx, dynamicClient, gvr, "", configName)
-	if err != nil || !found {
-		return false, err
+	if err != nil {
+		return "", false, err
+	}
+	if !found {
+		return fmt.Sprintf("admission configuration %q is missing", configName), false, nil
 	}
 
 	entries, _, err := unstructured.NestedSlice(obj.Object, "webhooks")
 	if err != nil {
-		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+		return "", false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
 			fmt.Sprintf("failed to read webhooks from %s %q", gvr.Resource, configName), err)
 	}
 	for _, e := range entries {
@@ -437,10 +451,11 @@ func hasTrainerWebhook(ctx context.Context, dynamicClient dynamic.Interface,
 			continue
 		}
 		if entry[keyName] == webhookName {
-			return true, nil
+			return "", true, nil
 		}
 	}
-	return false, nil
+	return fmt.Sprintf("admission configuration %q exists but does not contain the %q webhook",
+		configName, webhookName), false, nil
 }
 
 // trainerResourceClient returns the namespaced or cluster-scoped client for gvr.
@@ -556,7 +571,19 @@ func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface
 // Both paths route through here so the verdict does not depend on whether the clock
 // ran out during a probe or during a sleep: the same cluster state must not produce
 // two different codes.
-func classifyPollExpiry(ctx, pollCtx context.Context, last trainerInstall) error {
+//
+// observed carries a concrete incomplete observation — a probe that succeeded and
+// named the object that is not there — and it is what separates the two failing
+// codes. NotFound may only be synthesized from such an observation. Deriving it from
+// an empty one would report a degraded or slow apiserver, where every probe attempt
+// was a read timeout and nothing was ever read, as a customer deployment defect; and
+// it would report a probe that found the installation complete as one that found
+// nothing. With no observation to stand on, the honest verdict is the timeout that
+// actually happened. The allowance is enforced either way — only the classification
+// differs.
+//
+// unobserved is the reason to report in that case.
+func classifyPollExpiry(ctx, pollCtx context.Context, observed trainerInstall, unobserved string) error {
 	if ctx.Err() != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
 			"canceled while waiting for the recipe-declared Kubeflow Trainer", ctx.Err())
@@ -565,20 +592,25 @@ func classifyPollExpiry(ctx, pollCtx context.Context, last trainerInstall) error
 		return nil
 	}
 
+	verdict := fmt.Sprintf(
+		"the recipe declares the %s component but its Kubeflow Trainer installation "+
+			"did not become complete within %s: %%s. The benchmark will not self-install "+
+			"over a delivered component that failed to deploy",
+		kubeflowTrainerComponent, trainerInstallWaitTimeout)
+
+	if observed.Incomplete == "" {
+		if unobserved == "" {
+			unobserved = "the allowance expired before any probe could tell"
+		}
+		return aicrErrors.New(aicrErrors.ErrCodeTimeout, fmt.Sprintf(verdict, unobserved))
+	}
+
 	// ErrCodeNotFound, not Unavailable: the read succeeded and the answer was "not
 	// deployed". Unavailable is this package's code for a transport failure — see
 	// the decision table on validators.Require — and using it here would file a
 	// product defect alongside apiserver hiccups, telling whoever triages it to
 	// re-run rather than to fix their deployment.
-	reason := last.Incomplete
-	if reason == "" {
-		reason = "no complete installation was found"
-	}
-	return aicrErrors.New(aicrErrors.ErrCodeNotFound, fmt.Sprintf(
-		"the recipe declares the %s component but its Kubeflow Trainer installation "+
-			"did not become complete within %s: %s. The benchmark will not self-install "+
-			"over a delivered component that failed to deploy",
-		kubeflowTrainerComponent, trainerInstallWaitTimeout, reason))
+	return aicrErrors.New(aicrErrors.ErrCodeNotFound, fmt.Sprintf(verdict, observed.Incomplete))
 }
 
 // awaitTrainerController waits for a Trainer the benchmark does not own to finish
@@ -637,7 +669,12 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 			// exactly when the apiserver is degraded that the transport signal is
 			// worth the most.
 			if errors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
-				if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
+				// last is the newest concrete observation, and it is the zero value
+				// until some probe completes. When every attempt was cut short by the
+				// deadline there is nothing on the cluster to point at, so this stays
+				// a timeout rather than becoming a deployment defect.
+				if verdict := classifyPollExpiry(ctx, pollCtx, last,
+					"no probe completed before the allowance expired"); verdict != nil {
 					return trainerInstall{}, verdict
 				}
 			}
@@ -660,13 +697,16 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 		// The complete case claims only what was observed. The wait never measures when
 		// the installation became complete, only when it saw that it was, so wording it
 		// as a transition would assert a time nobody read.
-		expired := install
+		//
+		// A complete probe is not an incomplete observation, so it is reported as the
+		// timeout it is: the installation is there, and the only finding is a rollout
+		// or a read slower than the budget.
+		observed, unobserved := install, ""
 		if ok {
-			expired = trainerInstall{
-				Incomplete: "the installation was observed complete only after the allowance expired",
-			}
+			observed = trainerInstall{}
+			unobserved = "the installation was observed complete only after the allowance expired"
 		}
-		if verdict := classifyPollExpiry(ctx, pollCtx, expired); verdict != nil {
+		if verdict := classifyPollExpiry(ctx, pollCtx, observed, unobserved); verdict != nil {
 			return trainerInstall{}, verdict
 		}
 		if ok {
@@ -676,7 +716,8 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 
 		select {
 		case <-pollCtx.Done():
-			if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
+			if verdict := classifyPollExpiry(ctx, pollCtx, last,
+				"no probe completed before the allowance expired"); verdict != nil {
 				return trainerInstall{}, verdict
 			}
 			// unreachable: this case fires only once pollCtx is done, and

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -648,7 +648,18 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 		// just after the deadline, and taking ok on that read would let the wait
 		// outrun its own allowance — the bound has to cover the answer, not only
 		// the question.
-		if verdict := classifyPollExpiry(ctx, pollCtx, last); verdict != nil {
+		//
+		// Report why from *this* probe, not the previous one. When ok is true the
+		// installation is complete, so reusing last would blame a missing object the
+		// probe just found — sending an operator to look for something that is there,
+		// when the real finding is a rollout slower than its budget.
+		expired := last
+		if ok {
+			expired = trainerInstall{
+				Incomplete: "the installation became complete, but only after the allowance expired",
+			}
+		}
+		if verdict := classifyPollExpiry(ctx, pollCtx, expired); verdict != nil {
 			return trainerInstall{}, verdict
 		}
 		if ok {

--- a/validators/performance/trainer_probe_test.go
+++ b/validators/performance/trainer_probe_test.go
@@ -17,7 +17,9 @@ package main
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -717,6 +719,62 @@ func TestTrainerResourceRefString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.ref.String(); got != tt.want {
 				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsTrainerInstalled_MutatingConfigReasonsAreDistinct pins the two shapes of a
+// missing mutating webhook apart.
+//
+// "The configuration does not exist" and "the configuration exists but does not
+// serve our webhook" need different remedies, and flattening both to the first tells
+// an operator to create an object that is already on the cluster — which, on the
+// generic upstream configuration names another operator may own, is the shape most
+// likely to be hit. The validating-webhook discovery path already keeps them apart;
+// this is the same contract on the mutating one.
+func TestIsTrainerInstalled_MutatingConfigReasonsAreDistinct(t *testing.T) {
+	tests := []struct {
+		name         string
+		objs         []runtime.Object
+		wantContains string
+		wantAbsent   string
+	}{
+		{
+			name: "configuration absent",
+			objs: withoutObject(completeTrainerInstall(), dropByName(trainerMutatingWebhookConfig)),
+			wantContains: fmt.Sprintf("admission configuration %q is missing",
+				trainerMutatingWebhookConfig),
+		},
+		{
+			name: "configuration present but serving another operator's webhook",
+			objs: append(
+				withoutObject(completeTrainerInstall(), dropByName(trainerMutatingWebhookConfig)),
+				webhookConfig("MutatingWebhookConfiguration", trainerMutatingWebhookConfig,
+					"defaulter.other.example.com"),
+			),
+			wantContains: fmt.Sprintf("exists but does not contain the %q webhook",
+				trainerMutatingWebhookName),
+			wantAbsent: fmt.Sprintf("admission configuration %q is missing",
+				trainerMutatingWebhookConfig),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			install, installed, err := isTrainerInstalled(context.Background(), newTrainerFakeClient(tt.objs...))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if installed {
+				t.Fatal("incomplete Trainer installation reported as installed")
+			}
+			if !strings.Contains(install.Incomplete, tt.wantContains) {
+				t.Errorf("reason = %q, want it to contain %q", install.Incomplete, tt.wantContains)
+			}
+			if tt.wantAbsent != "" && strings.Contains(install.Incomplete, tt.wantAbsent) {
+				t.Errorf("reason %q tells the operator to create a configuration that "+
+					"already exists", install.Incomplete)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The NCCL benchmark decides whether to self-install Kubeflow Trainer by probing the cluster. It now decides from the recipe, so a recipe that ships the component and fails to deploy it produces an error instead of a silently-installed workaround.

First part of #2297 only. No evidence-classification or derive-from-shipped work here.

## Motivation / Context

Part of #2297. Part of #2217.

`ensureTrainerInstalled` probed for a Trainer and installed one when it found none. Two consequences:

- **The same recipe validated differently** depending on what happened to be installed.
- **Deployment failures were masked.** A recipe shipping `kubeflow-trainer` whose Trainer failed to deploy got an ephemeral fixture installed over the gap, and the benchmark then reported a passing bandwidth result for a cluster that cannot run TrainJobs at all.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Validator (`pkg/validator`)

## Implementation Notes

`ensureTrainerInstalled` takes the recipe's declaration and keys on it:

| Recipe declares | Live installation | Behaviour |
|---|---|---|
| yes | complete | use the delivered installation — **unchanged** |
| yes | still rolling out | **poll**, bounded by `TrainerControllerReadyTimeout` |
| yes | never completes | **fail**, naming the component and what was missing |
| no | present | reuse it — **unchanged** |
| no | absent | install an ephemeral fixture and tear it down — **unchanged** |

Two rows are new: the poll, and the failure. Previously an incomplete installation went straight to the install/conflict path.

**`ErrCodeNotFound`, not `Unavailable`.** `validators/applicability.go` is the in-repo authority: *clean read, absent/empty │ recipe DECLARES → FAIL (NotFound)*, with `Unavailable` reserved for transport failures. The read here succeeds and the answer is "not deployed", so filing it under `Unavailable` would tell whoever triages the new failures to re-run rather than to fix their deployment.

**`NotFound` is synthesized only from a concrete incomplete observation** — a probe that succeeded and named the object that is not there. The allowance can also run out with nothing observed at all: every probe attempt cut short by the deadline, or a probe that came back complete just after it. Deriving `NotFound` from those would file a degraded or slow apiserver as a customer deployment defect, and would report a probe that found the installation complete as one that found nothing. With no observation to stand on, the verdict keeps its `ErrCodeTimeout` classification. The rollout allowance is enforced either way — the wait still fails; only the code differs.

**A missing mutating admission configuration reports which kind of missing it is.** An absent configuration has to be created; one that exists but serves another operator's webhook — likely on the generic, unprefixed upstream names — has to be reconciled with whatever owns that name. Both were flattened to "the configuration is missing", which sent an operator to create an object already on the cluster. The reason is now carried out, matching the validating-webhook discovery path.

**The poll exists because `isTrainerInstalled` is an existence probe, not a readiness one.** It reports incomplete for a CRD present but not yet `Established`, or a controller Deployment that has not appeared — ordinary states on the bundle→deploy→validate path. Without the wait, a validate started while the chart was landing would report a deployment that had not failed.

**Cancellation is separated from the deadline.** `pollCtx` expires both when the rollout allowance runs out and when the parent run is aborted; only the first is a deployment defect. A canceled parent yields `ErrCodeTimeout`. A genuine transport failure keeps its own classification — expiry wins only for context-derived errors, since `ExitCodeFromError` reads the outermost code and a swallowed 503 would send the operator to fix the wrong thing.

**The allowance bounds the probe, not only the sleeps.** Probes run under the poll context, and expiry is rechecked before a result is accepted, so a read completing just after the deadline cannot report success.

**The failure is self-diagnosing.** `isTrainerInstalled` already determined which object was missing in order to log it; that reason is now carried on `trainerInstall.Incomplete` and named in the error.

**Applicability is deliberately untouched.** It is already recipe-derived through `supportedNCCLCombinations` and the `nccl-benchmark-profile` constraint. Gating it on `RecipeDeclares` would be a regression: the `nccl-all-reduce-bw*` constraints are declared on six base overlays, none of which carry `kubeflow-trainer`, so the benchmark would be skipped on every recipe that declares it.

**Standalone and no-recipe runs are unaffected.** `RecipeDeclares` is nil-safe and returns `false` without a recipe, so those keep today's behaviour exactly.

## Testing

- `go test ./validators/... ./pkg/defaults/ -race -count=1` — all packages pass
- `golangci-lint run -c .golangci.yaml ./validators/performance/...` — 0 issues

Tests are table-driven over the decision, asserting the error **code** rather than only the message. Nine separate tests cover branches a table row cannot reach, plus one over the two shapes of an unusable mutating admission configuration. Each was control-verified — the guard was neutralised and the test confirmed to fail with the predicted message, then restored:

- **rollout then complete** — a stateful fake reports incomplete on the first probe and complete later, the state a fall-through bug lived in
- **canceled run** — asserts `ErrCodeTimeout`, not `ErrCodeNotFound`, so an aborted run is never filed as a failed deployment
- **slow first read** — a probe outliving the allowance must not report success, and with a complete installation underneath the verdict is `ErrCodeTimeout`
- **late final read** — the same, for a probe whose *last* read returns after expiry
- **read timeouts only** — the allowance expires with no probe ever reaching a conclusion; nothing was observed, so this is `ErrCodeTimeout` and not a deployment defect
- **transport failure past the deadline** — asserts the *outermost* code is `Unavailable`, the value `ExitCodeFromError` resolves
- **expiry on an incomplete probe** — `ErrCodeNotFound`, and the reason must name the object the probe that just ran found missing, not the previous iteration's result
- **late-success wording** — the reason may claim only that completeness was *observed* after expiry, not when it occurred
- **mutating configuration reasons** — an absent configuration and one serving another operator's webhook must not report the same reason

The timing tests passed ten consecutive `-race` runs.

The not-declared-and-absent row is covered by e2e rather than unit tests: it downloads and kustomize-builds the upstream release archive.

## Risk Assessment

- [x] **Medium** — Touches multiple components or has broader impact

The new failure path is reachable on any recipe declaring `kubeflow-trainer` whose Trainer does not become complete within the rollout allowance — previously a silent self-install, now a failed check. That is the intended correction, but it will surface as newly-failing validations on clusters where the component is broken.

**Rollout notes:** No API or recipe changes. A cluster whose delivered Trainer is healthy sees identical behaviour.


### End-to-end validation on a live cluster

Verified on an EKS GB200 cluster (`yljtrxpmzu-dgxc-k8s-aws-use1`, 2x GB200, 4 GPUs each) by
uninstalling the Kubeflow Trainer Helm release and running the same recipe twice, changing
only the validator image. Note the fix ships in the `aicr-validators/performance` **image**,
not the `aicr` CLI binary, so a local CLI build alone does not exercise it.

Cluster state under test: Trainer controller and admission webhook removed, CRDs still
present — the partial state a `helm uninstall` leaves behind, and exactly the ambiguous
case the bounded poll exists for.

| Validator image | `nccl-all-reduce-bw-net` |
|---|---|
| `main` (`:edge`) — before | **passed** |
| this PR — after | **failed** |

Before, on `main`, the benchmark silently installed an ephemeral fixture over the missing
component and certified inter-node bandwidth for a cluster that cannot run a TrainJob at
all. After, it refuses and reports:

```
[NOT_FOUND] the recipe declares the kubeflow-trainer component but its Kubeflow Trainer
installation did not become complete within 2m0s: admission configuration
"validator.trainer.kubeflow.org" is missing. The benchmark will not self-install over a
delivered component that failed to deploy
```

That confirms on real hardware what the unit tests assert: the `NOT_FOUND` code rather than
`Unavailable`, the component named, the specific missing object named, and the 2m rollout
allowance honoured before failing. `nccl-all-reduce-bw-nvls` now fails at the same Trainer
check instead of proceeding to an unrelated IMEX timeout, which is the correct ordering.

A second run with a recipe that does **not** declare `kubeflow-trainer`, against the same
Trainer-absent cluster, passed `nccl-all-reduce-bw-net` — the benchmark self-installed its
own fixture and produced a bandwidth result. So the `not declared / absent -> self-install`
row is unchanged and non-declaring recipes are unaffected.

`nccl-all-reduce-bw-nvls` failed identically in both the before and after runs with
`timed out waiting for DRA driver to reconcile ComputeDomain into a ResourceClaimTemplate`.
That is pre-existing cluster infrastructure, unrelated to this change; it appears in the
`main` control run too.

The Kubeflow Trainer was reinstalled afterwards from the captured Helm values (chart
`kubeflow-trainer-2.2.1`, namespace `kubeflow-system`) and verified healthy, and the
validator artifacts were removed.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — N/A, no user-facing surface changes
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed and signed off (`git commit -S -s`)



