### PR TITLE
feat(validator): add CRE NeMo goodput check for EKS H100

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -693,7 +693,7 @@ silently fall back.
 Full list (defaults, semantics) is in the `validators/performance`
 package godoc. NCCL variants exposed today: `nccl-all-reduce-bw`,
 `nccl-all-reduce-bw-net`, `nccl-all-reduce-bw-nvls`. Opt-in CRE NCCL
-for EKS H100: `nccl-cre-all-reduce-bw`. Inference:
+for EKS H100: `nccl-cre-all-reduce-bw` and `cre-training-goodput`. Inference:
 `inference-perf` (Dynamo + AIPerf).
 
 > **Constraint-name contract.** Each NCCL variant looks up a

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -53,14 +53,15 @@ ones) that match the target fabric:
 | `nccl-all-reduce-bw-net` | NET (EFA on EKS by default; ConnectX RoCE via `AICR_NCCL_FABRIC=roce`) | GB200 + EKS. Asserts EFA actually carried traffic — catches silent fallback to Socket when the NVIDIA driver is missing `NVreg_GrdmaPciTopoCheckOverride=1`. |
 | `nccl-all-reduce-bw-nvls` | NVLS (MNNVL across an NVL72 IMEX domain) | GB200 + EKS, and GB200 + OKE. Asserts the NVLS communicator actually initialized — catches silent fallback to EFA (EKS) or Socket (OKE) when the IMEX domain is misconfigured. |
 
-An opt-in Cluster Readiness Engine (CRE) NCCL check is available for EKS H100.
-It is not attached to shipped overlays while CRE remains private and the
-result has not been correlated with the TrainJob path. The check requires a
-same-named constraint:
+An opt-in Cluster Readiness Engine (CRE) pair of checks is available for EKS H100.
+They are not attached to shipped overlays while CRE remains private and the
+NCCL result has not been correlated with the TrainJob path. Each check requires
+a same-named constraint:
 
 | Check | What it measures |
 |---|---|
 | `nccl-cre-all-reduce-bw` | EFA bus bandwidth from a CRE `WorkloadRun` `BandwidthMeasurement`; AICR still asserts the transport from launcher logs |
+| `cre-training-goodput` | Runtime goodput from a CRE-managed NeMo/Megatron training `WorkloadRun` |
 
 The applicability column is the *default*, derived from the recipe's
 `criteria`. A recipe whose criteria fall outside it can still run these

--- a/pkg/validator/catalog/catalog_test.go
+++ b/pkg/validator/catalog/catalog_test.go
@@ -1178,6 +1178,22 @@ func TestEmbeddedCatalog_CRENCCLAllReduceBWEntryExists(t *testing.T) {
 	t.Fatalf("no embedded catalog entry named %q", v1.CRENCCLAllReduceBWCheckName)
 }
 
