### PR TITLE
feat: accept target artifact versions defined by ADR-022

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,25 @@ Releases follow a **bi-weekly cadence**. A new release is cut every two weeks.
 | Pre-release | Before a regular release, as needed | `rc` | Any maintainer can create for testing |
 | Major | Planned | `major` | Requires team agreement and advance communication |
 
+## Artifact Compatibility and Deprecation
+
+Artifact `apiVersion` maturity is independent of the AICR release version and
+is governed by [ADR-022](docs/design/022-artifact-maturity-and-deprecation.md).
+Retiring an artifact version owes the following window on the AICR release
+axis:
+
+- Alpha: no deprecation window.
+- Beta: readable for two releases after deprecation.
+- GA: readable for the rest of the current AICR major version; removal requires
+  the next `vMAJOR` release.
+
+For beta and GA bumps, stage the new reader in Release N before switching the
+emitter in Release N+1. The initial alpha-to-target migration is the explicit
+three-release sequence in ADR-022 §3: readers first, emitters second, then alpha
+and legacy empty headers retire. Release notes must identify any deprecation,
+the last release that reads the retiring version, and the required artifact
+recapture, regeneration, or authored-header edit.
+
 ## What Goes Into a Release
 
 A release includes everything merged to `main` since the last tag. There is no cherry-picking or feature branching for releases — if it's on `main`, it ships.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,10 @@ scripts, and decoupling environment specifics (e.g., StorageClass) from recipe
 content so bundles are portable.
 
 **Versioning policy.** Document the major-bump policy for each surface in
-`RELEASING.md` and wire compatibility tests into CI.
+`RELEASING.md` and wire compatibility tests into CI. Artifact maturity and
+reader/emitter rollout follow
+[ADR-022](docs/design/022-artifact-maturity-and-deprecation.md); project v1 and
+artifact maturity are separate axes.
 
 **Acceptance:**
 

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -3157,6 +3157,38 @@ components:
               not:
                 required: [selectedProfile]
 
+    LegacyBundleRecipeV1Request:
+      description: >
+        Additive default-track RecipeResult accepted by POST /v1/bundle: any
+        combination of apiVersion absent, empty, aicr.run/v1alpha2, or
+        aicr.run/v1 with kind absent, empty, Recipe, or RecipeResult. The
+        legacy Recipe kind is normalized to RecipeResult before emission.
+        metadata.selectedProfile and configuration are reserved for the
+        profile track.
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponseBase"
+        - type: object
+          not:
+            required: [configuration]
+          properties:
+            apiVersion:
+              type: string
+              description: >
+                aicr.run/v1alpha2, aicr.run/v1, absent, or empty after a legacy struct
+                round trip
+              enum: ["", aicr.run/v1alpha2, aicr.run/v1]
+            kind:
+              type: string
+              description: >
+                RecipeResult, the legacy Recipe value, absent, or empty for a
+                round-tripped artifact
+              enum: ["", Recipe, RecipeResult]
+              example: RecipeResult
+            metadata:
+              type: object
+              not:
+                required: [selectedProfile]
+
     LegacyBundleRecipeV2Request:
       description: >
         Additive legacy RecipeResult accepted by POST /v2/bundle: any
@@ -3165,7 +3197,8 @@ components:
         kind absent, empty, or RecipeResult. One branch covers the whole
         legacy square because DecodeRecipeResult accepts every cell of it —
         kind is enforced only when non-empty, and only the profile track requires it —
-        and /v1/bundle's BundleRecipeRequest admits the same shapes, so any
+        and /v1/bundle's LegacyBundleRecipeV1Request admits the same default
+        shapes, so any
         narrower branch leaves /v2/bundle stricter than its own server
         (previously true for the empty-header round trip, then again for
         apiVersion v1alpha2 with kind absent). The legacy kind Recipe is
@@ -3214,20 +3247,18 @@ components:
         RecipeResult accepted by POST /v1/bundle. Release N readers accept
         aicr.run/v1alpha2 and aicr.run/v1 for default recipes, plus
         aicr.run/v1alpha3 and aicr.run/v1beta2 for profile/configuration schema
-        shapes. Legacy artifacts with absent or empty header fields are
-        accepted. The kind value Recipe is also accepted: it was the value this
-        contract published through v0.18.0, so clients written against that
-        spec must keep working.
+        shapes. Default-track legacy artifacts with absent or empty header
+        fields are accepted. The kind value Recipe is also accepted on that
+        branch: it was the value this contract published through v0.18.0, so
+        clients written against that spec must keep working.
 
-        A legacy kind is normalized on ingest rather than echoed: an absent,
-        empty, or Recipe kind is stamped as RecipeResult, so the generated
-        bundle's recipe.yaml always carries the canonical kind and reloads via
-        aicr bundle -r and aicr validate -r. Only kind is rewritten; a request
-        that omits apiVersion still yields an artifact with an empty
-        apiVersion, which every reader accepts as the legacy shape. Any kind
-        outside this enum is rejected with a 400, matching the /v2/bundle
-        decode path and the kind values the CLI file loader accepts for a
-        hydrated RecipeResult.
+        A default-track legacy kind is normalized on ingest rather than echoed:
+        an absent, empty, or Recipe kind is stamped as RecipeResult, so the
+        generated bundle's recipe.yaml always carries the canonical kind and
+        reloads via aicr bundle -r and aicr validate -r. Only kind is rewritten;
+        a request that omits apiVersion still yields an artifact with an empty
+        apiVersion, which every reader accepts as the legacy shape. The strict
+        configured branch requires the canonical RecipeResult kind.
 
         The shared artifact gate rejects any apiVersion outside those four
         values with a 400, here and on the CLI file-load path alike. An absent
@@ -3235,43 +3266,13 @@ components:
         ADR-022 Release N reader-first window.
 
         metadata.selectedProfile remains reserved for aicr.run/v1alpha3 and
-        aicr.run/v1beta2, and is rejected on this route. Typed configuration is accepted only when
-        apiVersion is on that profile track. Bodies stamped with either profile
-        version are decoded strictly; unknown fields are rejected with a 400 response.
-      allOf:
-        - $ref: "#/components/schemas/RecipeResponseBase"
-        - type: object
-          if:
-            anyOf:
-              - not:
-                  required: [apiVersion]
-              - required: [apiVersion]
-                properties:
-                  apiVersion:
-                    enum: ["", aicr.run/v1alpha2, aicr.run/v1]
-          then:
-            not:
-              required: [configuration]
-          properties:
-            apiVersion:
-              type: string
-              description: >
-                Supported RecipeResult API version, or empty after a legacy
-                struct round trip.
-                Accepted values follow the ADR-022 Release N reader-first
-                window.
-              enum: ["", aicr.run/v1alpha2, aicr.run/v1, aicr.run/v1alpha3, aicr.run/v1beta2]
-            kind:
-              type: string
-              description: >
-                RecipeResult, the legacy Recipe value published through
-                v0.18.0, or empty for a legacy artifact. The legacy values are
-                normalized to RecipeResult in the generated bundle.
-              enum: ["", Recipe, RecipeResult]
-            metadata:
-              type: object
-              not:
-                required: [selectedProfile]
+        aicr.run/v1beta2, and is rejected on this route. Typed configuration is
+        accepted only when apiVersion is on that profile track. The configured
+        branch is closed at its typed object boundaries, so unknown profile or
+        configuration fields are rejected with a 400 response.
+      oneOf:
+        - $ref: "#/components/schemas/LegacyBundleRecipeV1Request"
+        - $ref: "#/components/schemas/ConfiguredRecipeResponse"
 
     QueryRequest:
       type: object

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -1271,9 +1271,10 @@ paths:
       description: >
         Uses the same query parameters and ZIP response as POST /v1/bundle.
         The body is an already-selected RecipeResult, so this route has no
-        profile-selection field. Legacy recipes stamped aicr.run/v1alpha2 or
-        omitting apiVersion are accepted; v1alpha3 profile recipes are decoded
-        strictly. Content-Type must be application/json or application/x-yaml.
+        profile-selection field. Default recipes stamped aicr.run/v1alpha2,
+        aicr.run/v1, or omitting apiVersion are accepted; profile recipes
+        stamped aicr.run/v1alpha3 or aicr.run/v1beta2 are decoded strictly.
+        Content-Type must be application/json or application/x-yaml.
         Query parameter details are documented on POST /v1/bundle.
       parameters:
         - $ref: "#/components/parameters/RequestId"
@@ -2799,8 +2800,11 @@ components:
       description: >
         Complete legacy, profile-aware, or Slurm-accounting-aware recipe
         response with metadata and component references. Recipes without typed
-        configuration use aicr.run/v1alpha2; profile-bearing recipes and
-        recipes carrying configuration.slurm.accounting use aicr.run/v1alpha3.
+        configuration emitted by this release use aicr.run/v1alpha2;
+        profile-bearing recipes and recipes carrying
+        configuration.slurm.accounting use aicr.run/v1alpha3. The schema also
+        admits the ADR-022 reader-first profile target aicr.run/v1beta2 for
+        bundle request reuse; this release does not emit it.
       allOf:
         - $ref: "#/components/schemas/RecipeResponseBase"
         - type: object
@@ -2808,7 +2812,7 @@ components:
           properties:
             apiVersion:
               type: string
-              enum: [aicr.run/v1alpha2, aicr.run/v1alpha3]
+              enum: [aicr.run/v1alpha2, aicr.run/v1alpha3, aicr.run/v1beta2]
               example: aicr.run/v1alpha2
             kind:
               type: string
@@ -2852,14 +2856,15 @@ components:
         - $ref: "#/components/schemas/RecipeResponse"
         - type: object
           description: >
-            Closed aicr.run/v1alpha3 RecipeResult shape. Unknown fields are
-            rejected at its typed object boundaries.
+            Closed profile-bearing RecipeResult shape. aicr.run/v1alpha3 is
+            emitted; aicr.run/v1beta2 is accepted during ADR-022 Release N.
+            Unknown fields are rejected at its typed object boundaries.
           required: [metadata, componentRefs]
           additionalProperties: false
           properties:
             apiVersion:
               type: string
-              enum: [aicr.run/v1alpha3]
+              enum: [aicr.run/v1alpha3, aicr.run/v1beta2]
             kind:
               type: string
               enum: [RecipeResult]
@@ -2995,14 +3000,15 @@ components:
         - $ref: "#/components/schemas/RecipeResponse"
         - type: object
           description: >
-            Closed accounting-configured aicr.run/v1alpha3 RecipeResult shape
-            without a selected profile.
+            Closed accounting-configured RecipeResult shape without a selected
+            profile. aicr.run/v1alpha3 is emitted; aicr.run/v1beta2 is
+            accepted during ADR-022 Release N.
           required: [metadata, configuration, componentRefs]
           additionalProperties: false
           properties:
             apiVersion:
               type: string
-              enum: [aicr.run/v1alpha3]
+              enum: [aicr.run/v1alpha3, aicr.run/v1beta2]
             kind:
               type: string
               enum: [RecipeResult]
@@ -3137,7 +3143,8 @@ components:
     LegacyRecipeResponse:
       description: >
         Additive legacy recipe shape. Unknown fields remain accepted for
-        compatibility, but metadata.selectedProfile is reserved for v1alpha3.
+        compatibility, but metadata.selectedProfile is reserved for the
+        profile-bearing schema track.
       allOf:
         - $ref: "#/components/schemas/RecipeResponse"
         - type: object
@@ -3153,17 +3160,18 @@ components:
     LegacyBundleRecipeV2Request:
       description: >
         Additive legacy RecipeResult accepted by POST /v2/bundle: any
-        combination of apiVersion absent, empty, or aicr.run/v1alpha2 with
+        combination of apiVersion absent, empty, aicr.run/v1alpha2, or
+        aicr.run/v1 with
         kind absent, empty, or RecipeResult. One branch covers the whole
         legacy square because DecodeRecipeResult accepts every cell of it —
-        kind is enforced only when non-empty, and only v1alpha3 requires it —
+        kind is enforced only when non-empty, and only the profile track requires it —
         and /v1/bundle's BundleRecipeRequest admits the same shapes, so any
         narrower branch leaves /v2/bundle stricter than its own server
         (previously true for the empty-header round trip, then again for
         apiVersion v1alpha2 with kind absent). The legacy kind Recipe is
         v1-only: the strict v2 decode path rejects it.
-        metadata.selectedProfile remains reserved for v1alpha3.
-        configuration is likewise reserved for v1alpha3; legacy request
+        metadata.selectedProfile remains reserved for v1alpha3/v1beta2.
+        configuration is likewise reserved for v1alpha3/v1beta2; default request
         headers cannot carry typed Slurm accounting configuration.
       allOf:
         - $ref: "#/components/schemas/RecipeResponseBase"
@@ -3174,9 +3182,9 @@ components:
             apiVersion:
               type: string
               description: >
-                aicr.run/v1alpha2, absent, or empty after a legacy struct
+                aicr.run/v1alpha2, aicr.run/v1, absent, or empty after a legacy struct
                 round trip
-              enum: ["", aicr.run/v1alpha2]
+              enum: ["", aicr.run/v1alpha2, aicr.run/v1]
             kind:
               type: string
               description: >
@@ -3190,12 +3198,12 @@ components:
     BundleRecipeV2Request:
       description: >
         Version-partitioned RecipeResult accepted by POST /v2/bundle.
-        Legacy input with apiVersion aicr.run/v1alpha2 or no apiVersion remains
-        additive; v1alpha3 input is closed and requires either
+        Default input with apiVersion aicr.run/v1alpha2, aicr.run/v1, or no
+        apiVersion remains additive; v1alpha3/v1beta2 input is closed and requires either
         metadata.selectedProfile or configuration.slurm.accounting. The
         branches are disjoint on apiVersion:
-        the legacy branch admits only absent/empty/v1alpha2 and prohibits
-        selectedProfile, while both configured branches require v1alpha3.
+        the default branch admits only absent/empty/v1alpha2/v1 and prohibits
+        selectedProfile, while both configured branches require the profile track.
       oneOf:
         - $ref: "#/components/schemas/LegacyBundleRecipeV2Request"
         - $ref: "#/components/schemas/ProfileRecipeResponse"
@@ -3203,9 +3211,10 @@ components:
 
     BundleRecipeRequest:
       description: >
-        RecipeResult accepted by POST /v1/bundle. Current aicr.run/v1alpha2
-        and aicr.run/v1alpha3 artifacts, plus legacy artifacts with absent or
-        empty header fields, are
+        RecipeResult accepted by POST /v1/bundle. Release N readers accept
+        aicr.run/v1alpha2 and aicr.run/v1 for default recipes, plus
+        aicr.run/v1alpha3 and aicr.run/v1beta2 for profile/configuration schema
+        shapes. Legacy artifacts with absent or empty header fields are
         accepted. The kind value Recipe is also accepted: it was the value this
         contract published through v0.18.0, so clients written against that
         spec must keep working.
@@ -3220,19 +3229,15 @@ components:
         decode path and the kind values the CLI file loader accepts for a
         hydrated RecipeResult.
 
-        apiVersion deliberately has no equivalent legacy window. The artifact
-        group/version bump is a hard break with no transition period (see
-        docs/design/011-artifact-apiversion-policy.md), so an artifact stamped
-        with a prior group/version must be regenerated rather than sent. This
-        rule is enforced: the shared artifact gate rejects any apiVersion
-        outside aicr.run/v1alpha2 and aicr.run/v1alpha3 with a 400, here and on
-        the CLI file-load path alike. An absent or empty apiVersion is still
-        admitted as the legacy shape.
+        The shared artifact gate rejects any apiVersion outside those four
+        values with a 400, here and on the CLI file-load path alike. An absent
+        or empty apiVersion remains admitted as the legacy shape through the
+        ADR-022 Release N reader-first window.
 
         metadata.selectedProfile remains reserved for aicr.run/v1alpha3 and
-        is rejected on this route. Typed configuration is accepted only when
-        apiVersion is aicr.run/v1alpha3. Bodies stamped aicr.run/v1alpha3 are
-        decoded strictly; unknown fields are rejected with a 400 response.
+        aicr.run/v1beta2, and is rejected on this route. Typed configuration is accepted only when
+        apiVersion is on that profile track. Bodies stamped with either profile
+        version are decoded strictly; unknown fields are rejected with a 400 response.
       allOf:
         - $ref: "#/components/schemas/RecipeResponseBase"
         - type: object
@@ -3243,7 +3248,7 @@ components:
               - required: [apiVersion]
                 properties:
                   apiVersion:
-                    enum: ["", aicr.run/v1alpha2]
+                    enum: ["", aicr.run/v1alpha2, aicr.run/v1]
           then:
             not:
               required: [configuration]
@@ -3253,9 +3258,9 @@ components:
               description: >
                 Supported RecipeResult API version, or empty after a legacy
                 struct round trip.
-                Prior group/versions are not accepted — see the schema
-                description for the hard-break policy.
-              enum: ["", aicr.run/v1alpha2, aicr.run/v1alpha3]
+                Accepted values follow the ADR-022 Release N reader-first
+                window.
+              enum: ["", aicr.run/v1alpha2, aicr.run/v1, aicr.run/v1alpha3, aicr.run/v1beta2]
             kind:
               type: string
               description: >

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -2278,7 +2278,7 @@ components:
         apiVersion:
           type: string
           description: API version
