### PR TITLE
refactor(header): give each ADR-022 schema track its own emitter constant

### DIFF
--- a/docs/design/011-artifact-apiversion-policy.md
+++ b/docs/design/011-artifact-apiversion-policy.md
@@ -82,9 +82,15 @@ This ADR establishes the durable, schema-level gate.
 - `header.APIVersionV1Alpha2` = `v1alpha2`
 - `header.GroupVersion` = `aicr.run/v1alpha2`
 
-All package-local constants alias `header.GroupVersion` rather than redeclaring
-the literal: `snapshotter.FullAPIVersion`, `recipe.RecipeAPIVersion`,
-`recipe.RecipeCriteriaAPIVersion`, and `config.APIVersion`.
+All package-local constants alias a `pkg/header` constant rather than
+redeclaring the literal: `snapshotter.FullAPIVersion`,
+`recipe.RecipeResultAPIVersion`, `recipe.RecipeMetadataAPIVersion`,
+`recipe.RecipeCriteriaAPIVersion`, `recipe.ComponentRegistryAPIVersion`,
+`recipe.RecipeProfileAPIVersion`, `localformat.ProvenanceAPIVersion`, and
+`config.APIVersion`. Per the ADR-022 amendment below, each aliases the
+constant for its wire kind's schema track (`header.StableGroupVersion`,
+`header.AuthoringGroupVersion`, or `header.ProfileGroupVersion`) rather than
+`header.GroupVersion` directly.
 
 > **ADR-022 amendment.** `pkg/header` remains the canonical home for
 > the API group, version segments, and complete group/version strings, but the

--- a/docs/design/011-artifact-apiversion-policy.md
+++ b/docs/design/011-artifact-apiversion-policy.md
@@ -86,8 +86,8 @@ All package-local constants alias a `pkg/header` constant rather than
 redeclaring the literal: `snapshotter.FullAPIVersion`,
 `recipe.RecipeResultAPIVersion`, `recipe.RecipeMetadataAPIVersion`,
 `recipe.RecipeCriteriaAPIVersion`, `recipe.ComponentRegistryAPIVersion`,
-`recipe.RecipeProfileAPIVersion`, `localformat.ProvenanceAPIVersion`, and
-`config.APIVersion`. Per the ADR-022 amendment below, each aliases the
+`recipe.RecipeProfileAPIVersion`, `recipe.ConfiguredRecipeResultAPIVersion`,
+`localformat.ProvenanceAPIVersion`, and `config.APIVersion`. Per the ADR-022 amendment below, each aliases the
 constant for its wire kind's schema track (`header.StableGroupVersion`,
 `header.AuthoringGroupVersion`, or `header.ProfileGroupVersion`) rather than
 `header.GroupVersion` directly.

--- a/pkg/bundler/accounting_test.go
+++ b/pkg/bundler/accounting_test.go
@@ -164,7 +164,7 @@ func TestEnforceAccountingOwnershipWarnsForLegacyOverride(t *testing.T) {
 				t.Fatalf("New() error = %v", err)
 			}
 			result := accountingBundlerTestResult(recipe.AccountingModeDisabled)
