### PR TITLE
docs(aibom): correct the record left stale by the v1.3.0 re-pin

### DIFF
--- a/docs/design/019-k8s-aibom-runtime-inventory.md
+++ b/docs/design/019-k8s-aibom-runtime-inventory.md
@@ -680,8 +680,8 @@ A third entry is the signal to revisit rather than extend by reflex.
 | Selection and opt-out semantics | Resolved — E |
 | Non-alpha storage API and migration policy | Resolved — A |
 | Concrete user-demand case | Resolved — D |
-| Managed-cluster qualification and measured cost | Planned — [#2271](https://github.com/NVIDIA/aicr/issues/2271) |
-| Upgrade, rollback, uninstall, support evidence | Planned — [#2282](https://github.com/NVIDIA/aicr/issues/2282) |
+| Managed-cluster qualification and measured cost | Planned — [#2310](https://github.com/NVIDIA/aicr/issues/2310) |
+| Upgrade, rollback, uninstall, support evidence | Planned — [#2311](https://github.com/NVIDIA/aicr/issues/2311) |
 
 Decision 4 is unchanged: chart, image, CRDs, and the public status contract
 remain one versioned set, so the graduation release requires full

--- a/recipes/components/k8s-aibom/values.yaml
+++ b/recipes/components/k8s-aibom/values.yaml
@@ -15,7 +15,8 @@
 # k8s-aibom Helm values
 # Optional runtime AI-workload inventory. Registry-only: no stock recipe
 # selects this component. The digest and defaults below were qualified as one
-# coherent v1.2.0 artifact set under ADR-019.
+# coherent v1.3.0 artifact set under ADR-019, re-pinned from v1.2.0 when
+# upstream graduated the API to v1beta1.
 
 image:
   repository: ghcr.io/googlecloudplatform/k8s-aibom
@@ -58,8 +59,10 @@ securityContext:
   runAsUser: 65532
   allowPrivilegeEscalation: false
 
-# Measured at 0, 250, and 1,000 replicas-zero workloads. At 1,000 workloads,
-# the final v1.2.0 image converged in 14s and remained below 231m CPU / 49MiB.
+# Envelope measured on GKE with the qualified v1.3.0 image (#2310), at 0, 251,
+# and 1,001 workloads, each a Deployment with replicas set to zero. At 1,001
+# workloads memory reached 67-69MiB and steady-state CPU was 1-2m, both well
+# inside the requests below. Convergence completed within 10s.
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
## Summary

Corrects two places where the record went stale when #2309 re-pinned `k8s-aibom` to chart v1.3.0.

## Motivation / Context

The ADR-019 requirement-status table pointed the upgrade-evidence row at #2282, which closed as the requalification and never carried that evidence, and pointed the managed-cluster row at the epic rather than at the issue tracking it. Both now point at the issues that actually track them.

The component values still described the pinned digest as a v1.2.0 artifact set after the re-pin moved it to v1.3.0, and stated the resource envelope without saying it was measured on Kind, or that neither the v1.3.0 image nor a managed control plane has been re-measured against it.

Fixes: N/A
Related: #2271, #2309, #2310, #2311

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`) — component values comment only
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Comment-only in the values file, so no rendered output changes and no golden moves.

ADR-019's dated Status block is deliberately left untouched. It records what was accepted on 2026-08-19, and the ADR itself says so; the requalified v1.3.0 set is recorded separately in the amendment. Only the forward-looking requirement-status rows were wrong.

## Testing

```bash
make qualify
```

`Codebase qualification completed`, exit 0, zero failures.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A. No behavior change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, no functional change
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
