### PR TITLE
fix(snapshot): honor --format on the agent Job delivery path

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -700,7 +700,7 @@ them:
 err = snapshotter.DeliverSnapshot(snapCtx, snap.Raw, snapshotter.SnapshotDelivery{
 	Output:     "snapshot.json",                 // file; "" or "-" for stdout; cm://ns/name for a ConfigMap
 	Kubeconfig: "/path/to/target-kubeconfig",    // only used for a cm:// Output
-	Format:     serializer.FormatJSON,           // "" and FormatYAML both deliver the agent's bytes verbatim
+	Format:     serializer.FormatJSON,           // "" and FormatYAML deliver the agent's bytes verbatim to a file or stdout
 })
 ```
 
@@ -711,10 +711,17 @@ rendered report, and `Format` is ignored.
 
 The agent always stages YAML, so `Format` is where a JSON or table rendering
 happens. YAML (and the zero value, for callers written before the field
-existed) is a byte copy — fields a newer agent image emits than the calling
-binary models survive. `FormatJSON` re-encodes the same keys through a generic
-map, preserving those fields; `FormatTable` renders the typed `Snapshot` and is
-therefore the one format that can drop them.
+existed) is a byte copy for file and stdout destinations — fields a newer agent
+image emits than the calling binary models survive. `FormatJSON` re-encodes the
+same keys through a generic map, preserving those fields; `FormatTable` renders
+the typed `Snapshot` and is therefore the one format that can drop them.
+
+A `cm://` destination is the exception to the byte copy: the writer derives the
+`snapshot.<ext>` data key, the `format` and `timestamp` entries, and the
+resource labels from the parsed document, so it re-serializes even for YAML. It
+does so deterministically and through a generic map, so unmodeled fields still
+survive; only the exact bytes do not. Deliver to a file or stdout when you need
+byte-identical YAML.
 
 `WrapResolved` turns a `*pkg/recipe.RecipeResult` — typically one taken from
 `RecipeResult.Resolved()` and then projected by the caller — back into a

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -698,15 +698,23 @@ them:
 
 ```go
 err = snapshotter.DeliverSnapshot(snapCtx, snap.Raw, snapshotter.SnapshotDelivery{
-	Output:     "snapshot.yaml",                 // file; "" or "-" for stdout; cm://ns/name for a ConfigMap
+	Output:     "snapshot.json",                 // file; "" or "-" for stdout; cm://ns/name for a ConfigMap
 	Kubeconfig: "/path/to/target-kubeconfig",    // only used for a cm:// Output
+	Format:     serializer.FormatJSON,           // "" and FormatYAML both deliver the agent's bytes verbatim
 })
 ```
 
 A `cm://` destination is written, not assumed — including when it differs from
 the `AgentConfig.Output` used at collection time. Set `TemplatePath` to render
 through a Go template instead of copying bytes; `Output` then names the
-rendered report.
+rendered report, and `Format` is ignored.
+
+The agent always stages YAML, so `Format` is where a JSON or table rendering
+happens. YAML (and the zero value, for callers written before the field
+existed) is a byte copy — fields a newer agent image emits than the calling
+binary models survive. `FormatJSON` re-encodes the same keys through a generic
+map, preserving those fields; `FormatTable` renders the typed `Snapshot` and is
+therefore the one format that can drop them.
 
 `WrapResolved` turns a `*pkg/recipe.RecipeResult` — typically one taken from
 `RecipeResult.Resolved()` and then projected by the caller — back into a

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -109,10 +109,10 @@ aicr snapshot [flags]
 - **ConfigMap**: Kubernetes ConfigMap URI (`cm://namespace/configmap-name`)
 
 **Output Formats:** `--format` applies to every destination.
-- `yaml` (default) delivers the agent's document byte-for-byte, so fields emitted by a newer `--image` than the CLI survive.
+- `yaml` (default) delivers the agent's document byte-for-byte to a file or stdout, so fields emitted by a newer `--image` than the CLI survive.
 - `json` re-encodes that document with the same keys, which is what `aicr diff --target snapshot.json` and `jq` expect. Since `aicr diff` picks its decoder from the file extension, pair `--format json` with a `.json` path.
 - `table` is a flattened `FIELD`/`VALUE` rendering for humans and cannot be read back by `aicr diff`, `aicr validate --snapshot`, or `aicr recipe --snapshot`.
-- ConfigMap destinations store the rendering under the `snapshot.yaml`, `snapshot.json`, or `snapshot.txt` data key alongside a `format` key; AICR's ConfigMap readers follow that key, so `yaml` and `json` are both consumable from `cm://`.
+- ConfigMap destinations store the rendering under the `snapshot.yaml`, `snapshot.json`, or `snapshot.txt` data key alongside a `format` key; AICR's ConfigMap readers follow that key, so `yaml` and `json` are both consumable from `cm://`. Because those keys and the resource labels are derived from the document, a `cm://` destination re-serializes it (deterministically, and without dropping unmodeled fields) rather than storing the agent's exact bytes — use a file or stdout when you need byte-identical YAML.
 - `--template` supplies its own rendering and therefore requires `--format yaml` (or no `--format`).
 
 **What it captures:**

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -108,6 +108,13 @@ aicr snapshot [flags]
 - **File**: Local file path (`/path/to/snapshot.yaml`)
 - **ConfigMap**: Kubernetes ConfigMap URI (`cm://namespace/configmap-name`)
 
