### PR TITLE
chore(evidence): publish GB300 EKS training and inference attestations

### DIFF
--- a/recipes/evidence/gb300-eks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-b6f03b62702a258a1d5049a4a56eaa1685af63de5dbb1dcb7491e2bbce5a7e3a.yaml
+++ b/recipes/evidence/gb300-eks-ubuntu-inference-dynamo/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-b6f03b62702a258a1d5049a4a56eaa1685af63de5dbb1dcb7491e2bbce5a7e3a.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-08-27T02:38:17Z
+    bundle:
+      digest: sha256:b6f03b62702a258a1d5049a4a56eaa1685af63de5dbb1dcb7491e2bbce5a7e3a
+      oci: ghcr.io/yuanchen8911/aicr-evidence:gb300-eks-ubuntu-inference-dynamo-68f9ab248671
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 83467473
+recipe: gb300-eks-ubuntu-inference-dynamo
+schemaVersion: 1.0.0

--- a/recipes/evidence/gb300-eks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-c19d7932a51fc76366eb095a95c57fdaaa13d5b5cd48b77635dc1d58ec8ed886.yaml
+++ b/recipes/evidence/gb300-eks-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-c19d7932a51fc76366eb095a95c57fdaaa13d5b5cd48b77635dc1d58ec8ed886.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-08-27T02:11:28Z
+    bundle:
+      digest: sha256:c19d7932a51fc76366eb095a95c57fdaaa13d5b5cd48b77635dc1d58ec8ed886
+      oci: ghcr.io/yuanchen8911/aicr-evidence:gb300-eks-ubuntu-training-kubeflow-4f20654d159b
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 83467634
+recipe: gb300-eks-ubuntu-training-kubeflow
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Signed recipe-evidence for the two GB300 EKS leaves added in #2382, captured on the `nhensley-gb300` UAT cluster.

| Recipe | Phases | Bundle digest |
|---|---|---|
| `gb300-eks-ubuntu-training-kubeflow` | 4/4 · 8/8 · 2/2 | `sha256:c19d7932a51f…` |
| `gb300-eks-ubuntu-inference-dynamo` | 4/4 · 11/11 · 1/1 | `sha256:b6f03b62702a…` |

## Motivation / Context

#2382 added the GB300 EKS overlays. This publishes the attestations for them so both leaves appear on the validation dashboard.

Measured on hardware:

- Training — NCCL all-reduce net **44.93 GB/s** (gate `>= 40`), nvls **842.46 GB/s** (gate `>= 700`)
- Inference — **84,536 tok/s** (gate `>= 60000`), TTFT p99 **807 ms** (gate `<= 2000`)

Both runs used the cluster's dedicated CPU worker pool, so the control plane is no longer pinned onto GPU nodes.

## Type of Change

- [x] Other: evidence publication (no code or recipe changes)

## Component(s) Affected

- [x] Recipes / evidence (`recipes/evidence/`)

## Implementation Notes

Generated with `aicr validate --phase all --emit-attestation --push ghcr.io/yuanchen8911/aicr-evidence --no-sign`, then signed by the fork's `Recipe Evidence: Sign` workflow, which relocated the flat pointers to their per-source paths.

Signed with **GitHub Actions ambient OIDC**, not a personal identity:

```
issuer:   https://token.actions.githubusercontent.com
identity: .../evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
```

That matches the existing community allowlist entry `5bf9e82f0e90a11528ac85f4bcb866c8`, so no allowlist change is needed. Keyless signing writes the identity permanently to the public Rekor log, so a non-personal signer is deliberate — Rekor index `83467634` for the training bundle.

## Testing

```bash
aicr evidence verify recipes/evidence/gb300-eks-ubuntu-training-kubeflow/5bf9e82f.../sha256-c19d7932....yaml   # exit 0
aicr evidence verify recipes/evidence/gb300-eks-ubuntu-inference-dynamo/5bf9e82f.../sha256-b6f03b62....yaml   # exit 0
```

Both report `bundle valid — all checks passed`. Local `evidence verify` exit 0 predicts the "Enforce per-source pointer contract" gate passing.

## Risk Assessment

- [x] **Low** — adds two pointer files. No code, recipe, or catalog changes.

**Note for review:** evidence pointer YAMLs are machine-generated and carry no license header, consistent with every previously merged pointer. Automated review tends to flag this; it is expected for this file type.