+func TestEmbeddedCatalog_CRETrainingGoodputEntryExists(t *testing.T) {
+	cat, err := LoadWithDataProvider(context.Background(), nil, "v0.0.0-next", "")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	for _, v := range cat.Validators {
+		if v.Name == v1.CRETrainingGoodputCheckName {
+			if v.Phase != "performance" {
+				t.Errorf("%q phase = %q, want performance", v1.CRETrainingGoodputCheckName, v.Phase)
+			}
+			return
+		}
+	}
+	t.Fatalf("no embedded catalog entry named %q", v1.CRETrainingGoodputCheckName)
+}
+
 func TestCatalogEmbedding(t *testing.T) {
 	// Simulate embedding in a CR spec
 	type ValidatorCatalogSpec struct {

--- a/pkg/validator/v1/job_plan_internal.go
+++ b/pkg/validator/v1/job_plan_internal.go
@@ -65,6 +65,11 @@ const (
 	// integration is validated, and no embedded overlay enables it.
 	CRENCCLAllReduceBWCheckName = "nccl-cre-all-reduce-bw"
 
+	// CRETrainingGoodputCheckName is the catalog name of the CRE-driven
+	// NeMo/Megatron training check. It is limited to EKS H100 while CRE
+	// integration is validated, and no embedded overlay enables it.
+	CRETrainingGoodputCheckName = "cre-training-goodput"
+
 	// ncclFabricEnv selects the NET fabric (efa default | roce). Forwarded to
 	// the NET check pod so the in-Job validator can observe it. This is the
 	// orchestrator (forwarding) end; the validator-pod (reading) end defines the

--- a/recipes/validators/catalog.yaml
+++ b/recipes/validators/catalog.yaml
@@ -296,3 +296,10 @@ validators:
     timeout: 30m
     args: ["nccl-cre-all-reduce-bw"]
     env: []
+  - name: cre-training-goodput
+    phase: performance
+    description: "Verify EKS H100 NeMo training goodput via a Cluster Readiness Engine WorkloadRun"
+    image: ghcr.io/nvidia/aicr-validators/performance:latest
+    timeout: 30m
+    args: ["cre-training-goodput"]
+    env: []

--- a/validators/performance/consts.go
+++ b/validators/performance/consts.go
@@ -23,6 +23,7 @@ const (
 	keyName                     = "name"
 	checkNameNCCLAllReduceBW    = "nccl-all-reduce-bw"
 	checkNameCRENCCLAllReduceBW = "nccl-cre-all-reduce-bw"
+	checkNameCRETrainingGoodput = "cre-training-goodput"
 
 	// nodeJobName is the name of both the NCCL worker replicatedJob and its
 	// primary container in testdata/{accelerator}/{service}/runtime.yaml.

--- a/validators/performance/cre_goodput.go
+++ b/validators/performance/cre_goodput.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/validators"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+func checkCRETrainingGoodput(ctx *validators.Context) error {
+	constraint, found := findPerformanceConstraint(ctx, checkNameCRETrainingGoodput)
+	if !found {
+		return validators.Skip(fmt.Sprintf("no %s constraint in recipe", checkNameCRETrainingGoodput))
+	}
+	if ctx.ValidationInput == nil {
+		return validators.Skip("no validation input")
+	}
+	if ctx.ValidationInput.Criteria.Service != recipe.CriteriaServiceEKS ||
+		ctx.ValidationInput.Criteria.Accelerator != recipe.CriteriaAcceleratorH100 {
+		return validators.Skip(fmt.Sprintf(
+			"%s currently supports only eks × h100, got %s × %s",
+			checkNameCRETrainingGoodput,
+			ctx.ValidationInput.Criteria.Service,
+			ctx.ValidationInput.Criteria.Accelerator,
+		))
+	}
+
+	threshold, err := parseThreshold(constraint.Value)
+	if err != nil {
+		return err
+	}
+
+	gpuConfig, err := determineGPUConfig(
+		ctx,
+		ctx.ValidationInput.Criteria.Service,
+		ctx.ValidationInput.Criteria.Accelerator,
+		ctx.NodeSelector,
+	)
+	if err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to determine GPU configuration", err)
+	}
+	if gpuConfig.WorkerCount < 2 {
+		return aicrErrors.New(aicrErrors.ErrCodeNotFound,
+			fmt.Sprintf("recipe declares %s but the cluster has fewer than 2 GPU nodes", checkNameCRETrainingGoodput))
+	}
+	if ctx.DynamicClient == nil {
+		return aicrErrors.New(aicrErrors.ErrCodeInternal, "dynamic client is required to create a WorkloadRun")
+	}
+
+	runObj := buildCRETrainingWorkloadRun(ctx.Namespace, gpuConfig, ctx.NodeSelector)
+	if err := deleteCREWorkloadRun(ctx.Ctx, ctx.DynamicClient, ctx.Namespace, creTrainingRunName); err != nil {
+		return err
+	}
+	defer func() {
+		if deleteErr := deleteCREWorkloadRun(
+			context.Background(),
+			ctx.DynamicClient,
+			ctx.Namespace,
+			creTrainingRunName,
+		); deleteErr != nil {
+			slog.Warn("failed to delete CRE training WorkloadRun", "error", deleteErr)
+		}
+	}()
+
+	if err := createUnstructured(ctx.Ctx, ctx.DynamicClient, workloadRunGVR, ctx.Namespace, runObj); err != nil {
+		return err
+	}
+	run, err := waitForWorkloadRunTerminal(ctx.Ctx, ctx.DynamicClient, ctx.Namespace, creTrainingRunName)
+	if err != nil {
+		return err
+	}
+	if unstructuredConditionTrue(run, "Failed") {
+		return aicrErrors.New(aicrErrors.ErrCodeInternal, "CRE training WorkloadRun failed")
+	}
+
+	status, err := getGoodputStatus(
+		ctx.Ctx,
+		ctx.DynamicClient,
+		ctx.Namespace,
+		creTrainingRunName,
+		run.GetCreationTimestamp(),
+	)
+	if err != nil {
+		return err
+	}
+	ratio, err := parseGoodputRatio(status)
+	if err != nil {
+		return err
+	}
+
+	actual := strconv.FormatFloat(ratio, 'f', 4, 64)
+	fmt.Printf("CRE NeMo training goodput ratio: %s\n", actual)
+	fmt.Printf("Constraint: %s → %v\n", constraint.Value, ratio >= threshold)
+	for _, metric := range []string{
+		"avgTFLOPSPerGPU",
+		"avgStepTimeSec",
+		"interruptionCount",
+		"lostWorkTimeSec",
+	} {
+		if value, ok := status[metric]; ok {
+			fmt.Printf("%s: %v\n", metric, value)
+		}
+	}
+
+	if ratio < threshold {
+		return aicrErrors.New(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("goodput ratio %s does not satisfy constraint %q", actual, constraint.Value))
+	}
+	return nil
+}
+
+const (
+	creTrainingRunName           = "aicr-cre-nemo"
+	creLogProfileTrainingGoodput = "megatron-training"
+	creTrainingImage             = "nvcr.io/nvidia/pytorch:25.08-py3"
+	creTrainingScript            = `#!/bin/bash
+set -euo pipefail
+cd /mnt/workspace/megatron-lm
+torchrun \
+  --nproc_per_node="${PET_NPROC_PER_NODE}" \
+  --nnodes="${PET_NNODES}" \
+  pretrain_gpt.py \
+    --num-layers 79 \
+    --hidden-size 8192 \
+    --num-attention-heads 64 \
+    --seq-length 8192 \
+    --micro-batch-size 1 \
+    --train-iters 50 \
+    --bf16
+`
+	creTrainingCloneScript = `set -euo pipefail
+if [ ! -d "/mnt/workspace/megatron-lm/.git" ]; then
+  git clone --depth 1 -b core_v0.15.2 \
+    https://github.com/NVIDIA/Megatron-LM.git /mnt/workspace/megatron-lm
+fi
+`
+)
+
+var goodputMeasurementGVR = schema.GroupVersionResource{
+	Group: creAPIGroup, Version: versionV1alpha1, Resource: "goodputmeasurements",
+}
+
+func buildCRETrainingWorkloadRun(namespace string, gpuConfig *gpuConfiguration, nodeSelector map[string]string) *unstructured.Unstructured {
+	spec := map[string]any{
+		"image":       creTrainingImage,
+		"numNodes":    int64(gpuConfig.WorkerCount),
+		"gpusPerNode": int64(gpuConfig.GPUCountPerNode),
+		"framework": map[string]any{
+			"exec": map[string]any{
+				"command": []any{"/bin/bash", "/config/train.sh"},
+			},
+		},
+		"config": map[string]any{
+			"inline": map[string]any{"train.sh": creTrainingScript},
+		},
+		"initContainers": []any{
+			map[string]any{
+				"name":    "megatron-clone",
+				"image":   creTrainingImage,
+				"command": []any{"/bin/bash", "-c"},
+				"args":    []any{creTrainingCloneScript},
+				"volumeMounts": []any{
+					map[string]any{"name": "workspace", "mountPath": "/mnt/workspace"},
+				},
+			},
+		},
+		"volumes": []any{
+			map[string]any{
+				"name":     "workspace",
+				"emptyDir": map[string]any{"medium": "Memory"},
+			},
+		},
+		"volumeMounts": []any{
+			map[string]any{"name": "workspace", "mountPath": "/mnt/workspace"},
+		},
+		"env": []any{
+			map[string]any{"name": "PYTHONPATH", "value": "/mnt/workspace/megatron-lm"},
+			map[string]any{"name": "CUDA_DEVICE_MAX_CONNECTIONS", "value": "1"},
+		},
+		"goodputMeasurement": map[string]any{
+			"logProfileRef":  creLogProfileTrainingGoodput,
+			"sampleInterval": "10s",
+		},
+	}
+	addCRETarget(spec, gpuConfig, nodeSelector)
+	return newCREWorkloadRun(namespace, creTrainingRunName, spec)
+}
+
+func parseGoodputRatio(status map[string]any) (float64, error) {
+	raw, ok := status["result"]
+	if !ok || raw == nil {
+		return 0, aicrErrors.New(aicrErrors.ErrCodeNotFound, "GoodputMeasurement status.result is empty")
+	}
+	switch value := raw.(type) {
+	case string:
+		ratio, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return 0, aicrErrors.Wrap(aicrErrors.ErrCodeInvalidRequest, "invalid goodput result", err)
+		}
+		return ratio, nil
+	case float64:
+		return value, nil
+	default:
+		return 0, aicrErrors.New(aicrErrors.ErrCodeInvalidRequest,
+			fmt.Sprintf("unsupported goodput result type %T", raw))
+	}
+}
+
+func getGoodputStatus(ctx context.Context, client dynamic.Interface, namespace, runName string, createdAt metav1.Time) (map[string]any, error) {
+	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	list, err := client.Resource(goodputMeasurementGVR).Namespace(namespace).List(listCtx, metav1.ListOptions{})
+	if err != nil {
+		return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to list GoodputMeasurements", err)
+	}
+	for i := range list.Items {
+		if !measurementBelongsToRun(&list.Items[i], runName, createdAt) {
+			continue
+		}
+		status, found, nestedErr := unstructured.NestedMap(list.Items[i].Object, "status")
+		if nestedErr != nil {
+			return nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read GoodputMeasurement status", nestedErr)
+		}
+		if found {
+			return status, nil
+		}
+	}
+	return nil, aicrErrors.New(aicrErrors.ErrCodeNotFound, "no GoodputMeasurement status for CRE training WorkloadRun")
+}

--- a/validators/performance/cre_goodput_test.go
+++ b/validators/performance/cre_goodput_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	v1 "github.com/NVIDIA/aicr/pkg/validator/v1"
+	"github.com/NVIDIA/aicr/validators"
+)
+
+func TestCheckCRETrainingGoodputSkipsWithoutConstraint(t *testing.T) {
+	err := checkCRETrainingGoodput(&validators.Context{ValidationInput: v1.NewValidationInput()})
+	if !validators.IsSkip(err) {
+		t.Fatalf("expected Skip, got %v", err)
+	}
+}
+
+func TestBuildCRETrainingWorkloadRun(t *testing.T) {
+	cfg := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 8}
+	obj := buildCRETrainingWorkloadRun(
+		"ns",
+		cfg,
+		map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3"},
+	)
+	spec := obj.Object["spec"].(map[string]any)
+	if spec["image"] != creTrainingImage {
+		t.Errorf("image = %v, want %s", spec["image"], creTrainingImage)
+	}
+	framework := spec["framework"].(map[string]any)
+	exec := framework["exec"].(map[string]any)
+	command := exec["command"].([]any)
+	if len(command) != 2 || command[1] != "/config/train.sh" {
+		t.Errorf("command = %v, want /bin/bash /config/train.sh", command)
+	}
+	config := spec["config"].(map[string]any)["inline"].(map[string]any)
+	if config["train.sh"] != creTrainingScript {
+		t.Error("training script does not match the pinned CRE EKS H100 workload")
+	}
+	goodput := spec["goodputMeasurement"].(map[string]any)
+	if goodput["logProfileRef"] != creLogProfileTrainingGoodput {
+		t.Errorf("logProfileRef = %v, want %s", goodput["logProfileRef"], creLogProfileTrainingGoodput)
+	}
+}
+
+func TestParseGoodputRatio(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  map[string]any
+		want    float64
+		wantErr bool
+	}{
+		{name: "string", status: map[string]any{"result": "0.95"}, want: 0.95},
+		{name: "JSON number", status: map[string]any{"result": float64(0.9)}, want: 0.9},
+		{name: "missing", status: map[string]any{}, wantErr: true},
+		{name: "invalid", status: map[string]any{"result": "bad"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGoodputRatio(tt.status)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/validators/performance/main.go
+++ b/validators/performance/main.go
@@ -21,6 +21,7 @@
 //	performance nccl-all-reduce-bw-net
 //	performance nccl-all-reduce-bw-nvls
 //	performance nccl-cre-all-reduce-bw
+//	performance cre-training-goodput
 package main
 
 import (
@@ -33,6 +34,7 @@ func main() {
 		"nccl-all-reduce-bw-net":    checkNCCLAllReduceBWNET,
 		"nccl-all-reduce-bw-nvls":   checkNCCLAllReduceBWNVLS,
 		checkNameCRENCCLAllReduceBW: checkCRENCCLAllReduceBW,
+		checkNameCRETrainingGoodput: checkCRETrainingGoodput,
 		"inference-perf":            checkInferencePerf,
 	})
 }


### PR DESCRIPTION
**WIP / draft — do not review.** Stacked CRE EKS H100 work; not ready for human review.

## Summary

- Add opt-in `cre-training-goodput`: CRE `WorkloadRun` for Megatron/NeMo goodput on EKS H100.
- Stacked on the NCCL WorkloadRun PR.

## Motivation / Context

Fixes: N/A
Related: `feat/cre-catalog-nccl-eks-h100`, `feat/cre-nccl-workloadrun-eks-h100`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] Validator (`pkg/validator`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `validators/performance`

## Implementation Notes

Skip without the same-named constraint and unless criteria are `eks` × `h100`. No overlay enablement.

## Testing

```bash
# Local `go test` did not complete: GOPROXY downloads of k8s.io v0.36.4 reset on this machine.
# CI on this draft is the test gate. Cluster e2e is out of scope for this PR.
```

## Risk Assessment

- [x] **Medium** — Touches multiple components or has broader impact

**Rollout notes:** Inactive until a recipe lists the constraint. After the NCCL PR merges, retarget this PR to `main`.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