+**Output Formats:** `--format` applies to every destination.
+- `yaml` (default) delivers the agent's document byte-for-byte, so fields emitted by a newer `--image` than the CLI survive.
+- `json` re-encodes that document with the same keys, which is what `aicr diff --target snapshot.json` and `jq` expect. Since `aicr diff` picks its decoder from the file extension, pair `--format json` with a `.json` path.
+- `table` is a flattened `FIELD`/`VALUE` rendering for humans and cannot be read back by `aicr diff`, `aicr validate --snapshot`, or `aicr recipe --snapshot`.
+- ConfigMap destinations store the rendering under the `snapshot.yaml`, `snapshot.json`, or `snapshot.txt` data key alongside a `format` key; AICR's ConfigMap readers follow that key, so `yaml` and `json` are both consumable from `cm://`.
+- `--template` supplies its own rendering and therefore requires `--format yaml` (or no `--format`).
+
 **What it captures:**
 - **SystemD Services**: containerd, docker, kubelet configurations
 - **OS Configuration**: grub, kmod, sysctl, release info

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -156,6 +156,20 @@ func (o *snapshotCmdOptions) toAgentConfig() *aicr.AgentConfig {
 	}
 }
 
+// toSnapshotDelivery projects the resolved output options onto the delivery
+// descriptor that Job mode writes through. It exists as a named projection —
+// like toAgentConfig — because delivery is where the user's --format is
+// applied: the agent Job always stages YAML in a ConfigMap, so a format
+// dropped here is a format silently ignored (issue #2398).
+func (o *snapshotCmdOptions) toSnapshotDelivery() snapshotter.SnapshotDelivery {
+	return snapshotter.SnapshotDelivery{
+		Output:       o.tmplOpts.outputPath,
+		TemplatePath: o.tmplOpts.templatePath,
+		Kubeconfig:   o.kubeconfig,
+		Format:       o.tmplOpts.format,
+	}
+}
+
 // parseSnapshotCmdOptions resolves snapshot command inputs by merging CLI
 // flags with the optional --config (AICRConfig) source. CLI flags always win
 // over config values. Returns a fully-typed snapshotCmdOptions that callers
@@ -590,12 +604,9 @@ See examples/templates/snapshot-template.md.tmpl for a sample template.
 			// Deliver the RAW agent bytes, never a re-serialization of the
 			// parsed snapshot: a newer agent image can emit fields this
 			// binary's Snapshot type does not model, and a typed round trip
-			// would silently drop them.
-			return snapshotter.DeliverSnapshot(ctx, snap.Raw, snapshotter.SnapshotDelivery{
-				Output:       agentCfg.Output,
-				TemplatePath: agentCfg.TemplatePath,
-				Kubeconfig:   agentCfg.Kubeconfig,
-			})
+			// would silently drop them. YAML delivery is a byte copy for
+			// that reason; json and table necessarily re-render.
+			return snapshotter.DeliverSnapshot(ctx, snap.Raw, opts.toSnapshotDelivery())
 		},
 	}
 }

