### PR TITLE
docs: bind ADR-022 migration to releases, start ComponentUpgrades at beta

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,11 +26,23 @@ axis:
   the next `vMAJOR` release.
 
 For beta and GA bumps, stage the new reader in Release N before switching the
-emitter in Release N+1. The initial alpha-to-target migration is the explicit
-three-release sequence in ADR-022 §3: readers first, emitters second, then alpha
-and legacy empty headers retire. Release notes must identify any deprecation,
-the last release that reads the retiring version, and the required artifact
-recapture, regeneration, or authored-header edit.
+emitter in Release N+1. Release notes must identify any deprecation, the last
+release that reads the retiring version, and the required artifact recapture,
+regeneration, or authored-header edit.
+
+The initial alpha-to-target migration is the explicit three-release sequence in
+ADR-022 §3, bound to these releases:
+
+| Release | Reads | Emits | Tracking |
+|---|---|---|---|
+| v0.21 | alpha and target | alpha | [#2404](https://github.com/NVIDIA/aicr/pull/2404) |
+| v0.22 | alpha and target | target | [#2416](https://github.com/NVIDIA/aicr/issues/2416) |
+| v0.23 | target only | target | [#2417](https://github.com/NVIDIA/aicr/issues/2417) |
+
+Cutting v0.22 or v0.23 means completing the corresponding issue in that release,
+not after it. The consumer-facing form of this table, including the per-kind
+target values, is in
+[`docs/integrator/data-extension.md`](docs/integrator/data-extension.md#catalog-and-binary-compatibility).
 
 ## What Goes Into a Release
 

--- a/docs/design/021-component-upgrade-safety.md
+++ b/docs/design/021-component-upgrade-safety.md
@@ -144,9 +144,9 @@ Records are keyed by semver ranges, not explicit version pairs, so they do not g
 
 **A transition may also carry `hooks`.** Steps describe what a human does; `hooks` reference AICR-authored migration manifests that ship as a release beside the component. The field is defined in [Decision 4](#decision-4-migration-content-ships-as-an-adjacent-generated-release), which owns its delivery; it is listed here so the transition schema is complete in one place.
 
-**The loader fails closed on an unrecognized `apiVersion`.** Records are stamped `aicr.run/v1alpha2`, the current track per [ADR-013](013-aicr-run-domain-migration.md); `aicr.run/v1alpha1` never existed. An unreadable or unrecognized record MUST return `ErrCodeInvalidRequest` naming the value found and the value expected. It MUST NOT be skipped, and it MUST NOT degrade to `unknown`.
+**The loader fails closed on an unrecognized `apiVersion`.** Records are stamped `aicr.run/v1beta1`, the target assigned to `ComponentUpgrades` by [ADR-022 §2](022-artifact-maturity-and-deprecation.md). The kind starts at its target rather than on the alpha track: ADR-022 Release N already accepts `aicr.run/v1beta1` for authoring artifacts, so there is no alpha version to emit and later retire. An unreadable or unrecognized record MUST return `ErrCodeInvalidRequest` naming the value found and the value expected. It MUST NOT be skipped, and it MUST NOT degrade to `unknown`.
 
-That last clause matters for the same reason `unknown` and `unversioned` are separate verdicts. "A record exists and I could not read it" is not "no record exists", and collapsing them hides which action closes the gap. A loader that quietly skips a record it cannot parse would reproduce this ADR's own motivating failure, the silent one, inside the tool built to prevent it. The catalog loader today checks `kind` only and never `apiVersion` (see ADR-015 and [#1812](https://github.com/NVIDIA/aicr/issues/1812)), and `recipes/upgrades/*.yaml` sits in the same tree an external `--data` catalog points at, so a record loader inherits that behavior unless it opts out explicitly.
+That last clause matters for the same reason `unknown` and `unversioned` are separate verdicts. "A record exists and I could not read it" is not "no record exists", and collapsing them hides which action closes the gap. A loader that quietly skips a record it cannot parse would reproduce this ADR's own motivating failure, the silent one, inside the tool built to prevent it. The catalog loader used to check `kind` only and never `apiVersion` (see ADR-015 and [#1812](https://github.com/NVIDIA/aicr/issues/1812)); [ADR-022 §8](022-artifact-maturity-and-deprecation.md) closed that, and `recipes/upgrades/*.yaml` sits in the same tree an external `--data` catalog points at, so a record loader must implement the ADR-022 gate rather than needing to opt out of a fail-open one. The obligation is on this still-unimplemented loader; it does not share `provider.go`'s registry gate, so "inherits" would describe the fail-closed policy default, not code reuse.
 
 **Fields are validated against the verdict.** A `manual` or `blocked` record MUST carry at least one step, since both are defined by the work they require; a `safe` record MUST carry none, and MUST carry `verifiedBy`.
 
@@ -229,7 +229,7 @@ What it is good for is the thing an operator needs *before* upgrading rather tha
 
 | Field | Required | Notes |
 |---|---|---|
-| `apiVersion` | yes | `aicr.run/v1alpha2`. The loader fails closed on anything else. |
+| `apiVersion` | yes | `aicr.run/v1beta1`, per [ADR-022 §2](022-artifact-maturity-and-deprecation.md). The loader fails closed on anything else. |
 | `kind`, `component` | yes | `ComponentUpgrades`; `component` must match the registry entry. |
 | `transitions[]` | yes | One or more. |
 | `.from`, `.to` | yes | Semver ranges. A record applies when the source satisfies `from` and the target is at or past `to`'s lower bound. `to` MUST NOT reach past the currently pinned version; widen `from` backward instead. |
@@ -559,7 +559,7 @@ The real nodewright `skyhook.nvidia.com` to `nodewright.nvidia.com` rename, draw
 
 ```yaml
 # recipes/upgrades/nodewright-operator.yaml
-apiVersion: aicr.run/v1alpha2
+apiVersion: aicr.run/v1beta1
 kind: ComponentUpgrades
 component: nodewright-operator
 transitions:

--- a/docs/design/022-artifact-maturity-and-deprecation.md
+++ b/docs/design/022-artifact-maturity-and-deprecation.md
@@ -3,8 +3,18 @@
 ## Status
 
 Accepted on 2026-08-26 by ratification in
-[#2373](https://github.com/NVIDIA/aicr/pull/2373). Amends
-[ADR-011](011-artifact-apiversion-policy.md): §1 keeps `pkg/header` as the
+[#2373](https://github.com/NVIDIA/aicr/pull/2373).
+
+Revised 2026-08-27 in [#2418](https://github.com/NVIDIA/aicr/pull/2418): §2's
+`ComponentUpgrades` row drops its pre-cut alpha branch and starts at
+`aicr.run/v1beta1` unconditionally, and §3 binds N, N+1, and N+2 to concrete
+AICR releases. Release N's reader support merged in
+[#2404](https://github.com/NVIDIA/aicr/pull/2404) and ships in v0.21, so `main`
+already accepts `aicr.run/v1beta1`; a kind introduced now can start at its
+target without violating §7's rule that a new kind is never stamped with a
+version the tree does not accept, and without a shipped alpha version to retire.
+
+Amends [ADR-011](011-artifact-apiversion-policy.md): §1 keeps `pkg/header` as the
 single source of version strings but replaces its single-version alias rule;
 §3 becomes kind/schema-scoped, covers AICR catalog inputs, and retires its
 empty-`apiVersion` tolerance through the initial migration; §4 is replaced by
@@ -85,7 +95,7 @@ pretending that the legacy `Recipe` input is distinct from the canonical
 | `RecipeMetadata`, `RecipeMixin` (catalog) | `v1alpha2` | `aicr.run/v1beta1` | Authoring schema exercised by 105 shipped catalog files (101 overlays, 4 mixins) |
 | `ComponentRegistry` | `v1alpha2` | `aicr.run/v1beta1` | Required root of an external `--data` catalog; authoring schema consumed by bundling and validation |
 | `RecipeMetadata`, `RecipeResult` (profile-bearing) | `v1alpha3` | `aicr.run/v1beta2` | Newest (ADR-015), 2 overlays, opt-in via profiles; remains distinct from ordinary `RecipeMetadata` |
-| `ComponentUpgrades` (proposed by #2343) | Not shipped; proposed `v1alpha2` before the cut | `aicr.run/v1beta1` | New, still-evolving authoring schema; its loader and records are not implemented |
+| `ComponentUpgrades` (proposed by [ADR-021](021-component-upgrade-safety.md)) | Not shipped | `aicr.run/v1beta1` | New, still-evolving authoring schema; its loader and records are not implemented. Starts at its target, with no alpha version to retire |
 
 `BundleProvenance` here means the bundle-root `provenance.yaml` document emitted
 by deployers through `localformat.WriteProvenance`, not the in-toto provenance
@@ -137,6 +147,19 @@ alpha-to-target migration therefore uses a bounded three-release sequence:
    empty-value exceptions from all in-scope read gates. This is the earliest
    release that may satisfy the artifact-version part of the v1 GA gate.
 
+The sequence is bound to concrete AICR releases:
+
+| Release | Reads | Emits | Tracking |
+|---|---|---|---|
+| N — v0.21 | alpha + target | alpha | [#2404](https://github.com/NVIDIA/aicr/pull/2404) |
+| N+1 — v0.22 | alpha + target | target | [#2416](https://github.com/NVIDIA/aicr/issues/2416) |
+| N+2 — v0.23 | target only | target | [#2417](https://github.com/NVIDIA/aicr/issues/2417) |
+
+Releases before N accept only the alpha values, so a target-stamped artifact
+does not load on v0.20 or earlier. `RELEASING.md` and
+[`docs/integrator/data-extension.md`](../integrator/data-extension.md#catalog-and-binary-compatibility)
+carry the consumer-facing form of this table.
+
 Before N+1 starts emitting target artifacts, every producer and consumer in a
 pipeline must run Release N or later. Mixed pipelines containing an older
 binary are unsupported. Artifact-bearing HTTP boundaries follow this sequence
@@ -156,10 +179,10 @@ embedded in a bundle no longer load in N+2. AICR has no conversion layer, so an
 immutable archive whose source cannot be recaptured remains readable only with
 a retained N or N+1 binary. The N-through-N+1 interval is the migration window.
 
-Merge order with #2343 is explicit. If `ComponentUpgrades` lands before N+1,
-its records, loader gate, examples, and tests participate in this sequence and
-switch to `aicr.run/v1beta1`. If it lands at or after N+1, it starts at
-`v1beta1` and has no shipped alpha version to retire.
+`ComponentUpgrades` does not participate in this sequence regardless of when it
+lands. Its records, loader gate, examples, and tests start at `aicr.run/v1beta1`
+directly, because N already accepts that value and the kind has no shipped alpha
+version to retire.
 
 **The empty-`apiVersion` tolerance retires at N+2.** ADR-011 §3 accepts an
 empty value in the snapshot, recipe, and criteria loaders for artifacts
@@ -233,7 +256,16 @@ The beta N+3 calculation never shortens that GA boundary.
 ### 7. A new kind starts on the current track
 
 A kind introduced before §3's Release N+1 emitter switch is stamped
-`aicr.run/v1alpha2` by default. At or after N+1, a new kind starts at
+`aicr.run/v1alpha2` by default, unless its §2 row selects otherwise. The row
+wins. `ComponentUpgrades` uses that override: it starts at `aicr.run/v1beta1`
+whenever it lands, because Release N already accepts that value and starting at
+the target spares the kind an emitter flip at N+1 and a retirement at N+2.
+Prefer the override for a new kind whose **beta** target track the tree already
+accepts; the alpha default exists for kinds whose target does not yet parse. A
+`v1` start is not covered by this preference and remains subject to the GA bar
+in the next paragraph.
+
+At or after N+1, a new kind starts at
 `aicr.run/v1beta1` by default; it may start at
 `aicr.run/v1` only when its introducing decision establishes that its public
 contract is already ready for GA obligations. There is no implicit post-v1 alpha
@@ -289,9 +321,9 @@ ADR-011's domain carve-out remains unchanged. `ValidatorCatalog`
 formats are separate schemas and are not gated by ADR-022. The bundle-root
 `BundleProvenance` document in §2 is an AICR artifact and remains in scope.
 
-The `ComponentUpgrades` loader proposed by #2343 follows the same pre-use rule
-and reads the version selected by its §2 row and merge order, not a separately
-frozen literal. Catalog authors need a published statement of which binary
+The `ComponentUpgrades` loader proposed by ADR-021 follows the same pre-use rule
+and reads the version selected by its §2 row, not a separately frozen literal.
+Catalog authors need a published statement of which binary
 versions accept which catalog versions. Loud, actionable breakage is the
 intent; silent downgrade is not.
 
@@ -302,10 +334,11 @@ intent; silent downgrade is not.
 - `pkg/header` remains the single source of version strings while package-local
   emitters and readers select versions by wire kind and schema family, following
   the discriminator pattern ADR-015 established.
-- The initial migration spans N through N+2. N stages readers, N+1 switches
-  emitters and committed inputs, and N+2 rejects alpha and empty values. Stored
-  artifacts must be migrated during that interval or read with a retained older
-  binary; authored configs and external catalogs require manual edits.
+- The initial migration spans N through N+2, bound to v0.21, v0.22, and v0.23.
+  N stages readers, N+1 switches emitters and committed inputs, and N+2 rejects
+  alpha and empty values. Stored artifacts must be migrated during that interval
+  or read with a retained older binary; authored configs and external catalogs
+  require manual edits.
 - `AICRConfig` and the profile-bearing kinds ship at beta and are *expected* to
   evolve after v1.0.0, which makes the deprecation channel (#2115) load-bearing.
   Shared fields reachable from a GA artifact cannot break with them.

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -76,15 +76,6 @@ counterpart **wholesale** — to override just `helm.defaultVersion`, copy the
 full embedded entry and change that one field, or the other coordinates
 (repository, chart, scheduling paths) are silently dropped.
 
-During the ADR-022 reader-first release, `ComponentRegistry`, ordinary
-`RecipeMetadata`, and `RecipeMixin` inputs accept `aicr.run/v1alpha2` and the
-target `aicr.run/v1beta1`. Profile-bearing `RecipeMetadata` accepts
-`aicr.run/v1alpha3` and `aicr.run/v1beta2`. AICR validates the raw external
-`registry.yaml` header before merging it with the embedded registry, and checks
-metadata/mixin headers before hydration. Empty, unknown, or wrong-kind AICR
-catalog headers fail with `INVALID_REQUEST`; they are never replaced by an
-embedded header and silently continued.
-
 Overriding a component's `defaultVersion` this way takes effect for every
 embedded overlay that references the component: embedded overlays do not pin
 versions that equal the registry default, so resolution falls back to your
@@ -96,6 +87,55 @@ consumes it never walks `--data` trees, so your external overlays may pin
 freely without declaring anything or rebuilding AICR.) See issue
 [#1616](https://github.com/NVIDIA/aicr/issues/1616) and
 [Chart Version Pinning](recipe-development.md#chart-version-pinning).
+
+## Catalog and binary compatibility
+
+AICR validates every catalog header before it is used, so a catalog authored
+against a binary you are not running fails loudly instead of resolving something
+plausible and wrong. The accepted values per kind, and the releases in which
+they change, are defined by
+[ADR-022](https://github.com/NVIDIA/aicr/blob/main/docs/design/022-artifact-maturity-and-deprecation.md).
+
+Each catalog kind has a current value and a target value:
+
+| Kind | Current | Target |
+|---|---|---|
+| `ComponentRegistry` | `aicr.run/v1alpha2` | `aicr.run/v1beta1` |
+| `RecipeMetadata`, `RecipeMixin` (ordinary) | `aicr.run/v1alpha2` | `aicr.run/v1beta1` |
+| `RecipeMetadata` (profile-bearing) | `aicr.run/v1alpha3` | `aicr.run/v1beta2` |
+| `AICRConfig` (not a catalog file; see [CLI config](../user/cli-config.md)) | `aicr.run/v1alpha2` | `aicr.run/v1beta1` |
+
+Which binary accepts which catalog:
+
+| AICR release | Accepts | Writes and documents |
+|---|---|---|
+| v0.20 and earlier | anything — catalog headers were ungated | current |
+| v0.21 | current and target | current |
+| v0.22 | current and target | target |
+| v0.23 and later | target only | target |
+
+**v0.20 and earlier cannot tell you whether your catalog is compatible.** Those
+releases did not gate catalog headers at all: an external `registry.yaml` whose
+`apiVersion` differed was merged anyway and restamped with the embedded value,
+and `RecipeMetadata` and `RecipeMixin` headers were never checked. So a
+target-stamped catalog does not fail on them — it loads silently and may resolve
+something you did not intend. Closing that fail-open behavior is what ADR-022 §8
+did in v0.21 (issue
+[#1812](https://github.com/NVIDIA/aicr/issues/1812)). Treat v0.20 as unable to
+validate your catalog rather than as a compatibility floor you can rely on.
+
+Switch to the **target** value before v0.23, which stops accepting the current
+one. Catalogs are authored inputs, so this is a manual edit in your tree. AICR
+does not rewrite them, and there is no conversion layer.
+
+Empty, unknown, or wrong-kind AICR catalog headers fail with `INVALID_REQUEST`
+naming the value observed, the values expected for that kind, and the
+remediation. AICR validates the raw external `registry.yaml` header **before**
+merging it with the embedded registry, and checks metadata and mixin headers
+before hydration, so an unaccepted external header is never replaced by an
+embedded one and silently carried forward. Unrelated YAML in the tree keeps its
+existing skip behavior, and `ValidatorCatalog` sits on a separate API domain
+outside this contract.
 
 ## Adding a criteria value
 

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -599,8 +599,12 @@ The shared artifact gate rejects any `apiVersion` outside
 `aicr.run/v1alpha2`, `aicr.run/v1`, `aicr.run/v1alpha3`, and
 `aicr.run/v1beta2` with a 400, on this endpoint as well as on the CLI file-load
 path. An absent or empty `apiVersion` is still admitted as the legacy shape
-during ADR-022 Release N. This is a reader-first window: generated recipes keep
-their alpha headers until the emitter-switch release.
+through v0.22, and v0.23 stops admitting it along with the alpha values. The
+reader and emitter clocks are separate: v0.21 and v0.22 both read the alpha
+values, the target values, and the empty header, while generated recipes keep
+their alpha headers until v0.22 switches the emitters. See
+[Catalog and binary compatibility](../integrator/data-extension.md#catalog-and-binary-compatibility)
+for the release-by-release table.
 
 #### Components
 

--- a/docs/user/cli-config.md
+++ b/docs/user/cli-config.md
@@ -32,7 +32,7 @@ The schema's source of truth is
 
 ```yaml
 kind: AICRConfig               # required, exactly this value
-apiVersion: aicr.run/v1alpha2  # required; v1beta1 is also accepted in Release N
+apiVersion: aicr.run/v1alpha2  # required; v1beta1 also accepted, see below
 metadata:
   name: gke-h100-training      # optional, identifying only
 spec:
@@ -45,9 +45,17 @@ spec:
 
 Each `spec.*` section is optional and each command reads only its own section,
 so a file may carry just one section or any combination. A document with none
-of the five sections is rejected. AICR still writes and documents
-`aicr.run/v1alpha2` during the ADR-022 reader-first release, but the loader also
-accepts the target `aicr.run/v1beta1`; empty and unknown values are rejected.
+of the five sections is rejected.
+
+`AICRConfig` is an authored file, so its `apiVersion` is yours to set. v0.21
+writes and documents `aicr.run/v1alpha2` and the loader also accepts the
+target `aicr.run/v1beta1`; empty and unknown values are rejected. v0.22 switches
+the documented value to the target and v0.23 stops accepting `aicr.run/v1alpha2`,
+so edit your config before upgrading to v0.23. The full release-by-release table
+is in
+[Catalog and binary compatibility](../integrator/data-extension.md#catalog-and-binary-compatibility);
+the policy behind it is
+[ADR-022](https://github.com/NVIDIA/aicr/blob/main/docs/design/022-artifact-maturity-and-deprecation.md).
 
 ## Loading, Precedence, and Secrets
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -1070,17 +1070,24 @@ Validation can be run in different phases to validate different aspects of the d
 >
 > **Version skew:** Snapshots and recipes record the `aicr` version that produced them. When the recipe, the snapshot, and the running binary report different release versions, `validate` logs a single advisory warning (`version skew detected across validate inputs`) naming all three. This is a debugging breadcrumb — mixing artifacts from different versions can surface as confusing failures — and does **not** fail the command. Dev (`dev`) and pre-release (`-next`) builds are ignored to avoid noise.
 >
-> **apiVersion gate:** During the ADR-022 reader-first release, AICR still
+> **apiVersion gate:** During v0.21, the ADR-022 reader-first release, AICR still
 > emits `aicr.run/v1alpha2` for snapshots and default recipes, and
-> `aicr.run/v1alpha3` for profile/configuration recipes. Readers additionally
+> `aicr.run/v1alpha3` for profile-bearing recipes. Readers additionally
 > accept `aicr.run/v1` for snapshots and default recipes,
 > `aicr.run/v1beta1` for config and ordinary catalog inputs, and
 > `aicr.run/v1beta2` for profile-bearing inputs. Unsupported artifact headers
 > fail fast; raw external catalog headers are checked before merge or
 > hydration. Recapture, regenerate, or update the authored header with a
 > version supported by the running AICR release. See
-> [ADR-011](../design/011-artifact-apiversion-policy.md) and
-> [ADR-022](../design/022-artifact-maturity-and-deprecation.md).
+> [ADR-011](https://github.com/NVIDIA/aicr/blob/main/docs/design/011-artifact-apiversion-policy.md)
+> and
+> [ADR-022](https://github.com/NVIDIA/aicr/blob/main/docs/design/022-artifact-maturity-and-deprecation.md). v0.22 switches
+> the emitters to the target values and v0.23 stops accepting the alpha values,
+> along with the empty header that the snapshot, recipe, and criteria readers
+> still tolerate. `AICRConfig` and external catalog headers already reject an
+> empty value, so they have no tolerance to retire.
+> [Catalog and binary compatibility](../integrator/data-extension.md#catalog-and-binary-compatibility)
+> has the release-by-release table.
 
 Phases run sequentially with `--phase all` and all phases run by default, producing results regardless of earlier failures; use `--fail-fast` to stop after the first failing phase. For what each phase actually checks (deployment-phase readiness signals, graceful-skip semantics, RBAC, Day-N re-verification, and evidence), see [Validation](validation.md).
 


### PR DESCRIPTION
## Summary

Drops the `ComponentUpgrades` pre-cut alpha branch from ADR-022 §2 so the kind starts at `aicr.run/v1beta1` unconditionally, binds the §3 migration sequence to concrete releases (v0.21 / v0.22 / v0.23), and publishes the binary-to-artifact compatibility statement ADR-022 §8 requires.

## Motivation / Context

Release N of the ADR-022 staged migration shipped in #2404. Three follow-ups were left implicit:

1. **`ComponentUpgrades` had a two-branch answer** (`v1alpha2` before the cut, `v1beta1` at or after), so whoever implements ADR-021 would have had to reason about merge order to pick a version. That conditional is now unnecessary: Release N already accepts `aicr.run/v1beta1`, so the kind can start at its target without violating §7's rule that a new kind is never stamped with a version the tree does not accept, and with no alpha version to emit and later retire. ADR-021 is aligned to the same value in the same PR so the two ADRs do not contradict each other.

2. **The sequence was abstract.** ADR-022 said "Release N", "N+1", "N+2" with nothing binding those to AICR releases, so neither a maintainer nor a catalog author could tell which binary does what. Now bound to v0.21, v0.22, v0.23 and tracked by #2416 and #2417.

3. **ADR-022 §8 says "Catalog authors need a published statement of which binary versions accept which catalog versions"** and no such statement existed. `docs/user/cli-config.md` and `docs/integrator/data-extension.md` described the accepted set as "Release N", which a catalog author cannot map to a binary.

Fixes: N/A
Related: #2114, #2416, #2417, #1812, #2404

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**New canonical section:** `docs/integrator/data-extension.md#catalog-and-binary-compatibility` carries the per-kind current/target table and the release-by-release accept/emit table. `RELEASING.md`, `docs/user/cli-config.md`, `docs/user/cli-reference.md`, `docs/user/api-reference.md`, and ADR-022 §3 all link to it rather than restating it, so there is one place to update at v0.22 and v0.23.

**§7 was clarified, not changed.** Its `aicr.run/v1alpha2` default for kinds introduced before N+1 still stands; the edit makes explicit that an explicit §2 row overrides it, which is what `ComponentUpgrades` now uses. Added guidance to prefer the override for any new kind whose target track the tree already accepts, since the alpha default only earns its keep when the target does not yet parse.

**`AICRConfig` appears in the catalog table** with a note that it is not a catalog file, because `cli-config.md` links here for the release schedule and a reader should find their kind.

This PR contains no behavior change. Two follow-up PRs complete the v0.21 work: staging the OpenAPI response enums, and splitting the emitter constants along the ADR-022 kind boundaries.

## Testing

```bash
make lint   # go vet, golangci-lint (0 issues), license headers, AGENTS sync,
            # docs filenames, MDX, MDX-parse (54 files), chart-version pins
make test   # PASS, total coverage 84.1% (floor is 80%)
```

Verified every new anchor link resolves to a real heading (`#catalog-and-binary-compatibility`). No Go source changed, so the per-package coverage delta gate does not apply.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Documentation and ADR text only. No emitter, reader, or gate behavior changes in this PR.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
