### PR TITLE
docs: finish DaemonSet casing pass and bump a stale aicrd tag

### DIFF
--- a/docs/integrator/kubernetes-deployment.md
+++ b/docs/integrator/kubernetes-deployment.md
@@ -609,7 +609,7 @@ as HTTP 429 responses with the `X-RateLimit-*` headers.
 ```shell
 # Update image
 kubectl set image deployment/aicrd \
-  api-server=ghcr.io/nvidia/aicrd:v0.8.0 \
+  api-server=ghcr.io/nvidia/aicrd:v0.19.0 \
   -n aicr
 
 # Watch rollout

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1526,7 +1526,7 @@ The `--accelerated-node-selector` and `--accelerated-node-toleration` flags cont
 
 NFD (Node Feature Discovery) workers must run on **all nodes** (GPU, CPU, and system) to detect hardware features. This matches the gpu-operator default behavior where NFD workers also run on control-plane nodes. The `--accelerated-node-selector` is intentionally not applied to NFD workers so they are not restricted to GPU nodes.
 
-> **Note:** When no `--accelerated-node-toleration` is specified, a default toleration (`operator: Exists`) is applied to both GPU daemonsets and NFD workers, allowing them to run on nodes with any taint.
+> **Note:** When no `--accelerated-node-toleration` is specified, a default toleration (`operator: Exists`) is applied to both GPU DaemonSets and NFD workers, allowing them to run on nodes with any taint.
 
 **Example:**
 
@@ -1544,7 +1544,7 @@ aicr bundle --recipe recipe.yaml \
 > **Cluster node requirements:** This example assumes the cluster has nodes labeled `nodeGroup=system-worker` with taints `dedicated=system-workload:NoSchedule,NoExecute` for system infrastructure, and GPU nodes labeled `nodeGroup=gpu-worker` with taints `dedicated=worker-workload:NoSchedule,NoExecute`.
 
 This results in:
-- **GPU daemonsets** (driver, device-plugin, toolkit, dcgm): `nodeSelector=nodeGroup=gpu-worker` + tolerations for `dedicated=worker-workload` with both `NoSchedule` and `NoExecute`
+- **GPU DaemonSets** (driver, device-plugin, toolkit, dcgm): `nodeSelector=nodeGroup=gpu-worker` + tolerations for `dedicated=worker-workload` with both `NoSchedule` and `NoExecute`
 - **NFD workers**: no nodeSelector (runs on all nodes) + tolerations for `dedicated=worker-workload` with both `NoSchedule` and `NoExecute`
 - **System components** (gpu-operator controller, NFD gc/master, dynamo grove, agentgateway proxy): `nodeSelector=nodeGroup=system-worker` + tolerations for `dedicated=system-workload` with both `NoSchedule` and `NoExecute`
 
@@ -2629,9 +2629,9 @@ Components that use operator patterns with custom resources that reconcile async
 
 ##### DRA kubelet plugin registration
 
-After installing `nvidia-dra-driver-gpu`, the script automatically restarts the DRA kubelet plugin daemonset. This is a best-effort mitigation for a known issue: after uninstall/reinstall, the kubelet's plugin watcher (`fsnotify`) may not detect new registration sockets, causing `DRA driver gpu.nvidia.com is not registered` errors.
+After installing `nvidia-dra-driver-gpu`, the script automatically restarts the DRA kubelet plugin DaemonSet. This is a best-effort mitigation for a known issue: after uninstall/reinstall, the kubelet's plugin watcher (`fsnotify`) may not detect new registration sockets, causing `DRA driver gpu.nvidia.com is not registered` errors.
 
-If DRA pods fail with this error after redeployment, the daemonset restart alone may not be sufficient — a **node reboot** is required to reset the kubelet's plugin registration state. To reboot GPU nodes:
+If DRA pods fail with this error after redeployment, the DaemonSet restart alone may not be sufficient — a **node reboot** is required to reset the kubelet's plugin registration state. To reboot GPU nodes:
 
 ```bash
 # Cordon, drain, and reboot the affected node


### PR DESCRIPTION
> **This is a follow-up to #2335.** That PR (the release-prep documentation sweep) was approved with two non-blocking minor findings, which it left unfixed. This PR fixes both. It is docs-only: 2 files, +5/−5.

## Summary

Fixes the two 🟡 minor findings from the review on #2335: a `DaemonSet` casing mismatch that #2335 introduced, and a stale `aicrd` image tag its version sweep missed.

## Motivation / Context

**F1 — casing mismatch #2335 introduced.** That PR cased the `GPU DaemonSets` table header in `cli-reference.md` (L1520) but left the same section's Note (L1529) and bullet (L1547) reading `GPU daemonsets`. A casing sweep that creates a within-section mismatch is worse than one that skips the section, so this should not sit.

While fixing it I re-swept the file for the same class and found two more prose instances in the DRA kubelet plugin section (L2632, L2634). Those are fixed here too, so the file does not need a third pass.

Left lowercase on purpose, because lowercase is correct there:

- `--ignore-daemonsets` (L2639) — a `kubectl` flag
- `CRD/namespace/daemonset create` (L92) — an RBAC resource-name list

**F2 — stale server image tag missed by the version sweep.** The rolling-update example in `kubernetes-deployment.md` (L612) pinned `ghcr.io/nvidia/aicrd` to `v0.8.0`, roughly eleven releases old, in a copy-pasteable command. #2335 normalized client tags using a pattern matching `aicr:` / `aicr_` / `aicr@` — which never matches `aicrd:`, so the server image slipped through. Bumped to `v0.19.0`.

A broader re-sweep confirms that was the only stale `aicrd:` tag in `docs/`.

Fixes: N/A
Related: #2335 (this PR completes its review follow-ups)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

Deliberately **not** included, to keep this scoped to the two review findings:

- `docs/integrator/components/nodewright.md` L52 says "provide the configuration via configmaps" — same lowercase-kind class, but a different file that neither #2335 nor its review touched. Noting it rather than folding it in.
- The RBAC permission list in `agent-deployment.md` (`apps/daemonsets`, `serviceaccounts`, `configmaps`, `roles, rolebindings`) is correctly lowercase — those are API resource names, not kind references.
- The `aicrd:v1.0.0` placeholder in `.github/actions/README.md` is a parameter example, not a version claim.
- The `v0.8.12` SBOM sample in `supply-chain-verification.md` is one internally coherent captured attestation across five sites; the review already refuted bumping it.

## Testing

Docs-only; no Go, YAML schema, or build inputs touched, so tests, e2e, and Go lint cannot regress from this diff.

```bash
./tools/check-docs-filenames    # OK: all doc filenames follow kebab-case convention
./tools/check-docs-mdx          # OK: all doc files are MDX-safe
./tools/check-docs-mdx-parse    # OK: 54 doc file(s) parse as MDX
./tools/check-agents-sync       # OK: AGENTS.md is in sync with .claude/CLAUDE.md
git diff --check                # clean
```

Also re-ran a repo-wide sweep for lowercase Kubernetes kind names in prose (excluding code fences, inline code, and URLs) to confirm this pass is complete for `cli-reference.md`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — prose casing and one example image tag.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (`make lint`) — doc-lint subset run, see Testing
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, documentation only
- [x] I updated docs if user-facing behavior changed — N/A, no behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
