### PR TITLE
chore: add mikecook to copy-pr-bot trustees

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -37,3 +37,4 @@ additional_trustees:
   - varmesh
   - bmcadams1
   - srao-nv
+  - mikecook


### PR DESCRIPTION
## Summary
Add `mikecook` to the `additional_trustees` list in `copy-pr-bot.yaml` so PRs from this account are automatically synced for CI without requiring a maintainer to comment `/ok to test` each time.
## Motivation / Context
`copy-pr-bot` gates CI runs on PRs from non-org accounts behind manual maintainer approval; `additional_trustees` is the allowlist of accounts exempted from that gate. Adding `mikecook` here avoids that manual step on future PRs from this account.
Fixes: N/A
Related: N/A
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling
## Component(s) Affected
- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: CI configuration (`.github/copy-pr-bot.yaml`)
## Implementation Notes
None — single-line data addition, no logic change.
## Testing
```bash
# No code paths affected; nothing to run. Change is a one-line YAML list
# addition, validated by inspection.
Risk Assessment
Low — Isolated change, well-tested, easy to revert
Medium — Touches multiple components or has broader impact
High — Breaking change, affects critical paths, or complex rollout
Rollout notes: N/A — takes effect on the next PR opened from this account; no migration or flag needed.

Checklist
Tests pass locally (make test with -race)
Linter passes (make lint)
I did not skip/disable tests to make CI green
I added/updated tests for new functionality
I updated docs if user-facing behavior changed
Changes follow existing patterns in the codebase
Commits are cryptographically signed (git commit -S) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)