### PR TITLE
fix(mirror): enforce Helm render version floor

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -1255,17 +1255,12 @@ const (
 	// default (currently v1.27.0 in Helm 3.x), which is too old for
 	// charts that declare a kubeVersion constraint (e.g., >=1.32.0-0).
 	//
-	// This is a render-safe fallback, not a support floor. This constant
-	// must stay at or above the strictest kubeVersion any bundled chart
-	// declares. Do NOT lower it to match the ">= 1.25" recipe floor in
-	// recipes/overlays/base.yaml: that is the constraint recipes are
-	// validated against, and a recipe that declares one never reaches this
-	// default (see mirror.KubeVersionFromConstraints).
-	//
-	// The invariant binds this constant only. The constraint path is
-	// unbounded below: KubeVersionFromConstraints returns the recipe's own
-	// value, so a recipe carrying nothing but base.yaml's ">= 1.25" renders
-	// with --kube-version 1.25.
+	// This is a render-safe floor, not a support floor. This constant must
+	// stay at or above the strictest kubeVersion any bundled chart declares.
+	// Do NOT lower it to match the ">= 1.25" recipe floor in
+	// recipes/overlays/base.yaml: recipes are validated against their own
+	// constraints, while mirror discovery raises lower versions to this
+	// value solely for Helm rendering (see mirror.KubeVersionFromConstraints).
 	MirrorDefaultKubeVersion = "1.33.0"
 
 	// MirrorDiscoveryConcurrency caps the number of components rendered in

--- a/pkg/mirror/discover.go
+++ b/pkg/mirror/discover.go
@@ -33,9 +33,12 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/helm"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/version"
 )
 
 const logKeyComponent = "component"
+
+var mirrorRenderFloor = version.MustParseVersion(defaults.MirrorDefaultKubeVersion)
 
 // Option configures a Lister.
 type Option func(*Lister)
@@ -534,11 +537,20 @@ const k8sConstraintName = "K8s.server.version"
 // the recipe's K8s.server.version constraint. The constraint value is
 // typically a semver range like ">= 1.32.4"; this function extracts the
 // version digits so it can be passed to `helm template --kube-version`.
-// Returns defaults.MirrorDefaultKubeVersion if no constraint is found.
+// Returns defaults.MirrorDefaultKubeVersion if no valid constraint is found
+// or the extracted version is below the render-safe floor.
 func KubeVersionFromConstraints(constraints []recipe.Constraint) string {
 	for _, c := range constraints {
 		if c.Name == k8sConstraintName {
-			return extractVersion(c.Value)
+			kubeVersion := extractVersion(c.Value)
+			parsedVersion, err := version.ParseVersion(kubeVersion)
+			if err != nil {
+				return defaults.MirrorDefaultKubeVersion
+			}
+			if parsedVersion.Compare(mirrorRenderFloor) < 0 {
+				return defaults.MirrorDefaultKubeVersion
+			}
+			return kubeVersion
 		}
 	}
 	return defaults.MirrorDefaultKubeVersion

--- a/pkg/mirror/discover.go
+++ b/pkg/mirror/discover.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Masterminds/semver/v3"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/NVIDIA/aicr/pkg/bom"
@@ -33,12 +34,11 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/helm"
 	"github.com/NVIDIA/aicr/pkg/recipe"
-	"github.com/NVIDIA/aicr/pkg/version"
 )
 
 const logKeyComponent = "component"
 
-var mirrorRenderFloor = version.MustParseVersion(defaults.MirrorDefaultKubeVersion)
+var mirrorRenderFloor = semver.MustParse(defaults.MirrorDefaultKubeVersion)
 
 // Option configures a Lister.
 type Option func(*Lister)