-          enum: [aicr.run/v1alpha2]
+          enum: [aicr.run/v1alpha2, aicr.run/v1]
           example: aicr.run/v1alpha2
         metadata:
           type: object
@@ -3050,7 +3050,10 @@ components:
             criteria:
               $ref: "#/components/schemas/CriteriaV2"
             configuration:
-              $ref: "#/components/schemas/ConfiguredRecipeConfiguration"
+              allOf:
+                - $ref: "#/components/schemas/ConfiguredRecipeConfiguration"
+                - type: object
+                  required: [slurm]
             componentRefs:
               type: array
               minItems: 1

--- a/docs/contributor/recipe.md
+++ b/docs/contributor/recipe.md
@@ -209,9 +209,10 @@ names the ones at the end of a chain.
 
 `RecipeMetadata.Spec.Profile` declares one overlay-scoped enum for qualified
 configuration ownership modes. A declaration requires recipe apiVersion
-`aicr.run/v1alpha3`; that version without a declaration, or a declaration on
-the legacy version, is rejected. Profile-version metadata and recipe
-artifacts are strictly decoded so an unknown field cannot silently disappear.
+`aicr.run/v1alpha3` or its ADR-022 target `aicr.run/v1beta2`; either profile
+track without a declaration, or a declaration on a default-track version, is
+rejected. Profile-version metadata and recipe artifacts are strictly decoded
+so an unknown field cannot silently disappear.
 
 The core `ProfileValue` contract is closed to `advertiser`, `constraints`,
 and `componentRefs{name,overrides}`. It rejects `valuesFile`, component

--- a/docs/design/011-artifact-apiversion-policy.md
+++ b/docs/design/011-artifact-apiversion-policy.md
@@ -1,7 +1,6 @@
 # ADR-011: Artifact apiVersion Policy and Compatibility Gate
 
-> **Proposed amendment by
-> [ADR-022](022-artifact-maturity-and-deprecation.md).** If accepted, ADR-022
+> **Amended by [ADR-022](022-artifact-maturity-and-deprecation.md).** ADR-022
 > introduces a per-kind maturity map for v1. It amends §1 so package-local
 > constants select a kind-specific version defined by `pkg/header`, amends §3 so
 > acceptance is scoped by wire kind and schema track and covers AICR catalog
@@ -87,12 +86,13 @@ All package-local constants alias `header.GroupVersion` rather than redeclaring
 the literal: `snapshotter.FullAPIVersion`, `recipe.RecipeAPIVersion`,
 `recipe.RecipeCriteriaAPIVersion`, and `config.APIVersion`.
 
-> **Prospective ADR-022 change.** `pkg/header` remains the canonical home for
+> **ADR-022 amendment.** `pkg/header` remains the canonical home for
 > the API group, version segments, and complete group/version strings, but the
-> single `header.GroupVersion` alias requirement ends when the per-kind map
-> lands. Each package-local emitter constant selects the header-defined version
-> assigned to its wire kind and schema track. No package redeclares a version
-> literal.
+> single `header.GroupVersion` alias is no longer the universal policy. Each
+> package-local emitter constant selects the header-defined version assigned to
+> its wire kind and schema track. No package redeclares a version literal.
+> During ADR-022 Release N, existing emitters intentionally remain on their
+> alpha aliases while readers also accept the target constants.
 
 ### 2. Evolution rule
 
@@ -117,11 +117,12 @@ snapshot and recipe loaders apply them:
   `ErrCodeInvalidRequest` and a message naming the value, the expected value,
   and the remediation (regenerate/recapture with a matching `aicr` version).
 
-> **Prospective ADR-022 change.** The initial migration makes every AICR
-> artifact gate kind/schema-scoped, extends that gate to catalog inputs, and at
-> its final release rejects empty values in the snapshot, recipe, and criteria
-> loaders that currently tolerate them. `AICRConfig` is already strict and has
-> no empty-value exception to retire.
+> **ADR-022 amendment.** Every AICR artifact gate is kind/schema-scoped and the
+> gate extends to AICR catalog inputs. Raw `RecipeMetadata`, `RecipeMixin`, and
+> `ComponentRegistry` headers are validated before hydration or merge; empty or
+> unknown catalog headers fail closed. The initial migration retains the
+> existing empty-value exceptions in the snapshot, recipe, and criteria loaders
+> until Release N+2. `AICRConfig` remains strict and has no exception to retire.
 
 The gate lives in the shared loaders — `recipe.LoadFromFileWithProvider` (used
 by both CLI and server via `pkg/client/v1`) and the new
@@ -134,10 +135,9 @@ strengthens rather than changes this: SDK consumers hit the same gate.) This mir
 
 ### 4. Transition window on a future bump
 
-> **Proposed replacement by ADR-022 §4 and §6.** This section remains the
-> current policy while ADR-022 is Proposed. If ADR-022 is accepted, its
-> maturity-specific obligations and rollout sequences supersede the
-> unconditional rule below.
+> **Replaced by ADR-022 §4 and §6.** The text below is retained as historical
+> context and is no longer normative. ADR-022's maturity-specific obligations
+> and rollout sequences govern future bumps.
 
 When the schema is bumped (e.g. to `v1alpha2`), add the new value to
 `header.IsSupportedAPIVersion` **while keeping the old one**, so a transition
@@ -157,10 +157,12 @@ ADR-013 for the rationale.
   with a clear, actionable error instead of failing obscurely downstream.
 - Version literals remain single-sourced in `pkg/header`; kind-specific emitter
   constants and read gates select among those header-defined values.
-- Current general/default artifacts use `aicr.run/v1alpha2`; profile-bearing
-  `RecipeMetadata` and `RecipeResult` use `aicr.run/v1alpha3`. Older snapshots,
-  recipes, and criteria may carry an empty `apiVersion` and remain tolerated;
-  `AICRConfig` does not. Per ADR-013's hard break, legacy
+- During ADR-022 Release N, emitters still use `aicr.run/v1alpha2` for
+  general/default artifacts and `aicr.run/v1alpha3` for profile-bearing
+  `RecipeMetadata` and `RecipeResult`. Kind/schema-scoped readers additionally
+  accept their `aicr.run/v1`, `aicr.run/v1beta1`, or `aicr.run/v1beta2` target.
+  Older snapshots, recipes, and criteria may carry an empty `apiVersion` and
+  remain tolerated; catalogs and `AICRConfig` do not. Per ADR-013's hard break, legacy
   `aicr.nvidia.com/v1alpha1` artifacts are rejected and must be regenerated.
 - The gate is intentionally not a security control; the unsigned header can
   still be edited. Authenticated provenance remains the supply-chain workstream.

