### PR TITLE
style(api): match sibling enum style and reflow the /v1 legacy paragraph

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -2814,13 +2814,7 @@ components:
           properties:
             apiVersion:
               type: string
-              enum:
-                [
-                  aicr.run/v1alpha2,
-                  aicr.run/v1alpha3,
-                  aicr.run/v1,
-                  aicr.run/v1beta2,
-                ]
+              enum: [aicr.run/v1alpha2, aicr.run/v1alpha3, aicr.run/v1, aicr.run/v1beta2]
               example: aicr.run/v1alpha2
             kind:
               type: string

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -509,10 +509,9 @@ disabled and use the default-track response shape. That track is
 `aicr.run/v1alpha2` today, and the schema also admits its ADR-022 target
 `aicr.run/v1` so a client generated from this spec tolerates the value a
 release before AICR emits it. `/v1` never carries a profile-track version.
-`/v1/recipe` and
-`/v1/query` reject a composition after it adopts a profile even when the request
-omits selection, and `/v1/bundle` rejects a profile-bearing body. Migrate a
-converted workflow to v2 as one cut-over.
+`/v1/recipe` and `/v1/query` reject a composition after it adopts a
+profile even when the request omits selection, and `/v1/bundle` rejects a
+profile-bearing body. Migrate a converted workflow to v2 as one cut-over.
 
 **AKS/GKE cut-over:** the AKS and GKE families are the embedded adopters, so
 `/v1/recipe` and `/v1/query` requests with `service=aks` or `service=gke` now


### PR DESCRIPTION
## Summary

Two cosmetic follow-ups to #2419, raised in review by @njhensley after that PR had already merged.

## Motivation / Context

Both were flagged as non-blocking nitpicks on #2419, and both arrived on an approved PR that merged before I could fold them in. They are correct, so this carries them over rather than dropping them.

**1. `RecipeResponse` apiVersion enum was the only multi-line flow array.** Every other `apiVersion` enum in `server.yaml` is inline, including `LegacyRecipeResponse` edited a few lines below and the three request enums:

| Line | Schema | Style |
|---|---|---|
| 2281 | `RecipeCriteria` | inline |
| **2817** | **`RecipeResponse`** | **multi-line (this PR collapses it)** |
| 2875 | `ProfileRecipeResponse` | inline |
| 3019 | `ConfiguredRecipeResponse` | inline |
| 3168 | `LegacyRecipeResponse` | inline |
| 3193 / 3234 | legacy bundle requests | inline |

The inline form is 89 characters against the repo's 200-character `line-length` cap, and yamllint passes either way, so nothing forced the multi-line style. It only hurt diff readability and set an inconsistent precedent for the next enum edit.

**2. Orphaned source line in `api-reference.md`.** The sentence #2419 inserted left ``​`/v1/recipe` and`` alone on a 16-character line between 74- and 80-character neighbors. Markdown joins adjacent lines, so the rendered output was already correct; this is source readability only.

Fixes: N/A
Related: #2419, #2416

## Type of Change

- [x] Refactoring (no functional changes)

## Component(s) Affected

- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

No semantic change to either file. The enum admits exactly the same four values before and after — YAML flow sequences are style-only — and the reflowed paragraph has identical rendered text.

## Testing

```bash
make check-docs-mdx check-docs-mdx-parse   # OK: MDX-safe; 54 doc file(s) parse
make lint-yaml                             # clean
go test ./pkg/server/... -count=1          # ok
```

`TestOpenAPIV1BundleRecipeContract` parses the spec and asserts the `RecipeResponse` enum membership, so it would fail if collapsing the flow array changed the parsed value set. It passes.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Whitespace and formatting only. No behavior, no contract change.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