@@ -543,11 +543,11 @@ func KubeVersionFromConstraints(constraints []recipe.Constraint) string {
 	for _, c := range constraints {
 		if c.Name == k8sConstraintName {
 			kubeVersion := extractVersion(c.Value)
-			parsedVersion, err := version.ParseVersion(kubeVersion)
+			parsedVersion, err := semver.NewVersion(kubeVersion)
 			if err != nil {
 				return defaults.MirrorDefaultKubeVersion
 			}
-			if parsedVersion.Compare(mirrorRenderFloor) < 0 {
+			if parsedVersion.LessThan(mirrorRenderFloor) {
 				return defaults.MirrorDefaultKubeVersion
 			}
 			return kubeVersion

--- a/pkg/mirror/discover_test.go
+++ b/pkg/mirror/discover_test.go
@@ -691,6 +691,20 @@ func TestKubeVersionFromConstraints(t *testing.T) {
 			want: defaults.MirrorDefaultKubeVersion,
 		},
 		{
+			name: "major only version below render floor returns default",
+			constraints: []recipe.Constraint{
+				{Name: "K8s.server.version", Value: ">= 1"},
+			},
+			want: defaults.MirrorDefaultKubeVersion,
+		},
+		{
+			name: "prerelease below render floor returns default",
+			constraints: []recipe.Constraint{
+				{Name: "K8s.server.version", Value: ">= 1.33.0-0"},
+			},
+			want: defaults.MirrorDefaultKubeVersion,
+		},
+		{
 			name: "version equal to render floor",
 			constraints: []recipe.Constraint{
 				{Name: "K8s.server.version", Value: defaults.MirrorDefaultKubeVersion},

--- a/pkg/mirror/discover_test.go
+++ b/pkg/mirror/discover_test.go
@@ -677,32 +677,46 @@ func TestKubeVersionFromConstraints(t *testing.T) {
 			want: defaults.MirrorDefaultKubeVersion,
 		},
 		{
-			name: "semver range >= 1.32.4",
+			name: "version below render floor returns default",
 			constraints: []recipe.Constraint{
 				{Name: "K8s.server.version", Value: ">= 1.32.4"},
 			},
-			want: "1.32.4",
+			want: defaults.MirrorDefaultKubeVersion,
 		},
 		{
-			name: "semver range >= 1.25",
+			name: "major minor version below render floor returns default",
 			constraints: []recipe.Constraint{
 				{Name: "K8s.server.version", Value: ">= 1.25"},
 			},
-			want: "1.25",
+			want: defaults.MirrorDefaultKubeVersion,
 		},
 		{
-			name: "exact version",
+			name: "version equal to render floor",
 			constraints: []recipe.Constraint{
-				{Name: "K8s.server.version", Value: "1.34.0"},
+				{Name: "K8s.server.version", Value: defaults.MirrorDefaultKubeVersion},
+			},
+			want: defaults.MirrorDefaultKubeVersion,
+		},
+		{
+			name: "version above render floor",
+			constraints: []recipe.Constraint{
+				{Name: "K8s.server.version", Value: ">= 1.34.0"},
 			},
 			want: "1.34.0",
 		},
 		{
-			name: "version with v prefix",
+			name: "version above render floor with v prefix",
 			constraints: []recipe.Constraint{
-				{Name: "K8s.server.version", Value: ">= v1.32.0"},
+				{Name: "K8s.server.version", Value: ">= v1.34.1"},
 			},
-			want: "1.32.0",
+			want: "1.34.1",
+		},
+		{
+			name: "invalid version returns default",
+			constraints: []recipe.Constraint{
+				{Name: "K8s.server.version", Value: "not-a-version"},
+			},
+			want: defaults.MirrorDefaultKubeVersion,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Enforce `defaults.MirrorDefaultKubeVersion` (`1.33.0`) as the Helm rendering floor during mirror discovery. Lower, prerelease, or invalid recipe versions now use the render-safe default.

Fixes: #2340
Related: #2336

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Other: mirror discovery (`pkg/mirror`, `pkg/defaults`)

## Implementation Notes

Use strict semantic version ordering for the render floor so precision-aware matching cannot let major-only or prerelease versions bypass it. This only changes the Kubernetes capability version passed to offline Helm rendering; recipe validation constraints remain unchanged.

## Testing

```bash
go test -race ./pkg/mirror/...
# 63 tests passed

golangci-lint run -c .golangci.yaml ./pkg/mirror/...
# 0 issues
```

Real CLI verification with Helm `v4.2.4`:

```bash
aicr mirror list --service eks --accelerator a100 --intent training --os ubuntu
```

The recipe resolves Kubernetes `>= 1.30`. Before the fix, discovery returned 32 images and the DRA component failed to render. After the fix, it returned 33 images and included:

```text
registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1
```

`make qualify` reached the full race suite but root-only permission-negative tests failed because paths such as `/nonexistent` and read-only directories remain writable by root.

## Risk Assessment

- [x] **Low** - Isolated behavior with unit and real Helm coverage

**Rollout notes:** N/A

## Checklist

- [x] Affected race tests and lint checks pass
- [x] Tests cover below, equal, above, major-only, prerelease, prefixed, and invalid versions
- [x] Changes follow existing patterns
- [x] Commits are cryptographically signed and DCO signed off