--- a/docs/design/022-artifact-maturity-and-deprecation.md
+++ b/docs/design/022-artifact-maturity-and-deprecation.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Proposed. If accepted, amends
+Accepted on 2026-08-26 by ratification in
+[#2373](https://github.com/NVIDIA/aicr/pull/2373). Amends
 [ADR-011](011-artifact-apiversion-policy.md): §1 keeps `pkg/header` as the
 single source of version strings but replaces its single-version alias rule;
 §3 becomes kind/schema-scoped, covers AICR catalog inputs, and retires its

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -76,6 +76,15 @@ counterpart **wholesale** — to override just `helm.defaultVersion`, copy the
 full embedded entry and change that one field, or the other coordinates
 (repository, chart, scheduling paths) are silently dropped.
 
+During the ADR-022 reader-first release, `ComponentRegistry`, ordinary
+`RecipeMetadata`, and `RecipeMixin` inputs accept `aicr.run/v1alpha2` and the
+target `aicr.run/v1beta1`. Profile-bearing `RecipeMetadata` accepts
+`aicr.run/v1alpha3` and `aicr.run/v1beta2`. AICR validates the raw external
+`registry.yaml` header before merging it with the embedded registry, and checks
+metadata/mixin headers before hydration. Empty, unknown, or wrong-kind AICR
+catalog headers fail with `INVALID_REQUEST`; they are never replaced by an
+embedded header and silently continued.
+
 Overriding a component's `defaultVersion` this way takes effect for every
 embedded overlay that references the component: embedded overlays do not pin
 versions that equal the registry default, so resolution falls back to your
@@ -244,12 +253,13 @@ mechanics:
 - **A same-path replacement replaces the declaration too.** An external
   `overlays/aks.yaml` completely replaces the embedded file — including its
   `spec.profile` block. Keep the declaration in the replacement — dropping it
-  while keeping `apiVersion: aicr.run/v1alpha3` fails catalog validation
+  while keeping profile apiVersion `aicr.run/v1alpha3` or
+  `aicr.run/v1beta2` fails catalog validation
   (the version⟺declaration cross-check). That guardrail protects an
-  integrator *editing* a v1alpha3 file: de-profiling one requires BOTH
+  integrator *editing* a profile-track file: de-profiling one requires BOTH
   removing the declaration AND downgrading the overlay to the legacy
   apiVersion. It does NOT protect the upgrade path — a pre-existing legacy
-  (`aicr.run/v1alpha2`) external `overlays/aks.yaml`, authored before the
+  (`aicr.run/v1alpha2` or `aicr.run/v1beta1`) external `overlays/aks.yaml`, authored before the
   family's conversion, already satisfies both conditions. Upgrading AICR
   with such a catalog in `--data` silently preserves the unprofiled family:
   resolution succeeds with no error, no `selectedProfile` on the recipe, and

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -409,11 +409,12 @@ Same as `GET /v1/query` — see the [GET /v1/query error responses](#get-v1query
 
 `v2` in the route and `apiVersion` in a recipe document are independent
 version axes. The route segment versions the transient HTTP contract;
-`aicr.run/v1alpha2` and `aicr.run/v1alpha3` identify persisted recipe schemas.
-Therefore, `/v2/recipe` can return either artifact version and `/v2/bundle`
-accepts both, plus versionless legacy artifacts. Selecting a profile or resolving
-a Slurm accounting mode—not the route number—determines whether the artifact
-uses `v1alpha3`.
+`aicr.run/v1alpha2` and `aicr.run/v1alpha3` are the recipe schemas emitted by
+this reader-first release. `/v2/bundle` also accepts their ADR-022 targets:
+`aicr.run/v1` for a default recipe and `aicr.run/v1beta2` for a
+profile/configuration recipe, plus versionless legacy artifacts. Selecting a
+profile or resolving a Slurm accounting mode—not the route number—determines
+which schema track applies.
 
 `/v2/recipe`, `/v2/query`, and `/v2/bundle` expose the configured HTTP contract
 for profiles and Slurm accounting. The AKS and GKE families are the embedded
@@ -476,9 +477,9 @@ selector: metadata.selectedProfile
 **POST `/v2/bundle`.** Uses the same query parameters and ZIP response as
 `POST /v1/bundle`. It carries no profile-selection field because its body is
 an already-selected `RecipeResult`. It accepts legacy
-`aicr.run/v1alpha2` recipes, including older artifacts that omit
-`apiVersion`, and strictly decodes profiled or accounting-configured
-`aicr.run/v1alpha3` recipes. The
+`aicr.run/v1alpha2` and `aicr.run/v1` default recipes, including older
+artifacts that omit `apiVersion`, and strictly decodes profiled or
+accounting-configured `aicr.run/v1alpha3` and `aicr.run/v1beta2` recipes. The
 request requires `Content-Type: application/json` or `Content-Type:
 application/x-yaml`; missing, aliased, or unsupported media types are
 rejected.
@@ -561,8 +562,9 @@ Generate deployment bundles from a recipe.
 **Request Body:**
 
 The request body is the recipe (`RecipeResult`) directly. No wrapper object is
-needed. Current artifacts carry `apiVersion: aicr.run/v1alpha2` or
-`aicr.run/v1alpha3` and `kind: RecipeResult`. The v1alpha3 form identifies
+needed. This release emits `apiVersion: aicr.run/v1alpha2` or
+`aicr.run/v1alpha3` and `kind: RecipeResult`; its bundle readers additionally
+accept `aicr.run/v1` and `aicr.run/v1beta2`, respectively. The profile track identifies
 recipes carrying `metadata.selectedProfile`, typed
 `configuration.slurm.accounting`, or both; profile-bearing artifacts must use
 `/v2/bundle`. New clients should preserve the version emitted by recipe
@@ -590,15 +592,12 @@ CLI file loader for the same values — `aicr bundle -r` accepts a
 `RecipeResult` artifact it too accepts only `RecipeResult` or an absent kind.
 `apiVersion` is validated separately, as described next.
 
-`apiVersion` has no equivalent legacy window on purpose. An artifact
-group/version bump is a hard break with no transition period, so a recipe
-stamped with a prior group/version should be regenerated rather than sent.
-
-This one is enforced. The shared artifact gate rejects any `apiVersion` outside
-`aicr.run/v1alpha2` and `aicr.run/v1alpha3` with a 400, on this endpoint as well
-as on the CLI file-load path, so a prior group/version fails rather than being
-silently accepted. An absent or empty `apiVersion` is still admitted as the
-legacy shape.
+The shared artifact gate rejects any `apiVersion` outside
+`aicr.run/v1alpha2`, `aicr.run/v1`, `aicr.run/v1alpha3`, and
+`aicr.run/v1beta2` with a 400, on this endpoint as well as on the CLI file-load
+path. An absent or empty `apiVersion` is still admitted as the legacy shape
+during ADR-022 Release N. This is a reader-first window: generated recipes keep
+their alpha headers until the emitter-switch release.
 
 #### Components
 

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -32,7 +32,7 @@ The schema's source of truth is
 
 ```yaml
 kind: AICRConfig               # required, exactly this value
-apiVersion: aicr.run/v1alpha2  # required, exactly this value
+apiVersion: aicr.run/v1alpha2  # required; v1beta1 is also accepted in Release N
 metadata:
   name: gke-h100-training      # optional, identifying only
 spec:
@@ -45,7 +45,9 @@ spec:
 
 Each `spec.*` section is optional and each command reads only its own section,
 so a file may carry just one section or any combination. A document with none
-of the five sections is rejected.
+of the five sections is rejected. AICR still writes and documents
+`aicr.run/v1alpha2` during the ADR-022 reader-first release, but the loader also
+accepts the target `aicr.run/v1beta1`; empty and unknown values are rejected.
 
 ## Loading, Precedence, and Secrets
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1070,14 +1070,17 @@ Validation can be run in different phases to validate different aspects of the d
 >
 > **Version skew:** Snapshots and recipes record the `aicr` version that produced them. When the recipe, the snapshot, and the running binary report different release versions, `validate` logs a single advisory warning (`version skew detected across validate inputs`) naming all three. This is a debugging breadcrumb — mixing artifacts from different versions can surface as confusing failures — and does **not** fail the command. Dev (`dev`) and pre-release (`-next`) builds are ignored to avoid noise.
 >
-> **apiVersion gate:** Snapshots and catalog artifacts use `aicr.run/v1alpha2`;
-> recipe results with a selected configuration profile or configured Slurm
-> accounting use `aicr.run/v1alpha3`. Loading an
-> artifact stamped with an unsupported `apiVersion` fails fast; regenerate or
-> recapture it with a matching `aicr` version. Legacy recipes without
-> profile or accounting configuration retain v1alpha2 semantics. See
+> **apiVersion gate:** During the ADR-022 reader-first release, AICR still
+> emits `aicr.run/v1alpha2` for snapshots and default recipes, and
+> `aicr.run/v1alpha3` for profile/configuration recipes. Readers additionally
+> accept `aicr.run/v1` for snapshots and default recipes,
+> `aicr.run/v1beta1` for config and ordinary catalog inputs, and
+> `aicr.run/v1beta2` for profile-bearing inputs. Unsupported artifact headers
+> fail fast; raw external catalog headers are checked before merge or
+> hydration. Recapture, regenerate, or update the authored header with a
+> version supported by the running AICR release. See
 > [ADR-011](../design/011-artifact-apiversion-policy.md) and
-> [ADR-016](../design/016-slurm-accounting-enablement.md).
+> [ADR-022](../design/022-artifact-maturity-and-deprecation.md).
 
 Phases run sequentially with `--phase all` and all phases run by default, producing results regardless of earlier failures; use `--fail-fast` to stop after the first failing phase. For what each phase actually checks (deployment-phase readiness signals, graceful-skip semantics, RBAC, Day-N re-verification, and evidence), see [Validation](validation.md).
 

--- a/pkg/bundler/deployer/localformat/provenance.go
+++ b/pkg/bundler/deployer/localformat/provenance.go
@@ -56,7 +56,8 @@ const ProvenanceFileName = "provenance.yaml"
 
 // ProvenanceAPIVersion / ProvenanceKind identify the document shape using
 // AICR's K8s-style convention. Bump the apiVersion when a downstream
-// consumer would need to branch on shape (v1alpha1 → v1beta1 → v1).
+// consumer would need to branch on shape. ADR-022 assigns BundleProvenance a
+// target of aicr.run/v1 while this Release N emitter remains on v1alpha2.
 // Additive fields do not require a bump.
 // The current v1alpha2 segment tracks header.GroupVersion and reflects the
 // aicr.run domain-migration version bump (signal-only, no shape change).

--- a/pkg/cli/snapshot_config_test.go
+++ b/pkg/cli/snapshot_config_test.go
@@ -442,7 +442,7 @@ spec:
 
 // TestSnapshotCmd_InvalidConfig_LegacyAPIVersion confirms a legacy
 // aicr.nvidia.com apiVersion is rejected fail-closed at config-load time.
-// After the aicr.run hard-break migration, only aicr.run/v1alpha2 is valid.
+// The old aicr.nvidia.com domain remains outside the ADR-022 read window.
 func TestSnapshotCmd_InvalidConfig_LegacyAPIVersion(t *testing.T) {
 	tmp := t.TempDir()
 	cfgPath := filepath.Join(tmp, "config.yaml")

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -1367,7 +1367,7 @@ func TestClient_NoCacheGrowthAcrossManyCloseCycles(t *testing.T) {
 
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 

--- a/pkg/client/v1/aicr_test.go
+++ b/pkg/client/v1/aicr_test.go
@@ -258,7 +258,7 @@ func TestNewClient_IsolatedDataProvider(t *testing.T) {
 	dirB := t.TempDir()
 	for _, dir := range []string{dirA, dirB} {
 		if err := os.WriteFile(filepath.Join(dir, "registry.yaml"),
-			[]byte("components: []\n"), 0o600); err != nil {
+			[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 			t.Fatalf("setup: write registry.yaml in %s: %v", dir, err)
 		}
 	}
@@ -306,7 +306,7 @@ func TestClient_ConcurrentResolveAndClose(t *testing.T) {
 
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 
@@ -357,7 +357,7 @@ func TestClient_CloseIsIdempotent(t *testing.T) {
 
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 
@@ -397,7 +397,7 @@ func TestResolveRecipeRejectsPinnedReferences(t *testing.T) {
 	// contain a registry.yaml. Write a minimal one so setup succeeds
 	// and we can exercise ResolveRecipe's pinned-rejection path.
 	tmp := t.TempDir()
-	minimalRegistry := "components: []\n"
+	minimalRegistry := "apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
 		[]byte(minimalRegistry), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
@@ -458,7 +458,7 @@ func TestBundleComponents_RequiresInternalRecipeResult(t *testing.T) {
 
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(tmp)))
@@ -497,7 +497,7 @@ func TestBundleComponents_NilInputsRejected(t *testing.T) {
 
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 
@@ -579,7 +579,7 @@ func TestResolveRecipe_RejectsNegativeNodes(t *testing.T) {
 	// never runs (negative Nodes rejection short-circuits before that),
 	// but NewClient still validates the source on construction.
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(tmp)))
@@ -638,7 +638,7 @@ func TestResolveRecipe_OSEnablesOSPinnedOverlays(t *testing.T) {
 	// ones) remain reachable for resolution.
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 	client, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(tmp)))
@@ -688,7 +688,7 @@ func TestBundleAndValidate_RejectCrossClientRecipeResult(t *testing.T) {
 		t.Helper()
 		tmp := t.TempDir()
 		if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-			[]byte("components: []\n"), 0o600); err != nil {
+			[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 			t.Fatalf("setup: write registry.yaml: %v", err)
 		}
 		c, err := aicr.NewClient(aicr.WithRecipeSource(aicr.FilesystemSource(tmp)))
@@ -800,7 +800,7 @@ spec:
 		t.Helper()
 		dir := t.TempDir()
 		if err := os.WriteFile(filepath.Join(dir, "registry.yaml"),
-			[]byte("components: []\n"), 0o600); err != nil {
+			[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 			t.Fatalf("setup %s: registry.yaml: %v", marker, err)
 		}
 		if err := os.MkdirAll(filepath.Join(dir, "overlays"), 0o755); err != nil {
@@ -936,7 +936,7 @@ func TestResolveRecipeWithProfile(t *testing.T) {
 		t.Fatalf("setup overlays directory: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup registry.yaml: %v", err)
 	}
 	overlay := []byte(`apiVersion: aicr.run/v1alpha3
@@ -1778,7 +1778,7 @@ func TestClient_NoCacheGrowthAcrossManyCloseCycles(t *testing.T) {
 
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup: write registry.yaml: %v", err)
 	}
 

--- a/pkg/client/v1/testdata/external-catalog/registry.yaml
+++ b/pkg/client/v1/testdata/external-catalog/registry.yaml
@@ -4,4 +4,6 @@
 # This fixture contributes no components. It exists so the overlay beside it
 # can register a criteria value the EMBEDDED catalog does not know, which is
 # the condition that made config-driven external catalogs unusable.
+apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
 components: []

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -136,9 +136,16 @@ func TestValidate_Errors(t *testing.T) {
 			wantSub: "invalid kind",
 		},
 		{
-			name: "wrong apiVersion",
+			name: "wrong stable-track apiVersion",
 			mutate: func(c *config.AICRConfig) {
-				c.APIVersion = "v1"
+				c.APIVersion = header.GroupVersionV1
+			},
+			wantSub: "invalid apiVersion",
+		},
+		{
+			name: "wrong profile-track apiVersion",
+			mutate: func(c *config.AICRConfig) {
+				c.APIVersion = header.GroupVersionV1Beta2
 			},
 			wantSub: "invalid apiVersion",
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,6 +48,16 @@ func TestValidate_HappyPath(t *testing.T) {
 	}
 }
 
+func TestValidate_AcceptsReleaseNTargetAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := newValid()
+	cfg.APIVersion = header.GroupVersionV1Beta1
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() rejected Release N target apiVersion: %v", err)
+	}
+}
+
 func TestValidate_BothSpecsPopulated(t *testing.T) {
 	cfg := newValid()
 	cfg.Spec.Bundle = &config.BundleSpec{

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
@@ -37,9 +38,10 @@ func (c *AICRConfig) Validate() error {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("invalid kind %q: expected %q", c.Kind, Kind))
 	}
-	if c.APIVersion != APIVersion {
+	if !header.IsSupportedAuthoringAPIVersion(c.APIVersion) {
 		return errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("invalid apiVersion %q: expected %q", c.APIVersion, APIVersion))
+			fmt.Sprintf("invalid apiVersion %q: expected %q or %q; update the config header to a version accepted by this aicr release",
+				c.APIVersion, APIVersion, header.GroupVersionV1Beta1))
 	}
 	if c.Spec.Snapshot == nil && c.Spec.Recipe == nil && c.Spec.Bundle == nil &&
 		c.Spec.Validate == nil && c.Spec.Verify == nil {

--- a/pkg/header/doc.go
+++ b/pkg/header/doc.go
@@ -59,16 +59,18 @@
 //
 // # API Versioning
 //
-// The APIVersion field enables evolution of data formats. The current group and
-// version is GroupVersion ("aicr.run/v1alpha2"); APIGroup derives from Domain.
-// Per ADR-013 the move from the legacy aicr.nvidia.com/v1alpha1 group was a hard
-// break — the old value is rejected, not migrated.
+// The APIVersion field enables evolution of data formats. GroupVersion remains
+// the Release N alpha emitter value for general artifacts; target versions and
+// kind/schema-scoped gates are defined alongside it. APIGroup derives from
+// Domain. Per ADR-013 the move from the legacy aicr.nvidia.com/v1alpha1 group
+// was a hard break — the old value is rejected, not migrated.
 //
-// Callers should gate on IsSupportedAPIVersion rather than comparing literals,
-// so the single source of truth in this package stays authoritative:
+// Callers should select the gate for the artifact's schema track rather than
+// comparing literals, so the single source of truth in this package stays
+// authoritative. IsSupportedAPIVersion covers the stable artifact track:
 //
 //	if h.APIVersion != "" && !header.IsSupportedAPIVersion(h.APIVersion) {
-//	    return fmt.Errorf("unsupported apiVersion %q; expected %s", h.APIVersion, header.GroupVersion)
+//	    return fmt.Errorf("unsupported apiVersion %q", h.APIVersion)
 //	}
 //
 // # Kind Field

--- a/pkg/header/doc.go
+++ b/pkg/header/doc.go
@@ -70,7 +70,8 @@
 // authoritative. IsSupportedAPIVersion covers the stable artifact track:
 //
 //	if h.APIVersion != "" && !header.IsSupportedAPIVersion(h.APIVersion) {
-//	    return fmt.Errorf("unsupported apiVersion %q", h.APIVersion)
+//	    return errors.New(errors.ErrCodeInvalidRequest,
+//	        fmt.Sprintf("unsupported apiVersion %q", h.APIVersion))
 //	}
 //
 // # Kind Field

--- a/pkg/header/header.go
+++ b/pkg/header/header.go
@@ -19,16 +19,16 @@ import (
 )
 
 // AICR artifact API versioning. These constants are the single source of
-// truth for the group/version stamped into every AICR artifact header
-// (snapshot, recipe, config). Package-local aliases (e.g.
-// snapshotter.FullAPIVersion, recipe.RecipeAPIVersion, config.APIVersion)
-// must reference GroupVersion rather than redeclaring the literal.
+// truth for every AICR artifact group/version. Package-local emitters and
+// readers select a version by wire kind and schema track; see ADR-022.
 //
-// Evolution policy (see docs/design/011-artifact-apiversion-policy.md):
-// schema changes within a version must be additive-only; a breaking change
-// requires a new version segment. This is a hard break: the old value is NOT
-// accepted alongside the new one — there is no transition window. Artifacts
-// stamped with a prior group/version must be regenerated.
+// Evolution policy (see docs/design/011-artifact-apiversion-policy.md and
+// docs/design/022-artifact-maturity-and-deprecation.md): schema changes within
+// a version must be additive-only; a breaking change requires a new version
+// segment. Alpha versions owe no deprecation window. Beta versions remain
+// readable for two AICR releases after deprecation, and GA versions remain
+// readable through the current AICR major version. Version bumps that owe a
+// window stage readers before emitters.
 const (
 	// Domain is the single source of truth for the AICR API domain. Every
 	// role (apiVersion group, K8s label/annotation keys, attestation and
@@ -45,11 +45,33 @@ const (
 	// desired-state configuration. Other artifact kinds remain on v1alpha2.
 	APIVersionV1Alpha3 = "v1alpha3"
 
+	// APIVersionV1Beta1 is the ADR-022 target for authoring and configuration
+	// artifacts: AICRConfig, ordinary RecipeMetadata, RecipeMixin, and
+	// ComponentRegistry.
+	APIVersionV1Beta1 = "v1beta1"
+
+	// APIVersionV1Beta2 is the ADR-022 target for profile-bearing
+	// RecipeMetadata and RecipeResult artifacts.
+	APIVersionV1Beta2 = "v1beta2"
+
+	// APIVersionV1 is the ADR-022 target for stable public artifacts:
+	// Snapshot, default RecipeResult, RecipeCriteria, and BundleProvenance.
+	APIVersionV1 = "v1"
+
 	// GroupVersion is the canonical "group/version" string for AICR artifacts.
 	GroupVersion = APIGroup + "/" + APIVersionV1Alpha2
 
 	// RecipeResultGroupVersion is the current configured RecipeResult schema.
 	RecipeResultGroupVersion = APIGroup + "/" + APIVersionV1Alpha3
+
+	// GroupVersionV1Beta1 is the target authoring/configuration group/version.
+	GroupVersionV1Beta1 = APIGroup + "/" + APIVersionV1Beta1
+
+	// GroupVersionV1Beta2 is the target profile-bearing group/version.
+	GroupVersionV1Beta2 = APIGroup + "/" + APIVersionV1Beta2
+
+	// GroupVersionV1 is the target stable public artifact group/version.
+	GroupVersionV1 = APIGroup + "/" + APIVersionV1
 )
 
 // IsSupportedAPIVersion reports whether v is an artifact apiVersion this binary
@@ -57,12 +79,36 @@ const (
 // that tolerate a missing apiVersion for backward compatibility with older
 // artifacts must special-case "" before calling this.
 //
-// Bumping the artifact schema is a hard break: replace GroupVersion with the
-// new value rather than accepting both. The prior value is rejected — artifacts
-// stamped with an older group/version must be regenerated, not migrated.
+// This compatibility helper covers the stable artifact track only. Callers
+// reading authoring or profile-bearing artifacts must use the corresponding
+// schema-track helper instead of treating versions as globally interchangeable.
 func IsSupportedAPIVersion(v string) bool {
 	switch v {
-	case GroupVersion:
+	case GroupVersion, GroupVersionV1:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSupportedAuthoringAPIVersion reports whether v is accepted for an
+// ADR-022 authoring/configuration artifact during the Release N reader-first
+// window.
+func IsSupportedAuthoringAPIVersion(v string) bool {
+	switch v {
+	case GroupVersion, GroupVersionV1Beta1:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSupportedProfileAPIVersion reports whether v is accepted for a
+// profile-bearing RecipeMetadata or RecipeResult during the Release N
+// reader-first window.
+func IsSupportedProfileAPIVersion(v string) bool {
+	switch v {
+	case RecipeResultGroupVersion, GroupVersionV1Beta2:
 		return true
 	default:
 		return false
@@ -70,15 +116,11 @@ func IsSupportedAPIVersion(v string) bool {
 }
 
 // IsSupportedRecipeResultAPIVersion reports whether v is a RecipeResult
-// version understood by this binary. v1alpha2 remains readable for legacy
-// recipes; newly configured Slurm recipes use v1alpha3.
+// version understood by this binary. The gate is the union of the default and
+// profile-bearing schema tracks; callers must still enforce the bidirectional
+// version/profile discriminator contract.
 func IsSupportedRecipeResultAPIVersion(v string) bool {
-	switch v {
-	case GroupVersion, RecipeResultGroupVersion:
-		return true
-	default:
-		return false
-	}
+	return IsSupportedAPIVersion(v) || IsSupportedProfileAPIVersion(v)
 }
 
 // Kind represents the type of AICR resource.

--- a/pkg/header/header_test.go
+++ b/pkg/header/header_test.go
@@ -31,6 +31,16 @@ func TestGroupVersion(t *testing.T) {
 	if want := APIGroup + "/" + APIVersionV1Alpha2; GroupVersion != want {
 		t.Errorf("GroupVersion = %q, want %q", GroupVersion, want)
 	}
+	versions := map[string]string{
+		GroupVersionV1:      APIGroup + "/" + APIVersionV1,
+		GroupVersionV1Beta1: APIGroup + "/" + APIVersionV1Beta1,
+		GroupVersionV1Beta2: APIGroup + "/" + APIVersionV1Beta2,
+	}
+	for got, want := range versions {
+		if got != want {
+			t.Errorf("target group/version = %q, want %q", got, want)
+		}
+	}
 }
 
 func TestIsSupportedAPIVersion(t *testing.T) {
@@ -42,6 +52,9 @@ func TestIsSupportedAPIVersion(t *testing.T) {
 		want bool
 	}{
 		{"current", "aicr.run/v1alpha2", true},
+		{"target", "aicr.run/v1", true},
+		{"authoring target rejected", "aicr.run/v1beta1", false},
+		{"profile target rejected", "aicr.run/v1beta2", false},
 		{"old group+version rejected", "aicr.nvidia.com/v1alpha1", false},
 		{"old group new version rejected", "aicr.nvidia.com/v1alpha2", false},
 		{"new group old version rejected", "aicr.run/v1alpha1", false},
@@ -58,6 +71,45 @@ func TestIsSupportedAPIVersion(t *testing.T) {
 	}
 }
 
+func TestSchemaTrackAPIVersions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		check    func(string) bool
+		accepted []string
+		rejected []string
+	}{
+		{
+			name:     "authoring",
+			check:    IsSupportedAuthoringAPIVersion,
+			accepted: []string{GroupVersion, GroupVersionV1Beta1},
+			rejected: []string{"", GroupVersionV1, RecipeResultGroupVersion, GroupVersionV1Beta2},
+		},
+		{
+			name:     "profile",
+			check:    IsSupportedProfileAPIVersion,
+			accepted: []string{RecipeResultGroupVersion, GroupVersionV1Beta2},
+			rejected: []string{"", GroupVersion, GroupVersionV1, GroupVersionV1Beta1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			for _, version := range tt.accepted {
+				if !tt.check(version) {
+					t.Errorf("%s track rejected %q", tt.name, version)
+				}
+			}
+			for _, version := range tt.rejected {
+				if tt.check(version) {
+					t.Errorf("%s track accepted %q", tt.name, version)
+				}
+			}
+		})
+	}
+}
+
 func TestIsSupportedRecipeResultAPIVersion(t *testing.T) {
 	t.Parallel()
 
@@ -67,6 +119,9 @@ func TestIsSupportedRecipeResultAPIVersion(t *testing.T) {
 	}{
 		{version: GroupVersion, want: true},
 		{version: RecipeResultGroupVersion, want: true},
+		{version: GroupVersionV1, want: true},
+		{version: GroupVersionV1Beta2, want: true},
+		{version: GroupVersionV1Beta1, want: false},
 		{version: "", want: false},
 		{version: "aicr.run/v1alpha4", want: false},
 	}

--- a/pkg/recipe/accounting.go
+++ b/pkg/recipe/accounting.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"gopkg.in/yaml.v3"
 )
@@ -377,10 +378,10 @@ func (r *RecipeResult) validateAccountingConfiguration() error {
 	if !present {
 		return nil
 	}
-	if r.APIVersion != ConfiguredRecipeResultAPIVersion {
+	if !header.IsSupportedProfileAPIVersion(r.APIVersion) {
 		return errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("configuration.slurm.accounting requires apiVersion %q (got %q)",
-				ConfiguredRecipeResultAPIVersion, r.APIVersion))
+			fmt.Sprintf("configuration.slurm.accounting requires apiVersion %q or %q (got %q)",
+				ConfiguredRecipeResultAPIVersion, header.GroupVersionV1Beta2, r.APIVersion))
 	}
 	if r.Criteria == nil || r.Criteria.Platform != CriteriaPlatformSlurm {
 		return errors.New(errors.ErrCodeInvalidRequest,

--- a/pkg/recipe/adapter_test.go
+++ b/pkg/recipe/adapter_test.go
@@ -738,7 +738,9 @@ func buildProviderWithValues(t *testing.T, valuesPath string, values map[string]
 		t.Fatalf("marshal values: %v", err)
 	}
 
-	registryYAML := []byte(`components: []
+	registryYAML := []byte(`apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+components: []
 `)
 	baseYAML := []byte(`kind: RecipeMetadata
 apiVersion: aicr.run/v1alpha2

--- a/pkg/recipe/builder_test.go
+++ b/pkg/recipe/builder_test.go
@@ -408,7 +408,9 @@ func TestConstraintEvalResult(t *testing.T) {
 func buildIsolationProvider(t *testing.T, overlayName string) DataProvider {
 	t.Helper()
 
-	registryYAML := []byte(`components: []
+	registryYAML := []byte(`apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
+components: []
 `)
 	baseYAML := []byte(`kind: RecipeMetadata
 apiVersion: aicr.run/v1alpha2

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -22,8 +22,12 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"gopkg.in/yaml.v3"
 )
+
+// ComponentRegistryKind is the wire kind for component registry documents.
+const ComponentRegistryKind = "ComponentRegistry"
 
 // ComponentRegistry holds the declarative configuration for all components.
 // This is loaded from embedded recipe data (recipes/registry.yaml) at startup.
@@ -415,12 +419,15 @@ func loadComponentRegistryFor(provider DataProvider) (*ComponentRegistry, error)
 	defer cancel()
 	data, err := provider.ReadFile(ctx, "registry.yaml")
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read registry.yaml", err)
+		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInternal, "failed to read registry.yaml")
 	}
 
 	var registry ComponentRegistry
 	if err := yaml.Unmarshal(data, &registry); err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to parse registry.yaml", err)
+	}
+	if err := validateComponentRegistryHeader(&registry, "registry.yaml"); err != nil {
+		return nil, err
 	}
 
 	// Fail closed on the reserved deployer key for EVERY loaded registry
@@ -457,6 +464,23 @@ func loadComponentRegistryFor(provider DataProvider) (*ComponentRegistry, error)
 	}
 
 	return &registry, nil
+}
+
+func validateComponentRegistryHeader(registry *ComponentRegistry, source string) error {
+	if registry == nil {
+		return errors.New(errors.ErrCodeInvalidRequest, source+" is empty")
+	}
+	if registry.Kind != ComponentRegistryKind {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s has kind %q, expected %q; use a ComponentRegistry document compatible with this aicr release",
+				source, registry.Kind, ComponentRegistryKind))
+	}
+	if !header.IsSupportedAuthoringAPIVersion(registry.APIVersion) {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("%s has apiVersion %q, expected %q or %q for %s; update the registry header for this aicr release",
+				source, registry.APIVersion, RecipeAPIVersion, header.GroupVersionV1Beta1, ComponentRegistryKind))
+	}
+	return nil
 }
 
 // Get returns the component configuration by name.

--- a/pkg/recipe/components_test.go
+++ b/pkg/recipe/components_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	stderrors "errors"
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -1214,6 +1215,43 @@ func TestGetComponentRegistry_PerProviderIsolation(t *testing.T) {
 	}
 	if rB.Get("alpha-only") != nil {
 		t.Errorf("registry B leaked alpha-only component")
+	}
+}
+
+func TestLoadComponentRegistry_ReleaseNHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		wantErr    bool
+	}{
+		{name: "current alpha", apiVersion: RecipeAPIVersion, kind: ComponentRegistryKind},
+		{name: "target beta", apiVersion: "aicr.run/v1beta1", kind: ComponentRegistryKind},
+		{name: "empty version", apiVersion: "", kind: ComponentRegistryKind, wantErr: true},
+		{name: "unknown version", apiVersion: "aicr.run/v9", kind: ComponentRegistryKind, wantErr: true},
+		{name: "wrong kind", apiVersion: RecipeAPIVersion, kind: "RecipeMetadata", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp := newInMemoryProvider("registry-header-"+tt.name, map[string][]byte{
+				"registry.yaml": fmt.Appendf(nil, "apiVersion: %s\nkind: %s\ncomponents: []\n", tt.apiVersion, tt.kind),
+			})
+			t.Cleanup(func() { EvictCachedRegistry(dp) })
+
+			_, err := GetComponentRegistryFor(dp)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("GetComponentRegistryFor() error = nil, want header rejection")
+				}
+				if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+					t.Fatalf("error = %v, want ErrCodeInvalidRequest", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetComponentRegistryFor() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/recipe/oskind"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"gopkg.in/yaml.v3"
@@ -798,6 +799,19 @@ const RecipeCriteriaKind = "RecipeCriteria"
 // artifact apiVersion has a single source of truth.
 const RecipeCriteriaAPIVersion = RecipeAPIVersion
 
+func validateRecipeCriteriaHeader(kind, apiVersion string) error {
+	if kind != "" && kind != RecipeCriteriaKind {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid kind %q, expected %q", kind, RecipeCriteriaKind))
+	}
+	if apiVersion != "" && !header.IsSupportedAPIVersion(apiVersion) {
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("invalid apiVersion %q for %s, expected %q or %q; regenerate the criteria with a matching aicr version",
+				apiVersion, RecipeCriteriaKind, RecipeCriteriaAPIVersion, header.GroupVersionV1))
+	}
+	return nil
+}
+
 // RecipeCriteria represents a Kubernetes-style criteria resource.
 // This is the format used in criteria files and API requests.
 //
@@ -928,12 +942,8 @@ func LoadCriteriaFromFile(path string, reg *CriteriaRegistry) (*Criteria, error)
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to load criteria file", err)
 	}
 
-	// Validate kind and apiVersion
-	if raw.Kind != "" && raw.Kind != RecipeCriteriaKind {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid kind %q, expected %q", raw.Kind, RecipeCriteriaKind))
-	}
-	if raw.APIVersion != "" && raw.APIVersion != RecipeCriteriaAPIVersion {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid apiVersion %q, expected %q", raw.APIVersion, RecipeCriteriaAPIVersion))
+	if err := validateRecipeCriteriaHeader(raw.Kind, raw.APIVersion); err != nil {
+		return nil, err
 	}
 
 	return validateAndConvertRawSpec(&raw.Spec, reg)
@@ -972,12 +982,8 @@ func LoadCriteriaFromFileWithContext(ctx context.Context, path string, reg *Crit
 		return nil, err
 	}
 
-	// Validate kind and apiVersion
-	if raw.Kind != "" && raw.Kind != RecipeCriteriaKind {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid kind %q, expected %q", raw.Kind, RecipeCriteriaKind))
-	}
-	if raw.APIVersion != "" && raw.APIVersion != RecipeCriteriaAPIVersion {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid apiVersion %q, expected %q", raw.APIVersion, RecipeCriteriaAPIVersion))
+	if err := validateRecipeCriteriaHeader(raw.Kind, raw.APIVersion); err != nil {
+		return nil, err
 	}
 
 	return validateAndConvertRawSpec(&raw.Spec, reg)
@@ -1007,12 +1013,8 @@ func loadCriteriaFromHTTPWithContext(ctx context.Context, url string, reg *Crite
 		return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest, "failed to deserialize criteria")
 	}
 
-	// Validate kind and apiVersion
-	if raw.Kind != "" && raw.Kind != RecipeCriteriaKind {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid kind %q, expected %q", raw.Kind, RecipeCriteriaKind))
-	}
-	if raw.APIVersion != "" && raw.APIVersion != RecipeCriteriaAPIVersion {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid apiVersion %q, expected %q", raw.APIVersion, RecipeCriteriaAPIVersion))
+	if err := validateRecipeCriteriaHeader(raw.Kind, raw.APIVersion); err != nil {
+		return nil, err
 	}
 
 	return validateAndConvertRawSpec(&raw.Spec, reg)
@@ -1094,12 +1096,8 @@ func ParseCriteriaFromBody(body io.Reader, contentType string, reg *CriteriaRegi
 		}
 	}
 
-	// Validate kind and apiVersion
-	if raw.Kind != "" && raw.Kind != RecipeCriteriaKind {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid kind %q, expected %q", raw.Kind, RecipeCriteriaKind))
-	}
-	if raw.APIVersion != "" && raw.APIVersion != RecipeCriteriaAPIVersion {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, fmt.Sprintf("invalid apiVersion %q, expected %q", raw.APIVersion, RecipeCriteriaAPIVersion))
+	if err := validateRecipeCriteriaHeader(raw.Kind, raw.APIVersion); err != nil {
+		return nil, err
 	}
 
 	return validateAndConvertRawSpec(&raw.Spec, reg)

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -942,6 +942,21 @@ spec:
 			wantErr: false,
 		},
 		{
+			name:     "Release N target apiVersion",
+			filename: "target.yaml",
+			content: `kind: RecipeCriteria
+apiVersion: aicr.run/v1
+spec:
+  service: eks`,
+			want: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorAny,
+				Intent:      CriteriaIntentAny,
+				OS:          CriteriaOSAny,
+				Platform:    CriteriaPlatformAny,
+			},
+		},
+		{
 			name:     "partial fields - only spec.service",
 			filename: "partial.yaml",
 			content: `kind: RecipeCriteria
@@ -1150,7 +1165,7 @@ func TestLoadCriteriaFromFileWithContext(t *testing.T) {
 	t.Run("local file", func(t *testing.T) {
 		// Create a temporary file with criteria
 		content := `kind: RecipeCriteria
-apiVersion: aicr.run/v1alpha2
+apiVersion: aicr.run/v1
 metadata:
   name: test-criteria
 spec:
@@ -1276,6 +1291,18 @@ func TestParseCriteriaFromBody(t *testing.T) {
 				Nodes:       0,
 			},
 			wantErr: false,
+		},
+		{
+			name:        "JSON body with Release N target apiVersion",
+			body:        `{"kind":"RecipeCriteria","apiVersion":"aicr.run/v1","spec":{"service":"eks"}}`,
+			contentType: "application/json",
+			want: &Criteria{
+				Service:     CriteriaServiceEKS,
+				Accelerator: CriteriaAcceleratorAny,
+				Intent:      CriteriaIntentAny,
+				OS:          CriteriaOSAny,
+				Platform:    CriteriaPlatformAny,
+			},
 		},
 		{
 			name: "YAML body with application/x-yaml",

--- a/pkg/recipe/criteria_test.go
+++ b/pkg/recipe/criteria_test.go
@@ -1033,6 +1033,24 @@ spec:
 			wantErr: true,
 		},
 		{
+			name:     "profile target rejected for RecipeCriteria",
+			filename: "profile_target.yaml",
+			content: `kind: RecipeCriteria
+apiVersion: aicr.run/v1beta2
+spec:
+  service: eks`,
+			wantErr: true,
+		},
+		{
+			name:     "authoring target rejected for RecipeCriteria",
+			filename: "authoring_target.yaml",
+			content: `kind: RecipeCriteria
+apiVersion: aicr.run/v1beta1
+spec:
+  service: eks`,
+			wantErr: true,
+		},
+		{
 			name:     "invalid service type",
 			filename: "invalid_service.yaml",
 			content: `kind: RecipeCriteria

--- a/pkg/recipe/decode.go
+++ b/pkg/recipe/decode.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"gopkg.in/yaml.v3"
 )
@@ -43,24 +44,24 @@ func DecodeRecipeResult(data []byte, format serializer.Format) (*RecipeResult, e
 		return nil, errors.PropagateOrWrap(headerErr, errors.ErrCodeInvalidRequest,
 			"failed to decode recipe artifact header")
 	}
-	if artifactHeader.APIVersion == RecipeProfileAPIVersion && artifactHeader.Kind == "" {
+	if header.IsSupportedProfileAPIVersion(artifactHeader.APIVersion) && artifactHeader.Kind == "" {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("recipe artifact apiVersion %q requires kind %q",
-				RecipeProfileAPIVersion, RecipeResultKind))
+				artifactHeader.APIVersion, RecipeResultKind))
 	}
 	if artifactHeader.Kind != "" && artifactHeader.Kind != RecipeResultKind {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("recipe artifact has kind %q, expected %q",
 				artifactHeader.Kind, RecipeResultKind))
 	}
-	if artifactHeader.APIVersion == RecipeProfileAPIVersion {
+	if header.IsSupportedProfileAPIVersion(artifactHeader.APIVersion) {
 		if profileErr := validateProfileExcludedOverlays(data, format); profileErr != nil {
 			return nil, profileErr
 		}
 	}
 
 	var opts []serializer.ReaderOption
-	if artifactHeader.APIVersion == RecipeProfileAPIVersion {
+	if header.IsSupportedProfileAPIVersion(artifactHeader.APIVersion) {
 		opts = append(opts, serializer.WithStrict())
 	}
 	reader, err := serializer.NewReader(format, bytes.NewReader(data), opts...)

--- a/pkg/recipe/doc.go
+++ b/pkg/recipe/doc.go
@@ -199,7 +199,7 @@
 //
 //	type RecipeCriteria struct {
 //	    Kind       string    // Must be "RecipeCriteria"
-//	    APIVersion string    // Must be "aicr.run/v1alpha2"
+//	    APIVersion string    // Release N accepts "aicr.run/v1alpha2" or "aicr.run/v1"
 //	    Metadata   struct {
 //	        Name string       // Optional descriptive name
 //	    }

--- a/pkg/recipe/loader.go
+++ b/pkg/recipe/loader.go
@@ -88,16 +88,10 @@ func LoadFromFileWithProviderProfile(
 
 	// Reject an artifact stamped with an apiVersion this build does not
 	// understand before an overlay can trigger provider-backed hydration.
-	// Empty is tolerated for legacy files, while v1alpha3 is the strict
-	// profile artifact version introduced by ADR-015.
-	if inputAPIVersion != "" &&
-		!header.IsSupportedAPIVersion(inputAPIVersion) &&
-		inputAPIVersion != RecipeProfileAPIVersion {
-
-		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("recipe file has apiVersion %q, which this aicr build does not support (expected %q or %q); "+
-				"regenerate the recipe with a matching aicr version",
-				inputAPIVersion, header.GroupVersion, RecipeProfileAPIVersion))
+	// The accepted set is selected by wire kind/schema track; an empty value
+	// remains tolerated here for pre-apiVersion recipe files through Release N.
+	if versionErr := validateRecipeInputAPIVersion(rec.Kind, inputAPIVersion); versionErr != nil {
+		return nil, versionErr
 	}
 
 	// Users often pass overlay files directly; auto-hydrate so they don't need
@@ -107,7 +101,7 @@ func LoadFromFileWithProviderProfile(
 			"file", path)
 
 		var readerOpts []serializer.ReaderOption
-		if inputAPIVersion == RecipeProfileAPIVersion {
+		if header.IsSupportedProfileAPIVersion(inputAPIVersion) {
 			readerOpts = append(readerOpts, serializer.WithStrict())
 		}
 		overlayReader, parseErr := serializer.NewReader(
@@ -160,7 +154,7 @@ func LoadFromFileWithProviderProfile(
 					"is already baked into metadata.selectedProfile; a profile selection applies "+
 					"only to overlay inputs", path))
 		}
-		if inputAPIVersion == RecipeProfileAPIVersion {
+		if header.IsSupportedProfileAPIVersion(inputAPIVersion) {
 			rec, err = DecodeRecipeResult(sourceData, sourceFormat)
 			if err != nil {
 				return nil, errors.PropagateOrWrap(err, errors.ErrCodeInvalidRequest,
@@ -177,10 +171,10 @@ func LoadFromFileWithProviderProfile(
 
 	// The strict profile artifact version requires its discriminator. Empty
 	// kind remains allowed only for legacy RecipeResult files that predate it.
-	if rec.Kind == "" && inputAPIVersion == RecipeProfileAPIVersion {
+	if rec.Kind == "" && header.IsSupportedProfileAPIVersion(inputAPIVersion) {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("recipe file apiVersion %q requires kind %q",
-				RecipeProfileAPIVersion, RecipeResultKind))
+				inputAPIVersion, RecipeResultKind))
 	}
 	if rec.Kind != "" && rec.Kind != RecipeResultKind {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
@@ -201,6 +195,34 @@ func LoadFromFileWithProviderProfile(
 	}
 
 	return rec, nil
+}
+
+func validateRecipeInputAPIVersion(kind, apiVersion string) error {
+	if apiVersion == "" {
+		return nil
+	}
+
+	if kind == RecipeMetadataKind {
+		if header.IsSupportedAuthoringAPIVersion(apiVersion) ||
+			header.IsSupportedProfileAPIVersion(apiVersion) {
+
+			return nil
+		}
+		return errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("recipe metadata file has apiVersion %q, which this aicr build does not support (expected %q, %q, %q, or %q); "+
+				"update the catalog header for this aicr release",
+				apiVersion, RecipeAPIVersion, header.GroupVersionV1Beta1,
+				RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
+	}
+
+	if header.IsSupportedRecipeResultAPIVersion(apiVersion) {
+		return nil
+	}
+	return errors.New(errors.ErrCodeInvalidRequest,
+		fmt.Sprintf("recipe file has apiVersion %q, which this aicr build does not support (expected %q, %q, %q, or %q); "+
+			"regenerate the recipe with a matching aicr version",
+			apiVersion, RecipeAPIVersion, header.GroupVersionV1,
+			RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
 }
 
 func ensureDirectOverlayProfileApplied(

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -161,6 +161,12 @@ spec:
 			errContain:  `apiVersion "aicr.nvidia.com/v1alpha1"`,
 		},
 		{
+			name:        "authoring target rejected for RecipeResult",
+			yamlContent: "kind: RecipeResult\napiVersion: aicr.run/v1beta1\ncriteria:\n  service: eks\n",
+			wantErr:     true,
+			errContain:  `apiVersion "aicr.run/v1beta1"`,
+		},
+		{
 			name: "profile RecipeResult loads strictly",
 			yamlContent: `kind: RecipeResult
 apiVersion: aicr.run/v1alpha3
@@ -223,6 +229,19 @@ profie: typo
 		{
 			name: "profile RecipeResult requires kind",
 			yamlContent: `apiVersion: aicr.run/v1alpha3
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+componentRefs: []
+`,
+			wantErr:    true,
+			errContain: `requires kind "RecipeResult"`,
+		},
+		{
+			name: "Release N target profile RecipeResult requires kind",
+			yamlContent: `apiVersion: aicr.run/v1beta2
 metadata:
   selectedProfile:
     name: mode

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -79,6 +79,10 @@ func TestLoadFromFile(t *testing.T) {
 			},
 		},
 		{
+			name:        "Release N target RecipeResult loads directly",
+			yamlContent: "kind: RecipeResult\napiVersion: aicr.run/v1\ncriteria:\n  service: eks\n",
+		},
+		{
 			name:        "RecipeMetadata with criteria auto-hydrates",
 			yamlContent: "kind: RecipeMetadata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: test\nspec:\n  criteria:\n    service: eks\n    accelerator: h100\n    intent: training\n",
 			wantErr:     false,
@@ -91,6 +95,10 @@ func TestLoadFromFile(t *testing.T) {
 					t.Error("expected hydrated recipe with components")
 				}
 			},
+		},
+		{
+			name:        "Release N target RecipeMetadata auto-hydrates",
+			yamlContent: "kind: RecipeMetadata\napiVersion: aicr.run/v1beta1\nmetadata:\n  name: test\nspec:\n  criteria:\n    service: eks\n    accelerator: h100\n    intent: training\n",
 		},
 		{
 			name: "profile RecipeMetadata outside active catalog fails closed",
@@ -173,9 +181,35 @@ componentRefs: []
 			},
 		},
 		{
+			name: "Release N target profile RecipeResult loads strictly",
+			yamlContent: `kind: RecipeResult
+apiVersion: aicr.run/v1beta2
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+componentRefs: []
+`,
+		},
+		{
 			name: "profile RecipeResult rejects unknown field",
 			yamlContent: `kind: RecipeResult
 apiVersion: aicr.run/v1alpha3
+metadata:
+  selectedProfile:
+    name: mode
+    value: one
+    ownedPaths: {}
+profie: typo
+`,
+			wantErr:    true,
+			errContain: "field profie not found",
+		},
+		{
+			name: "Release N target profile RecipeResult rejects unknown field",
+			yamlContent: `kind: RecipeResult
+apiVersion: aicr.run/v1beta2
 metadata:
   selectedProfile:
     name: mode

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -577,9 +577,8 @@ func (r *RecipeResult) backfillComponentTypes() error {
 // silently emits an artifact it would not read back. (The file loader also
 // accepts RecipeMetadata, but as an overlay to hydrate rather than as a
 // RecipeResult; that input shape has no analog on this boundary.) Only Kind is
-// normalized: APIVersion is validated, never rewritten, because an artifact
-// group/version bump is a hard break with no transition window — see
-// docs/design/011-artifact-apiversion-policy.md. See issue #1953.
+// normalized: APIVersion is validated against the kind/schema-scoped read
+// window and never rewritten. See ADR-022 and issue #1953.
 func (r *RecipeResult) NormalizeKind() error {
 	if r == nil {
 		return nil

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"gopkg.in/yaml.v3"
 )
 
@@ -220,15 +221,21 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 			if readErr != nil {
 				return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, fmt.Sprintf("failed to read mixin %s", path), readErr)
 			}
+			var mixinHeader RecipeMetadataHeader
+			if parseErr := yaml.Unmarshal(content, &mixinHeader); parseErr != nil {
+				return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
+					fmt.Sprintf("failed to parse mixin header %s", path), parseErr)
+			}
+			if headerErr := validateRecipeMixinCatalogHeader(
+				mixinHeader.Kind, mixinHeader.APIVersion, path,
+			); headerErr != nil {
+				return headerErr
+			}
 			var mixin RecipeMixin
 			decoder := yaml.NewDecoder(bytes.NewReader(content))
 			decoder.KnownFields(true)
 			if parseErr := decoder.Decode(&mixin); parseErr != nil {
 				return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse mixin %s (unknown fields are not allowed)", path), parseErr)
-			}
-			if mixin.Kind != RecipeMixinKind {
-				return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-					fmt.Sprintf("mixin file %s has wrong kind %q, expected %q", path, mixin.Kind, RecipeMixinKind))
 			}
 			if _, exists := store.Mixins[mixin.Metadata.Name]; exists {
 				return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
@@ -274,28 +281,24 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 		if parseErr := yaml.Unmarshal(content, &metadataHeader); parseErr != nil {
 			return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest, fmt.Sprintf("failed to parse header for %s", path), parseErr)
 		}
-		if metadataHeader.APIVersion == RecipeProfileAPIVersion &&
-			metadataHeader.Kind != RecipeMetadataKind {
-
-			return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-				fmt.Sprintf("profile catalog file %s requires kind %q, got %q",
-					path, RecipeMetadataKind, metadataHeader.Kind))
+		isRecipeMetadata, profileVersion, headerErr := classifyRecipeMetadataCatalogHeader(
+			&metadataHeader, path,
+		)
+		if headerErr != nil {
+			return headerErr
 		}
-		// Skip files with a different kind (e.g., ValidatorCatalog) only
-		// after the profile apiVersion has been gated. A misspelled kind on a
-		// v1alpha3 profile overlay must not silently remove the declaration.
-		if metadataHeader.Kind != "" && metadataHeader.Kind != RecipeMetadataKind {
+		if !isRecipeMetadata {
 			slog.Debug("skipping non-recipe YAML", "path", path, "kind", metadataHeader.Kind)
 			return nil
 		}
 
 		var metadata RecipeMetadata
-		if metadataHeader.APIVersion == RecipeProfileAPIVersion {
+		if profileVersion {
 			decoder := yaml.NewDecoder(bytes.NewReader(content))
 			decoder.KnownFields(true)
 			if parseErr := decoder.Decode(&metadata); parseErr != nil {
 				return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
-					fmt.Sprintf("failed to parse %s as strict %s RecipeMetadata", path, RecipeProfileAPIVersion),
+					fmt.Sprintf("failed to parse %s as strict %s RecipeMetadata", path, metadataHeader.APIVersion),
 					parseErr)
 			}
 			var trailing any
@@ -315,7 +318,7 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 			return aicrerrors.PropagateOrWrap(profileErr, aicrerrors.ErrCodeInvalidRequest,
 				fmt.Sprintf("invalid profile declaration in %s", path))
 		}
-		if metadata.APIVersion == RecipeProfileAPIVersion && metadata.Metadata.Name == "" {
+		if profileVersion && metadata.Metadata.Name == "" {
 			return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
 				fmt.Sprintf("profile RecipeMetadata %s requires metadata.name", path))
 		}
@@ -399,6 +402,59 @@ func buildMetadataStore(ctx context.Context, provider DataProvider) (*MetadataSt
 	}
 
 	return store, nil
+}
+
+func validateRecipeMixinCatalogHeader(kind, apiVersion, path string) error {
+	if kind != RecipeMixinKind {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("mixin file %s has kind %q, expected %q; use a RecipeMixin document compatible with this aicr release",
+				path, kind, RecipeMixinKind))
+	}
+	if !header.IsSupportedAuthoringAPIVersion(apiVersion) {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("mixin file %s has apiVersion %q, expected %q or %q for %s; update the catalog header for this aicr release",
+				path, apiVersion, RecipeAPIVersion, header.GroupVersionV1Beta1, RecipeMixinKind))
+	}
+	return nil
+}
+
+func classifyRecipeMetadataCatalogHeader(
+	metadata *RecipeMetadataHeader,
+	path string,
+) (bool, bool, error) {
+
+	if metadata.Kind != RecipeMetadataKind {
+		if isKnownNonMetadataAICRKind(metadata.Kind) {
+			return false, false, nil
+		}
+		if strings.HasPrefix(metadata.APIVersion, header.APIGroup+"/") {
+			return false, false, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+				fmt.Sprintf("AICR catalog file %s has kind %q, expected %q; fix the wire kind or move the unrelated document outside the recipe catalog",
+					path, metadata.Kind, RecipeMetadataKind))
+		}
+		return false, false, nil
+	}
+
+	profileVersion := header.IsSupportedProfileAPIVersion(metadata.APIVersion)
+	if !profileVersion && !header.IsSupportedAuthoringAPIVersion(metadata.APIVersion) {
+		return false, false, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("RecipeMetadata file %s has apiVersion %q, expected %q, %q, %q, or %q; update the catalog header for this aicr release",
+				path, metadata.APIVersion, RecipeAPIVersion, header.GroupVersionV1Beta1,
+				RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
+	}
+	return true, profileVersion, nil
+}
+
+func isKnownNonMetadataAICRKind(kind string) bool {
+	switch kind {
+	case "AICRConfig", "BundleProvenance", ComponentRegistryKind,
+		RecipeCriteriaKind, RecipeMixinKind, RecipeResultKind,
+		string(header.KindRecipe), string(header.KindSnapshot):
+
+		return true
+	default:
+		return false
+	}
 }
 
 // EvictCachedStore drops the cached MetadataStore for the supplied provider.

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -2716,8 +2716,155 @@ spec:
 	if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
 		t.Fatalf("error code = %v, want ErrCodeInvalidRequest", err)
 	}
