### PR TITLE
docs: clarify NCCL banner location and interface assumptions

### DIFF
--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -263,8 +263,9 @@ Also TrainJob-expressible. AICR fixes the resource name and the value is always
 primary interface. AICR's tested AKS runtime sets it, as does the EKS one — on
 a multi-NIC node, leaving NCCL to guess can send rendezvous traffic down an
 interface that cannot carry it. `eth0` assumes the pod's primary interface is
-named that; under `hostNetwork` or a non-standard CNI it may not be. Confirm on
-a running pod with `kubectl exec ... -- ip route get 1.1.1.1` and pin whatever
+named that; under `hostNetwork` or a non-standard CNI it may not be. Confirm
+on a running pod with
+`kubectl exec -n <namespace> <pod> -- ip route get 1.1.1.1` and pin whatever
 that reports.
 
 The same repeat-every-resource caveat applies.
@@ -307,8 +308,9 @@ kubectl logs -n <namespace> -c node --tail=-1 --prefix \
 
 This selects the `node` replicated job, which is where a node-only runtime such
 as `torch-distributed` prints the banner. If your runtime uses an MPI launcher —
-as AICR's tested AKS runtime does — the ranks are aggregated in the `launcher`
-pod and the `node` pods run only sshd, so select
+as AICR's tested AKS runtime does — the rank processes still execute on the
+`node` pods, but they are started over sshd and `mpirun` aggregates their
+stdout in the `launcher` pod, so select
 `jobset.sigs.k8s.io/replicatedjob-name=launcher` instead. A grep against `node`
 on such a runtime finds nothing, which is not evidence of socket fallback.
 

--- a/docs/user/fabric-attached-training.md
+++ b/docs/user/fabric-attached-training.md
@@ -262,7 +262,10 @@ Also TrainJob-expressible. AICR fixes the resource name and the value is always
 `NCCL_SOCKET_IFNAME` pins NCCL's bootstrap and out-of-band traffic to the
 primary interface. AICR's tested AKS runtime sets it, as does the EKS one — on
 a multi-NIC node, leaving NCCL to guess can send rendezvous traffic down an
-interface that cannot carry it.
+interface that cannot carry it. `eth0` assumes the pod's primary interface is
+named that; under `hostNetwork` or a non-standard CNI it may not be. Confirm on
+a running pod with `kubectl exec ... -- ip route get 1.1.1.1` and pin whatever
+that reports.
 
 The same repeat-every-resource caveat applies.
 
@@ -297,10 +300,17 @@ socket fallback:
 # Select workers by label rather than guessing the generated pod name.
 # --tail=-1 is required: with a selector, kubectl defaults to the last 10 lines
 # and would omit the transport banner, which NCCL prints during init.
-kubectl logs -n <namespace> -c node --tail=-1 \
+kubectl logs -n <namespace> -c node --tail=-1 --prefix \
   -l jobset.sigs.k8s.io/jobset-name=<trainjob-name>,jobset.sigs.k8s.io/replicatedjob-name=node \
   | grep -i 'NCCL INFO.*Using network'
 ```
+
+This selects the `node` replicated job, which is where a node-only runtime such
+as `torch-distributed` prints the banner. If your runtime uses an MPI launcher —
+as AICR's tested AKS runtime does — the ranks are aggregated in the `launcher`
+pod and the `node` pods run only sshd, so select
+`jobset.sigs.k8s.io/replicatedjob-name=launcher` instead. A grep against `node`
+on such a runtime finds nothing, which is not evidence of socket fallback.
 
 Expect the plugin name — `FasTrak` for TCPXO, `AWS Libfabric` for EFA, `IB` for
 InfiniBand. **`Socket` means the fabric is not in use** and the job is running


### PR DESCRIPTION
## Summary

Three small clarifications to `docs/user/fabric-attached-training.md`: where the NCCL transport banner actually lands on an MPI-launcher runtime, that `eth0` is an assumption to confirm rather than a fact, and pod attribution on the verification `kubectl logs` command.

## Motivation / Context

Follow-up to #2315, addressing review feedback left on that PR after it merged.

- **MPI launcher vs node pods.** The verification command selects `replicatedjob-name=node`. On an MPI-launcher runtime the NCCL ranks are aggregated in the `launcher` pod and the `node` pods run only sshd, so the grep finds nothing — which a reader could misread as socket fallback. Confirmed against `validators/performance/nccl_all_reduce_bw_constraint.go`: `waitForLauncherPodAndGetLogs` selects `jobset.sigs.k8s.io/replicatedjob-name=launcher` for run output, while the `node` selector in `collectNCCLWorkerDiagnostics` is documented as failure-path diagnostics only. AICR's tested AKS runtime is MPI-based; the EKS `torch-distributed` examples on the page are node-only, so both cases are now stated.
- **`eth0` asserted flatly.** The page already tells readers to read EFA counts and GKE network names per cluster, but stated `eth0` as bare fact. Now hedged in parallel, with `ip route get 1.1.1.1` as the confirmation step for `hostNetwork` or a non-standard CNI.
- **Missing pod attribution.** `kubectl logs -l` without `--prefix` concatenates worker logs with no pod names.

Fixes: N/A
Related: #2315

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

Deliberately minimal — no restructuring, no new sections, no unrelated fixes. No headings were added or renamed, so no anchors changed and no inbound links needed updating.

## Testing

```bash
make check-docs-filenames      # OK: all doc filenames follow kebab-case convention
make check-docs-mdx            # OK: all doc files are MDX-safe
make check-docs-mdx-parse      # OK: 54 doc file(s) parse as MDX
```

Also verified by hand: code fences balanced (14), all four YAML blocks free of a bare `...` document-end marker, and every relative link on the page still resolves (including the three anchor targets in `docs/integrator/gke-tcpxo-networking.md`).

Full `make qualify` was skipped because this is a docs-only change — no `.go`, YAML, or build inputs are touched, so Go tests, e2e, and Go lint cannot regress from it. The scoped checks above are exactly the gates that apply to `docs/**`; CI additionally runs lychee link checking on docs PRs.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, docs-only; scoped docs gates run instead
- [x] Linter passes (`make lint`) — docs lint targets run; Go/YAML lint N/A
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, docs-only
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