-			result.APIVersion = recipe.RecipeAPIVersion
+			result.APIVersion = recipe.RecipeResultAPIVersion
 			result.Configuration = nil
 
 			if err := b.enforceAccountingOwnership(result); err != nil {
@@ -513,7 +513,7 @@ func accountingBundlerTestResult(mode recipe.AccountingMode) *recipe.RecipeResul
 	install := mode == recipe.AccountingModeAICRProvided
 	return &recipe.RecipeResult{
 		Kind:       recipe.RecipeResultKind,
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		Criteria:   &recipe.Criteria{Platform: recipe.CriteriaPlatformSlurm},
 		Configuration: &recipe.RecipeConfiguration{
 			Slurm: &recipe.SlurmConfiguration{

--- a/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
+++ b/pkg/bundler/deployer/argocdhelm/argocdhelm_test.go
@@ -507,7 +507,7 @@ func TestGenerate_ProfileLockTemplate(t *testing.T) {
 			t.Fatalf("profile guard stat error = %v", err)
 		}
 
-		result.APIVersion = recipe.RecipeAPIVersion
+		result.APIVersion = recipe.RecipeResultAPIVersion
 		result.Metadata.SelectedProfile = nil
 		if _, err := g.Generate(t.Context(), outputDir); err != nil {
 			t.Fatalf("unprofiled regeneration error = %v", err)

--- a/pkg/bundler/deployer/localformat/provenance.go
+++ b/pkg/bundler/deployer/localformat/provenance.go
@@ -56,13 +56,14 @@ const ProvenanceFileName = "provenance.yaml"
 
 // ProvenanceAPIVersion / ProvenanceKind identify the document shape using
 // AICR's K8s-style convention. Bump the apiVersion when a downstream
-// consumer would need to branch on shape. ADR-022 assigns BundleProvenance a
-// target of aicr.run/v1 while this Release N emitter remains on v1alpha2.
-// Additive fields do not require a bump.
-// The current v1alpha2 segment tracks header.GroupVersion and reflects the
-// aicr.run domain-migration version bump (signal-only, no shape change).
+// consumer would need to branch on shape. Additive fields do not require a
+// bump.
+//
+// BundleProvenance is on the ADR-022 stable artifact track, so this aliases
+// header.StableGroupVersion; the track's target is header.GroupVersionV1 and
+// this Release N emitter still writes v1alpha2.
 const (
-	ProvenanceAPIVersion = header.GroupVersion
+	ProvenanceAPIVersion = header.StableGroupVersion
 	ProvenanceKind       = "BundleProvenance"
 )
 

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -116,7 +116,7 @@ func (p *mutatingValuesProvider) Source(path string) string {
 func newRecipeResultForBundleTest(owner *Client, refs []recipe.ComponentRef, facadeComponents []ComponentRef) *RecipeResult {
 	internal := &recipe.RecipeResult{
 		Kind:          "RecipeResult",
-		APIVersion:    recipe.RecipeAPIVersion,
+		APIVersion:    recipe.RecipeResultAPIVersion,
 		ComponentRefs: refs,
 	}
 	return &RecipeResult{
@@ -1146,7 +1146,7 @@ func TestAdoptRecipe_DeepCopiesForClientIsolation(t *testing.T) {
 	// One caller-owned raw recipe reused across both adopts.
 	input := &recipe.RecipeResult{
 		Kind:       recipe.RecipeResultKind,
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 		ComponentRefs: []recipe.ComponentRef{
 			{Name: "c1", Type: recipe.ComponentTypeHelm, Source: "https://charts.example.com", Chart: "c1", Version: "1.0.0"},
@@ -1425,7 +1425,7 @@ func TestAdoptRecipe_RejectsIncoherentRef(t *testing.T) {
 	base := func(refs []recipe.ComponentRef) *recipe.RecipeResult {
 		return &recipe.RecipeResult{
 			Kind:          recipe.RecipeResultKind,
-			APIVersion:    recipe.RecipeAPIVersion,
+			APIVersion:    recipe.RecipeResultAPIVersion,
 			Criteria:      &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 			ComponentRefs: refs,
 		}
@@ -1503,7 +1503,7 @@ func TestAdoptRecipe_NormalizesKind(t *testing.T) {
 
 			input := &recipe.RecipeResult{
 				Kind:       tt.kind,
-				APIVersion: recipe.RecipeAPIVersion,
+				APIVersion: recipe.RecipeResultAPIVersion,
 				Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 				ComponentRefs: []recipe.ComponentRef{
 					{
@@ -1623,7 +1623,7 @@ func TestAdoptRecipe_BoundsProviderIO(t *testing.T) {
 
 	_, err := c.AdoptRecipe(context.Background(), &recipe.RecipeResult{
 		Kind:       recipe.RecipeResultKind,
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 		ComponentRefs: []recipe.ComponentRef{
 			{
@@ -1667,7 +1667,7 @@ func TestClient_CloseDrainsInflightAdopt(t *testing.T) {
 		defer close(adoptDone)
 		_, _ = c.adoptRecipe(context.Background(), &recipe.RecipeResult{
 			Kind:       recipe.RecipeResultKind,
-			APIVersion: recipe.RecipeAPIVersion,
+			APIVersion: recipe.RecipeResultAPIVersion,
 			Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 			ComponentRefs: []recipe.ComponentRef{
 				{Name: "gpu-operator", Version: "v1"}, // type-less -> forces registry back-fill
@@ -1723,7 +1723,7 @@ func TestAdoptRecipe_RejectsVersionlessHelmRef(t *testing.T) {
 
 	input := &recipe.RecipeResult{
 		Kind:       recipe.RecipeResultKind,
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 		ComponentRefs: []recipe.ComponentRef{
 			{
@@ -1765,7 +1765,7 @@ func TestAdoptRecipe_RejectsVersionlessHelmRef(t *testing.T) {
 	// trims the argument and installs latest).
 	wsInput := &recipe.RecipeResult{
 		Kind:       recipe.RecipeResultKind,
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		Criteria:   &recipe.Criteria{Service: recipe.CriteriaServiceEKS},
 		ComponentRefs: []recipe.ComponentRef{
 			{

--- a/pkg/component/harness_test.go
+++ b/pkg/component/harness_test.go
@@ -143,7 +143,7 @@ func (h *TestHarness) createDefaultRecipe() *recipe.Recipe {
 			},
 		},
 	}
-	r.Init(header.KindRecipe, recipe.RecipeAPIVersion, "test")
+	r.Init(header.KindRecipe, recipe.RecipeResultAPIVersion, "test")
 	return r
 }
 
@@ -223,7 +223,7 @@ func (rb *RecipeBuilder) Build() *recipe.Recipe {
 	r := &recipe.Recipe{
 		Measurements: rb.measurements,
 	}
-	r.Init(header.KindRecipe, recipe.RecipeAPIVersion, "test")
+	r.Init(header.KindRecipe, recipe.RecipeResultAPIVersion, "test")
 	return r
 }
 
@@ -474,7 +474,7 @@ func createStandardTestRecipeResult(componentName string, overrides map[string]a
 
 	return &recipe.RecipeResult{
 		Kind:       "RecipeResult",
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		ComponentRefs: []recipe.ComponentRef{
 			{
 				Name:      componentName,
@@ -497,7 +497,7 @@ func createRecipeResultWithoutComponent(componentName string) *recipe.RecipeResu
 
 	return &recipe.RecipeResult{
 		Kind:       "RecipeResult",
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		ComponentRefs: []recipe.ComponentRef{
 			{
 				Name:    otherName,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,9 +19,11 @@ import "github.com/NVIDIA/aicr/pkg/header"
 // Kind is the kind value for AICRConfig documents.
 const Kind = "AICRConfig"
 
-// APIVersion is the apiVersion for AICRConfig documents. It aliases the
-// canonical header.GroupVersion (single source of truth).
-const APIVersion = header.GroupVersion
+// APIVersion is the apiVersion for AICRConfig documents. AICRConfig is on the
+// ADR-022 authoring and configuration track, so this aliases
+// header.AuthoringGroupVersion; the track's target is
+// header.GroupVersionV1Beta1.
+const APIVersion = header.AuthoringGroupVersion
 
 // AICRConfig is the top-level schema for the --config file accepted by
 // the aicr CLI's snapshot, recipe, bundle, validate, and verify commands.

--- a/pkg/header/adr022_map_test.go
+++ b/pkg/header/adr022_map_test.go
@@ -48,7 +48,16 @@ type adr022Row struct {
 
 // adr022Map mirrors the ADR-022 §2 per-kind maturity map. Every AICR wire kind
 // with an emitter has a row; §7 requires a new kind to add one in the same
-// change that introduces it.
+// change that introduces it. A kind emitted through more than one constant
+// gets a row per constant, or an edit to the unbound one passes unnoticed.
+//
+// Scope: this file pins the *constant* contract — that each track constant
+// routes to the right gate and target. It does not verify that an individual
+// emit site selected the right constant. A catalog emitter that referenced
+// RecipeResultAPIVersion instead of RecipeMetadataAPIVersion is invisible here
+// and stays invisible at the emitter switch, because the stable and authoring
+// constants carry the same string until then. Guarding emitter selection needs
+// a per-artifact round-trip assertion; see issue #2423.
 //
 // ComponentUpgrades (ADR-021) has a §2 row but no emitter yet, so it has no
 // row here. It starts at header.GroupVersionV1Beta1, which
@@ -101,6 +110,18 @@ func adr022Map() []adr022Row {
 		{
 			kind:    "RecipeMetadata, RecipeResult (profile-bearing)",
 			emitted: recipe.RecipeProfileAPIVersion,
+			target:  header.GroupVersionV1Beta2,
+			accepts: header.IsSupportedProfileAPIVersion,
+		},
+		{
+			// Second constant on the same track. A configuration-bearing
+			// RecipeResult is stamped through ConfiguredRecipeResultAPIVersion
+			// (accounting.go, runtimeinventory.go) rather than
+			// RecipeProfileAPIVersion (metadata_store.go), so binding only the
+			// latter would let a future edit repoint this one alone and still
+			// pass every assertion below.
+			kind:    "RecipeResult (configuration-bearing)",
+			emitted: recipe.ConfiguredRecipeResultAPIVersion,
 			target:  header.GroupVersionV1Beta2,
 			accepts: header.IsSupportedProfileAPIVersion,
 		},

--- a/pkg/header/adr022_map_test.go
+++ b/pkg/header/adr022_map_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header_test
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/bundler/deployer/localformat"
+	"github.com/NVIDIA/aicr/pkg/config"
+	"github.com/NVIDIA/aicr/pkg/header"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
+)
+
+// adr022Row is one row of the ADR-022 §2 per-kind maturity map, bound to the
+// constants and read gate the tree actually uses rather than to string
+// literals. A row that disagrees with the map is a contract bug.
+//
+// The emitter constants live in five packages. Nothing previously tied them
+// to the gate that must accept them or to the target they are headed for, so
+// "did we get every emitter?" was answerable only by grep. That is the
+// question the ADR-022 §3 emitter switch turns on, and this table answers it.
+type adr022Row struct {
+	// kind names the row as it appears in the ADR-022 §2 map.
+	kind string
+
+	// emitted is the value this release stamps on the artifact.
+	emitted string
+
+	// target is the §2 target the emitted value becomes at the emitter switch.
+	target string
+
+	// accepts is the kind/schema-scoped read gate guarding this row.
+	accepts func(string) bool
+}
+
+// adr022Map mirrors the ADR-022 §2 per-kind maturity map. Every AICR wire kind
+// with an emitter has a row; §7 requires a new kind to add one in the same
+// change that introduces it.
+//
+// ComponentUpgrades (ADR-021) has a §2 row but no emitter yet, so it has no
+// row here. It starts at header.GroupVersionV1Beta1, which
+// IsSupportedAuthoringAPIVersion already accepts; add a row with its constant
+// when its loader lands.
+func adr022Map() []adr022Row {
+	return []adr022Row{
+		{
+			kind:    "Snapshot",
+			emitted: snapshotter.FullAPIVersion,
+			target:  header.GroupVersionV1,
+			accepts: header.IsSupportedAPIVersion,
+		},
+		{
+			kind:    "RecipeResult (default resolved recipe)",
+			emitted: recipe.RecipeResultAPIVersion,
+			target:  header.GroupVersionV1,
+			accepts: header.IsSupportedAPIVersion,
+		},
+		{
+			kind:    "RecipeCriteria",
+			emitted: recipe.RecipeCriteriaAPIVersion,
+			target:  header.GroupVersionV1,
+			accepts: header.IsSupportedAPIVersion,
+		},
+		{
+			kind:    "BundleProvenance",
+			emitted: localformat.ProvenanceAPIVersion,
+			target:  header.GroupVersionV1,
+			accepts: header.IsSupportedAPIVersion,
+		},
+		{
+			kind:    "AICRConfig",
+			emitted: config.APIVersion,
+			target:  header.GroupVersionV1Beta1,
+			accepts: header.IsSupportedAuthoringAPIVersion,
+		},
+		{
+			kind:    "RecipeMetadata, RecipeMixin (catalog)",
+			emitted: recipe.RecipeMetadataAPIVersion,
+			target:  header.GroupVersionV1Beta1,
+			accepts: header.IsSupportedAuthoringAPIVersion,
+		},
+		{
+			kind:    "ComponentRegistry",
+			emitted: recipe.ComponentRegistryAPIVersion,
+			target:  header.GroupVersionV1Beta1,
+			accepts: header.IsSupportedAuthoringAPIVersion,
+		},
+		{
+			kind:    "RecipeMetadata, RecipeResult (profile-bearing)",
+			emitted: recipe.RecipeProfileAPIVersion,
+			target:  header.GroupVersionV1Beta2,
+			accepts: header.IsSupportedProfileAPIVersion,
+		},
+	}
+}
+
+// TestADR022EmittedValueIsReadable asserts a binary reads what it writes. An
+// emitter pointed at a value its own gate rejects would produce artifacts no
+// AICR release can load, including the one that wrote them.
+func TestADR022EmittedValueIsReadable(t *testing.T) {
+	t.Parallel()
+
+	for _, row := range adr022Map() {
+		t.Run(row.kind, func(t *testing.T) {
+			t.Parallel()
+			if !row.accepts(row.emitted) {
+				t.Errorf("emitted apiVersion %q is rejected by this kind's read gate",
+					row.emitted)
+			}
+		})
+	}
+}
+
+// TestADR022TargetIsReadableBeforeTheEmitterSwitch asserts the ADR-022 §3
+// reader-first invariant: every §2 target parses now, a release before any
+// emitter writes it. Without this a rollback to the current release cannot
+// read artifacts the next release produced.
+func TestADR022TargetIsReadableBeforeTheEmitterSwitch(t *testing.T) {
+	t.Parallel()
+
+	for _, row := range adr022Map() {
+		t.Run(row.kind, func(t *testing.T) {
+			t.Parallel()
+			if !row.accepts(row.target) {
+				t.Errorf("ADR-022 target apiVersion %q is rejected by this kind's read gate; "+
+					"§3 requires readers to accept the target before emitters write it",
+					row.target)
+			}
+		})
+	}
+}
+
+// TestADR022EmittersAreStillOnAlpha pins the migration stage. AICR is in
+// ADR-022 §3 Release N: readers accept both tracks, emitters still write the
+// alpha values.
+//
+// The emitter switch (v0.22, issue #2416) makes this test fail, which is the
+// point — it forces that release to update this table rather than flipping
+// constants and discovering the blast radius in review. When it does, invert
+// this to assert emitted == target and delete the alpha branch.
+func TestADR022EmittersAreStillOnAlpha(t *testing.T) {
+	t.Parallel()
+
+	alpha := map[string]bool{
+		header.GroupVersion:             true,
+		header.RecipeResultGroupVersion: true,
+	}
+
+	for _, row := range adr022Map() {
+		t.Run(row.kind, func(t *testing.T) {
+			t.Parallel()
+			if !alpha[row.emitted] {
+				t.Errorf("emitted apiVersion %q is not an alpha value; if this is the "+
+					"ADR-022 emitter switch, update this test and the migration table "+
+					"in RELEASING.md together", row.emitted)
+			}
+			if row.emitted == row.target {
+				t.Errorf("emitted apiVersion equals the target %q; emitters do not "+
+					"switch until Release N+1", row.target)
+			}
+		})
+	}
+}
+
+// TestADR022TracksShareAlphaButNotTargets is why the stable and authoring
+// emitter constants are separate despite carrying the same string today.
+//
+// header.StableGroupVersion == header.AuthoringGroupVersion during the
+// reader-first release, so a package that aliases either one, or aliases
+// header.GroupVersion directly, looks correct now and silently emits the wrong
+// value at the switch. Snapshot goes to aicr.run/v1 while AICRConfig goes to
+// aicr.run/v1beta1; one shared constant cannot serve both.
+func TestADR022TracksShareAlphaButNotTargets(t *testing.T) {
+	t.Parallel()
+
+	if header.StableGroupVersion != header.AuthoringGroupVersion {
+		t.Fatalf("the tracks have already diverged (stable %q, authoring %q); "+
+			"this test documents the reader-first release and needs updating",
+			header.StableGroupVersion, header.AuthoringGroupVersion)
+	}
+
+	if header.GroupVersionV1 == header.GroupVersionV1Beta1 {
+		t.Errorf("stable and authoring targets are both %q; ADR-022 §2 sends them "+
+			"to different maturities", header.GroupVersionV1)
+	}
+}
+
+// TestADR022RowUsesItsTracksGate asserts each kind is guarded by the gate for
+// its own track, not merely by some gate that happens to accept the alpha
+// value all three share today.
+//
+// Every gate accepts header.GroupVersion during the reader-first release, so a
+// kind wired to the wrong one still reads its own artifacts and looks correct.
+// The targets are what distinguish the tracks, so that is what this checks: a
+// gate must accept its row's target and reject the other two.
+func TestADR022RowUsesItsTracksGate(t *testing.T) {
+	t.Parallel()
+
+	allTargets := []string{
+		header.GroupVersionV1,
+		header.GroupVersionV1Beta1,
+		header.GroupVersionV1Beta2,
+	}
+
+	for _, row := range adr022Map() {
+		t.Run(row.kind, func(t *testing.T) {
+			t.Parallel()
+			for _, target := range allTargets {
+				accepted := row.accepts(target)
+				if target == row.target && !accepted {
+					t.Errorf("gate rejects this row's own target %q", target)
+				}
+				if target != row.target && accepted {
+					t.Errorf("gate accepts %q, which belongs to another track; "+
+						"this row's target is %q, so it is wired to the wrong gate",
+						target, row.target)
+				}
+			}
+		})
+	}
+}
+
+// TestADR022GatesRejectEmptyAndUnknown asserts every gate fails closed. The
+// empty string is rejected here by design: loaders that still tolerate a
+// missing apiVersion special-case it before calling the gate, and ADR-022 §3
+// retires that tolerance at Release N+2 (issue #2417).
+func TestADR022GatesRejectEmptyAndUnknown(t *testing.T) {
+	t.Parallel()
+
+	// aicr.run/v1alpha1 in particular has never been valid on this domain:
+	// ADR-013 moved the version to v1alpha2 at the domain rename, so the
+	// legacy pairing was aicr.nvidia.com/v1alpha1.
+	rejected := []string{
+		"",
+		"aicr.run/v1alpha1",
+		"aicr.run/v1alpha9",
+		"aicr.nvidia.com/v1alpha1",
+		"v1",
+	}
+
+	for _, row := range adr022Map() {
+		t.Run(row.kind, func(t *testing.T) {
+			t.Parallel()
+			for _, version := range rejected {
+				if row.accepts(version) {
+					t.Errorf("read gate accepted %q, want rejected", version)
+				}
+			}
+		})
+	}
+}

--- a/pkg/header/doc.go
+++ b/pkg/header/doc.go
@@ -35,14 +35,19 @@
 // Initialize a header for a recipe via Init:
 //
 //	var h header.Header
-//	h.Init(header.KindRecipe, header.GroupVersion, "v1.0.0")
+//	h.Init(header.KindRecipe, header.StableGroupVersion, "v1.0.0")
 //	// h.Metadata == map[string]string{"timestamp": "...", "version": "v1.0.0"}
+//
+// Recipe and Snapshot are both on the stable artifact track, hence
+// StableGroupVersion. An emitter for an authoring or profile-bearing kind
+// passes AuthoringGroupVersion or ProfileGroupVersion instead; see the API
+// Versioning section below.
 //
 // For reproducible-build callers (SLSA, signed artifacts) inject a fixed
 // timestamp via InitWithTime instead of Init:
 //
 //	var h header.Header
-//	h.InitWithTime(header.KindSnapshot, header.GroupVersion, "v1.0.0", buildTime)
+//	h.InitWithTime(header.KindSnapshot, header.StableGroupVersion, "v1.0.0", buildTime)
 //
 // # Serialization
 //
@@ -99,7 +104,7 @@
 //
 // Init writes the timestamp using RFC3339 format in UTC:
 //
-//	h.Init(header.KindRecipe, header.GroupVersion, "v1.0.0")
+//	h.Init(header.KindRecipe, header.StableGroupVersion, "v1.0.0")
 //	// h.Metadata["timestamp"] == "2025-12-30T10:30:00Z"
 //
 // # Validation

--- a/pkg/header/doc.go
+++ b/pkg/header/doc.go
@@ -38,10 +38,12 @@
 //	h.Init(header.KindRecipe, header.StableGroupVersion, "v1.0.0")
 //	// h.Metadata == map[string]string{"timestamp": "...", "version": "v1.0.0"}
 //
-// Recipe and Snapshot are both on the stable artifact track, hence
-// StableGroupVersion. An emitter for an authoring or profile-bearing kind
-// passes AuthoringGroupVersion or ProfileGroupVersion instead; see the API
-// Versioning section below.
+// The resolved RecipeResult shown here and Snapshot are both on the stable
+// artifact track, hence StableGroupVersion. An authored catalog RecipeMetadata
+// is colloquially a "recipe" too but sits on the authoring track, and a
+// profile-bearing artifact on its own track, so those emitters pass
+// AuthoringGroupVersion or ProfileGroupVersion instead; see the API Versioning
+// section below.
 //
 // For reproducible-build callers (SLSA, signed artifacts) inject a fixed
 // timestamp via InitWithTime instead of Init:

--- a/pkg/header/doc.go
+++ b/pkg/header/doc.go
@@ -59,11 +59,16 @@
 //
 // # API Versioning
 //
-// The APIVersion field enables evolution of data formats. GroupVersion remains
-// the Release N alpha emitter value for general artifacts; target versions and
-// kind/schema-scoped gates are defined alongside it. APIGroup derives from
-// Domain. Per ADR-013 the move from the legacy aicr.nvidia.com/v1alpha1 group
-// was a hard break — the old value is rejected, not migrated.
+// The APIVersion field enables evolution of data formats. APIGroup derives
+// from Domain. Per ADR-013 the move from the legacy aicr.nvidia.com/v1alpha1
+// group was a hard break — the old value is rejected, not migrated.
+//
+// ADR-022 splits artifacts across three schema tracks. An emitter aliases the
+// constant for its track — StableGroupVersion, AuthoringGroupVersion, or
+// ProfileGroupVersion — never GroupVersion directly. The first two carry the
+// same string during the reader-first release and diverge at the emitter
+// switch, so aliasing by value rather than by track compiles and passes tests
+// today while emitting the wrong version later.
 //
 // Callers should select the gate for the artifact's schema track rather than
 // comparing literals, so the single source of truth in this package stays

--- a/pkg/header/doc.go
+++ b/pkg/header/doc.go
@@ -38,12 +38,13 @@
 //	h.Init(header.KindRecipe, header.StableGroupVersion, "v1.0.0")
 //	// h.Metadata == map[string]string{"timestamp": "...", "version": "v1.0.0"}
 //
-// The resolved RecipeResult shown here and Snapshot are both on the stable
-// artifact track, hence StableGroupVersion. An authored catalog RecipeMetadata
-// is colloquially a "recipe" too but sits on the authoring track, and a
-// profile-bearing artifact on its own track, so those emitters pass
-// AuthoringGroupVersion or ProfileGroupVersion instead; see the API Versioning
-// section below.
+// KindRecipe shown here is the legacy input kind, distinct from
+// KindRecipeResult and normalized to it per ADR-022 §2; both sit on the stable
+// artifact track alongside Snapshot, hence StableGroupVersion. An authored
+// catalog RecipeMetadata is colloquially a "recipe" too but sits on the
+// authoring track, and a profile-bearing artifact on its own track, so those
+// emitters pass AuthoringGroupVersion or ProfileGroupVersion instead; see the
+// API Versioning section below.
 //
 // For reproducible-build callers (SLSA, signed artifacts) inject a fixed
 // timestamp via InitWithTime instead of Init:

--- a/pkg/header/header.go
+++ b/pkg/header/header.go
@@ -22,6 +22,15 @@ import (
 // truth for every AICR artifact group/version. Package-local emitters and
 // readers select a version by wire kind and schema track; see ADR-022.
 //
+// Three tracks exist. StableGroupVersion, AuthoringGroupVersion, and
+// ProfileGroupVersion name the value each track emits today; GroupVersionV1,
+// GroupVersionV1Beta1, and GroupVersionV1Beta2 name where each is headed.
+// StableGroupVersion and AuthoringGroupVersion carry the same string during
+// the reader-first release and diverge at the emitter switch, so a package
+// emitter must alias the constant for its track rather than the string it
+// happens to equal. Aliasing GroupVersion directly is what made the switch a
+// refactor instead of an edit.
+//
 // Evolution policy (see docs/design/011-artifact-apiversion-policy.md and
 // docs/design/022-artifact-maturity-and-deprecation.md): schema changes within
 // a version must be additive-only; a breaking change requires a new version
@@ -63,6 +72,21 @@ const (
 
 	// RecipeResultGroupVersion is the current configured RecipeResult schema.
 	RecipeResultGroupVersion = APIGroup + "/" + APIVersionV1Alpha3
+
+	// StableGroupVersion is the value emitted for the ADR-022 stable artifact
+	// track: Snapshot, the default RecipeResult, RecipeCriteria, and
+	// BundleProvenance. Its §2 target is GroupVersionV1.
+	StableGroupVersion = GroupVersion
+
+	// AuthoringGroupVersion is the value emitted for the ADR-022 authoring and
+	// configuration track: AICRConfig, ordinary RecipeMetadata, RecipeMixin,
+	// and ComponentRegistry. Its §2 target is GroupVersionV1Beta1.
+	AuthoringGroupVersion = GroupVersion
+
+	// ProfileGroupVersion is the value emitted for the ADR-022 profile-bearing
+	// track: profile RecipeMetadata and RecipeResult. Its §2 target is
+	// GroupVersionV1Beta2.
+	ProfileGroupVersion = RecipeResultGroupVersion
 
 	// GroupVersionV1Beta1 is the target authoring/configuration group/version.
 	GroupVersionV1Beta1 = APIGroup + "/" + APIVersionV1Beta1

--- a/pkg/oci/push_test.go
+++ b/pkg/oci/push_test.go
@@ -441,7 +441,7 @@ func TestOCIPackagingIntegration(t *testing.T) {
 	// (RecipeResult is required because bundlers use GetComponentRef)
 	rec := &recipe.RecipeResult{
 		Kind:       "RecipeResult",
-		APIVersion: recipe.RecipeAPIVersion,
+		APIVersion: recipe.RecipeResultAPIVersion,
 		ComponentRefs: []recipe.ComponentRef{
 			{
 				Name:       "cert-manager",

--- a/pkg/recipe/accounting_test.go
+++ b/pkg/recipe/accounting_test.go
@@ -193,8 +193,8 @@ func TestApplyBuildConfigRejectsProfileAccountingOwnershipOverlap(t *testing.T) 
 				if result.Configuration != nil {
 					t.Fatal("applyBuildConfig() mutated configuration before rejecting ownership overlap")
 				}
-				if result.APIVersion != RecipeAPIVersion {
-					t.Fatalf("apiVersion = %q after rejection, want %q", result.APIVersion, RecipeAPIVersion)
+				if result.APIVersion != RecipeResultAPIVersion {
+					t.Fatalf("apiVersion = %q after rejection, want %q", result.APIVersion, RecipeResultAPIVersion)
 				}
 			}
 		})
@@ -515,7 +515,7 @@ func TestBuilderDeploymentOrderMatchesEnabledComponents(t *testing.T) {
 func accountingTestResult() *RecipeResult {
 	return &RecipeResult{
 		Kind:       RecipeResultKind,
-		APIVersion: RecipeAPIVersion,
+		APIVersion: RecipeResultAPIVersion,
 		Criteria:   &Criteria{Platform: CriteriaPlatformSlurm},
 		ComponentRefs: []ComponentRef{
 			{

--- a/pkg/recipe/adapter_test.go
+++ b/pkg/recipe/adapter_test.go
@@ -885,7 +885,7 @@ func TestWithResolvedValues(t *testing.T) {
 	newResult := func() *RecipeResult {
 		return &RecipeResult{
 			Kind:       "RecipeResult",
-			APIVersion: RecipeAPIVersion,
+			APIVersion: RecipeResultAPIVersion,
 			ComponentRefs: []ComponentRef{
 				{Name: "pinned", Type: ComponentTypeHelm, Overrides: map[string]any{"from": "provider"}},
 				{Name: "unpinned", Type: ComponentTypeHelm, Overrides: map[string]any{"from": "provider"}},

--- a/pkg/recipe/builder_test.go
+++ b/pkg/recipe/builder_test.go
@@ -248,8 +248,8 @@ func TestBuilder_BuildFromCriteriaWithEvaluator(t *testing.T) {
 			if result.Kind != RecipeResultKind {
 				t.Errorf("expected kind %s, got %q", RecipeResultKind, result.Kind)
 			}
-			if result.APIVersion != RecipeAPIVersion {
-				t.Errorf("expected apiVersion %s, got %q", RecipeAPIVersion, result.APIVersion)
+			if result.APIVersion != RecipeResultAPIVersion {
+				t.Errorf("expected apiVersion %s, got %q", RecipeResultAPIVersion, result.APIVersion)
 			}
 		})
 	}

--- a/pkg/recipe/components.go
+++ b/pkg/recipe/components.go
@@ -29,6 +29,12 @@ import (
 // ComponentRegistryKind is the wire kind for component registry documents.
 const ComponentRegistryKind = "ComponentRegistry"
 
+// ComponentRegistryAPIVersion is the apiVersion expected on a registry.yaml.
+// ComponentRegistry is on the ADR-022 authoring track, so this aliases
+// header.AuthoringGroupVersion; the track's target is
+// header.GroupVersionV1Beta1.
+const ComponentRegistryAPIVersion = header.AuthoringGroupVersion
+
 // ComponentRegistry holds the declarative configuration for all components.
 // This is loaded from embedded recipe data (recipes/registry.yaml) at startup.
 type ComponentRegistry struct {
@@ -478,7 +484,7 @@ func validateComponentRegistryHeader(registry *ComponentRegistry, source string)
 	if !header.IsSupportedAuthoringAPIVersion(registry.APIVersion) {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("%s has apiVersion %q, expected %q or %q for %s; update the registry header for this aicr release",
-				source, registry.APIVersion, RecipeAPIVersion, header.GroupVersionV1Beta1, ComponentRegistryKind))
+				source, registry.APIVersion, ComponentRegistryAPIVersion, header.GroupVersionV1Beta1, ComponentRegistryKind))
 	}
 	return nil
 }

--- a/pkg/recipe/components_test.go
+++ b/pkg/recipe/components_test.go
@@ -1225,11 +1225,11 @@ func TestLoadComponentRegistry_ReleaseNHeaders(t *testing.T) {
 		kind       string
 		wantErr    bool
 	}{
-		{name: "current alpha", apiVersion: RecipeAPIVersion, kind: ComponentRegistryKind},
+		{name: "current alpha", apiVersion: ComponentRegistryAPIVersion, kind: ComponentRegistryKind},
 		{name: "target beta", apiVersion: "aicr.run/v1beta1", kind: ComponentRegistryKind},
 		{name: "empty version", apiVersion: "", kind: ComponentRegistryKind, wantErr: true},
 		{name: "unknown version", apiVersion: "aicr.run/v9", kind: ComponentRegistryKind, wantErr: true},
-		{name: "wrong kind", apiVersion: RecipeAPIVersion, kind: "RecipeMetadata", wantErr: true},
+		{name: "wrong kind", apiVersion: ComponentRegistryAPIVersion, kind: "RecipeMetadata", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/recipe/constraint_paths_test.go
+++ b/pkg/recipe/constraint_paths_test.go
@@ -281,7 +281,7 @@ func TestPrepareAndValidate_RejectsBadConstraintPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			rec := &RecipeResult{Kind: RecipeResultKind, APIVersion: RecipeAPIVersion}
+			rec := &RecipeResult{Kind: RecipeResultKind, APIVersion: RecipeResultAPIVersion}
 			tt.mutate(rec)
 
 			// The exported entry point carries no source, so no file prefix.

--- a/pkg/recipe/criteria.go
+++ b/pkg/recipe/criteria.go
@@ -795,9 +795,10 @@ func ParseCriteriaFromValues(values url.Values, reg *CriteriaRegistry) (*Criteri
 const RecipeCriteriaKind = "RecipeCriteria"
 
 // RecipeCriteriaAPIVersion is the API version for RecipeCriteria resources.
-// It aliases RecipeAPIVersion (ultimately header.GroupVersion) so every AICR
-// artifact apiVersion has a single source of truth.
-const RecipeCriteriaAPIVersion = RecipeAPIVersion
+// RecipeCriteria is on the ADR-022 stable artifact track, so this aliases
+// header.StableGroupVersion directly rather than chaining through a recipe
+// constant; the track's target is header.GroupVersionV1.
+const RecipeCriteriaAPIVersion = header.StableGroupVersion
 
 func validateRecipeCriteriaHeader(kind, apiVersion string) error {
 	if kind != "" && kind != RecipeCriteriaKind {

--- a/pkg/recipe/loader.go
+++ b/pkg/recipe/loader.go
@@ -211,7 +211,7 @@ func validateRecipeInputAPIVersion(kind, apiVersion string) error {
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("recipe metadata file has apiVersion %q, which this aicr build does not support (expected %q, %q, %q, or %q); "+
 				"update the catalog header for this aicr release",
-				apiVersion, RecipeAPIVersion, header.GroupVersionV1Beta1,
+				apiVersion, RecipeMetadataAPIVersion, header.GroupVersionV1Beta1,
 				RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
 	}
 
@@ -221,7 +221,7 @@ func validateRecipeInputAPIVersion(kind, apiVersion string) error {
 	return errors.New(errors.ErrCodeInvalidRequest,
 		fmt.Sprintf("recipe file has apiVersion %q, which this aicr build does not support (expected %q, %q, %q, or %q); "+
 			"regenerate the recipe with a matching aicr version",
-			apiVersion, RecipeAPIVersion, header.GroupVersionV1,
+			apiVersion, RecipeResultAPIVersion, header.GroupVersionV1,
 			RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
 }
 

--- a/pkg/recipe/metadata.go
+++ b/pkg/recipe/metadata.go
@@ -36,13 +36,26 @@ const RecipeMetadataKind = "RecipeMetadata"
 // RecipeResultKind is the kind value for RecipeResult resources.
 const RecipeResultKind = "RecipeResult"
 
-// RecipeAPIVersion is the API version for recipe metadata and result resources.
-// It aliases the canonical header.GroupVersion (single source of truth).
-const RecipeAPIVersion = header.GroupVersion
+// RecipeResultAPIVersion is the API version stamped on a default resolved
+// RecipeResult. RecipeResult is on the ADR-022 stable artifact track, so this
+// aliases header.StableGroupVersion; the track's target is
+// header.GroupVersionV1.
+const RecipeResultAPIVersion = header.StableGroupVersion
+
+// RecipeMetadataAPIVersion is the API version expected on an authored catalog
+// RecipeMetadata or RecipeMixin. Those are on the ADR-022 authoring track, so
+// this aliases header.AuthoringGroupVersion; the track's target is
+// header.GroupVersionV1Beta1.
+//
+// This is deliberately a separate constant from RecipeResultAPIVersion even
+// though both carry aicr.run/v1alpha2 today: ADR-022 sends the two kinds to
+// different targets, so a single shared constant could not be flipped.
+const RecipeMetadataAPIVersion = header.AuthoringGroupVersion
 
 // ConfiguredRecipeResultAPIVersion is the strict RecipeResult schema used
-// when typed desired-state configuration is present.
-const ConfiguredRecipeResultAPIVersion = header.RecipeResultGroupVersion
+// when typed desired-state configuration is present. It is on the ADR-022
+// profile-bearing track; the track's target is header.GroupVersionV1Beta2.
+const ConfiguredRecipeResultAPIVersion = header.ProfileGroupVersion
 
 // GPUDriverState values recorded in RecipeResult.Metadata.GPUDriverState
 // by snapshot-driven resolution (see pkg/client/v1 gpu_driver_state.go).

--- a/pkg/recipe/metadata_store.go
+++ b/pkg/recipe/metadata_store.go
@@ -413,7 +413,7 @@ func validateRecipeMixinCatalogHeader(kind, apiVersion, path string) error {
 	if !header.IsSupportedAuthoringAPIVersion(apiVersion) {
 		return aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
 			fmt.Sprintf("mixin file %s has apiVersion %q, expected %q or %q for %s; update the catalog header for this aicr release",
-				path, apiVersion, RecipeAPIVersion, header.GroupVersionV1Beta1, RecipeMixinKind))
+				path, apiVersion, RecipeMetadataAPIVersion, header.GroupVersionV1Beta1, RecipeMixinKind))
 	}
 	return nil
 }
@@ -439,7 +439,7 @@ func classifyRecipeMetadataCatalogHeader(
 	if !profileVersion && !header.IsSupportedAuthoringAPIVersion(metadata.APIVersion) {
 		return false, false, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest,
 			fmt.Sprintf("RecipeMetadata file %s has apiVersion %q, expected %q, %q, %q, or %q; update the catalog header for this aicr release",
-				path, metadata.APIVersion, RecipeAPIVersion, header.GroupVersionV1Beta1,
+				path, metadata.APIVersion, RecipeMetadataAPIVersion, header.GroupVersionV1Beta1,
 				RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
 	}
 	return true, profileVersion, nil
@@ -1017,7 +1017,7 @@ func finalizeRecipeResult(provider DataProvider, criteria *Criteria, mergedSpec 
 
 	result := &RecipeResult{
 		Kind:            RecipeResultKind,
-		APIVersion:      RecipeAPIVersion,
+		APIVersion:      RecipeResultAPIVersion,
 		Criteria:        criteria,
 		Constraints:     mergedSpec.Constraints,
 		ComponentRefs:   mergedSpec.ComponentRefs,

--- a/pkg/recipe/metadata_store_test.go
+++ b/pkg/recipe/metadata_store_test.go
@@ -1731,7 +1731,7 @@ func TestMixinConstraintFailureExcludesOnlyAffectedCandidateChain(t *testing.T) 
 		Mixins: map[string]*RecipeMixin{
 			"kernel-gate": {
 				Kind:       RecipeMixinKind,
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeMetadataAPIVersion,
 				Metadata: struct {
 					Name string `json:"name" yaml:"name"`
 				}{
@@ -1748,7 +1748,7 @@ func TestMixinConstraintFailureExcludesOnlyAffectedCandidateChain(t *testing.T) 
 			},
 			"monitoring-gate": {
 				Kind:       RecipeMixinKind,
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeMetadataAPIVersion,
 				Metadata: struct {
 					Name string `json:"name" yaml:"name"`
 				}{
@@ -1918,7 +1918,7 @@ func TestMixinConstraintFailurePreservesSharedAncestorsForSurvivingLeaf(t *testi
 		Mixins: map[string]*RecipeMixin{
 			"failing-mixin": {
 				Kind:       RecipeMixinKind,
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeMetadataAPIVersion,
 				Metadata: struct {
 					Name string `json:"name" yaml:"name"`
 				}{Name: "failing-mixin"},
@@ -1931,7 +1931,7 @@ func TestMixinConstraintFailurePreservesSharedAncestorsForSurvivingLeaf(t *testi
 			},
 			"passing-mixin": {
 				Kind:       RecipeMixinKind,
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeMetadataAPIVersion,
 				Metadata: struct {
 					Name string `json:"name" yaml:"name"`
 				}{Name: "passing-mixin"},
@@ -2073,7 +2073,7 @@ func TestMixinConstraintFailureDegradesForUnstatedDimension(t *testing.T) {
 		Mixins: map[string]*RecipeMixin{
 			"monitoring-gate": {
 				Kind:       RecipeMixinKind,
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeMetadataAPIVersion,
 				Metadata: struct {
 					Name string `json:"name" yaml:"name"`
 				}{Name: "monitoring-gate"},
@@ -2173,7 +2173,7 @@ func TestMixinConstraintFailClosedOnInternalEvaluatorError(t *testing.T) {
 		Mixins: map[string]*RecipeMixin{
 			"os-gate": {
 				Kind:       RecipeMixinKind,
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeMetadataAPIVersion,
 				Metadata: struct {
 					Name string `json:"name" yaml:"name"`
 				}{Name: "os-gate"},
@@ -2238,7 +2238,7 @@ func TestMixinConstraintFailClosedOnUnstructuredEvaluatorError(t *testing.T) {
 		Mixins: map[string]*RecipeMixin{
 			"os-gate": {
 				Kind:       RecipeMixinKind,
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeMetadataAPIVersion,
 				Metadata: struct {
 					Name string `json:"name" yaml:"name"`
 				}{Name: "os-gate"},

--- a/pkg/recipe/profile.go
+++ b/pkg/recipe/profile.go
@@ -33,10 +33,12 @@ import (
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
-// RecipeProfileAPIVersion is the Release N emitter version for RecipeMetadata
-// and RecipeResult when a configuration profile is present. Readers also
-// accept the target profile version through header.IsSupportedProfileAPIVersion.
-const RecipeProfileAPIVersion = header.RecipeResultGroupVersion
+// RecipeProfileAPIVersion is the emitter version for RecipeMetadata and
+// RecipeResult when a configuration profile is present. These are on the
+// ADR-022 profile-bearing track, so this aliases header.ProfileGroupVersion;
+// the track's target is header.GroupVersionV1Beta2, which readers already
+// accept through header.IsSupportedProfileAPIVersion.
+const RecipeProfileAPIVersion = header.ProfileGroupVersion
 
 const (
 	profileComponentEnabledPath = "enabled"
@@ -594,7 +596,7 @@ func (r *RecipeResult) ValidateProfileContract() error {
 	default:
 		return errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("recipe has unsupported apiVersion %q; expected %q, %q, %q, or %q",
-				r.APIVersion, RecipeAPIVersion, header.GroupVersionV1,
+				r.APIVersion, RecipeResultAPIVersion, header.GroupVersionV1,
 				RecipeProfileAPIVersion, header.GroupVersionV1Beta2))
 	}
 

--- a/pkg/recipe/profile_aks_test.go
+++ b/pkg/recipe/profile_aks_test.go
@@ -251,7 +251,7 @@ func TestAKSDefaultKeepsPreProfileEffectiveValues(t *testing.T) {
 		t.Fatal("embedded catalog is missing the aks overlay")
 	}
 	aksOverlay.Spec.Profile = nil
-	aksOverlay.APIVersion = RecipeAPIVersion
+	aksOverlay.APIVersion = RecipeMetadataAPIVersion
 
 	profiled, err := profiledStore.BuildRecipeResult(ctx, aksCriteria())
 	if err != nil {
@@ -384,7 +384,7 @@ func TestAKSLegacyExternalShadowStaysUnprofiled(t *testing.T) {
 	if unmarshalErr := yaml.Unmarshal(embeddedAKS, &doc); unmarshalErr != nil {
 		t.Fatalf("parse embedded aks overlay: %v", unmarshalErr)
 	}
-	doc["apiVersion"] = RecipeAPIVersion
+	doc["apiVersion"] = RecipeMetadataAPIVersion
 	spec, ok := doc["spec"].(map[string]any)
 	if !ok {
 		t.Fatalf("embedded aks overlay spec = %T, want map", doc["spec"])
@@ -445,8 +445,8 @@ func TestAKSLegacyExternalShadowStaysUnprofiled(t *testing.T) {
 		t.Fatalf("aks overlay still declares a profile (%#v); external shadow did not replace it",
 			aksOverlay.Spec.Profile)
 	}
-	if aksOverlay.APIVersion != RecipeAPIVersion {
-		t.Fatalf("aks overlay apiVersion = %q, want legacy %q", aksOverlay.APIVersion, RecipeAPIVersion)
+	if aksOverlay.APIVersion != RecipeMetadataAPIVersion {
+		t.Fatalf("aks overlay apiVersion = %q, want legacy %q", aksOverlay.APIVersion, RecipeMetadataAPIVersion)
 	}
 
 	result, err := store.BuildRecipeResult(ctx, aksCriteria())
@@ -458,8 +458,8 @@ func TestAKSLegacyExternalShadowStaysUnprofiled(t *testing.T) {
 		t.Fatalf("selectedProfile = %#v, want nil (unprofiled legacy shadow)",
 			result.Metadata.SelectedProfile)
 	}
-	if result.APIVersion != RecipeAPIVersion {
-		t.Fatalf("apiVersion = %q, want legacy %q", result.APIVersion, RecipeAPIVersion)
+	if result.APIVersion != RecipeResultAPIVersion {
+		t.Fatalf("apiVersion = %q, want legacy %q", result.APIVersion, RecipeResultAPIVersion)
 	}
 	for _, c := range result.Constraints {
 		if c.Name == "K8s.aks-gpu-pools.gpu-driver" {

--- a/pkg/recipe/profile_integration_test.go
+++ b/pkg/recipe/profile_integration_test.go
@@ -258,8 +258,8 @@ func TestUnprofiledCriteriaStayLegacy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildFromCriteria() error = %v", err)
 	}
-	if result.APIVersion != RecipeAPIVersion {
-		t.Fatalf("apiVersion = %q, want %q", result.APIVersion, RecipeAPIVersion)
+	if result.APIVersion != RecipeResultAPIVersion {
+		t.Fatalf("apiVersion = %q, want %q", result.APIVersion, RecipeResultAPIVersion)
 	}
 	if result.Metadata.SelectedProfile != nil {
 		t.Fatalf("selectedProfile = %#v, want nil for an unprofiled composition",

--- a/pkg/recipe/profile_test.go
+++ b/pkg/recipe/profile_test.go
@@ -587,7 +587,7 @@ func TestBuildRecipeResultWithProfile(t *testing.T) {
 
 	t.Run("selection without declaration fails", func(t *testing.T) {
 		legacy := testProfileStore(nil)
-		legacy.Overlays["aks"].APIVersion = RecipeAPIVersion
+		legacy.Overlays["aks"].APIVersion = RecipeMetadataAPIVersion
 		result, err := legacy.BuildRecipeResultWithProfile(ctx, criteria, "gpuStack=operator-managed")
 		if err == nil || result != nil {
 			t.Fatalf("BuildRecipeResultWithProfile() = (%#v, %v), want error", result, err)
@@ -596,12 +596,12 @@ func TestBuildRecipeResultWithProfile(t *testing.T) {
 
 	t.Run("composition without declaration stays legacy", func(t *testing.T) {
 		legacy := testProfileStore(nil)
-		legacy.Overlays["aks"].APIVersion = RecipeAPIVersion
+		legacy.Overlays["aks"].APIVersion = RecipeMetadataAPIVersion
 		result, err := legacy.BuildRecipeResult(ctx, criteria)
 		if err != nil {
 			t.Fatalf("BuildRecipeResult() error = %v", err)
 		}
-		if result.APIVersion != RecipeAPIVersion || result.Metadata.SelectedProfile != nil {
+		if result.APIVersion != RecipeResultAPIVersion || result.Metadata.SelectedProfile != nil {
 			t.Fatalf("legacy result apiVersion=%q selectedProfile=%#v",
 				result.APIVersion, result.Metadata.SelectedProfile)
 		}
@@ -626,7 +626,7 @@ func TestProfileResolutionGuards(t *testing.T) {
 
 	t.Run("typed declaration requires profile api version", func(t *testing.T) {
 		overlay := newOverlay("service", &Criteria{Service: CriteriaServiceAKS}, testProfileDeclaration())
-		overlay.APIVersion = RecipeAPIVersion
+		overlay.APIVersion = RecipeMetadataAPIVersion
 		store := &MetadataStore{
 			Base:     base,
 			Overlays: map[string]*RecipeMetadata{"service": overlay},
@@ -826,7 +826,7 @@ func TestProfileArtifactContract(t *testing.T) {
 		result  *RecipeResult
 		wantErr string
 	}{
-		{name: "legacy", result: &RecipeResult{APIVersion: RecipeAPIVersion}},
+		{name: "legacy", result: &RecipeResult{APIVersion: RecipeResultAPIVersion}},
 		{name: "Release N target default", result: &RecipeResult{APIVersion: header.GroupVersionV1}},
 		{
 			name: "profile",
@@ -917,7 +917,7 @@ func TestProfileArtifactContract(t *testing.T) {
 		{
 			name: "legacy with selection",
 			result: &RecipeResult{
-				APIVersion: RecipeAPIVersion,
+				APIVersion: RecipeResultAPIVersion,
 				Metadata:   RecipeResultMetadata{SelectedProfile: selected},
 			},
 			wantErr: "cannot carry",
@@ -1184,7 +1184,7 @@ componentRefs: []
 		},
 		{
 			name:    "legacy version with selected profile",
-			data:    []byte(strings.Replace(string(valid), RecipeProfileAPIVersion, RecipeAPIVersion, 1)),
+			data:    []byte(strings.Replace(string(valid), RecipeProfileAPIVersion, RecipeResultAPIVersion, 1)),
 			wantErr: "cannot carry",
 		},
 	}
@@ -1358,7 +1358,7 @@ spec:
 		content []byte
 		wantErr string
 	}{
-		{name: "legacy without profile", content: overlay(RecipeAPIVersion, "")},
+		{name: "legacy without profile", content: overlay(RecipeMetadataAPIVersion, "")},
 		{name: "target authoring without profile", content: overlay(header.GroupVersionV1Beta1, "")},
 		{name: "empty version without profile", content: overlay("", ""), wantErr: `apiVersion ""`},
 		{name: "unknown version without profile", content: overlay("aicr.run/v99", ""), wantErr: `apiVersion "aicr.run/v99"`},
@@ -1387,7 +1387,7 @@ spec:
 		},
 		{
 			name:    "legacy version with declaration",
-			content: overlay(RecipeAPIVersion, validProfile),
+			content: overlay(RecipeMetadataAPIVersion, validProfile),
 			wantErr: "expected \"aicr.run/v1alpha3\"",
 		},
 		{

--- a/pkg/recipe/provider_test.go
+++ b/pkg/recipe/provider_test.go
@@ -170,9 +170,9 @@ func TestLayeredDataProvider_ValidatesRawExternalRegistryBeforeMerge(t *testing.
 			if err := yaml.Unmarshal(data, &merged); err != nil {
 				t.Fatalf("unmarshal merged registry: %v", err)
 			}
-			if merged.APIVersion != RecipeAPIVersion {
+			if merged.APIVersion != ComponentRegistryAPIVersion {
 				t.Errorf("merged registry apiVersion = %q, want current emitter %q",
-					merged.APIVersion, RecipeAPIVersion)
+					merged.APIVersion, ComponentRegistryAPIVersion)
 			}
 		})
 	}

--- a/pkg/recipe/yaml_test.go
+++ b/pkg/recipe/yaml_test.go
@@ -123,7 +123,7 @@ func TestAllMetadataFilesHaveRequiredFields(t *testing.T) {
 				t.Errorf("invalid kind: got %q, want %q", metadata.Kind, RecipeMetadataKind)
 			}
 			switch metadata.APIVersion {
-			case RecipeAPIVersion:
+			case RecipeMetadataAPIVersion:
 				if metadata.Spec.Profile != nil {
 					t.Errorf("overlay declares a profile but keeps apiVersion %q; want %q",
 						metadata.APIVersion, RecipeProfileAPIVersion)
@@ -134,7 +134,7 @@ func TestAllMetadataFilesHaveRequiredFields(t *testing.T) {
 				}
 			default:
 				t.Errorf("invalid apiVersion: got %q, want %q or %q",
-					metadata.APIVersion, RecipeAPIVersion, RecipeProfileAPIVersion)
+					metadata.APIVersion, RecipeMetadataAPIVersion, RecipeProfileAPIVersion)
 			}
 		})
 	}

--- a/pkg/server/bundle_handler_test.go
+++ b/pkg/server/bundle_handler_test.go
@@ -758,8 +758,8 @@ func TestBundleHandler_LegacyRecipeHeaders(t *testing.T) {
 	if got := fixture["kind"]; got != recipe.RecipeResultKind {
 		t.Fatalf("fixture kind = %v, want %q", got, recipe.RecipeResultKind)
 	}
-	if got := fixture["apiVersion"]; got != recipe.RecipeAPIVersion {
-		t.Fatalf("fixture apiVersion = %v, want %q", got, recipe.RecipeAPIVersion)
+	if got := fixture["apiVersion"]; got != recipe.RecipeResultAPIVersion {
+		t.Fatalf("fixture apiVersion = %v, want %q", got, recipe.RecipeResultAPIVersion)
 	}
 
 	tests := []struct {

--- a/pkg/server/openapi_sync_test.go
+++ b/pkg/server/openapi_sync_test.go
@@ -235,7 +235,7 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 			// a client generated from this spec does not reject the first
 			// response carrying one.
 			apiVersions: []string{
-				recipe.RecipeAPIVersion,
+				recipe.RecipeResultAPIVersion,
 				recipe.ConfiguredRecipeResultAPIVersion,
 				header.GroupVersionV1,
 				header.GroupVersionV1Beta2,
@@ -268,7 +268,7 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 			schema:  spec.Components.Schemas["LegacyRecipeResponse"],
 			baseRef: "#/components/schemas/RecipeResponse",
 			apiVersions: []string{
-				recipe.RecipeAPIVersion,
+				recipe.RecipeResultAPIVersion,
 				header.GroupVersionV1,
 			},
 		},
@@ -321,7 +321,7 @@ func TestOpenAPIV1BundleRecipeContract(t *testing.T) {
 	legacyBundle := spec.Components.Schemas["LegacyBundleRecipeV1Request"]
 	legacyClosure := allOfConstraint(t, legacyBundle, "#/components/schemas/RecipeResponseBase")
 	if got, want := legacyClosure.Properties["apiVersion"].Enum,
-		[]string{"", recipe.RecipeAPIVersion, header.GroupVersionV1}; !equalStringsUnordered(got, want) {
+		[]string{"", recipe.RecipeResultAPIVersion, header.GroupVersionV1}; !equalStringsUnordered(got, want) {
 		t.Errorf("LegacyBundleRecipeV1Request apiVersion enum = %v, want %v", got, want)
 	}
 	if got, want := legacyClosure.Properties["kind"].Enum,

--- a/pkg/server/recipe_handler.go
+++ b/pkg/server/recipe_handler.go
@@ -745,6 +745,6 @@ func normalizeLegacyRecipeResult(result *recipe.RecipeResult, v2 bool) *recipe.R
 	projected := result.DeepCopy()
 	projected.BindDataProvider(result.DataProvider())
 	projected.Configuration = nil
-	projected.APIVersion = recipe.RecipeAPIVersion
+	projected.APIVersion = recipe.RecipeResultAPIVersion
 	return projected
 }

--- a/pkg/server/recipe_handler_test.go
+++ b/pkg/server/recipe_handler_test.go
@@ -638,7 +638,7 @@ func TestHandleRecipes_SlurmAccountingModeRoutes(t *testing.T) {
 			method:      http.MethodGet,
 			target:      "/v1/recipe?service=eks&accelerator=h100&intent=training&os=ubuntu&platform=slurm",
 			wantStatus:  http.StatusOK,
-			wantVersion: recipe.RecipeAPIVersion,
+			wantVersion: recipe.RecipeResultAPIVersion,
 		},
 		{
 			name:        "v2 GET accepts accounting mode",
@@ -1222,7 +1222,7 @@ func TestNormalizeLegacyRecipeResultDoesNotMutateBorrowedResult(t *testing.T) {
 
 		t.Fatal("normalizeLegacyRecipeResult() mutated borrowed result")
 	}
-	if projected.Configuration != nil || projected.APIVersion != recipe.RecipeAPIVersion {
+	if projected.Configuration != nil || projected.APIVersion != recipe.RecipeResultAPIVersion {
 		t.Errorf("legacy projection = %#v, want v1alpha2 without configuration", projected)
 	}
 	if projected.DataProvider() != provider {

--- a/pkg/snapshotter/version.go
+++ b/pkg/snapshotter/version.go
@@ -17,6 +17,6 @@ package snapshotter
 import "github.com/NVIDIA/aicr/pkg/header"
 
 // FullAPIVersion is the complete API version string stamped into snapshot
-// headers. It aliases the canonical header.GroupVersion so the artifact
-// apiVersion has a single source of truth across packages.
-const FullAPIVersion = header.GroupVersion
+// headers. Snapshot is on the ADR-022 stable artifact track, so this aliases
+// header.StableGroupVersion; the track's target is header.GroupVersionV1.
+const FullAPIVersion = header.StableGroupVersion


### PR DESCRIPTION
## Summary

Gives each ADR-022 schema track its own emitter constant, so the v0.22 emitter switch is one edit per track instead of a refactor. No emitted value changes.

## Motivation / Context

ADR-022 §3 Release N (#2404) staged the readers. The emitters were left aliased along the *old* single-track shape, where one constant serves kinds with different targets:

| Constant | Aliased by | ADR-022 target |
|---|---|---|
| `header.GroupVersion` | `snapshotter.FullAPIVersion` | `aicr.run/v1` |
| `header.GroupVersion` | `localformat.ProvenanceAPIVersion` | `aicr.run/v1` |
| `header.GroupVersion` | `config.APIVersion` | **`aicr.run/v1beta1`** |
| `recipe.RecipeAPIVersion` | default `RecipeResult` emit sites, `RecipeCriteriaAPIVersion` | `aicr.run/v1` |
| `recipe.RecipeAPIVersion` | expected value quoted for `RecipeMetadata`, `RecipeMixin`, `ComponentRegistry` | **`aicr.run/v1beta1`** |

`RecipeAPIVersion` alone spanned two targets, so v0.22 could not flip it. "Flip the emitters" was therefore a refactor plus a flip, done under release pressure with no test proving the sweep was complete.

Fixes: N/A
Related: #2416, #2404, #2114

## Type of Change

- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**Three track constants in `pkg/header`:** `StableGroupVersion`, `AuthoringGroupVersion`, `ProfileGroupVersion`. Each package emitter now aliases the constant for its track rather than the string it happens to equal today.

**`recipe.RecipeAPIVersion` is removed**, replaced by `RecipeResultAPIVersion` (stable track) and `RecipeMetadataAPIVersion` (authoring track). `ComponentRegistry` gets `ComponentRegistryAPIVersion`. This is a source-level break for anything importing `pkg/recipe` directly; `make api-diff` confirms it is outside the frozen `pkg/client/v1` SDK surface. I chose the rename over a deprecated alias deliberately: an alias would have left ~70 call sites on a name that is wrong for half the kinds it names, which is the exact trap this PR exists to remove.

**Values are identical.** Stable and authoring both resolve to `aicr.run/v1alpha2`, profile to `aicr.run/v1alpha3`. That equality is why the bug was invisible, and it is why `TestADR022TracksShareAlphaButNotTargets` exists to document it.

**Test call sites were retargeted by subject, not mechanically.** A test asserting on a `RecipeMixin` or an overlay now uses `RecipeMetadataAPIVersion`; one asserting on a `RecipeResult` uses `RecipeResultAPIVersion`. Same value today, so this is invisible now — but a mislabeled site becomes a spurious failure at v0.22, which is time taken from the release that can least afford it.

**New `pkg/header/adr022_map_test.go`** binds each ADR-022 §2 kind to its emitter constant, its target, and its read gate. The five emitter constants live in five packages and nothing previously tied them together, so "did we get every emitter?" was a grep. Four invariants:

- a binary reads what it writes;
- every §2 target is already readable, which is the §3 reader-first rule;
- each kind uses its **own track's** gate, not one that merely accepts the shared alpha value;
- emitters are still on alpha, which pins the migration stage.

That last one fails at v0.22 by design, forcing #2416 to update the table rather than discovering the blast radius in review.

## Testing

```bash
make test       # PASS, total coverage 84.1% (floor 80%)
make lint       # golangci-lint 0 issues; license, AGENTS sync, docs, MDX, chart pins all OK
make api-diff   # No incompatible SDK facade or transparent-alias target changes since v0.20.0
```

Verified the new guards are load-bearing rather than trivially green: rewiring the `AICRConfig` row to the stable gate (`IsSupportedAPIVersion`) fails two tests with actionable messages —

```
TestADR022TargetIsReadableBeforeTheEmitterSwitch/AICRConfig:
  ADR-022 target apiVersion "aicr.run/v1beta1" is rejected by this kind's read gate
TestADR022RowUsesItsTracksGate/AICRConfig:
  gate accepts "aicr.run/v1", which belongs to another track
```

Reverted before committing. No production statements changed (constants and comments only), so package coverage is structurally unchanged and no new exported function is uncovered.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** No behavior change and no emitted value change — every artifact carries the same `apiVersion` before and after. The only externally visible effect is the `pkg/recipe` constant rename, which is outside the SDK compatibility gate.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
