### PR TITLE
ci: enforce the DGXC Go proxy, closing the fallthrough gap

### DIFF
--- a/.github/workflows/dgxc-goproxy-probe.yaml
+++ b/.github/workflows/dgxc-goproxy-probe.yaml
@@ -25,12 +25,48 @@
 # `refs/pull/N/merge` instead and cannot validate the identity mapping the
 # exchange actually matches on.
 #
-# What a green run proves: the OIDC exchange mints a token, GOPROXY is ordered
-# with Artifactory first, GOSUMDB verification is intact, and a real module graph
-# resolves. What it does NOT prove: coverage. Under `routed` the resolver falls
-# through to `direct` on 404/410, so a module Artifactory does not carry is
-# fetched from the public internet and the build still goes green. Only
-# `enforced` closes that, and only once the graph is known to be served.
+# Runs in `enforced` mode: GOPROXY carries no `,direct` fallback, so a module
+# Artifactory does not serve is a hard failure rather than a silent fetch from
+# the public internet.
+#
+# That also makes this workflow its own coverage measurement. Under `routed` a
+# green run proved only that nothing was *rejected*; a 404 fell through and the
+# build still passed, so coverage was unknown. With the fallback gone, a green
+# run means every module in the resolved graph came from Artifactory — there is
+# nowhere else it could have come from. No separate reporting step is needed:
+# the failure mode names the unserved module directly.
+#
+# Safe to enforce here first because nothing depends on this workflow. It
+# verifies a property; it does not build or ship anything. If Artifactory turns
+# out not to serve some module, the blast radius is one red check on main.
+#
+# ---------------------------------------------------------------------------
+# THIS FILE IS TEMPORARY. Delete it as part of #2374.
+#
+# Almost every assertion below exists because this workflow builds nothing:
+# `cache: false`, the cold-cache check, the download count, and the archive
+# canary all answer "did anything actually happen?" A real build answers that
+# by existing — if Artifactory cannot serve a module, `go build` fails. The
+# build is the assertion.
+#
+# When #2374 lands and real jobs resolve through the proxy, carry over only:
+#
+#   - `mode: enforced` on the action
+#   - `id-token: write` and the credential teardown step
+#   - the GOPROXY assertion (exact match, single entry)
+#
+# That last one is the only guard worth keeping, because it catches what a
+# build cannot: the action silently no-opping, or a revert to `routed`. Either
+# looks perfectly healthy while routing nothing.
+#
+# Everything else dies with this file. The vendor-equivalence and
+# resolver-posture steps in particular exist only because the repo vendors,
+# which is the thing #2374 removes.
+#
+# If a proxy canary is still wanted afterwards, write a new ~20-line
+# dispatch-only one. Its job is separating "the proxy is broken" from "the code
+# is broken" when a build fails — an ops tool, not this measurement rig.
+# ---------------------------------------------------------------------------
 name: DGXC Go Proxy Probe
 
 on:
@@ -87,6 +123,17 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
           go-version-file: go.mod
+          # Required for this workflow to measure anything. setup-go caches
+          # GOMODCACHE and GOCACHE by default, and the proxy action sets
+          # GOFLAGS=-mod=readonly so Go reads the module cache rather than
+          # vendor/. A cache restored from an earlier run therefore satisfies
+          # `go mod download` without contacting Artifactory at all, and the
+          # job goes green having proven nothing.
+          #
+          # This is not hypothetical: the first enforced run here hit a 608 MB
+          # cache and emitted zero `go: downloading` lines. Every other job in
+          # the repo should keep caching; this one exists to force real fetches.
+          cache: false
 
       # No tooling is installed in this job, so rule 4 ("install tooling before
       # configuring the proxy") is satisfied trivially. That is not true of
@@ -94,7 +141,7 @@ jobs:
       - name: Configure the DGXC Go proxy
         uses: ./.github/actions/setup-dgxc-goproxy
         with:
-          mode: routed
+          mode: enforced
 
       # Non-optional. GOPROXY is an ordered list and Go consults later entries
       # only on 404/410, so `proxy.golang.org,<artifactory>,direct` looks routed,
