### PR TITLE
fix(api): stage ADR-022 default-track target in recipe response enums

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -2803,8 +2803,10 @@ components:
         configuration emitted by this release use aicr.run/v1alpha2;
         profile-bearing recipes and recipes carrying
         configuration.slurm.accounting use aicr.run/v1alpha3. The schema also
-        admits the ADR-022 reader-first profile target aicr.run/v1beta2 for
-        bundle request reuse; this release does not emit it.
+        admits both ADR-022 targets, aicr.run/v1 for the default track and
+        aicr.run/v1beta2 for the profile track, so a client generated from this
+        spec tolerates them a release before the emitter switch. This release
+        emits neither.
       allOf:
         - $ref: "#/components/schemas/RecipeResponseBase"
         - type: object
@@ -2812,7 +2814,13 @@ components:
           properties:
             apiVersion:
               type: string
-              enum: [aicr.run/v1alpha2, aicr.run/v1alpha3, aicr.run/v1beta2]
+              enum:
+                [
+                  aicr.run/v1alpha2,
+                  aicr.run/v1alpha3,
+                  aicr.run/v1,
+                  aicr.run/v1beta2,
+                ]
               example: aicr.run/v1alpha2
             kind:
               type: string
@@ -3147,14 +3155,17 @@ components:
       description: >
         Additive legacy recipe shape. Unknown fields remain accepted for
         compatibility, but metadata.selectedProfile is reserved for the
-        profile-bearing schema track.
+        profile-bearing schema track. Narrowed to the default track: this
+        release emits aicr.run/v1alpha2 and the ADR-022 target aicr.run/v1 is
+        admitted ahead of the emitter switch, so /v1 responses never carry a
+        profile-track version.
       allOf:
         - $ref: "#/components/schemas/RecipeResponse"
         - type: object
           properties:
             apiVersion:
               type: string
-              enum: [aicr.run/v1alpha2]
+              enum: [aicr.run/v1alpha2, aicr.run/v1]
             metadata:
               type: object
               not:

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -505,7 +505,11 @@ output.
 
 The `/v1` routes remain the legacy contract. Explicit profile and
 `slurmAccountingMode` input is rejected; Slurm recipes remain implicitly
-disabled and use the `aicr.run/v1alpha2` response shape. `/v1/recipe` and
+disabled and use the default-track response shape. That track is
+`aicr.run/v1alpha2` today, and the schema also admits its ADR-022 target
+`aicr.run/v1` so a client generated from this spec tolerates the value a
+release before AICR emits it. `/v1` never carries a profile-track version.
+`/v1/recipe` and
 `/v1/query` reject a composition after it adopts a profile even when the request
 omits selection, and `/v1/bundle` rejects a profile-bearing body. Migrate a
 converted workflow to v2 as one cut-over.