-	if !strings.Contains(err.Error(), `requires kind "RecipeMetadata"`) {
+	if !strings.Contains(err.Error(), `expected "RecipeMetadata"`) {
 		t.Fatalf("error = %v, want RecipeMetadata kind requirement", err)
+	}
+}
+
+func TestLoadMetadataStore_AcceptsReleaseNTargetCatalogHeaders(t *testing.T) {
+	provider := newInMemoryProvider("target-catalog", map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1beta1
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/target.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1beta1
+metadata:
+  name: target
+spec:
+  criteria:
+    service: eks
+  componentRefs: []
+`),
+		"mixins/target.yaml": []byte(`kind: RecipeMixin
+apiVersion: aicr.run/v1beta1
+metadata:
+  name: target-mixin
+spec: {}
+`),
+		"evidence/unrelated.yaml": []byte("signers:\n  first-party: []\n"),
+		"strict-config.yaml": []byte(`kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+spec:
+  recipe:
+    criteriaStrict: true
+`),
+	})
+	t.Cleanup(func() { EvictCachedStore(provider) })
+
+	store, err := LoadMetadataStoreFor(t.Context(), provider)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor() error = %v", err)
+	}
+	if _, ok := store.GetRecipeByName("target"); !ok {
+		t.Fatal("target-version RecipeMetadata was not loaded")
+	}
+	if _, ok := store.Mixins["target-mixin"]; !ok {
+		t.Fatal("target-version RecipeMixin was not loaded")
+	}
+	if _, ok := store.Overlays[""]; ok {
+		t.Fatal("unrelated headerless YAML was misclassified as RecipeMetadata")
+	}
+}
+
+func TestLoadMetadataStore_AcceptsReleaseNProfileTarget(t *testing.T) {
+	provider := newInMemoryProvider("target-profile-catalog", map[string][]byte{
+		"overlays/base.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`),
+		"overlays/profile.yaml": []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1beta2
+metadata:
+  name: profile
+spec:
+  criteria:
+    service: aks
+  profile:
+    name: gpuStack
+    default: driver-installed
+    values:
+      driver-installed: {}
+`),
+	})
+	t.Cleanup(func() { EvictCachedStore(provider) })
+
+	store, err := LoadMetadataStoreFor(t.Context(), provider)
+	if err != nil {
+		t.Fatalf("LoadMetadataStoreFor() error = %v", err)
+	}
+	if _, ok := store.GetRecipeByName("profile"); !ok {
+		t.Fatal("target-version profile RecipeMetadata was not loaded")
+	}
+}
+
+func TestLoadMetadataStore_RejectsInvalidCatalogHeaders(t *testing.T) {
+	validBase := []byte(`kind: RecipeMetadata
+apiVersion: aicr.run/v1alpha2
+metadata:
+  name: base
+spec:
+  componentRefs: []
+`)
+	tests := []struct {
+		name string
+		path string
+		data []byte
+	}{
+		{
+			name: "empty RecipeMetadata version",
+			path: "overlays/bad.yaml",
+			data: []byte("kind: RecipeMetadata\napiVersion: \nmetadata:\n  name: bad\nspec: {}\n"),
+		},
+		{
+			name: "unknown RecipeMetadata version",
+			path: "overlays/bad.yaml",
+			data: []byte("kind: RecipeMetadata\napiVersion: aicr.run/v9\nmetadata:\n  name: bad\nspec: {}\n"),
+		},
+		{
+			name: "wrong AICR kind",
+			path: "overlays/bad.yaml",
+			data: []byte("kind: RecipeMetdata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: bad\nspec: {}\n"),
+		},
+		{
+			name: "empty RecipeMixin version",
+			path: "mixins/bad.yaml",
+			data: []byte("kind: RecipeMixin\napiVersion: \nmetadata:\n  name: bad\nspec: {}\n"),
+		},
+		{
+			name: "unknown RecipeMixin version",
+			path: "mixins/bad.yaml",
+			data: []byte("kind: RecipeMixin\napiVersion: aicr.run/v9\nmetadata:\n  name: bad\nspec: {}\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newInMemoryProvider("invalid-catalog-"+tt.name, map[string][]byte{
+				"overlays/base.yaml": validBase,
+				tt.path:              tt.data,
+			})
+			t.Cleanup(func() { EvictCachedStore(provider) })
+
+			_, err := LoadMetadataStoreFor(t.Context(), provider)
+			if err == nil {
+				t.Fatal("LoadMetadataStoreFor() error = nil, want header rejection")
+			}
+			if !errors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("error = %v, want ErrCodeInvalidRequest", err)
+			}
+			if got := aicrerrors.ExitCodeFromError(err); got != aicrerrors.ExitInvalidInput {
+				t.Fatalf("exit code = %d, want %d", got, aicrerrors.ExitInvalidInput)
+			}
+			if !strings.Contains(err.Error(), "expected") {
+				t.Errorf("error %q does not identify expected header values", err)
+			}
+		})
 	}
 }
 

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -2739,6 +2739,11 @@ spec:
     service: eks
   componentRefs: []
 `),
