### PR TITLE
ci: bump EKS UAT actuator image to v0.5.1

### DIFF
--- a/.github/workflows/uat-aws.yaml
+++ b/.github/workflows/uat-aws.yaml
@@ -171,12 +171,14 @@ jobs:
         ${{ inputs.test_config_dir }}/${{ inputs.accelerator }}-${{ inputs.intent }}${{
           inputs.deployer != 'helmfile' && format('-{0}', inputs.deployer) || ''
         }}-config.yaml
-      # v0.4.27 — required for node-group taints in the cluster-config schema
-      # (GPU pool carries skyhook.nvidia.com=runtime-required:NoSchedule until
-      # NodeWrite finishes tuning + reboot). Earlier v0.4.x pins predate taint
-      # support; v0.2.6 read .compute.nodeGroups.* directly and failed
-      # Terraform parse with "object with 1 attribute eks".
-      EKS_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:8bc33d14e6e5659d242aa2cdbcd69fca389cfcdb9e94f7a7a1b82fd33176befa"
+      # v0.5.1 — GPU-conditional worker taints (non-GPU worker pools stay
+      # untainted) + native GB300 (p6e-gb300/p6e-gb300r) EFA layout, on top of the
+      # node-group taint schema introduced in v0.4.27 (GPU pool carries
+      # skyhook.nvidia.com=runtime-required:NoSchedule until NodeWrite finishes
+      # tuning + reboot). Earlier v0.4.x pins predate taint support; v0.2.6 read
+      # .compute.nodeGroups.* directly and failed Terraform parse with
+      # "object with 1 attribute eks".
+      EKS_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:91762c28d63c6f47774e86a922b84596a8daed031b225b9e7a25bd4910829f9b"
       VALIDATOR_IMAGE_PREFIX: "ghcr.io/nvidia/aicr-validators"
       VALIDATOR_TAG: "uat-${{ github.run_id }}"
       # Target platform(s) for the main-cell image builds (snapshot-agent + the

--- a/.github/workflows/uat-janitor.yaml
+++ b/.github/workflows/uat-janitor.yaml
@@ -146,7 +146,7 @@ jobs:
     env:
       AWS_REGION: "us-east-1"
       JANITOR_CONFIG: "tests/uat/aws/cluster-config.yaml"
-      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:8bc33d14e6e5659d242aa2cdbcd69fca389cfcdb9e94f7a7a1b82fd33176befa"
+      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:91762c28d63c6f47774e86a922b84596a8daed031b225b9e7a25bd4910829f9b"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -184,7 +184,7 @@ jobs:
     env:
       AWS_REGION: "us-east-1"
       JANITOR_CONFIG: "tests/uat/aws/cluster-config-gb200.yaml"
-      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:8bc33d14e6e5659d242aa2cdbcd69fca389cfcdb9e94f7a7a1b82fd33176befa"
+      JANITOR_ACTUATOR_IMAGE: "ghcr.io/mchmarny/cluster/eks@sha256:91762c28d63c6f47774e86a922b84596a8daed031b225b9e7a25bd4910829f9b"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Bump the pinned `mchmarny/cluster` EKS actuator image from **v0.4.27** to **v0.5.1** across the AWS UAT create pin and both janitor pins.

## Motivation / Context

v0.5.1 adds **native GB300** (`p6e-gb300`/`p6e-gb300r`) EFA support and makes the `dedicated=worker-workload` worker taint **GPU-conditional** (non-GPU worker pools stay untainted, matching the AKS/GKE actuators). Those changes landed upstream via a merged PR.

The create pin (`uat-aws.yaml`) and both janitor pins (`uat-janitor.yaml`) are bumped **in lockstep** — they were already identical digests. Skewing them risks a stale janitor destroying a newer-actuator-created cluster with a mismatched Terraform provider/state on teardown.

Fixes: N/A
Related: N/A (upstream `mchmarny/cluster` v0.5.1)

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT CI workflows (AWS create + janitor)

## Implementation Notes

- Bumps the digest `8bc33d14…` → `91762c28…` in three places: `uat-aws.yaml` `EKS_IMAGE` (create) and `uat-janitor.yaml` `JANITOR_ACTUATOR_IMAGE` ×2 (h100 + gb200 teardown).
- Updated the version-rationale comment above `EKS_IMAGE`.
- Existing `accelerator: gb200`/`gb300` config overrides remain harmless: v0.5.1 auto-derives the family from the `p6e-*` prefix and still honors explicit overrides via `coalesce`.

## Testing

```bash
go test ./tests/uat/           # supply-chain / actuator-pinning tests — PASS with new digest
yamllint .github/workflows/uat-aws.yaml .github/workflows/uat-janitor.yaml   # clean
```

- v0.5.1 validated out-of-band against a **live GB300 EKS cluster** (local state): the actuator plan against a v0.4.27-created cluster shows **no resource replacement — 0 destroy**. The only in-place deltas are benign: auto-egress allowlist `+1 /32`, OIDC thumbprint now AWS-managed, two IRSA `assume_role_policy` recomputes (same hardcoded SAs), and cleanup of a redundant k8s-ELB SG rule.
- **Not yet exercised:** a full UAT AWS run (h100 p5 create → validate → teardown) on v0.5.1. Recommend a `uat-aws` dispatch on this branch before merge.

## Risk Assessment

- [x] **Medium** — Third-party actuator major-version bump (0.4 → 0.5) on the UAT AWS create + teardown path. In-place compatible in the GB300 validation, but the h100/gb200 UAT lanes have not been run on v0.5.1 yet.

**Rollout notes:** Revert = restore the v0.4.27 digest (`8bc33d14…`) in the same three lines. No state migration — the actuator manages ephemeral per-run clusters. Recommend a `uat-aws` run on this branch pre-merge.

## Checklist

- [x] Tests pass locally (relevant `tests/uat` supply-chain tests; full `make test` not run — YAML/CI-only change)
- [x] Linter passes (`yamllint` on changed workflows)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality (N/A — no new functionality)
- [ ] I updated docs if user-facing behavior changed (N/A)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