@@ -109,12 +156,94 @@ jobs:
           case "${proxy}" in
             *"|"*) echo "GOPROXY uses '|', which falls through on 401/403. Use ','."; exit 1 ;;
           esac
-          case "${proxy%%,*}" in
-            https://edge.urm.nvidia.com/*) ;;
-            *) echo "first GOPROXY entry is '${proxy%%,*}', not Artifactory"; exit 1 ;;
-          esac
+          # Exact match, not a host prefix. The `-cdn` repository variants are
+          # the one documented path on which Artifactory hands a client off to
+          # another origin (Direct Download), so pinning the repo key and not
+          # just the host closes it. Upstream F-009 records that Direct
+          # Download never engages for Go anyway — no module archive
+          # approaches its 100 MB threshold — but the assertion costs nothing.
+          expected="https://edge.urm.nvidia.com/artifactory/api/go/dgxc-go-virtual"
+          [ "${proxy}" = "${expected}" ] \
+            || { echo "GOPROXY is '${proxy}', expected exactly '${expected}'"; exit 1; }
           [ "$(go env GOSUMDB)" != off ] || { echo "GOSUMDB=off"; exit 1; }
-          echo "OK: Artifactory is first in GOPROXY and GOSUMDB is intact"
+          # Enforced means no fallback at all. Reject any comma rather than
+          # just `,direct`: Go consults later entries on 404/410 whatever they
+          # are, so `<artifactory>,https://proxy.golang.org` falls through to
+          # the public internet exactly like `,direct` would.
+          case "${proxy}" in
+            *,*) echo "GOPROXY has more than one entry ('${proxy}'); this is not enforced"; exit 1 ;;
+          esac
+          echo "OK: Artifactory is the only GOPROXY entry and GOSUMDB is intact"
+
+      # `go mod download -x` traces the URL Go *requested*, and http.Client.Do
+      # follows redirects inside that call, logging the final status against
+      # the original URL. So the download counters below cannot see a 3xx that
+      # hands the transfer to another origin: `served` would increment and
+      # `other` stay zero while the bytes came from elsewhere.
+      #
+      # Redirect behavior is a repository-level setting rather than per-module,
+      # so one request is a representative canary. The credential comes from
+      # the GOAUTH helper via curl --config so the token never reaches argv,
+      # where a process listing would expose it.
+      - name: Assert Artifactory serves bytes rather than redirecting
+        shell: bash
+        run: |
+          url="https://edge.urm.nvidia.com/artifactory/api/go/dgxc-go-virtual/gopkg.in/yaml.v2/@v/v2.4.0.zip"
+          auth="$("${GOAUTH}" | grep -i '^Authorization:')"
+          [ -n "${auth}" ] || { echo "::error::GOAUTH helper produced no Authorization header"; exit 1; }
+
+          # Command substitution with an explicit status capture, not process
+          # substitution. `read < <(...)` returns read's own status and
+          # discards curl's, so a transfer that fails *after* the response
+          # headers — a truncated body, exit 18 or 56 — still emits
+          # `%{http_code} 200` and every assertion below passes on a fetch
+          # that did not complete. Verified: a simulated exit 56 after output
+          # is silently accepted under process substitution and caught here.
+          #
+          # `|| rc=$?` keeps the assignment from tripping `set -e` before the
+          # status can be inspected, and the here-string below supplies the
+          # trailing newline `read` needs to avoid returning non-zero at EOF.
+          rc=0
+          out="$(
+            printf 'header = "%s"\nurl = "%s"\n' "${auth}" "${url}" \
+              | curl --config - -sSL --max-time 60 -o /dev/null \
+                     -w '%{http_code} %{num_redirects} %{url_effective}'
+          )" || rc=$?
+          [ "${rc}" -eq 0 ] \
+            || { echo "::error::curl exited ${rc}; the transfer did not complete"; exit 1; }
+          read -r status redirects effective <<<"${out}"
+          echo "status: ${status}"
+          echo "redirects: ${redirects}"
+          echo "final URL host: $(printf '%s' "${effective}" | sed -E 's#^https?://([^/]+)/.*#\1#')"
+
+          # Status first. Without it a 401 or 404 also reports zero redirects
+          # from the Artifactory host, so the two checks below would pass on a
+          # response that carried no archive at all — the same shape of false
+          # pass this canary was added to close.
+          [ "${status}" = "200" ] \
+            || { echo "::error::archive probe returned HTTP ${status}, not 200; nothing was served"; exit 1; }
+          [ "${redirects}" -eq 0 ] \
+            || { echo "::error::Artifactory redirected ${redirects} time(s) to ${effective}"; exit 1; }
+          case "${effective}" in
+            https://edge.urm.nvidia.com/*) ;;
+            *) echo "::error::bytes came from ${effective}, not Artifactory"; exit 1 ;;
+          esac
+          echo "OK: Artifactory served the archive directly (HTTP 200, no redirect to another origin)"
+
+      # Guards the guard. Both assertions above are satisfied by a job that
+      # never fetches anything, which is how the first enforced run passed on a
+      # restored module cache. Coverage is only demonstrated if modules were
+      # actually pulled through Artifactory.
+      - name: Assert the module cache is cold
+        shell: bash
+        run: |
+          modcache="$(go env GOMODCACHE)"
+          if [ -d "${modcache}/cache/download" ] \
+             && [ -n "$(find "${modcache}/cache/download" -name '*.zip' -print -quit 2>/dev/null)" ]; then
+            echo "::error::module cache is already populated at ${modcache}; this run cannot demonstrate proxy coverage"
+            exit 1
+          fi
+          echo "OK: module cache is cold, so anything resolved below came over the wire"
 
       # The real work. `go mod download` resolves from go.mod/go.sum rather
       # than reading vendor/, so it is a genuine application-dependency fetch