+		"overlays/headerless.yaml": []byte(`spec:
+  criteria:
+    service: gke
+  componentRefs: []
+`),
 		"mixins/target.yaml": []byte(`kind: RecipeMixin
 apiVersion: aicr.run/v1beta1
 metadata:
@@ -2767,6 +2772,9 @@ spec:
 	}
 	if _, ok := store.Overlays[""]; ok {
 		t.Fatal("unrelated headerless YAML was misclassified as RecipeMetadata")
+	}
+	if got := len(store.Overlays); got != 1 {
+		t.Fatalf("loaded %d overlays, want only the declared target overlay", got)
 	}
 }
 
@@ -2813,34 +2821,40 @@ spec:
   componentRefs: []
 `)
 	tests := []struct {
-		name string
-		path string
-		data []byte
+		name    string
+		path    string
+		data    []byte
+		wantSub string
 	}{
 		{
-			name: "empty RecipeMetadata version",
-			path: "overlays/bad.yaml",
-			data: []byte("kind: RecipeMetadata\napiVersion: \nmetadata:\n  name: bad\nspec: {}\n"),
+			name:    "empty RecipeMetadata version",
+			path:    "overlays/bad.yaml",
+			data:    []byte("kind: RecipeMetadata\napiVersion: \nmetadata:\n  name: bad\nspec: {}\n"),
+			wantSub: `apiVersion ""`,
 		},
 		{
-			name: "unknown RecipeMetadata version",
-			path: "overlays/bad.yaml",
-			data: []byte("kind: RecipeMetadata\napiVersion: aicr.run/v9\nmetadata:\n  name: bad\nspec: {}\n"),
+			name:    "unknown RecipeMetadata version",
+			path:    "overlays/bad.yaml",
+			data:    []byte("kind: RecipeMetadata\napiVersion: aicr.run/v9\nmetadata:\n  name: bad\nspec: {}\n"),
+			wantSub: `apiVersion "aicr.run/v9"`,
 		},
 		{
-			name: "wrong AICR kind",
-			path: "overlays/bad.yaml",
-			data: []byte("kind: RecipeMetdata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: bad\nspec: {}\n"),
+			name:    "wrong AICR kind",
+			path:    "overlays/bad.yaml",
+			data:    []byte("kind: RecipeMetdata\napiVersion: aicr.run/v1alpha2\nmetadata:\n  name: bad\nspec: {}\n"),
+			wantSub: `kind "RecipeMetdata"`,
 		},
 		{
-			name: "empty RecipeMixin version",
-			path: "mixins/bad.yaml",
-			data: []byte("kind: RecipeMixin\napiVersion: \nmetadata:\n  name: bad\nspec: {}\n"),
+			name:    "empty RecipeMixin version",
+			path:    "mixins/bad.yaml",
+			data:    []byte("kind: RecipeMixin\napiVersion: \nmetadata:\n  name: bad\nspec: {}\n"),
+			wantSub: `apiVersion ""`,
 		},
 		{
-			name: "unknown RecipeMixin version",
-			path: "mixins/bad.yaml",
-			data: []byte("kind: RecipeMixin\napiVersion: aicr.run/v9\nmetadata:\n  name: bad\nspec: {}\n"),
+			name:    "unknown RecipeMixin version",
+			path:    "mixins/bad.yaml",
+			data:    []byte("kind: RecipeMixin\napiVersion: aicr.run/v9\nmetadata:\n  name: bad\nspec: {}\n"),
+			wantSub: `apiVersion "aicr.run/v9"`,
 		},
 	}
 	for _, tt := range tests {
@@ -2861,8 +2875,8 @@ spec:
 			if got := aicrerrors.ExitCodeFromError(err); got != aicrerrors.ExitInvalidInput {
 				t.Fatalf("exit code = %d, want %d", got, aicrerrors.ExitInvalidInput)
 			}
-			if !strings.Contains(err.Error(), "expected") {
-				t.Errorf("error %q does not identify expected header values", err)
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q does not contain %q", err, tt.wantSub)
 			}
 		})
 	}