--- a/pkg/cli/snapshot_config_test.go
+++ b/pkg/cli/snapshot_config_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/urfave/cli/v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 // === Regression: --config wiring on snapshot command ===
@@ -602,6 +604,90 @@ func TestSnapshotCmdOptions_ToAgentConfig(t *testing.T) {
 	}
 	if ac.Limits.Memory().String() != "2Gi" {
 		t.Errorf("Limits Memory = %v, want 2Gi", ac.Limits.Memory())
+	}
+}
+
+// TestSnapshotCmdOptions_ToSnapshotDelivery is the CLI-side regression guard
+// for issue #2398: `aicr snapshot --format json` wrote the agent's YAML
+// because the resolved format never reached the delivery descriptor. The agent
+// Job always stages YAML, so a format dropped in this projection is a format
+// silently ignored.
+func TestSnapshotCmdOptions_ToSnapshotDelivery(t *testing.T) {
+	for _, format := range []serializer.Format{
+		serializer.FormatYAML, serializer.FormatJSON, serializer.FormatTable,
+	} {
+		opts := &snapshotCmdOptions{
+			kubeconfig: "/kube/config",
+			tmplOpts: &snapshotTemplateOptions{
+				outputPath:   "snapshot.out",
+				templatePath: "tpl.tmpl",
+				format:       format,
+			},
+		}
+		got := opts.toSnapshotDelivery()
+		wants := []struct {
+			name string
+			got  any
+			want any
+		}{
+			{"Output", got.Output, "snapshot.out"},
+			{"TemplatePath", got.TemplatePath, "tpl.tmpl"},
+			{"Kubeconfig", got.Kubeconfig, "/kube/config"},
+			{"Format", got.Format, format},
+		}
+		for _, w := range wants {
+			if !reflect.DeepEqual(w.got, w.want) {
+				t.Errorf("format %q: %s = %v, want %v", format, w.name, w.got, w.want)
+			}
+		}
+	}
+}
+
+// TestSnapshotCmd_FormatFlagResolves covers both flag spellings the issue
+// reported as ignored, plus the config-file source, since all three feed the
+// same resolved format.
+func TestSnapshotCmd_FormatFlagResolves(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want serializer.Format
+	}{
+		{"default is yaml", []string{"-o", "-"}, serializer.FormatYAML},
+		{"long flag", []string{"-o", "-", "--format", "json"}, serializer.FormatJSON},
+		{"short alias", []string{"-o", "-", "-t", "json"}, serializer.FormatJSON},
+		{"table", []string{"-o", "-", "--format", "table"}, serializer.FormatTable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := captureSnapshotOpts(t, tt.args)
+			if opts.tmplOpts.format != tt.want {
+				t.Errorf("format = %q, want %q", opts.tmplOpts.format, tt.want)
+			}
+			if got := opts.toSnapshotDelivery().Format; got != tt.want {
+				t.Errorf("delivery format = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSnapshotCmd_ConfigFormatResolves pins the config-file source of the
+// same field: spec.snapshot.output.format must reach delivery too.
+func TestSnapshotCmd_ConfigFormatResolves(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := `kind: AICRConfig
+apiVersion: aicr.run/v1alpha2
+spec:
+  snapshot:
+    output:
+      path: snapshot.json
+      format: json
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	opts := captureSnapshotOpts(t, []string{"--config", cfgPath})
+	if got := opts.toSnapshotDelivery().Format; got != serializer.FormatJSON {
+		t.Errorf("delivery format = %q, want json", got)
 	}
 }
 

--- a/pkg/snapshotter/agent.go
+++ b/pkg/snapshotter/agent.go
@@ -635,12 +635,15 @@ func DeliverSnapshot(ctx context.Context, data []byte, dest SnapshotDelivery) er
 	}
 
 	if dest.Output == "" || dest.Output == "-" || dest.Output == serializer.StdoutURI {
-		// Output snapshot data to stdout for consumption by caller. A short write
+		// Exactly the rendered bytes, no added terminator: stdout is a
+		// delivery destination like any other, so `aicr snapshot >
+		// snapshot.yaml` has to hash the same as `-o snapshot.yaml`.
+		// Every rendering already ends in a newline — the agent's
+		// document because it comes from MarshalYAMLDeterministic, JSON
+		// and table because renderSnapshotFormat terminates them — so
+		// this does not leave a terminal prompt dangling. A short write
 		// or broken pipe must surface, not silently drop the snapshot.
 		if _, err := os.Stdout.Write(rendered); err != nil {
-			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
-		}
-		if _, err := os.Stdout.Write([]byte("\n")); err != nil {
 			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
 		}
 		return nil

--- a/pkg/snapshotter/agent.go
+++ b/pkg/snapshotter/agent.go
@@ -563,9 +563,11 @@ type SnapshotDelivery struct {
 	Kubeconfig string
 
 	// Format is the rendering the caller asked for. The zero value and
-	// serializer.FormatYAML both deliver the agent's bytes verbatim; JSON
-	// and table re-render the document (see renderSnapshotFormat). Ignored
-	// when TemplatePath is set, since a template supplies its own
+	// serializer.FormatYAML both deliver the agent's bytes verbatim to
+	// stdout and file destinations; JSON and table re-render the document
+	// (see renderSnapshotFormat). A cm:// destination always re-serializes,
+	// whatever the format — see the ConfigMap section on DeliverSnapshot.
+	// Ignored when TemplatePath is set, since a template supplies its own
 	// rendering.
 	Format serializer.Format
 }
@@ -576,9 +578,10 @@ type SnapshotDelivery struct {
 // file.
 //
 // data must be the RAW bytes from DeployAndCollect, not a re-serialization of
-// the parsed Snapshot — see DeployAndCollect for why. Two modes necessarily
-// parse the document instead of copying bytes: a template, which exposes
-// Snapshot fields to the template, and a non-YAML Format.
+// the parsed Snapshot — see DeployAndCollect for why. Stdout and file
+// destinations copy those bytes when Format is YAML (or unset). Three modes
+// necessarily parse the document instead: a template, which exposes Snapshot
+// fields to the template, a non-YAML Format, and any cm:// destination.
 //
 // # ConfigMap destinations
 //
@@ -589,6 +592,14 @@ type SnapshotDelivery struct {
 // default internal ConfigMap and then delivers to cm://ns/name gets the
 // artifact it asked for instead of a silent no-op. Failures surface; a
 // destination the caller named is not something to log and skip past.
+//
+// A ConfigMap is a structured resource, not a byte sink: the writer derives
+// the snapshot.<ext> data key, the format and timestamp entries, and the
+// resource labels from the parsed document. So this destination re-serializes
+// even for YAML — deterministically, via serializer.MarshalYAMLDeterministic,
+// and through a generic map so no unmodeled field is lost. Only the exact
+// bytes are not preserved. A caller that needs byte-identical YAML should
+// deliver to a file or stdout.
 func DeliverSnapshot(ctx context.Context, data []byte, dest SnapshotDelivery) error {
 	if dest.TemplatePath != "" {
 		return deliverWithTemplate(ctx, data, dest.TemplatePath, dest.Output)

--- a/pkg/snapshotter/agent.go
+++ b/pkg/snapshotter/agent.go
@@ -15,7 +15,9 @@
 package snapshotter
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -559,6 +561,13 @@ type SnapshotDelivery struct {
 	// Empty means in-cluster or the standard discovery chain. Ignored for
 	// every other destination.
 	Kubeconfig string
+
+	// Format is the rendering the caller asked for. The zero value and
+	// serializer.FormatYAML both deliver the agent's bytes verbatim; JSON
+	// and table re-render the document (see renderSnapshotFormat). Ignored
+	// when TemplatePath is set, since a template supplies its own
+	// rendering.
+	Format serializer.Format
 }
 
 // DeliverSnapshot writes captured snapshot bytes to the user's destination:
@@ -567,9 +576,9 @@ type SnapshotDelivery struct {
 // file.
 //
 // data must be the RAW bytes from DeployAndCollect, not a re-serialization of
-// the parsed Snapshot — see DeployAndCollect for why. The one exception is the
-// template path, which necessarily parses the document to expose fields to the
-// template.
+// the parsed Snapshot — see DeployAndCollect for why. Two modes necessarily
+// parse the document instead of copying bytes: a template, which exposes
+// Snapshot fields to the template, and a non-YAML Format.
 //
 // # ConfigMap destinations
 //
@@ -585,29 +594,131 @@ func DeliverSnapshot(ctx context.Context, data []byte, dest SnapshotDelivery) er
 		return deliverWithTemplate(ctx, data, dest.TemplatePath, dest.Output)
 	}
 
-	switch {
-	case dest.Output == "" || dest.Output == "-" || dest.Output == serializer.StdoutURI:
+	// Resolve up front so every destination rejects the same set of
+	// formats. It matters most for the ConfigMap branch: serializer's
+	// ConfigMap writer coerces an unrecognized format to JSON, so without
+	// this a cm:// destination would quietly accept what stdout and file
+	// delivery reject.
+	format, err := resolveDeliveryFormat(dest.Format)
+	if err != nil {
+		return err
+	}
+
+	// A ConfigMap carries its format in the resource itself — the data key
+	// is snapshot.<ext> alongside a "format" entry, which is what the
+	// reader in pkg/serializer keys off — so the ConfigMap writer does the
+	// rendering rather than this function.
+	if strings.HasPrefix(dest.Output, serializer.ConfigMapURIScheme) {
+		if writeErr := writeSnapshotConfigMap(ctx, dest.Output, dest.Kubeconfig, data, format); writeErr != nil {
+			return writeErr
+		}
+		slog.Info("snapshot saved to ConfigMap",
+			slog.String("uri", dest.Output),
+			slog.String("format", string(format)))
+		return nil
+	}
+
+	rendered, err := renderSnapshotFormat(ctx, data, format)
+	if err != nil {
+		return err
+	}
+
+	if dest.Output == "" || dest.Output == "-" || dest.Output == serializer.StdoutURI {
 		// Output snapshot data to stdout for consumption by caller. A short write
 		// or broken pipe must surface, not silently drop the snapshot.
-		if _, err := os.Stdout.Write(data); err != nil {
+		if _, err := os.Stdout.Write(rendered); err != nil {
 			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
 		}
 		if _, err := os.Stdout.Write([]byte("\n")); err != nil {
 			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to stdout", err)
 		}
-	case strings.HasPrefix(dest.Output, serializer.ConfigMapURIScheme):
-		if err := writeSnapshotConfigMap(ctx, dest.Output, dest.Kubeconfig, data); err != nil {
-			return err
-		}
-		slog.Info("snapshot saved to ConfigMap", slog.String("uri", dest.Output))
-	default:
-		if err := serializer.WriteToFile(dest.Output, data); err != nil {
-			return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to file", err)
-		}
-		slog.Info("snapshot saved to file", slog.String("path", dest.Output))
+		return nil
 	}
 
+	if err := serializer.WriteToFile(dest.Output, rendered); err != nil {
+		return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot to file", err)
+	}
+	slog.Info("snapshot saved to file",
+		slog.String("path", dest.Output),
+		slog.String("format", string(format)))
+
 	return nil
+}
+
+// resolveDeliveryFormat resolves the delivery format and rejects anything
+// unsupported. The zero value is YAML: delivery predates
+// SnapshotDelivery.Format, so an SDK caller that never sets it must keep
+// getting the agent's YAML bytes.
+func resolveDeliveryFormat(format serializer.Format) (serializer.Format, error) {
+	if format == "" {
+		return serializer.FormatYAML, nil
+	}
+	if format.IsUnknown() {
+		return "", errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"unsupported snapshot output format",
+			map[string]any{"format": string(format), "supported": serializer.SupportedFormats()})
+	}
+	return format, nil
+}
+
+// renderSnapshotFormat converts the agent's raw YAML document into an already
+// resolved format, for stdout and file destinations.
+//
+// YAML returns data untouched: those bytes are byte-identical to what the
+// agent emitted, including fields this binary's Snapshot type does not model.
+// JSON re-encodes through a generic map for the same reason — a typed round
+// trip would drop those fields, and a JSON document with the same keys is
+// what `aicr diff --target snapshot.json` and jq consumers expect. Table is a
+// human rendering that goes through the typed struct, so it is the one format
+// that is lossy by construction; it matches what in-pod (local) collection
+// emits for the same flag.
+func renderSnapshotFormat(ctx context.Context, data []byte, format serializer.Format) ([]byte, error) {
+	switch format {
+	case serializer.FormatYAML:
+		return data, nil
+
+	case serializer.FormatJSON:
+		var doc map[string]any
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to parse snapshot for JSON output", err)
+		}
+		// json.Marshal sorts map keys, so the rendering is deterministic
+		// for a given document.
+		out, err := json.MarshalIndent(doc, "", "  ")
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to render snapshot as JSON", err)
+		}
+		return append(out, '\n'), nil
+
+	case serializer.FormatTable:
+		snap, err := parseSnapshotDocument(data, "table")
+		if err != nil {
+			return nil, err
+		}
+		var buf bytes.Buffer
+		if err := serializer.NewWriter(serializer.FormatTable, &buf).Serialize(ctx, snap); err != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal, "failed to render snapshot as a table", err)
+		}
+		return buf.Bytes(), nil
+
+	default:
+		// Unreachable via DeliverSnapshot, which resolves first; kept so a
+		// future caller cannot skip the check and fall through to YAML.
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			"unsupported snapshot output format",
+			map[string]any{"format": string(format), "supported": serializer.SupportedFormats()})
+	}
+}
+
+// parseSnapshotDocument unmarshals an agent document into this binary's
+// Snapshot type for the delivery modes that cannot copy bytes.
+func parseSnapshotDocument(data []byte, mode string) (*Snapshot, error) {
+	var snap Snapshot
+	if err := yaml.Unmarshal(data, &snap); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal,
+			fmt.Sprintf("failed to parse snapshot for %s output", mode), err)
+	}
+	return &snap, nil
 }
 
 // ParseResourceList converts a comma-separated "name=quantity" list
@@ -850,7 +961,11 @@ func (n *NodeSnapshotter) measureWithAgent(ctx context.Context) error {
 // carry the merged reading, and a transient Apply failure on the internal
 // hygiene rewrite must not discard an already-captured snapshot.
 func rewriteMergedSnapshotConfigMap(ctx context.Context, uri, kubeconfig string, snapshotData []byte, deliverViaConfigMap bool) error {
-	err := writeSnapshotConfigMap(ctx, uri, kubeconfig, snapshotData)
+	// YAML regardless of the caller's --format: this ConfigMap is the
+	// agent-to-controller staging vehicle, and pkg/k8s/agent's GetSnapshot
+	// reads its snapshot.yaml key. When the user asked for a cm://
+	// destination in another format, DeliverSnapshot re-applies it below.
+	err := writeSnapshotConfigMap(ctx, uri, kubeconfig, snapshotData, serializer.FormatYAML)
 	if err == nil {
 		return nil
 	}
@@ -864,27 +979,52 @@ func rewriteMergedSnapshotConfigMap(ctx context.Context, uri, kubeconfig string,
 }
 
 // writeSnapshotConfigMap applies snapshot bytes to a cm://namespace/name
-// destination, replacing whatever is there. Shared by DeliverSnapshot (the
-// caller's chosen destination) and the AKS-pool merge rewrite (replacing the
-// pre-merge content the agent Job stored).
-func writeSnapshotConfigMap(ctx context.Context, uri, kubeconfig string, snapshotData []byte) error {
+// destination in the requested format, replacing whatever is there. Shared by
+// DeliverSnapshot (the caller's chosen destination) and the AKS-pool merge
+// rewrite (replacing the pre-merge content the agent Job stored), which pins
+// YAML: pkg/k8s/agent reads the staging ConfigMap's snapshot.yaml key.
+//
+// The format is resolved here as well as in DeliverSnapshot, because the
+// ConfigMap writer coerces an unrecognized format to JSON — an unsupported
+// format must fail, not change the artifact's encoding.
+func writeSnapshotConfigMap(ctx context.Context, uri, kubeconfig string, snapshotData []byte, format serializer.Format) error {
 	namespace, name, err := pod.ParseConfigMapURI(uri)
 	if err != nil {
 		return errors.Wrap(errors.ErrCodeInvalidRequest, "failed to parse snapshot ConfigMap URI", err)
 	}
-	// Generic-map round trip, same reason as mergeAKSGPUPools: the typed
-	// Snapshot struct would drop fields a newer agent image emitted. The
-	// rawSnapshotDoc wrapper keeps the ConfigMap's kind/version labels
-	// populated from the document header.
-	var doc map[string]any
-	if err := yaml.Unmarshal(snapshotData, &doc); err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to parse snapshot for ConfigMap write", err)
+	format, err = resolveDeliveryFormat(format)
+	if err != nil {
+		return err
 	}
-	writer := serializer.NewConfigMapWriterWithKubeconfig(namespace, name, kubeconfig, serializer.FormatYAML)
-	if err := writer.Serialize(ctx, rawSnapshotDoc{doc: doc}); err != nil {
+	payload, err := configMapPayload(snapshotData, format)
+	if err != nil {
+		return err
+	}
+	writer := serializer.NewConfigMapWriterWithKubeconfig(namespace, name, kubeconfig, format)
+	if err := writer.Serialize(ctx, payload); err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to write snapshot ConfigMap", err)
 	}
 	return nil
+}
+
+// configMapPayload picks what the ConfigMap writer serializes.
+//
+// YAML and JSON go through the generic-map wrapper, same reason as
+// mergeAKSGPUPools: the typed Snapshot struct would drop fields a newer agent
+// image emitted, and rawSnapshotDoc still exposes the kind/version the writer
+// puts on the ConfigMap's labels. A table is a flattened FIELD/VALUE view the
+// writer derives by reflecting over exported fields, which a generic map
+// collapses into a single row — so that mode hands over the typed struct and
+// accepts the lossy round trip.
+func configMapPayload(snapshotData []byte, format serializer.Format) (any, error) {
+	if format == serializer.FormatTable {
+		return parseSnapshotDocument(snapshotData, "table")
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(snapshotData, &doc); err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to parse snapshot for ConfigMap write", err)
+	}
+	return rawSnapshotDoc{doc: doc}, nil
 }
 
 // rawSnapshotDoc lets a generic snapshot document flow through serializers
@@ -897,6 +1037,16 @@ type rawSnapshotDoc struct {
 
 //nolint:unparam // the (any, error) shape is yaml.Marshaler's fixed contract
 func (r rawSnapshotDoc) MarshalYAML() (any, error) { return r.doc, nil }
+
+// MarshalJSON keeps the no-field-loss guarantee on the JSON path: without it
+// the wrapper has no exported fields and would serialize as "{}".
+func (r rawSnapshotDoc) MarshalJSON() ([]byte, error) {
+	out, err := json.Marshal(r.doc)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to serialize snapshot document as JSON", err)
+	}
+	return out, nil
+}
 
 func (r rawSnapshotDoc) GetKind() header.Kind {
 	kind, _ := r.doc["kind"].(string)

--- a/pkg/snapshotter/agent_test.go
+++ b/pkg/snapshotter/agent_test.go
@@ -15,6 +15,7 @@
 package snapshotter
 
 import (
+	"encoding/json"
 	stderrors "errors"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -623,6 +625,182 @@ func TestDeliverSnapshot_FileIsByteIdentical(t *testing.T) {
 	}
 	if string(got) != snapshotFixture {
 		t.Errorf("delivered bytes differ from the agent's output\n got:\n%s\nwant:\n%s", got, snapshotFixture)
+	}
+}
+
+// TestDeliverSnapshot_HonorsFormat is the regression test for issue #2398:
+// `aicr snapshot --format json` used to write the agent's YAML into whatever
+// destination the user named, so a .json file held a YAML document and every
+// downstream consumer (aicr diff, which picks its decoder from the file
+// extension, and jq) failed on it. The agent always stages YAML, so delivery
+// is the only place the requested format can be applied.
+func TestDeliverSnapshot_HonorsFormat(t *testing.T) {
+	tests := []struct {
+		name       string
+		format     serializer.Format
+		wantPrefix string
+		wantHas    []string
+	}{
+		{
+			name:       "json",
+			format:     serializer.FormatJSON,
+			wantPrefix: "{",
+			wantHas:    []string{`"apiVersion": "aicr.run/v1alpha2"`, `"fromANewerAgent": true`},
+		},
+		{
+			name:       "table",
+			format:     serializer.FormatTable,
+			wantPrefix: "FIELD",
+			wantHas:    []string{"APIVersion", "aicr.run/v1alpha2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := filepath.Join(t.TempDir(), "snapshot.out")
+			if err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+				Output: out,
+				Format: tt.format,
+			}); err != nil {
+				t.Fatalf("DeliverSnapshot(%s): %v", tt.format, err)
+			}
+
+			got, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("read delivered snapshot: %v", err)
+			}
+			if !strings.HasPrefix(string(got), tt.wantPrefix) {
+				t.Errorf("delivered %s output does not start with %q — the agent's YAML was "+
+					"written unconverted:\n%s", tt.format, tt.wantPrefix, got)
+			}
+			for _, want := range tt.wantHas {
+				if !strings.Contains(string(got), want) {
+					t.Errorf("delivered %s output missing %q:\n%s", tt.format, want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestDeliverSnapshot_JSONDecodesAsSnapshot closes the loop the issue
+// reported: the JSON rendering must be readable by the same decoders that
+// consume a .json snapshot, and it must carry fields this binary's Snapshot
+// type does not model (the generic-map path, not a typed round trip).
+func TestDeliverSnapshot_JSONDecodesAsSnapshot(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "snapshot.json")
+	if err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+		Output: out,
+		Format: serializer.FormatJSON,
+	}); err != nil {
+		t.Fatalf("DeliverSnapshot(json): %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read delivered snapshot: %v", err)
+	}
+
+	var snap Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatalf("delivered .json does not decode as JSON: %v\n%s", err, data)
+	}
+	if snap.APIVersion != "aicr.run/v1alpha2" || snap.Metadata["version"] != "v9.9.9" {
+		t.Errorf("decoded snapshot = %+v, want the fixture's apiVersion and metadata", snap.Header)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal delivered JSON: %v", err)
+	}
+	if _, ok := doc["unmodeledField"]; !ok {
+		t.Error("JSON rendering dropped unmodeledField; it must go through a generic map so " +
+			"a newer agent image's fields survive delivery")
+	}
+}
+
+// TestDeliverSnapshot_UnsetFormatStaysByteIdentical protects SDK callers that
+// predate SnapshotDelivery.Format: the zero value must keep meaning "the
+// agent's YAML, unchanged".
+func TestDeliverSnapshot_UnsetFormatStaysByteIdentical(t *testing.T) {
+	for _, format := range []serializer.Format{"", serializer.FormatYAML} {
+		out := filepath.Join(t.TempDir(), "snapshot.yaml")
+		if err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+			Output: out,
+			Format: format,
+		}); err != nil {
+			t.Fatalf("DeliverSnapshot(%q): %v", format, err)
+		}
+		got, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("read delivered snapshot: %v", err)
+		}
+		if string(got) != snapshotFixture {
+			t.Errorf("format %q altered the agent's bytes\n got:\n%s\nwant:\n%s", format, got, snapshotFixture)
+		}
+	}
+}
+
+// TestDeliverSnapshot_RejectsUnknownFormat keeps an unrecognized format from
+// silently degrading to another encoding — the exact failure mode of issue
+// #2398. The CLI validates --format up front, so this is the SDK-caller guard.
+//
+// Every destination must reject the same set. The cm:// case is the one that
+// needs the explicit check: serializer's ConfigMap writer coerces an unknown
+// format to JSON, so without it that destination would succeed where stdout
+// and file delivery fail.
+func TestDeliverSnapshot_RejectsUnknownFormat(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	file := filepath.Join(dir, "snapshot.out")
+
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{"file", file},
+		{"stdout", "-"},
+		{"configmap", "cm://default/aicr-snapshot"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+				Output: tt.output,
+				Format: serializer.Format("toml"),
+			})
+			if err == nil {
+				t.Fatalf("DeliverSnapshot(%s, format=toml) = nil error, want a rejection", tt.output)
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error = %v, want code ErrCodeInvalidRequest", err)
+			}
+		})
+	}
+
+	// The rejection must land before any destination is touched — no
+	// truncated file, and for cm:// no cluster contact (this test has no
+	// cluster, so a format check that ran late would surface as a
+	// connection error instead of ErrCodeInvalidRequest above).
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("read working dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("rejected format still wrote to the destination: %v", entries)
+	}
+}
+
+// TestRawSnapshotDocMarshalJSON pins the wrapper's JSON contract: it has no
+// exported fields, so without MarshalJSON a cm:// destination in JSON format
+// would receive "{}" — a successful write of an empty snapshot.
+func TestRawSnapshotDocMarshalJSON(t *testing.T) {
+	got, err := json.Marshal(rawSnapshotDoc{doc: map[string]any{
+		"kind":           "Snapshot",
+		"futureTopLevel": "keep-me",
+	}})
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	want := `{"futureTopLevel":"keep-me","kind":"Snapshot"}`
+	if string(got) != want {
+		t.Errorf("MarshalJSON = %s, want %s", got, want)
 	}
 }
 