@@ -132,7 +261,27 @@ jobs:
       # needs.
       - name: Resolve the module graph through the proxy
         shell: bash
-        run: go mod download
+        run: |
+          go mod download -x 2>&1 | tee /tmp/godownload.log
+
+          # `-x` traces every request as `# get <url>` and its response as
+          # `# get <url>: <status>`. With a cold cache and a single-entry
+          # GOPROXY, counting module zips Artifactory served 200 *is* the
+          # coverage measurement — there is no other source they could have
+          # come from.
+          served="$(grep -cE '# get https://edge\.urm\.nvidia\.com/.*\.zip: 200 OK' /tmp/godownload.log || true)"
+          other="$(grep -oE '# get https://[a-z0-9.-]+/' /tmp/godownload.log \
+                     | grep -vc 'edge\.urm\.nvidia\.com' || true)"
+          echo "module zips served by Artifactory: ${served}"
+          echo "requests to other hosts: ${other}"
+
+          # Zero fetches is the signature of the false pass this workflow
+          # exists to prevent: every assertion above is satisfied by a job
+          # that never contacted anything.
+          [ "${served}" -gt 0 ] \
+            || { echo "::error::no module zips were fetched; this run proves nothing about coverage"; exit 1; }
+          [ "${other}" -eq 0 ] \
+            || { echo "::error::${other} request(s) went to a host other than Artifactory"; exit 1; }
 
       # The action exports GOFLAGS=-mod=readonly to GITHUB_ENV, which is
       # job-wide and cannot be scoped to one step. This repo commits vendor/,


### PR DESCRIPTION
## Summary

Flips one `main`-only verification workflow from `routed` to `enforced`, and fixes the ways it could pass without measuring anything.

**This is a no-op for users.** It changes no build, no release, and no PR. Its entire output is a trust claim.

## Motivation / Context

`routed` falls through to `direct` on 404/410, so a module Artifactory does not carry resolved from the public internet and the check still went green. We knew nothing was *rejected*; we did not know everything came *from* Artifactory. Upstream calls this out: **absence is not enforcement** (F-022).

Removing the fallback turns the workflow into its own coverage measurement. With no fallback and a cold cache there is nowhere else a module can come from, so a gap fails the build and names the module.