--- a/pkg/server/openapi_sync_test.go
+++ b/pkg/server/openapi_sync_test.go
@@ -227,11 +227,20 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 		kinds       []string
 	}{
 		{
-			name:        "base response",
-			schema:      spec.Components.Schemas["RecipeResponse"],
-			required:    []string{"apiVersion", "kind"},
-			apiVersions: []string{recipe.RecipeAPIVersion, recipe.ConfiguredRecipeResultAPIVersion, header.GroupVersionV1Beta2},
-			kinds:       []string{recipe.RecipeResultKind},
+			name:     "base response",
+			schema:   spec.Components.Schemas["RecipeResponse"],
+			required: []string{"apiVersion", "kind"},
+			// Both emitted alpha versions plus both ADR-022 targets. The
+			// targets are staged here a release before the emitter switch so
+			// a client generated from this spec does not reject the first
+			// response carrying one.
+			apiVersions: []string{
+				recipe.RecipeAPIVersion,
+				recipe.ConfiguredRecipeResultAPIVersion,
+				header.GroupVersionV1,
+				header.GroupVersionV1Beta2,
+			},
+			kinds: []string{recipe.RecipeResultKind},
 		},
 		{
 			name:        "profile response",
@@ -242,16 +251,26 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 			kinds:       []string{recipe.RecipeResultKind},
 		},
 		{
-			// /v1 responses are pinned to v1alpha2 by LegacyRecipeResponse,
-			// which wraps RecipeResponse and narrows the apiVersion enum.
-			// RecipeResponse itself now also admits v1alpha3 for /v2, so
-			// asserting on it directly would no longer prove v1 stays legacy.
+			// /v1 responses are narrowed to the default track by
+			// LegacyRecipeResponse, which wraps RecipeResponse and drops the
+			// profile-track versions from the apiVersion enum. RecipeResponse
+			// itself also admits v1alpha3 and v1beta2 for /v2, so asserting on
+			// it directly would no longer prove /v1 stays default-track.
 			// required and kind come from the RecipeResponse base and are
 			// checked there; this case owns the narrowing.
-			name:        "versioned response",
-			schema:      spec.Components.Schemas["LegacyRecipeResponse"],
-			baseRef:     "#/components/schemas/RecipeResponse",
-			apiVersions: []string{recipe.RecipeAPIVersion},
+			//
+			// The narrowing is by schema track, not by maturity: the ADR-022
+			// default target belongs here, because /v1 emits it at the
+			// emitter-switch release. Pinning this to v1alpha2 alone would
+			// break /v1 against its own published contract at that release,
+			// and v1alpha2 is retired one release later.
+			name:    "versioned response",
+			schema:  spec.Components.Schemas["LegacyRecipeResponse"],
+			baseRef: "#/components/schemas/RecipeResponse",
+			apiVersions: []string{
+				recipe.RecipeAPIVersion,
+				header.GroupVersionV1,
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the ADR-022 default-track target `aicr.run/v1` to the two recipe **response** `apiVersion` enums in the OpenAPI spec. Release N staged the target into every request enum but left both response enums behind.

## Motivation / Context

ADR-022 §3 stages readers a release ahead of emitters. #2404 applied that to artifact loaders and to the HTTP **request** enums, but not to the response side:

| Schema | Kind | Enum before this PR |
|---|---|---|
| `RecipeCriteria` | request | `[v1alpha2, v1]` |
| `LegacyBundleRecipeV1Request` | request | `["", v1alpha2, v1]` |
| `LegacyBundleRecipeV2Request` | request | `["", v1alpha2, v1]` |
| `ProfileRecipeResponse` | response | `[v1alpha3, v1beta2]` |
| `ConfiguredRecipeResponse` | response | `[v1alpha3, v1beta2]` |
| **`RecipeResponse`** | response | `[v1alpha2, v1alpha3, v1beta2]` — no `aicr.run/v1` |
| **`LegacyRecipeResponse`** | response | `[v1alpha2]` — pinned |

The profile target `v1beta2` was staged into `RecipeResponse`; the default target `v1` was not. An HTTP client is a reader of the response, so reader-first applies to it too. Without this change, the v0.22 emitter switch would have made `/v1/recipe` and `/v2/recipe` return `aicr.run/v1` in violation of their own published contract, breaking spec-validating clients at the flip instead of staging them a release ahead.

Pinning `/v1` to `v1alpha2` permanently was not a durable alternative: v0.23 retires that value, so `/v1` would have been emitting a version the tree no longer accepts.

Fixes: N/A
Related: #2404, #2416, #2114

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**`LegacyRecipeResponse` stays narrowed.** Its purpose is to keep `/v1` on the default schema track, and that still holds: the enum is now `[v1alpha2, v1]`, both default-track. The narrowing is by **schema track**, not by maturity, so `/v1` still never carries `v1alpha3` or `v1beta2`. The test comment explains this so the next person does not "restore" the pin.

**No emitter changes.** This release still emits `aicr.run/v1alpha2` and `aicr.run/v1alpha3`. The spec now describes what v0.22 will emit, one release early, which is the whole point of a reader-first stage. The schema descriptions say so explicitly.

## Testing

```bash
go test ./pkg/server/... -count=1     # ok
make lint                             # golangci-lint 0 issues, yamllint clean, MDX gates pass
make api-diff                         # No incompatible SDK facade changes since v0.20.0
```

Verified the guard is load-bearing rather than trivially satisfied: reverting the `LegacyRecipeResponse` enum to `[aicr.run/v1alpha2]` fails `TestOpenAPIV1BundleRecipeContract/versioned_response` with `apiVersion enum = [aicr.run/v1alpha2], want [aicr.run/v1alpha2 aicr.run/v1]`. Restored before committing.

Only a `_test.go` file changed on the Go side, so package coverage is unchanged and no new exported function was added.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Widening a response enum is additive for clients that validate responses against the spec, and inert for those that do not. No runtime behavior changes: no emitter, handler, or gate is touched.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