--- a/pkg/snapshotter/agent_test.go
+++ b/pkg/snapshotter/agent_test.go
@@ -15,8 +15,10 @@
 package snapshotter
 
 import (
+	"bytes"
 	"encoding/json"
 	stderrors "errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -735,6 +737,118 @@ func TestDeliverSnapshot_UnsetFormatStaysByteIdentical(t *testing.T) {
 		if string(got) != snapshotFixture {
 			t.Errorf("format %q altered the agent's bytes\n got:\n%s\nwant:\n%s", format, got, snapshotFixture)
 		}
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what
+// was written. The pipe is drained concurrently: a snapshot is larger than the
+// OS pipe buffer, so reading only after fn returns would deadlock on write.
+func captureStdout(t *testing.T, fn func()) []byte {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	saved := os.Stdout
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = saved })
+
+	drained := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, copyErr := io.Copy(&buf, reader)
+		if copyErr != nil {
+			t.Errorf("drain stdout: %v", copyErr)
+		}
+		drained <- buf.Bytes()
+	}()
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+	out := <-drained
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	return out
+}
+
+// TestDeliverSnapshot_StdoutMatchesFile pins stdout as a delivery destination
+// like any other: `aicr snapshot > snapshot.yaml` has to produce the same
+// artifact as `-o snapshot.yaml`, for every format. Stdout used to append a
+// newline the file path did not, so the two differed by a byte and a piped
+// hash could not reproduce the file.
+func TestDeliverSnapshot_StdoutMatchesFile(t *testing.T) {
+	for _, format := range []serializer.Format{"", serializer.FormatYAML, serializer.FormatJSON, serializer.FormatTable} {
+		t.Run(string(format), func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "snapshot.out")
+			if err := DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+				Output: file,
+				Format: format,
+			}); err != nil {
+				t.Fatalf("DeliverSnapshot(file, %q): %v", format, err)
+			}
+			wantBytes, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("read delivered snapshot: %v", err)
+			}
+
+			var deliverErr error
+			got := captureStdout(t, func() {
+				deliverErr = DeliverSnapshot(t.Context(), []byte(snapshotFixture), SnapshotDelivery{
+					Output: "-",
+					Format: format,
+				})
+			})
+			if deliverErr != nil {
+				t.Fatalf("DeliverSnapshot(stdout, %q): %v", format, deliverErr)
+			}
+
+			if !bytes.Equal(got, wantBytes) {
+				t.Errorf("stdout and file delivery differ for format %q\n stdout (%d bytes):\n%s\n file (%d bytes):\n%s",
+					format, len(got), got, len(wantBytes), wantBytes)
+			}
+			// Every rendering terminates itself, which is what lets
+			// stdout add nothing without gluing the next shell prompt
+			// to the output.
+			if len(wantBytes) > 0 && wantBytes[len(wantBytes)-1] != '\n' {
+				t.Errorf("format %q rendering is not newline-terminated; stdout would leave a "+
+					"dangling prompt:\n%s", format, wantBytes)
+			}
+		})
+	}
+}
+
+// TestDeliverSnapshot_StdoutPreservesTrailingNewline is the byte-identity
+// guarantee on the stdout path. The agent's document always ends in a newline
+// (MarshalYAMLDeterministic), and appending another gave it a trailing blank
+// line; an SDK caller can also hand over bytes with no terminator, and stdout
+// must not invent one. Neither input may be rewritten.
+func TestDeliverSnapshot_StdoutPreservesTrailingNewline(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"trailing newline", snapshotFixture},
+		{"no trailing newline", strings.TrimSuffix(snapshotFixture, "\n")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deliverErr error
+			got := captureStdout(t, func() {
+				deliverErr = DeliverSnapshot(t.Context(), []byte(tt.data), SnapshotDelivery{Output: "-"})
+			})
+			if deliverErr != nil {
+				t.Fatalf("DeliverSnapshot(stdout): %v", deliverErr)
+			}
+			if string(got) != tt.data {
+				t.Errorf("stdout altered the agent's bytes\n got  (%d bytes): %q\n want (%d bytes): %q",
+					len(got), got, len(tt.data), tt.data)
+			}
+		})
 	}
 }
 