Fixes: #2375
Related: #2372 (adoption, closed), #2374 (remove `vendor/` — this is the evidence that unblocks it)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/dgxc-goproxy-probe.yaml`

## Implementation Notes

**Why the workflow carries so many assertions.** Each closes a specific way it could go green while measuring nothing. Five were found in review of this PR:

| Assertion | The false pass it closes |
|---|---|
| `cache: false` plus a cold-cache check | A restored 608 MB module cache satisfied `go mod download` with **zero** fetches |
| Exact-match `GOPROXY`, no commas | `<artifactory>,<other-proxy>` still falls through on 404 |
| HTTP 200 on the archive canary | A `401`/`404` reports zero redirects from the Artifactory host |
| Redirect and final-host canary | `go mod download -x` logs the *requested* URL, so redirects are invisible to it |
| At least one module fetched | Zero downloads is the signature of every case above |
| `curl` exit status captured explicitly | `read < <(...)` discards it, so a body truncated *after* a 200 header still passed |

**Not adopted:** a network-layer outbound-host allowlist. Disproportionate for a workflow that ships nothing, and the canary covers the realistic slice. If that assumption needs to be stronger, it belongs where the proxy carries real build traffic — #2374.

## Disposition: this workflow is temporary

Worth stating up front so it does not become permanent by inertia.

**Almost every assertion here exists because this workflow builds nothing.** `cache: false`, the cold-cache check, the download count, the archive canary — all answer "did anything actually happen?" A real build answers that by existing: if Artifactory cannot serve a module, `go build` fails. The build is the assertion.

So once #2374 lands and real jobs resolve through the proxy, this file is deleted and only part of it moves:

| Migrates to real workflows | Dies with this file |
|---|---|
| `mode: enforced` on the action | `cache: false` and the cold-cache check — real jobs want caching |
| `id-token: write` and the credential teardown | The download-count assertion |
| The `GOPROXY` assertion (exact match, single entry) | The archive canary |
| | The vendor-equivalence and resolver-posture steps, whose reason to exist is `vendor/` |

The `GOPROXY` assertion is the one guard worth carrying: it catches the thing a build cannot, which is the action silently no-opping or a revert to `routed` — either of which looks fine while routing nothing.

A stripped-down dispatch-only probe (configure, assert, fetch one module, ~20 lines) may be worth keeping afterwards purely as an ops tool, to separate "the proxy is broken" from "the code is broken" when a build fails. That is a different artifact from this measurement rig.

The same note is in the workflow header, since that is where whoever touches it next will look.

## Testing

[Run 32874292024](https://github.com/NVIDIA/aicr/actions/runs/32874292024), all steps green:

```
GOPROXY=https://edge.urm.nvidia.com/artifactory/api/go/dgxc-go-virtual
OK: Artifactory is the only GOPROXY entry and GOSUMDB is intact
status: 200
redirects: 0
final URL host: edge.urm.nvidia.com
OK: Artifactory served the archive directly (HTTP 200, no redirect to another origin)
OK: module cache is cold, so anything resolved below came over the wire
module zips served by Artifactory: 224
requests to other hosts: 0
OK: vendor/ regenerated through the proxy is byte-identical to what is committed
```

**224 served zips matches the 224 modules in `vendor/modules.txt`** — cold cache, single-entry `GOPROXY`, nothing from any other host. Artifactory serves the entire graph.

Cold is also faster than cached here, 79s against 139s: the restore costs more than it saves at this graph size.

`make lint` and `yamllint` pass.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** The workflow has no `pull_request` trigger and is not a required status check, so it cannot block a PR. It runs post-merge on `main` when `go.mod`, `go.sum`, or `vendor/**` change. A failure is a red mark on a main commit and nothing more, because every build in this repo still resolves from `vendor/`. Reverting is one line.

Known limit, tracked in #2374: Dependabot PRs cannot run this check at all — they receive no `id-token: write` — so detection is post-merge for the path that produces most dependency changes here. Harmless while nothing builds from the proxy; a real gap after #2374.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, workflow-only; verified by real runs instead
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — header comments describe enforced semantics
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
