### PR TITLE
fix(ci): extend api-diff package load timeout

### DIFF
--- a/tools/api-diff-closure/main.go
+++ b/tools/api-diff-closure/main.go
@@ -36,7 +36,10 @@ import (
 	"time"
 )
 
-const goListTimeout = 2 * time.Minute
+// Building export data for the package dependency closure can take more than
+// two minutes on cold or contended CI runners. Keep enough bounded headroom for
+// that normal variance without masking a stuck go list process.
+const goListTimeout = 5 * time.Minute
 
 type rootSpecs []string
 


### PR DESCRIPTION
## Summary

- increase the bounded `go list` deadline from two minutes to five minutes
- document why cold or contended CI runners need the additional headroom
- leave the package loader and CI workflow unchanged

Fixes #2332.

## Testing

- `go test -race -count=1 ./tools/api-diff-closure/...`
- `golangci-lint run -c .golangci.yaml ./tools/api-diff-closure/...` — 0 issues
- `make qualify` — passed after rebasing onto current `main`