--- a/pkg/snapshotter/aksgpupools_test.go
+++ b/pkg/snapshotter/aksgpupools_test.go
@@ -25,6 +25,7 @@ import (
 
 	k8scollector "github.com/NVIDIA/aicr/pkg/collector/k8s"
 	"github.com/NVIDIA/aicr/pkg/measurement"
+	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 func writePoolsFile(t *testing.T, content string) string {
@@ -208,10 +209,10 @@ measurements:
 // TestWriteSnapshotConfigMapRejectsBadInput pins the guard branches; the
 // live write path requires a cluster and is covered by e2e.
 func TestWriteSnapshotConfigMapRejectsBadInput(t *testing.T) {
-	if err := writeSnapshotConfigMap(t.Context(), "not-a-cm-uri", "", []byte("{}")); err == nil {
+	if err := writeSnapshotConfigMap(t.Context(), "not-a-cm-uri", "", []byte("{}"), serializer.FormatYAML); err == nil {
 		t.Fatal("writeSnapshotConfigMap(bad URI) = nil, want error")
 	}
-	if err := writeSnapshotConfigMap(t.Context(), "cm://ns/name", "", []byte("{not yaml")); err == nil {
+	if err := writeSnapshotConfigMap(t.Context(), "cm://ns/name", "", []byte("{not yaml"), serializer.FormatYAML); err == nil {
 		t.Fatal("writeSnapshotConfigMap(garbage snapshot) = nil, want parse error")
 	}
 }

--- a/pkg/snapshotter/doc.go
+++ b/pkg/snapshotter/doc.go
@@ -58,7 +58,9 @@
 //
 // The agent stages YAML regardless of what the caller asked for, so
 // SnapshotDelivery.Format is where a JSON or table rendering is applied. Its
-// zero value, and FormatYAML, deliver those bytes unchanged.
+// zero value, and FormatYAML, deliver those bytes unchanged to a file or
+// stdout; a cm:// destination re-serializes the document to derive its data
+// key and labels, preserving unmodeled fields but not the exact bytes.
 //
 // Snapshot: Captured configuration data
 //

--- a/pkg/snapshotter/doc.go
+++ b/pkg/snapshotter/doc.go
@@ -56,6 +56,10 @@
 // the parsed Snapshot: a newer agent image can emit fields the local Snapshot
 // type does not model, and a typed round trip drops them silently.
 //
+// The agent stages YAML regardless of what the caller asked for, so
+// SnapshotDelivery.Format is where a JSON or table rendering is applied. Its
+// zero value, and FormatYAML, deliver those bytes unchanged.
+//
 // Snapshot: Captured configuration data
 //
 //	type Snapshot struct {


### PR DESCRIPTION
## Summary

`aicr snapshot` ignored `--format`/`-t` and always wrote YAML. The resolved format is now threaded into `snapshotter.SnapshotDelivery` and applied at delivery, for stdout, file, and `cm://` destinations alike.

## Motivation / Context

The agent Job always stages YAML in a ConfigMap, and the controller-side delivery copied those bytes verbatim to whatever destination the user named — so `--format json` silently produced a YAML document. Since `aicr diff` picks its decoder from the file extension, a `.json` snapshot then failed to load (`failed to decode JSON: invalid character 'a'` — the `a` of `apiVersion`), and `jq` consumers failed the same way. Because `snapshot` exited 0, the problem only surfaced downstream.

Fixes: #2398
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

`SnapshotDelivery` gains a `Format` field; `pkg/cli` projects it through a new `snapshotCmdOptions.toSnapshotDelivery()`, mirroring the existing `toAgentConfig()` projection so the plumbing is unit-testable rather than inline in the command's `Action`.

Rendering per format, chosen to preserve the version-skew guarantee that motivated raw-byte delivery in the first place:

- **YAML** (and the zero value, for SDK callers written before the field existed) stays a byte copy, so fields emitted by a newer agent `--image` than the CLI still survive.
- **JSON** re-encodes through a generic `map[string]any` for the same reason — a typed round trip would drop unmodeled fields. `json.Marshal` sorts map keys, so the rendering is deterministic, and the snapshot types' `json`/`yaml` tags match, so the output decodes straight back into `Snapshot`.
- **Table** renders the typed struct through `serializer`'s table writer, matching what in-pod (local) collection already emits for `--format table`. It is the one format that is lossy by construction.
- An unrecognized format is rejected with `INVALID_REQUEST` instead of degrading to YAML. The CLI already validates `--format`, so this is the SDK-caller guard.

`cm://` destinations keep carrying the format in the resource itself (`snapshot.yaml`/`snapshot.json`/`snapshot.txt` plus a `format` key), so the ConfigMap writer does that rendering. `rawSnapshotDoc` gained `MarshalJSON` — without it the wrapper has no exported fields and a JSON ConfigMap write would have succeeded with `{}`. The AKS-pool merge rewrite now pins `FormatYAML` explicitly: that ConfigMap is the agent-to-controller staging vehicle and `pkg/k8s/agent`'s `GetSnapshot` reads its `snapshot.yaml` key.

## Testing

```bash
go test ./pkg/cli/... ./pkg/snapshotter/...
golangci-lint run -c .golangci.yaml ./pkg/snapshotter/... ./pkg/cli/...
make test
```

`go test ./pkg/cli/... ./pkg/snapshotter/...` passes; `golangci-lint` reports 0 issues on both packages.

New tests: `TestDeliverSnapshot_HonorsFormat` (json/table actually convert), `TestDeliverSnapshot_JSONDecodesAsSnapshot` (the reported `snapshot -> diff` break, plus unmodeled-field survival), `TestDeliverSnapshot_UnsetFormatStaysByteIdentical`, `TestDeliverSnapshot_RejectsUnknownFormat`, `TestRawSnapshotDocMarshalJSON`, `TestSnapshotCmdOptions_ToSnapshotDelivery`, `TestSnapshotCmd_FormatFlagResolves` (both `--format` and `-t`), `TestSnapshotCmd_ConfigFormatResolves`.

Coverage: `pkg/snapshotter: 64.9% -> 65.9% (+1.0%)`, `pkg/cli: 75.7% -> 75.7% (unchanged)`. No new exported functions.

Local `make test` has two pre-existing failures unrelated to this change, confirmed identical on `origin/main` in a clean worktree and both caused by local tooling gaps: `pkg/oci` (`TestHelmPinnedVersionExplicitVersionPull` — installed helm is v3.19.0 vs the v4.2.4 pin) and `tests/releasepolicy` (`timeout: command not found` on macOS). Deferring the rest of the `make qualify` gate to CI.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Backwards compatible. `--format yaml` (the default) is unchanged and still byte-identical to the agent's output, so existing pipelines see no difference. `SnapshotDelivery.Format` is an additive field whose zero value preserves the old behavior for SDK callers. The only behavior change is that `json` and `table` now produce what they say — and previously nobody could depend on those values, since they emitted YAML.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — except the two pre-existing tooling failures noted above
- [ ] Linter passes (`make lint`) — `golangci-lint` clean on both affected packages; the full `make lint` and the rest of `make qualify` are deferred to CI
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
