### PR TITLE
fix(tests): derive release script network timeout from script budget

### DIFF
--- a/tests/releasepolicy/release_scripts_test.go
+++ b/tests/releasepolicy/release_scripts_test.go
@@ -1342,7 +1342,7 @@ func TestReleaseHomebrewBehavior(t *testing.T) {
 				"PATH="+bin+":"+os.Getenv("PATH"),
 				"RELEASE_TAG=v1.2.3",
 				"FAKE_CHECKSUMS="+checksumPath,
-				"AICR_NETWORK_TIMEOUT_SECONDS=5",
+				fmt.Sprintf("AICR_NETWORK_TIMEOUT_SECONDS=%d", networkTimeoutSeconds(scriptBudget(t))),
 			)
 			result := runScript(t, environment, ".github/scripts/publish-homebrew.sh", candidatePath, tap)
 			if (result.err != nil) != tc.wantErr {
@@ -1525,6 +1525,7 @@ func expectedReleaseAssets(tag string) []map[string]any {
 }
 
 type releaseFixture struct {
+	t             *testing.T
 	dir           string
 	bin           string
 	digestState   string
@@ -1551,6 +1552,7 @@ func newReleaseFixture(t *testing.T) releaseFixture {
 		t.Fatalf("create fake bin: %v", err)
 	}
 	fixture := releaseFixture{
+		t:             t,
 		dir:           dir,
 		bin:           bin,
 		digestState:   filepath.Join(dir, "digests.tsv"),
@@ -1714,7 +1716,7 @@ func (f releaseFixture) environment() []string {
 		"IS_PRERELEASE="+isPrerelease,
 		"GITHUB_SHA="+f.revision,
 		"GH_TOKEN=test-token",
-		"AICR_NETWORK_TIMEOUT_SECONDS=5",
+		fmt.Sprintf("AICR_NETWORK_TIMEOUT_SECONDS=%d", networkTimeoutSeconds(scriptBudget(f.t))),
 	)
 }
 
@@ -1763,6 +1765,48 @@ func scriptBudgetFor(remaining time.Duration) time.Duration {
 		budget = scriptHangCap
 	}
 	return budget
+}
+
+// networkTimeoutSeconds derives the AICR_NETWORK_TIMEOUT_SECONDS a script
+// invocation gets from that invocation's own external per-script deadline
+// (scriptBudget), instead of a fixed constant. A fixed value can't be safe in
+// both directions at once: long enough that scheduling jitter under a
+// parallel -race run doesn't false-trip the script's internal
+// `timeout --foreground` around a fake network command that should return
+// instantly (the identical_formula_is_a_no-op flake), yet short enough that,
+// on a tight -timeout targeted run, runScript's own context can't cancel the
+// whole process before that internal timeout gets a chance to fire and
+// report its own clean "failed to fetch..." error instead. Deriving it as
+// half the live budget keeps the internal timeout strictly under the
+// external one regardless of how tight or generous that budget is.
+func networkTimeoutSeconds(budget time.Duration) int {
+	seconds := int(budget / (2 * time.Second))
+	if seconds < 1 {
+		seconds = 1
+	}
+	return seconds
+}
+
+func TestNetworkTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name     string
+		budget   time.Duration
+		expected int
+	}{
+		{"ample budget", 10 * time.Minute, 300},
+		{"hang-cap budget", scriptHangCap, 45},
+		{"tight targeted run", 12500 * time.Millisecond, 6},
+		{"near zero floors at one second", 1500 * time.Millisecond, 1},
+		{"non-positive budget floors at one second", 0, 1},
+		{"expired deadline floors at one second", -5 * time.Second, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := networkTimeoutSeconds(tt.budget); got != tt.expected {
+				t.Errorf("networkTimeoutSeconds(%v) = %d, want %d", tt.budget, got, tt.expected)
+			}
+		})
+	}
 }
 
 func TestScriptBudgetFor(t *testing.T) {


### PR DESCRIPTION
TestReleaseHomebrewBehavior/identical_formula_is_a_no-op flaked under heavy parallel -race load: AICR_NETWORK_TIMEOUT_SECONDS was a hardcoded 5s wrapping the fake curl subprocess via `timeout --foreground`, and scheduling delay under contention could push even a trivial fake command past that budget, killing it and surfacing "failed to fetch public release checksums".

A fixed replacement value can't be safe in both directions: long enough to absorb realistic scheduling jitter, yet short enough that, on a tight -timeout targeted run, runScript's own external per-script context (scriptBudget) can't cancel the whole process before the script's internal timeout gets a chance to fire and report its own clean error first.

Replace the fixed constant with networkTimeoutSeconds(scriptBudget), derived as half of each invocation's live external budget. This keeps the internal timeout strictly under the external one at any budget size, so it structurally cannot lose that race, while widening the default case (10m suite timeout, budget capped at scriptHangCap) from 5s to 45s of headroom. Verified against the actual reported failure by temporarily forcing fakeCurl to sleep 8s: reproduces the exact "exit status 1" / "failed to fetch..." failure under the old fixed 5s, passes under the new derived value.

## Summary
`TestReleaseHomebrewBehavior/identical_formula_is_a_no-op` flaked under heavy parallel `-race` load because the release scripts' `AICR_NETWORK_TIMEOUT_SECONDS` was hardcoded to 5s in tests; this derives it instead from each script invocation's own external per-script budget (`scriptBudget`), so it scales with the available headroom and can't outrace it.
## Motivation / Context
Root-caused while validating an unrelated GB200 recipe PR whose full test suite hit this flake under `-race`: `timeout --foreground "${AICR_NETWORK_TIMEOUT_SECONDS}s"` wraps the faked `curl` subprocess in `.github/scripts/publish-homebrew.sh` (and the equivalent wrapper in `release-images.sh`), and scheduling delay under parallel-test contention could push even the trivial fake command past a fixed 5s budget, killing it and surfacing `failed to fetch public release checksums`. A fixed replacement constant can't be safe in both directions — long enough to absorb scheduling jitter, yet short enough to still resolve before `runScript`'s own external context deadline on a tight targeted `-timeout` run — so this derives it from the live budget instead.
Fixes: N/A
Related: N/A
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling
## Component(s) Affected
- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `tests/releasepolicy` (release script test harness only — no production script or CLI behavior changed)

## Implementation Notes
Added `networkTimeoutSeconds(budget time.Duration) int`, returning half of `scriptBudget(t)`, floored at 1s. Replaced the two hardcoded `AICR_NETWORK_TIMEOUT_SECONDS=5` sites with it. Verified against the real flake by temporarily forcing the test's fake `curl` to `sleep 8`: reproduced the exact failure under the old fixed value, passed under the new derived one, then reverted that scaffolding.
## Testing
```bash
make qualify
```
Passed.
## Risk Assessment
- [x] **Low** — Isolated change, well-tested, easy to revert
**Rollout notes:** N/A — test-only change, no production script, CLI, or API behavior affected.
## Checklist
- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed *(N/A)*
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)