--- a/pkg/recipe/profile.go
+++ b/pkg/recipe/profile.go
@@ -33,9 +33,9 @@ import (
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
-// RecipeProfileAPIVersion is the RecipeMetadata and RecipeResult version used
-// when a configuration profile is present. Other AICR artifact kinds remain on
-// header.GroupVersion.
+// RecipeProfileAPIVersion is the Release N emitter version for RecipeMetadata
+// and RecipeResult when a configuration profile is present. Readers also
+// accept the target profile version through header.IsSupportedProfileAPIVersion.
 const RecipeProfileAPIVersion = header.RecipeResultGroupVersion
 
 const (
@@ -542,20 +542,21 @@ func profileSummary(decl *ProfileDeclaration) *ProfileSummary {
 
 // ValidateRecipeMetadataProfile enforces the bidirectional version/declaration
 // contract for typed RecipeMetadata callers. Byte decoders additionally use
-// strict decoding for RecipeProfileAPIVersion so unknown keys cannot vanish.
+// strict decoding for the profile schema track so unknown keys cannot vanish.
 func ValidateRecipeMetadataProfile(metadata *RecipeMetadata) error {
 	if metadata == nil {
 		return nil
 	}
+	profileVersion := header.IsSupportedProfileAPIVersion(metadata.APIVersion)
 	switch {
-	case metadata.APIVersion == RecipeProfileAPIVersion && metadata.Spec.Profile == nil:
+	case profileVersion && metadata.Spec.Profile == nil:
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("RecipeMetadata uses apiVersion %q but has no spec.profile declaration",
-				RecipeProfileAPIVersion))
-	case metadata.Spec.Profile != nil && metadata.APIVersion != RecipeProfileAPIVersion:
+				metadata.APIVersion))
+	case metadata.Spec.Profile != nil && !profileVersion:
 		return errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("RecipeMetadata declares spec.profile but uses apiVersion %q; expected %q",
-				metadata.APIVersion, RecipeProfileAPIVersion))
+			fmt.Sprintf("RecipeMetadata declares spec.profile but uses apiVersion %q; expected %q or %q",
+				metadata.APIVersion, RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
 	case metadata.Spec.Profile != nil:
 		_, err := ValidateProfileDeclaration(metadata.Spec.Profile)
 		return err
@@ -571,14 +572,14 @@ func (r *RecipeResult) ValidateProfileContract() error {
 	if r == nil {
 		return nil
 	}
-	switch r.APIVersion {
-	case "", RecipeAPIVersion:
+	switch {
+	case r.APIVersion == "" || header.IsSupportedAPIVersion(r.APIVersion):
 		if r.Metadata.SelectedProfile != nil {
 			return errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("recipe apiVersion %q cannot carry metadata.selectedProfile", r.APIVersion))
 		}
 		return r.validateInlineDeepCopyCycles()
-	case RecipeProfileAPIVersion:
+	case header.IsSupportedProfileAPIVersion(r.APIVersion):
 		if err := r.validateProfileMetadataItems(); err != nil {
 			return err
 		}
@@ -588,12 +589,13 @@ func (r *RecipeResult) ValidateProfileContract() error {
 			}
 			return errors.New(errors.ErrCodeInvalidRequest,
 				fmt.Sprintf("recipe apiVersion %q requires metadata.selectedProfile or configuration.slurm.accounting",
-					RecipeProfileAPIVersion))
+					r.APIVersion))
 		}
 	default:
 		return errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("recipe has unsupported apiVersion %q; expected %q or %q",
-				r.APIVersion, RecipeAPIVersion, RecipeProfileAPIVersion))
+			fmt.Sprintf("recipe has unsupported apiVersion %q; expected %q, %q, %q, or %q",
+				r.APIVersion, RecipeAPIVersion, header.GroupVersionV1,
+				RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
 	}
 
 	selected := r.Metadata.SelectedProfile

--- a/pkg/recipe/profile_test.go
+++ b/pkg/recipe/profile_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 	"gopkg.in/yaml.v3"
 )
@@ -826,10 +827,18 @@ func TestProfileArtifactContract(t *testing.T) {
 		wantErr string
 	}{
 		{name: "legacy", result: &RecipeResult{APIVersion: RecipeAPIVersion}},
+		{name: "Release N target default", result: &RecipeResult{APIVersion: header.GroupVersionV1}},
 		{
 			name: "profile",
 			result: &RecipeResult{
 				APIVersion: RecipeProfileAPIVersion,
+				Metadata:   RecipeResultMetadata{SelectedProfile: selected},
+			},
+		},
+		{
+			name: "Release N target profile",
+			result: &RecipeResult{
+				APIVersion: header.GroupVersionV1Beta2,
 				Metadata:   RecipeResultMetadata{SelectedProfile: selected},
 			},
 		},
@@ -1350,9 +1359,11 @@ spec:
 		wantErr string
 	}{
 		{name: "legacy without profile", content: overlay(RecipeAPIVersion, "")},
-		{name: "empty version without profile", content: overlay("", "")},
-		{name: "unknown version without profile", content: overlay("aicr.run/v99", "")},
+		{name: "target authoring without profile", content: overlay(header.GroupVersionV1Beta1, "")},
+		{name: "empty version without profile", content: overlay("", ""), wantErr: "apiVersion"},
+		{name: "unknown version without profile", content: overlay("aicr.run/v99", ""), wantErr: "apiVersion"},
 		{name: "profile version with declaration", content: overlay(RecipeProfileAPIVersion, validProfile)},
+		{name: "target profile version with declaration", content: overlay(header.GroupVersionV1Beta2, validProfile)},
 		{
 			name:    "profile version without declaration",
 			content: overlay(RecipeProfileAPIVersion, ""),
@@ -1364,7 +1375,7 @@ spec:
 				string(overlay(RecipeProfileAPIVersion, validProfile)),
 				"kind: RecipeMetadata", "kind: RecipeMetdata", 1,
 			)),
-			wantErr: `requires kind "RecipeMetadata", got "RecipeMetdata"`,
+			wantErr: `has kind "RecipeMetdata", expected "RecipeMetadata"`,
 		},
 		{
 			name: "profile version requires metadata name",

--- a/pkg/recipe/profile_test.go
+++ b/pkg/recipe/profile_test.go
@@ -1360,8 +1360,8 @@ spec:
 	}{
 		{name: "legacy without profile", content: overlay(RecipeAPIVersion, "")},
 		{name: "target authoring without profile", content: overlay(header.GroupVersionV1Beta1, "")},
-		{name: "empty version without profile", content: overlay("", ""), wantErr: "apiVersion"},
-		{name: "unknown version without profile", content: overlay("aicr.run/v99", ""), wantErr: "apiVersion"},
+		{name: "empty version without profile", content: overlay("", ""), wantErr: `apiVersion ""`},
+		{name: "unknown version without profile", content: overlay("aicr.run/v99", ""), wantErr: `apiVersion "aicr.run/v99"`},
 		{name: "profile version with declaration", content: overlay(RecipeProfileAPIVersion, validProfile)},
 		{name: "target profile version with declaration", content: overlay(header.GroupVersionV1Beta2, validProfile)},
 		{

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -687,28 +687,6 @@ type catalogForMerge struct {
 	Validators []map[string]any `yaml:"validators"`
 }
 
-func validateExternalCatalogHeader(embedded, external *catalogForMerge) error {
-	if external == nil {
-		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-			"external "+catalogFileName+" is empty")
-	}
-	if embedded == nil {
-		return aicrerrors.New(aicrerrors.ErrCodeInternal,
-			"embedded "+catalogFileName+" is empty")
-	}
-	if external.APIVersion == "" || external.APIVersion != embedded.APIVersion {
-		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-			fmt.Sprintf("external %s has apiVersion %q, expected %q",
-				catalogFileName, external.APIVersion, embedded.APIVersion))
-	}
-	if external.Kind != embedded.Kind {
-		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
-			fmt.Sprintf("external %s has kind %q, expected %q",
-				catalogFileName, external.Kind, embedded.Kind))
-	}
-	return nil
-}
-
 // getMergedCatalog returns the merged catalogFileName content.
 // External catalog validators are merged with embedded, with external
 // taking precedence by name.
@@ -723,7 +701,7 @@ func (p *LayeredDataProvider) getMergedCatalog(ctx context.Context) ([]byte, err
 	p.mergedCatalogOnce.Do(func() {
 		p.mergedCatalog, p.mergedCatalogErr = mergeEmbeddedAndExternal(
 			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, catalogFileName,
-			validateExternalCatalogHeader, mergeCatalogs,
+			nil, mergeCatalogs,
 		)
 	})
 
@@ -737,6 +715,15 @@ func mergeCatalogs(embedded, external *catalogForMerge) *catalogForMerge {
 	slog.Debug("starting catalog merge",
 		"embedded_count", len(embedded.Validators),
 		"external_count", len(external.Validators))
+
+	// ValidatorCatalog uses a separate API domain and is explicitly outside
+	// ADR-022. Preserve its existing advisory mismatch behavior until that
+	// schema defines its own compatibility policy.
+	if external.APIVersion != "" && external.APIVersion != embedded.APIVersion {
+		slog.Warn("external catalog has different API version",
+			"embedded", embedded.APIVersion,
+			"external", external.APIVersion)
+	}
 
 	return &catalogForMerge{
 		APIVersion: embedded.APIVersion,

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -551,7 +551,8 @@ type fileReader interface {
 func mergeEmbeddedAndExternal[T any](
 	ctx context.Context,
 	embedded fileReader, externalDir string, maxFileSize int64, allowSymlinks bool,
-	fileName string, validateExternal func(*T) error, merge func(embedded, external *T) *T,
+	fileName string, validateExternal func(embedded, external *T) error,
+	merge func(embedded, external *T) *T,
 ) ([]byte, error) {
 
 	kind := filepath.Base(fileName)
@@ -579,7 +580,7 @@ func mergeEmbeddedAndExternal[T any](
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to parse external "+kind, unmarshalErr)
 	}
 	if validateExternal != nil {
-		if validateErr := validateExternal(&externalVal); validateErr != nil {
+		if validateErr := validateExternal(&embeddedVal, &externalVal); validateErr != nil {
 			return nil, validateErr
 		}
 	}
@@ -613,7 +614,7 @@ func (p *LayeredDataProvider) getMergedRegistry(ctx context.Context) ([]byte, er
 	p.mergedRegistryOnce.Do(func() {
 		p.mergedRegistry, p.mergedRegistryErr = mergeEmbeddedAndExternal(
 			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, registryFileName,
-			func(registry *ComponentRegistry) error {
+			func(_ *ComponentRegistry, registry *ComponentRegistry) error {
 				return validateComponentRegistryHeader(registry, "external "+registryFileName)
 			},
 			mergeRegistries,
@@ -686,6 +687,28 @@ type catalogForMerge struct {
 	Validators []map[string]any `yaml:"validators"`
 }
 
+func validateExternalCatalogHeader(embedded, external *catalogForMerge) error {
+	if external == nil {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			"external "+catalogFileName+" is empty")
+	}
+	if embedded == nil {
+		return aicrerrors.New(aicrerrors.ErrCodeInternal,
+			"embedded "+catalogFileName+" is empty")
+	}
+	if external.APIVersion == "" || external.APIVersion != embedded.APIVersion {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("external %s has apiVersion %q, expected %q",
+				catalogFileName, external.APIVersion, embedded.APIVersion))
+	}
+	if external.Kind != embedded.Kind {
+		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("external %s has kind %q, expected %q",
+				catalogFileName, external.Kind, embedded.Kind))
+	}
+	return nil
+}
+
 // getMergedCatalog returns the merged catalogFileName content.
 // External catalog validators are merged with embedded, with external
 // taking precedence by name.
@@ -699,7 +722,8 @@ type catalogForMerge struct {
 func (p *LayeredDataProvider) getMergedCatalog(ctx context.Context) ([]byte, error) {
 	p.mergedCatalogOnce.Do(func() {
 		p.mergedCatalog, p.mergedCatalogErr = mergeEmbeddedAndExternal(
-			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, catalogFileName, nil, mergeCatalogs,
+			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, catalogFileName,
+			validateExternalCatalogHeader, mergeCatalogs,
 		)
 	})
 
@@ -713,12 +737,6 @@ func mergeCatalogs(embedded, external *catalogForMerge) *catalogForMerge {
 	slog.Debug("starting catalog merge",
 		"embedded_count", len(embedded.Validators),
 		"external_count", len(external.Validators))
-
-	if external.APIVersion != "" && external.APIVersion != embedded.APIVersion {
-		slog.Warn("external catalog has different API version",
-			"embedded", embedded.APIVersion,
-			"external", external.APIVersion)
-	}
 
 	return &catalogForMerge{
 		APIVersion: embedded.APIVersion,

--- a/pkg/recipe/provider.go
+++ b/pkg/recipe/provider.go
@@ -498,7 +498,8 @@ func (p *LayeredDataProvider) WalkDir(ctx context.Context, root string, fn fs.Wa
 			return fn(relPath, d, nil)
 		})
 		if err != nil {
-			return aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to walk external directory tree", err)
+			return aicrerrors.PropagateOrWrap(err, aicrerrors.ErrCodeInternal,
+				"failed to walk external directory tree")
 		}
 	}
 
@@ -542,13 +543,15 @@ type fileReader interface {
 	ReadFile(ctx context.Context, path string) ([]byte, error)
 }
 
-// mergeEmbeddedAndExternal loads a YAML file from both embedded and external sources,
-// unmarshals each into type T, merges them using the provided function, and serializes
-// the result back to YAML bytes.
+// mergeEmbeddedAndExternal loads a YAML file from both embedded and external
+// sources, unmarshals each into type T, validates the raw external value when
+// a validator is supplied, merges them, and serializes the result back to YAML
+// bytes. Validation deliberately precedes merge so an embedded header cannot
+// erase an unsupported external one.
 func mergeEmbeddedAndExternal[T any](
 	ctx context.Context,
 	embedded fileReader, externalDir string, maxFileSize int64, allowSymlinks bool,
-	fileName string, merge func(embedded, external *T) *T,
+	fileName string, validateExternal func(*T) error, merge func(embedded, external *T) *T,
 ) ([]byte, error) {
 
 	kind := filepath.Base(fileName)
@@ -574,6 +577,11 @@ func mergeEmbeddedAndExternal[T any](
 	var externalVal T
 	if unmarshalErr := yaml.Unmarshal(externalData, &externalVal); unmarshalErr != nil {
 		return nil, aicrerrors.Wrap(aicrerrors.ErrCodeInternal, "failed to parse external "+kind, unmarshalErr)
+	}
+	if validateExternal != nil {
+		if validateErr := validateExternal(&externalVal); validateErr != nil {
+			return nil, validateErr
+		}
 	}
 
 	// Merge: external overrides embedded
@@ -604,7 +612,11 @@ func mergeEmbeddedAndExternal[T any](
 func (p *LayeredDataProvider) getMergedRegistry(ctx context.Context) ([]byte, error) {
 	p.mergedRegistryOnce.Do(func() {
 		p.mergedRegistry, p.mergedRegistryErr = mergeEmbeddedAndExternal(
-			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, registryFileName, mergeRegistries,
+			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, registryFileName,
+			func(registry *ComponentRegistry) error {
+				return validateComponentRegistryHeader(registry, "external "+registryFileName)
+			},
+			mergeRegistries,
 		)
 	})
 
@@ -655,12 +667,6 @@ func mergeRegistries(embedded, external *ComponentRegistry) *ComponentRegistry {
 		"embedded_count", len(embedded.Components),
 		"external_count", len(external.Components))
 
-	if external.APIVersion != "" && external.APIVersion != embedded.APIVersion {
-		slog.Warn("external registry has different API version",
-			"embedded", embedded.APIVersion,
-			"external", external.APIVersion)
-	}
-
 	return &ComponentRegistry{
 		APIVersion: embedded.APIVersion,
 		Kind:       embedded.Kind,
@@ -693,7 +699,7 @@ type catalogForMerge struct {
 func (p *LayeredDataProvider) getMergedCatalog(ctx context.Context) ([]byte, error) {
 	p.mergedCatalogOnce.Do(func() {
 		p.mergedCatalog, p.mergedCatalogErr = mergeEmbeddedAndExternal(
-			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, catalogFileName, mergeCatalogs,
+			ctx, p.embedded, p.externalDir, p.maxFileSize, p.allowSymlinks, catalogFileName, nil, mergeCatalogs,
 		)
 	})
 

--- a/pkg/recipe/provider_test.go
+++ b/pkg/recipe/provider_test.go
@@ -17,6 +17,7 @@ package recipe
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -117,6 +118,63 @@ components:
 	}
 	if !strings.Contains(content, "gpu-operator") {
 		t.Error("merged registry should contain gpu-operator from embedded")
+	}
+}
+
+func TestLayeredDataProvider_ValidatesRawExternalRegistryBeforeMerge(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		wantErr    bool
+	}{
+		{name: "target accepted", apiVersion: "aicr.run/v1beta1"},
+		{name: "unknown rejected", apiVersion: "aicr.run/v9", wantErr: true},
+		{name: "empty rejected", apiVersion: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			registry := "apiVersion: " + tt.apiVersion + "\nkind: ComponentRegistry\ncomponents:\n" +
+				"  - name: external-only\n    displayName: External Only\n"
+			if err := os.WriteFile(filepath.Join(tmpDir, registryFileName), []byte(registry), 0o600); err != nil {
+				t.Fatalf("write registry: %v", err)
+			}
+			provider, err := NewLayeredDataProvider(
+				NewEmbeddedDataProvider(GetEmbeddedFS(), "."),
+				LayeredProviderConfig{ExternalDir: tmpDir},
+			)
+			if err != nil {
+				t.Fatalf("NewLayeredDataProvider() error = %v", err)
+			}
+
+			data, err := provider.ReadFile(t.Context(), registryFileName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ReadFile() error = nil, want raw external header rejection")
+				}
+				if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+					t.Fatalf("error = %v, want ErrCodeInvalidRequest", err)
+				}
+				if observed := fmt.Sprintf("apiVersion %q", tt.apiVersion); !strings.Contains(err.Error(), observed) {
+					t.Errorf("error %q does not name observed header %q", err, observed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
+			}
+			if !strings.Contains(string(data), "external-only") {
+				t.Fatal("merged registry omitted accepted target-version component")
+			}
+			var merged ComponentRegistry
+			if err := yaml.Unmarshal(data, &merged); err != nil {
+				t.Fatalf("unmarshal merged registry: %v", err)
+			}
+			if merged.APIVersion != RecipeAPIVersion {
+				t.Errorf("merged registry apiVersion = %q, want current emitter %q",
+					merged.APIVersion, RecipeAPIVersion)
+			}
+		})
 	}
 }
 

--- a/pkg/recipe/provider_test.go
+++ b/pkg/recipe/provider_test.go
@@ -1079,6 +1079,71 @@ func setupCatalogTestDir(t *testing.T, catalogContent string) string {
 	return tmpDir
 }
 
+func TestLayeredDataProvider_ValidatesRawExternalCatalogBeforeMerge(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		wantField  string
+	}{
+		{
+			name:       "valid header accepted",
+			apiVersion: "validator.nvidia.com/v1alpha1",
+			kind:       "ValidatorCatalog",
+		},
+		{
+			name:      "empty apiVersion rejected",
+			kind:      "ValidatorCatalog",
+			wantField: "apiVersion",
+		},
+		{
+			name:       "unknown apiVersion rejected",
+			apiVersion: "validator.nvidia.com/v9",
+			kind:       "ValidatorCatalog",
+			wantField:  "apiVersion",
+		},
+		{
+			name:       "wrong kind rejected",
+			apiVersion: "validator.nvidia.com/v1alpha1",
+			kind:       "OtherCatalog",
+			wantField:  "kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			catalogContent := fmt.Sprintf(
+				"apiVersion: %q\nkind: %q\nvalidators: []\n", tt.apiVersion, tt.kind,
+			)
+			tmpDir := setupCatalogTestDir(t, catalogContent)
+			provider, err := NewLayeredDataProvider(
+				NewEmbeddedDataProvider(GetEmbeddedFS(), "."),
+				LayeredProviderConfig{ExternalDir: tmpDir},
+			)
+			if err != nil {
+				t.Fatalf("NewLayeredDataProvider() error = %v", err)
+			}
+
+			_, err = provider.ReadFile(t.Context(), catalogFileName)
+			if tt.wantField == "" {
+				if err != nil {
+					t.Fatalf("ReadFile() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("ReadFile() error = nil, want raw external header rejection")
+			}
+			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+				t.Fatalf("error = %v, want ErrCodeInvalidRequest", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantField) {
+				t.Errorf("error %q does not name invalid %s", err, tt.wantField)
+			}
+		})
+	}
+}
+
 // TestLayeredDataProvider_MergesCatalog tests catalog merging with external data.
 func TestLayeredDataProvider_MergesCatalog(t *testing.T) {
 	tmpDir := setupCatalogTestDir(t, testExternalCatalogContent)

--- a/pkg/recipe/provider_test.go
+++ b/pkg/recipe/provider_test.go
@@ -1079,42 +1079,30 @@ func setupCatalogTestDir(t *testing.T, catalogContent string) string {
 	return tmpDir
 }
 
-func TestLayeredDataProvider_ValidatesRawExternalCatalogBeforeMerge(t *testing.T) {
+func TestLayeredDataProvider_ValidatorCatalogRemainsOutsideADR022Gate(t *testing.T) {
 	tests := []struct {
-		name       string
-		apiVersion string
-		kind       string
-		wantField  string
+		name   string
+		header string
 	}{
 		{
-			name:       "valid header accepted",
-			apiVersion: "validator.nvidia.com/v1alpha1",
-			kind:       "ValidatorCatalog",
+			name:   "headerless catalog remains readable",
+			header: "",
 		},
 		{
-			name:      "empty apiVersion rejected",
-			kind:      "ValidatorCatalog",
-			wantField: "apiVersion",
+			name: "different version remains readable",
+			header: "apiVersion: validator.nvidia.com/v9\n" +
+				"kind: ValidatorCatalog\n",
 		},
 		{
-			name:       "unknown apiVersion rejected",
-			apiVersion: "validator.nvidia.com/v9",
-			kind:       "ValidatorCatalog",
-			wantField:  "apiVersion",
-		},
-		{
-			name:       "wrong kind rejected",
-			apiVersion: "validator.nvidia.com/v1alpha1",
-			kind:       "OtherCatalog",
-			wantField:  "kind",
+			name: "different kind remains readable",
+			header: "apiVersion: validator.nvidia.com/v1alpha1\n" +
+				"kind: OtherCatalog\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			catalogContent := fmt.Sprintf(
-				"apiVersion: %q\nkind: %q\nvalidators: []\n", tt.apiVersion, tt.kind,
-			)
+			catalogContent := tt.header + "validators:\n  - name: adr-022-scope-boundary\n"
 			tmpDir := setupCatalogTestDir(t, catalogContent)
 			provider, err := NewLayeredDataProvider(
 				NewEmbeddedDataProvider(GetEmbeddedFS(), "."),
@@ -1124,21 +1112,12 @@ func TestLayeredDataProvider_ValidatesRawExternalCatalogBeforeMerge(t *testing.T
 				t.Fatalf("NewLayeredDataProvider() error = %v", err)
 			}
 
-			_, err = provider.ReadFile(t.Context(), catalogFileName)
-			if tt.wantField == "" {
-				if err != nil {
-					t.Fatalf("ReadFile() error = %v", err)
-				}
-				return
+			data, err := provider.ReadFile(t.Context(), catalogFileName)
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
 			}
-			if err == nil {
-				t.Fatal("ReadFile() error = nil, want raw external header rejection")
-			}
-			if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
-				t.Fatalf("error = %v, want ErrCodeInvalidRequest", err)
-			}
-			if !strings.Contains(err.Error(), tt.wantField) {
-				t.Errorf("error %q does not name invalid %s", err, tt.wantField)
+			if !strings.Contains(string(data), "adr-022-scope-boundary") {
+				t.Fatal("merged catalog omitted external validator")
 			}
 		})
 	}

--- a/pkg/recipe/testdata/profile-overlay/registry.yaml
+++ b/pkg/recipe/testdata/profile-overlay/registry.yaml
@@ -4,4 +4,6 @@
 # This fixture contributes no components — it exists so the profiled overlay
 # beside it can layer over the embedded catalog. Every component the overlay
 # references resolves from the embedded registry.
+apiVersion: aicr.run/v1alpha2
+kind: ComponentRegistry
 components: []

--- a/pkg/server/bundle_handler.go
+++ b/pkg/server/bundle_handler.go
@@ -32,6 +32,7 @@ import (
 	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/header"
 	"github.com/NVIDIA/aicr/pkg/recipe"
 )
 
@@ -358,16 +359,16 @@ func decodeRecipeResultRequest(body io.Reader, result *recipe.RecipeResult) erro
 		return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
 			"failed to read request body", err)
 	}
-	var header struct {
+	var artifactHeader struct {
 		APIVersion string `json:"apiVersion"`
 	}
-	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&header); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&artifactHeader); err != nil {
 		return aicrerrors.Wrap(aicrerrors.ErrCodeInvalidRequest,
 			"failed to inspect request apiVersion", err)
 	}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	if header.APIVersion == recipe.ConfiguredRecipeResultAPIVersion {
+	if header.IsSupportedProfileAPIVersion(artifactHeader.APIVersion) {
 		decoder.DisallowUnknownFields()
 	}
 	if err := decoder.Decode(result); err != nil {

--- a/pkg/server/bundle_handler_test.go
+++ b/pkg/server/bundle_handler_test.go
@@ -91,8 +91,17 @@ func TestDecodeRecipeResultRequestStrictForConfiguredRecipes(t *testing.T) {
 			body: `{"apiVersion":"aicr.run/v1alpha3","kind":"RecipeResult","configuration":{"slurm":{"accounting":{"mode":"disabled"}}}}`,
 		},
 		{
+			name: "Release N target configured recipe succeeds",
+			body: `{"apiVersion":"aicr.run/v1beta2","kind":"RecipeResult","configuration":{"slurm":{"accounting":{"mode":"disabled"}}}}`,
+		},
+		{
 			name:    "configured rejects unknown field",
 			body:    `{"apiVersion":"aicr.run/v1alpha3","kind":"RecipeResult","configuration":{"slurm":{"accounting":{"mode":"disabled"}}},"unknownField":true}`,
+			wantErr: true,
+		},
+		{
+			name:    "Release N target configured rejects unknown field",
+			body:    `{"apiVersion":"aicr.run/v1beta2","kind":"RecipeResult","unknownField":true}`,
 			wantErr: true,
 		},
 		{
@@ -271,6 +280,19 @@ func TestProfileAwareBundleEndpoints(t *testing.T) {
 		}
 		if w.Header().Get("Content-Type") != "application/zip" {
 			t.Fatalf("Content-Type = %q, want application/zip", w.Header().Get("Content-Type"))
+		}
+	})
+
+	t.Run("v2 accepts Release N target profile artifact", func(t *testing.T) {
+		body := bytes.Replace(
+			profileBundleBody(t),
+			[]byte(recipe.RecipeProfileAPIVersion),
+			[]byte(header.GroupVersionV1Beta2),
+			1,
+		)
+		w := post(t, true, "", body)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 		}
 	})
 
@@ -747,6 +769,12 @@ func TestBundleHandler_LegacyRecipeHeaders(t *testing.T) {
 		{
 			name:   "canonical headers (control)",
 			mutate: func(map[string]any) {},
+		},
+		{
+			name: "Release N target apiVersion",
+			mutate: func(body map[string]any) {
+				body["apiVersion"] = header.GroupVersionV1
+			},
 		},
 		{
 			name: "both headers absent",

--- a/pkg/server/openapi_sync_test.go
+++ b/pkg/server/openapi_sync_test.go
@@ -243,10 +243,13 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 			// handler retains it for compatibility, so dropping it from the
 			// enum would make previously conforming clients spec-invalid
 			// against a request-validating gateway.
-			name:        "bundle request",
-			schema:      spec.Components.Schemas["BundleRecipeRequest"],
-			apiVersions: []string{"", recipe.RecipeAPIVersion, recipe.ConfiguredRecipeResultAPIVersion},
-			kinds:       []string{"", string(header.KindRecipe), recipe.RecipeResultKind},
+			name:   "bundle request",
+			schema: spec.Components.Schemas["BundleRecipeRequest"],
+			apiVersions: []string{
+				"", recipe.RecipeAPIVersion, header.GroupVersionV1,
+				recipe.ConfiguredRecipeResultAPIVersion, header.GroupVersionV1Beta2,
+			},
+			kinds: []string{"", string(header.KindRecipe), recipe.RecipeResultKind},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -349,7 +352,7 @@ func TestOpenAPIV2BundleContract(t *testing.T) {
 	legacyAPIVersion := openAPIObjectAt(t, legacyOverlay, "properties", "apiVersion")
 	legacyAPIVersions := openAPISequence(t, legacyAPIVersion["enum"],
 		"LegacyBundleRecipeV2Request apiVersion enum")
-	for _, value := range []string{"", "aicr.run/v1alpha2"} {
+	for _, value := range []string{"", "aicr.run/v1alpha2", "aicr.run/v1"} {
 		if !openAPIHasString(legacyAPIVersions, value) {
 			t.Errorf("LegacyBundleRecipeV2Request apiVersion enum missing %q", value)
 		}
@@ -634,7 +637,10 @@ func TestOpenAPIV1BundleLegacyConfigurationContract(t *testing.T) {
 		t.Error("BundleRecipeRequest does not prohibit configuration for legacy headers")
 	}
 
-	legacyHeaders := map[string]bool{"absent": false, "": false, recipe.RecipeAPIVersion: false}
+	legacyHeaders := map[string]bool{
+		"absent": false, "": false,
+		recipe.RecipeAPIVersion: false, header.GroupVersionV1: false,
+	}
 	condition := openAPIObjectAt(t, overlay, "if")
 	branches := openAPISequence(t, condition["anyOf"], "BundleRecipeRequest if.anyOf")
 	for _, branchValue := range branches {

--- a/pkg/server/openapi_sync_test.go
+++ b/pkg/server/openapi_sync_test.go
@@ -87,6 +87,7 @@ func TestOpenAPIEnumsMatchGoTypes(t *testing.T) {
 type openAPIContractSchema struct {
 	Ref        string                           `yaml:"$ref"`
 	AllOf      []openAPIContractSchema          `yaml:"allOf"`
+	OneOf      []openAPIContractSchema          `yaml:"oneOf"`
 	Required   []string                         `yaml:"required"`
 	Properties map[string]openAPIContractSchema `yaml:"properties"`
 	Enum       []string                         `yaml:"enum"`
@@ -237,20 +238,6 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 			baseRef:     "#/components/schemas/RecipeResponse",
 			apiVersions: []string{recipe.RecipeAPIVersion},
 		},
-		{
-			// The bundle request also admits the legacy Recipe kind: that was
-			// the value this contract published through v0.18.0, and the
-			// handler retains it for compatibility, so dropping it from the
-			// enum would make previously conforming clients spec-invalid
-			// against a request-validating gateway.
-			name:   "bundle request",
-			schema: spec.Components.Schemas["BundleRecipeRequest"],
-			apiVersions: []string{
-				"", recipe.RecipeAPIVersion, header.GroupVersionV1,
-				recipe.ConfiguredRecipeResultAPIVersion, header.GroupVersionV1Beta2,
-			},
-			kinds: []string{"", string(header.KindRecipe), recipe.RecipeResultKind},
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			baseRef := tt.baseRef
@@ -270,6 +257,36 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 				t.Errorf("kind enum = %v, want %v", gotKinds, tt.kinds)
 			}
 		})
+	}
+
+	bundleRequest := spec.Components.Schemas["BundleRecipeRequest"]
+	if len(bundleRequest.OneOf) != 2 {
+		t.Fatalf("BundleRecipeRequest.oneOf has %d entries, want 2", len(bundleRequest.OneOf))
+	}
+	refs := make(map[string]bool, len(bundleRequest.OneOf))
+	for _, branch := range bundleRequest.OneOf {
+		refs[branch.Ref] = true
+	}
+	for _, ref := range []string{
+		"#/components/schemas/LegacyBundleRecipeV1Request",
+		"#/components/schemas/ConfiguredRecipeResponse",
+	} {
+		if !refs[ref] {
+			t.Errorf("BundleRecipeRequest.oneOf does not reference %s", ref)
+		}
+	}
+
+	// The v1 legacy branch retains every default-track header shape the
+	// handler normalizes, while the profile-track branch remains closed.
+	legacyBundle := spec.Components.Schemas["LegacyBundleRecipeV1Request"]
+	legacyClosure := allOfConstraint(t, legacyBundle, "#/components/schemas/RecipeResponseBase")
+	if got, want := legacyClosure.Properties["apiVersion"].Enum,
+		[]string{"", recipe.RecipeAPIVersion, header.GroupVersionV1}; !equalStringsUnordered(got, want) {
+		t.Errorf("LegacyBundleRecipeV1Request apiVersion enum = %v, want %v", got, want)
+	}
+	if got, want := legacyClosure.Properties["kind"].Enum,
+		[]string{"", string(header.KindRecipe), recipe.RecipeResultKind}; !equalStringsUnordered(got, want) {
+		t.Errorf("LegacyBundleRecipeV1Request kind enum = %v, want %v", got, want)
 	}
 
 	base := spec.Components.Schemas["RecipeResponseBase"]
@@ -352,7 +369,7 @@ func TestOpenAPIV2BundleContract(t *testing.T) {
 	legacyAPIVersion := openAPIObjectAt(t, legacyOverlay, "properties", "apiVersion")
 	legacyAPIVersions := openAPISequence(t, legacyAPIVersion["enum"],
 		"LegacyBundleRecipeV2Request apiVersion enum")
-	for _, value := range []string{"", "aicr.run/v1alpha2", "aicr.run/v1"} {
+	for _, value := range []string{"", "aicr.run/v1alpha2", header.GroupVersionV1} {
 		if !openAPIHasString(legacyAPIVersions, value) {
 			t.Errorf("LegacyBundleRecipeV2Request apiVersion enum missing %q", value)
 		}
@@ -622,53 +639,87 @@ func TestOpenAPIV1BundleLegacyConfigurationContract(t *testing.T) {
 		t.Fatalf("parse spec: %v", err)
 	}
 
-	bundleRequest := openAPIObjectAt(t, spec, "components", "schemas", "BundleRecipeRequest")
-	allOf := openAPISequence(t, bundleRequest["allOf"], "BundleRecipeRequest.allOf")
-	if len(allOf) != 2 {
-		t.Fatalf("BundleRecipeRequest.allOf has %d entries, want 2", len(allOf))
+	schemas := openAPIObjectAt(t, spec, "components", "schemas")
+	bundleRequest := openAPIObjectAt(t, schemas, "BundleRecipeRequest")
+	refs := map[string]bool{}
+	for _, branchValue := range openAPISequence(t, bundleRequest["oneOf"], "BundleRecipeRequest.oneOf") {
+		branch := openAPIObject(t, branchValue, "BundleRecipeRequest.oneOf item")
+		ref, _ := branch["$ref"].(string)
+		refs[ref] = true
 	}
-	overlay := openAPIObject(t, allOf[1], "BundleRecipeRequest overlay")
-	thenNot := openAPIObjectAt(t, overlay, "then", "not")
+	if len(refs) != 2 || !refs["#/components/schemas/LegacyBundleRecipeV1Request"] ||
+		!refs["#/components/schemas/ConfiguredRecipeResponse"] {
+
+		t.Fatalf("BundleRecipeRequest.oneOf refs = %v, want legacy and configured branches", refs)
+	}
+	if refs["#/components/schemas/ProfileRecipeResponse"] {
+		t.Error("BundleRecipeRequest must not admit metadata.selectedProfile on /v1/bundle")
+	}
+
+	legacy := openAPIObjectAt(t, schemas, "LegacyBundleRecipeV1Request")
+	legacyAllOf := openAPISequence(t, legacy["allOf"], "LegacyBundleRecipeV1Request.allOf")
+	if len(legacyAllOf) != 2 {
+		t.Fatalf("LegacyBundleRecipeV1Request.allOf has %d entries, want 2", len(legacyAllOf))
+	}
+	legacyOverlay := openAPIObject(t, legacyAllOf[1], "LegacyBundleRecipeV1Request overlay")
+	legacyNot := openAPIObjectAt(t, legacyOverlay, "not")
 	if !openAPIHasString(
-		openAPISequence(t, thenNot["required"], "BundleRecipeRequest then.not.required"),
+		openAPISequence(t, legacyNot["required"], "LegacyBundleRecipeV1Request not.required"),
 		"configuration",
 	) {
 
-		t.Error("BundleRecipeRequest does not prohibit configuration for legacy headers")
+		t.Error("LegacyBundleRecipeV1Request does not prohibit configuration")
+	}
+	legacyMetadataNot := openAPIObjectAt(t, legacyOverlay, "properties", "metadata", "not")
+	if !openAPIHasString(openAPISequence(t, legacyMetadataNot["required"],
+		"LegacyBundleRecipeV1Request metadata.not.required"), "selectedProfile") {
+
+		t.Error("LegacyBundleRecipeV1Request does not prohibit selectedProfile")
 	}
 
-	legacyHeaders := map[string]bool{
-		"absent": false, "": false,
-		recipe.RecipeAPIVersion: false, header.GroupVersionV1: false,
+	configured := openAPIObjectAt(t, schemas, "ConfiguredRecipeResponse")
+	configuredAllOf := openAPISequence(t, configured["allOf"], "ConfiguredRecipeResponse.allOf")
+	configuredClosure := openAPIObject(t, configuredAllOf[1], "ConfiguredRecipeResponse closure")
+	if closed, ok := configuredClosure["additionalProperties"].(bool); !ok || closed {
+		t.Errorf("ConfiguredRecipeResponse additionalProperties = %v, want false",
+			configuredClosure["additionalProperties"])
 	}
-	condition := openAPIObjectAt(t, overlay, "if")
-	branches := openAPISequence(t, condition["anyOf"], "BundleRecipeRequest if.anyOf")
-	for _, branchValue := range branches {
-		branch := openAPIObject(t, branchValue, "BundleRecipeRequest if.anyOf item")
-		if notValue, ok := branch["not"]; ok {
-			not := openAPIObject(t, notValue, "BundleRecipeRequest absent apiVersion condition")
-			if openAPIHasString(openAPISequence(t, not["required"],
-				"BundleRecipeRequest absent apiVersion required"), "apiVersion") {
+	if !openAPIHasString(openAPISequence(t, configuredClosure["required"],
+		"ConfiguredRecipeResponse.required"), "configuration") {
 
-				legacyHeaders["absent"] = true
-			}
-		}
-		if propertiesValue, ok := branch["properties"]; ok {
-			properties := openAPIObject(t, propertiesValue,
-				"BundleRecipeRequest legacy apiVersion properties")
-			apiVersion := openAPIObjectAt(t, properties, "apiVersion")
-			for _, value := range openAPISequence(t, apiVersion["enum"],
-				"BundleRecipeRequest legacy apiVersion enum") {
-				if text, ok := value.(string); ok {
-					legacyHeaders[text] = true
-				}
-			}
+		t.Error("ConfiguredRecipeResponse does not require configuration")
+	}
+	configuredVersions := openAPISequence(t,
+		openAPIObjectAt(t, configuredClosure, "properties", "apiVersion")["enum"],
+		"ConfiguredRecipeResponse apiVersion enum")
+	for _, version := range []string{recipe.ConfiguredRecipeResultAPIVersion, header.GroupVersionV1Beta2} {
+		if !openAPIHasString(configuredVersions, version) {
+			t.Errorf("ConfiguredRecipeResponse apiVersion enum missing %q", version)
 		}
 	}
-	for header, found := range legacyHeaders {
-		if !found {
-			t.Errorf("BundleRecipeRequest legacy configuration condition does not cover apiVersion %q", header)
-		}
+	configuredMetadata := openAPIObjectAt(t, configuredClosure, "properties", "metadata")
+	configuredMetadataAllOf := openAPISequence(t, configuredMetadata["allOf"],
+		"ConfiguredRecipeResponse metadata.allOf")
+	configuredMetadataConstraint := openAPIObject(t, configuredMetadataAllOf[1],
+		"ConfiguredRecipeResponse metadata constraint")
+	configuredMetadataNot := openAPIObjectAt(t, configuredMetadataConstraint, "not")
+	if !openAPIHasString(openAPISequence(t, configuredMetadataNot["required"],
+		"ConfiguredRecipeResponse metadata.not.required"), "selectedProfile") {
+
+		t.Error("ConfiguredRecipeResponse does not prohibit selectedProfile")
+	}
+	configurationRef := openAPIObjectAt(t, configuredClosure, "properties", "configuration")
+	if got := configurationRef["$ref"]; got != "#/components/schemas/ConfiguredRecipeConfiguration" {
+		t.Errorf("ConfiguredRecipeResponse configuration = %v, want closed configuration schema", got)
+	}
+	configuration := openAPIObjectAt(t, schemas, "ConfiguredRecipeConfiguration")
+	configurationAllOf := openAPISequence(t, configuration["allOf"],
+		"ConfiguredRecipeConfiguration.allOf")
+	configurationClosure := openAPIObject(t, configurationAllOf[1],
+		"ConfiguredRecipeConfiguration closure")
+	if closed, ok := configurationClosure["additionalProperties"].(bool); !ok || closed {
+		t.Errorf("ConfiguredRecipeConfiguration additionalProperties = %v, want false",
+			configurationClosure["additionalProperties"])
 	}
 }
 

--- a/pkg/server/openapi_sync_test.go
+++ b/pkg/server/openapi_sync_test.go
@@ -227,6 +227,21 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 		kinds       []string
 	}{
 		{
+			name:        "base response",
+			schema:      spec.Components.Schemas["RecipeResponse"],
+			required:    []string{"apiVersion", "kind"},
+			apiVersions: []string{recipe.RecipeAPIVersion, recipe.ConfiguredRecipeResultAPIVersion, header.GroupVersionV1Beta2},
+			kinds:       []string{recipe.RecipeResultKind},
+		},
+		{
+			name:        "profile response",
+			schema:      spec.Components.Schemas["ProfileRecipeResponse"],
+			baseRef:     "#/components/schemas/RecipeResponse",
+			required:    []string{"metadata", "componentRefs"},
+			apiVersions: []string{recipe.ConfiguredRecipeResultAPIVersion, header.GroupVersionV1Beta2},
+			kinds:       []string{recipe.RecipeResultKind},
+		},
+		{
 			// /v1 responses are pinned to v1alpha2 by LegacyRecipeResponse,
 			// which wraps RecipeResponse and narrows the apiVersion enum.
 			// RecipeResponse itself now also admits v1alpha3 for /v2, so
@@ -257,6 +272,12 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 				t.Errorf("kind enum = %v, want %v", gotKinds, tt.kinds)
 			}
 		})
+	}
+
+	criteriaVersions := spec.Components.Schemas["RecipeCriteria"].Properties["apiVersion"].Enum
+	wantCriteriaVersions := []string{recipe.RecipeCriteriaAPIVersion, header.GroupVersionV1}
+	if !equalStringsUnordered(criteriaVersions, wantCriteriaVersions) {
+		t.Errorf("RecipeCriteria apiVersion enum = %v, want %v", criteriaVersions, wantCriteriaVersions)
 	}
 
 	bundleRequest := spec.Components.Schemas["BundleRecipeRequest"]
@@ -708,9 +729,26 @@ func TestOpenAPIV1BundleLegacyConfigurationContract(t *testing.T) {
 
 		t.Error("ConfiguredRecipeResponse does not prohibit selectedProfile")
 	}
-	configurationRef := openAPIObjectAt(t, configuredClosure, "properties", "configuration")
-	if got := configurationRef["$ref"]; got != "#/components/schemas/ConfiguredRecipeConfiguration" {
-		t.Errorf("ConfiguredRecipeResponse configuration = %v, want closed configuration schema", got)
+	configurationProperty := openAPIObjectAt(t, configuredClosure, "properties", "configuration")
+	configurationPropertyAllOf := openAPISequence(t, configurationProperty["allOf"],
+		"ConfiguredRecipeResponse configuration.allOf")
+	var configurationRefs, configurationConstraints []map[string]any
+	for _, value := range configurationPropertyAllOf {
+		entry := openAPIObject(t, value, "ConfiguredRecipeResponse configuration.allOf entry")
+		if entry["$ref"] == "#/components/schemas/ConfiguredRecipeConfiguration" {
+			configurationRefs = append(configurationRefs, entry)
+		} else {
+			configurationConstraints = append(configurationConstraints, entry)
+		}
+	}
+	if len(configurationRefs) != 1 || len(configurationConstraints) != 1 {
+		t.Fatalf("ConfiguredRecipeResponse configuration.allOf has %d schema refs and %d constraints, want 1 each",
+			len(configurationRefs), len(configurationConstraints))
+	}
+	if !openAPIHasString(openAPISequence(t, configurationConstraints[0]["required"],
+		"ConfiguredRecipeResponse configuration required"), "slurm") {
+
+		t.Error("ConfiguredRecipeResponse configuration does not require slurm")
 	}
 	configuration := openAPIObjectAt(t, schemas, "ConfiguredRecipeConfiguration")
 	configurationAllOf := openAPISequence(t, configuration["allOf"],

--- a/pkg/server/recipe_handler_test.go
+++ b/pkg/server/recipe_handler_test.go
@@ -54,7 +54,7 @@ func newProfileTestHandler(t *testing.T) *recipeHandler {
 		t.Fatalf("setup overlays directory: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"),
-		[]byte("components: []\n"), 0o600); err != nil {
+		[]byte("apiVersion: aicr.run/v1alpha2\nkind: ComponentRegistry\ncomponents: []\n"), 0o600); err != nil {
 		t.Fatalf("setup registry.yaml: %v", err)
 	}
 	overlay := []byte(`apiVersion: aicr.run/v1alpha3

--- a/pkg/snapshotter/loader.go
+++ b/pkg/snapshotter/loader.go
@@ -69,9 +69,9 @@ func LoadFromFileWithKubeconfig(ctx context.Context, path, kubeconfig string) (*
 
 	if snap.APIVersion != "" && !header.IsSupportedAPIVersion(snap.APIVersion) {
 		return nil, errors.New(errors.ErrCodeInvalidRequest,
-			fmt.Sprintf("snapshot file has apiVersion %q, which this aicr build does not support (expected %q); "+
+			fmt.Sprintf("snapshot file has apiVersion %q, which this aicr build does not support (expected %q or %q); "+
 				"recapture the snapshot with a matching aicr version",
-				snap.APIVersion, header.GroupVersion))
+				snap.APIVersion, header.GroupVersion, header.GroupVersionV1))
 	}
 
 	usable := 0

--- a/pkg/snapshotter/loader_test.go
+++ b/pkg/snapshotter/loader_test.go
@@ -48,6 +48,11 @@ func TestLoadFromFile(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name:        "Release N target apiVersion loads",
+			yamlContent: "kind: Snapshot\napiVersion: " + header.GroupVersionV1 + "\nmeasurements:\n  - type: K8s\n",
+			wantErr:     false,
+		},
+		{
 			name:        "empty apiVersion allowed for backward compat",
 			yamlContent: "kind: Snapshot\nmeasurements:\n  - type: K8s\n",
 			wantErr:     false,


### PR DESCRIPTION
## Summary

Ratifies ADR-022 and implements its Release N reader-first phase: AICR accepts the target artifact versions by wire kind and schema track while every emitter remains on its current alpha version. External AICR catalog headers now fail closed before merge or hydration.

## Motivation / Context

PR #2373 was intended as ratification of ADR-022. This change records that decision as Accepted and stages rollback-safe readers before a later PR switches emitters.

Fixes: N/A
Related: #2114, #2373

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

- Adds centrally defined `aicr.run/v1`, `aicr.run/v1beta1`, and `aicr.run/v1beta2` targets plus kind/schema-scoped Release N read gates.
- Keeps all Snapshot, RecipeResult, RecipeCriteria, AICRConfig, catalog, and BundleProvenance emitters on `v1alpha2` or `v1alpha3`.
- Validates raw external `ComponentRegistry` headers before merge and `RecipeMetadata`/`RecipeMixin` headers before hydration. Empty, unknown, or wrong catalog headers return `INVALID_REQUEST`; recognized unrelated YAML remains skipped.
- Extends bundle ingress and OpenAPI contracts for target default and profile RecipeResult versions, preserving strict decoding on the profile track.
- Marks ADR-022 Accepted, makes ADR-011's amendments unconditional, and records the maturity-specific release policy.

## Testing

```bash
unset GITLAB_TOKEN && make qualify
golangci-lint run -c .golangci.yaml ./pkg/header/... ./pkg/config/... ./pkg/recipe/... ./pkg/server/... ./pkg/snapshotter/... ./pkg/bundler/deployer/localformat/... ./pkg/cli/... ./pkg/client/v1/...
lychee --offline --no-progress 'docs/**/*.md'
```

`make qualify` passed, including race tests, 84.1% repository coverage, 24/24 e2e suites, lint, vulnerability scan, license checks, and API compatibility. Offline link checking covered 1,153 links with zero errors.

Affected-package coverage versus `origin/main`:

- `pkg/header`: 100.0% → 100.0%
- `pkg/config`: 93.5% → 93.6%
- `pkg/recipe`: 90.0% → 90.2%
- `pkg/server`: 84.0% → 84.0%
- `pkg/snapshotter`: 64.9% → 64.9%
- `pkg/bundler/deployer/localformat`: 81.9% → 81.9%

New exported read-gate functions have 100% coverage.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** This is Release N only. Existing alpha and legacy empty artifact tolerances remain readable where ADR-022 preserves them, and all emitters remain alpha. External AICR catalogs now require an explicit supported non-empty header. PR2 will switch emitters only after this reader-first release lands; alpha and legacy-empty retirement remains a later PR.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
