### PR TITLE
fix(validator): isolate each NCCL benchmark run in its own namespace

### DIFF
--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -118,8 +118,15 @@ constraint (10 % tolerance) → cleanup.
 
 Each variant (`-net`, `-nvls`, default) gets its own namespace, deleted on
 exit along with its `TrainingRuntime`/`TrainJob`. A namespace left behind by
-an interrupted run is reclaimed by its next retry (same run ID) or pruned on
-a later run (standalone runs, no run ID).
+an interrupted run is reclaimed by a same-run-ID retry only if no
+`Pending`/`Running`/`Unknown` pod remains in it and its execution lock (a
+`Lease` named `aicr-nccl-run-lock` in that namespace) has gone stale, 20
+minutes past its last renewal. Otherwise the retry fails with a conflict
+rather than risk two executions sharing one namespace; check
+`kubectl get pods -n <namespace>` and the Lease's age to find and clear
+whichever is actually stuck. A standalone run (no run ID) is never retried
+into its old namespace; that namespace is only pruned automatically, on a
+later run once an hour has passed and both conditions above hold.
 
 A passing CTRF entry:
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -110,10 +110,16 @@ can false-fail a healthy run. Making the NCCL gate fabric/transport-class
 aware is tracked in [#1256](https://github.com/NVIDIA/aicr/issues/1256).
 
 Expected flow (~5–10 min per variant): readiness pre-flight → deploy
-`TrainingRuntime` + `TrainJob` in `aicr-validation` → worker pods reach
-`Running` → run `all_reduce_perf` → parse peak bus bandwidth → verify the
-intended transport actually carried traffic (for `-net` / `-nvls`) → compare
-to recipe constraint (10 % tolerance) → cleanup.
+`TrainingRuntime` + `TrainJob` in a per-run namespace named
+`aicr-nccl-perf-<variant>-<run-id>` → worker pods reach `Running` → run
+`all_reduce_perf` → parse peak bus bandwidth → verify the intended transport
+actually carried traffic (for `-net` / `-nvls`) → compare to recipe
+constraint (10 % tolerance) → cleanup.
+
+Each variant (`-net`, `-nvls`, default) gets its own namespace, deleted on
+exit along with its `TrainingRuntime`/`TrainJob`. A namespace left behind by
+an interrupted run is reclaimed by its next retry (same run ID) or pruned on
+a later run (standalone runs, no run ID).
 
 A passing CTRF entry:
 

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -719,6 +719,13 @@ const (
 	// against a separate lister that lags that strongly-consistent read — a freshness the
 	// client cannot observe. This bounds how long we let the webhook cache catch up.
 	TrainJobAdmissionRetryTimeout = 1 * time.Minute
+
+	// NCCLResourceRecreateWait bounds waitForResourceGone in createUnstructured's
+	// same-run TrainJob reclaim. A controller-serviced finalizer (Trainer v2 /
+	// JobSet ownership) can hold the delete for a while, so this gets its own
+	// bound instead of the much shorter DiagnosticTimeout used for the rest of
+	// createUnstructured's calls.
+	NCCLResourceRecreateWait = 5 * time.Minute
 )
 
 // Inference performance validation timeouts.

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -699,8 +699,10 @@ const (
 
 	// NCCLExecutionLockStaleAge is how long an unrenewed run execution lock
 	// (see claimNCCLExecutionLock) is honored before a new caller may take
-	// it over. Only needs to cover claim-to-first-pod, not the full run, so
-	// a retry after a hard kill isn't stuck waiting out
+	// it over. Only needs to cover the gaps between renewals, not the full
+	// run. A live pod protects the namespace on its own via
+	// verifyNCCLNamespaceNotLive, regardless of lock staleness. Kept short
+	// so a retry after a hard kill isn't stuck waiting out
 	// NCCLStaleNamespacePruneAge instead.
 	NCCLExecutionLockStaleAge = 20 * time.Minute
 

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -699,9 +699,9 @@ const (
 
 	// NCCLExecutionLockStaleAge is how long an unrenewed run execution lock
 	// (see claimNCCLExecutionLock) is honored before a new caller may take
-	// it over. Only needs to cover the gaps between renewals, not the full
-	// run. A live pod protects the namespace on its own via
-	// verifyNCCLNamespaceNotLive, regardless of lock staleness. Kept short
+	// it over. It only needs to cover the gaps between renewals, not the
+	// full run, since a live pod protects the namespace on its own via
+	// verifyNCCLNamespaceNotLive regardless of lock staleness. Kept short
 	// so a retry after a hard kill isn't stuck waiting out
 	// NCCLStaleNamespacePruneAge instead.
 	NCCLExecutionLockStaleAge = 20 * time.Minute

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -691,6 +691,12 @@ const (
 	// NCCLTrainJobTimeout is the maximum time to wait for the NCCL all-reduce TrainJob to complete.
 	NCCLTrainJobTimeout = 30 * time.Minute
 
+	// NCCLStaleNamespacePruneAge is how old a leftover aicr-nccl-perf-* namespace
+	// must be before the best-effort prune in runNCCLTrainJob deletes it. Sized
+	// well past NCCLTrainJobTimeout so a namespace still owned by an in-progress
+	// sibling variant, or a run that is simply slow, is never touched.
+	NCCLStaleNamespacePruneAge = 2 * NCCLTrainJobTimeout
+
 	// NCCLLauncherPodTimeout is the maximum time to wait for the NCCL launcher pod to be created.
 	NCCLLauncherPodTimeout = 5 * time.Minute
 

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -697,6 +697,13 @@ const (
 	// sibling variant, or a run that is simply slow, is never touched.
 	NCCLStaleNamespacePruneAge = 2 * NCCLTrainJobTimeout
 
+	// NCCLExecutionLockStaleAge is how long an unrenewed run execution lock
+	// (see claimNCCLExecutionLock) is honored before a new caller may take
+	// it over. Only needs to cover claim-to-first-pod, not the full run, so
+	// a retry after a hard kill isn't stuck waiting out
+	// NCCLStaleNamespacePruneAge instead.
+	NCCLExecutionLockStaleAge = 20 * time.Minute
+
 	// NCCLLauncherPodTimeout is the maximum time to wait for the NCCL launcher pod to be created.
 	NCCLLauncherPodTimeout = 5 * time.Minute
 

--- a/pkg/validator/labels/labels.go
+++ b/pkg/validator/labels/labels.go
@@ -46,10 +46,10 @@ const (
 	ValueValidator  = "aicr-validator"
 )
 
-// Component label values for per-run benchmark namespaces, stamped alongside
-// ManagedBy so a stale-namespace prune can scope its List to exactly one
-// benchmark's namespaces server-side, instead of matching on a name prefix
-// that has to be kept in sync with the namespace-naming logic by hand.
+// Component label values for per-run benchmark namespaces, stamped
+// alongside ManagedBy so a stale-namespace prune can scope its List to
+// exactly one benchmark server-side, instead of matching a hand-maintained
+// name prefix.
 const (
 	ValueNCCLPerf      = "nccl-perf"
 	ValueInferencePerf = "inference-perf"

--- a/pkg/validator/labels/labels.go
+++ b/pkg/validator/labels/labels.go
@@ -45,3 +45,12 @@ const (
 	ValueValidation = "validation"
 	ValueValidator  = "aicr-validator"
 )
+
+// Component label values for per-run benchmark namespaces, stamped alongside
+// ManagedBy so a stale-namespace prune can scope its List to exactly one
+// benchmark's namespaces server-side, instead of matching on a name prefix
+// that has to be kept in sync with the namespace-naming logic by hand.
+const (
+	ValueNCCLPerf      = "nccl-perf"
+	ValueInferencePerf = "inference-perf"
+)

--- a/validators/performance/consts.go
+++ b/validators/performance/consts.go
@@ -18,6 +18,7 @@ package main
 const (
 	apiGroupAPIExtensions    = "apiextensions.k8s.io"
 	apiGroupApps             = "apps"
+	apiGroupRBAC             = "rbac.authorization.k8s.io"
 	resourceCRDs             = "customresourcedefinitions"
 	versionV1alpha1          = "v1alpha1"
 	versionV1beta1           = "v1beta1"

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -2055,6 +2055,22 @@ func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read namespace created by a concurrent caller", err)
 	}
+	if winner.DeletionTimestamp != nil {
+		// Wait for the terminating winner to fully disappear, then create
+		// ours, instead of handing back a namespace that would reject
+		// resource creation.
+		slog.Info("Namespace from a concurrent create race is terminating; waiting for full deletion",
+			"namespace", namespace)
+		if waitErr := waitForNamespaceGone(nsCtx, clients, namespace); waitErr != nil {
+			return nil, waitErr
+		}
+		created, createErr := clients.Create(nsCtx, ns, metav1.CreateOptions{})
+		if createErr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInternal,
+				"failed to create namespace after a concurrent owner finished terminating", createErr)
+		}
+		return created, nil
+	}
 	if !namespaceOwnedBy(winner, component) {
 		return nil, errors.New(errors.ErrCodeConflict, fmt.Sprintf(
 			"namespace %q was created by a concurrent caller without the expected %s=%s,%s=%s labels; refusing to adopt it",

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -35,6 +35,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/validator/catalog"
+	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	validatorv1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 	"github.com/NVIDIA/aicr/validators"
 	"github.com/NVIDIA/aicr/validators/helper"
@@ -1996,6 +1997,10 @@ func ensureHFTokenSecret(ctx *validators.Context, namespace string) error {
 // AlreadyExists, but subsequent resource creates inside it fail with
 // "... forbidden: ... because it is being terminated". Waiting here until the
 // prior Terminating instance is fully gone avoids that race.
+//
+// Stamps labels.ManagedBy so pruneStaleNCCLNamespaces can later scope its
+// sweep to namespaces this package actually created, not just ones that
+// match its naming convention.
 func ensureNamespace(ctx *validators.Context, namespace string) error {
 	nsCtx, cancel := context.WithTimeout(ctx.Ctx, defaults.InferenceNamespaceTerminationWait)
 	defer cancel()
@@ -2019,7 +2024,10 @@ func ensureNamespace(ctx *validators.Context, namespace string) error {
 		return nil
 	}
 
-	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   namespace,
+		Labels: map[string]string{labels.ManagedBy: labels.ValueValidator},
+	}}
 	_, err = clients.Create(nsCtx, ns, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1618,7 +1618,7 @@ func buildTolerations(node v1.Node) []v1.Toleration {
 // deferred cleanup in the caller always runs — even if later steps fail.
 func deployInferenceWorkload(ctx *validators.Context, config *inferenceWorkloadConfig) error {
 	// Create namespace (idempotent).
-	if err := ensureNamespace(ctx, config.namespace); err != nil {
+	if _, err := ensureNamespace(ctx, config.namespace); err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
 	}
 
@@ -2001,7 +2001,11 @@ func ensureHFTokenSecret(ctx *validators.Context, namespace string) error {
 // Stamps labels.ManagedBy so pruneStaleNCCLNamespaces can later scope its
 // sweep to namespaces this package actually created, not just ones that
 // match its naming convention.
-func ensureNamespace(ctx *validators.Context, namespace string) error {
+//
+// Returns the resulting namespace object (its UID included) so callers that
+// need one, such as an owning-UID delete precondition, don't have to issue a
+// further Get for it.
+func ensureNamespace(ctx *validators.Context, namespace string) (*v1.Namespace, error) {
 	nsCtx, cancel := context.WithTimeout(ctx.Ctx, defaults.InferenceNamespaceTerminationWait)
 	defer cancel()
 
@@ -2012,27 +2016,37 @@ func ensureNamespace(ctx *validators.Context, namespace string) error {
 	case apierrors.IsNotFound(err):
 		// Namespace doesn't exist — Create below will succeed.
 	case err != nil:
-		return errors.Wrap(errors.ErrCodeInternal, "failed to check namespace", err)
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to check namespace", err)
 	case existing.DeletionTimestamp != nil:
 		slog.Info("Namespace is terminating from a prior run; waiting for full deletion",
 			"namespace", namespace)
 		if waitErr := waitForNamespaceGone(nsCtx, clients, namespace); waitErr != nil {
-			return waitErr
+			return nil, waitErr
 		}
 	default:
 		// Already exists and is usable — nothing to do.
-		return nil
+		return existing, nil
 	}
 
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name:   namespace,
 		Labels: map[string]string{labels.ManagedBy: labels.ValueValidator},
 	}}
-	_, err = clients.Create(nsCtx, ns, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
+	created, err := clients.Create(nsCtx, ns, metav1.CreateOptions{})
+	if err == nil {
+		return created, nil
 	}
-	return nil
+	if !apierrors.IsAlreadyExists(err) {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
+	}
+	// Lost a create race to a concurrent caller. Fetch the winning object
+	// rather than returning nil, so a UID-precondition caller still gets
+	// something to pin its later delete to.
+	winner, err := clients.Get(nsCtx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read namespace created by a concurrent caller", err)
+	}
+	return winner, nil
 }
 
 // waitForNamespaceGone watches the given namespace until it is removed.

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1998,18 +1998,15 @@ func ensureHFTokenSecret(ctx *validators.Context, namespace string) error {
 // "... forbidden: ... because it is being terminated". Waiting here until the
 // prior Terminating instance is fully gone avoids that race.
 //
-// Stamps labels.ManagedBy and the given component value so
-// pruneStaleNCCLNamespaces can scope its List server-side to namespaces
-// this package actually created for one benchmark, not just ones matching
-// a naming convention.
+// The namespace is stamped with labels.ManagedBy and component so
+// pruneStaleNCCLNamespaces can scope its List server-side, instead of
+// matching a naming convention.
 //
-// Returns the resulting namespace object, UID included, so a caller
-// needing one (e.g. an owning-UID delete precondition) doesn't have to
-// issue a further Get. Also returns whether this call's own Create landed,
-// as opposed to reusing an existing namespace or adopting a concurrent
-// caller's race-winning Create, so a caller that wants to roll back a
-// namespace it alone is responsible for (e.g. on a later, unrelated
-// failure) doesn't tear down one it merely adopted.
+// The bool result reports whether this call's own Create landed, as
+// opposed to reusing or adopting a namespace that already existed, so a
+// caller rolling back on a later failure doesn't tear down one it merely
+// adopted. The namespace result carries its UID either way, for a caller
+// that needs one without a further Get.
 func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.Namespace, bool, error) {
 	nsCtx, cancel := context.WithTimeout(ctx.Ctx, defaults.InferenceNamespaceTerminationWait)
 	defer cancel()

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1619,7 +1619,7 @@ func buildTolerations(node v1.Node) []v1.Toleration {
 func deployInferenceWorkload(ctx *validators.Context, config *inferenceWorkloadConfig) error {
 	// Create namespace (idempotent).
 	if _, _, err := ensureNamespace(ctx, config.namespace, labels.ValueInferencePerf); err != nil {
-		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
+		return err
 	}
 
 	// Mark deployed early (namespace now exists) so cleanup tears down the

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -2024,8 +2024,13 @@ func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.
 		if waitErr := waitForNamespaceGone(nsCtx, clients, namespace); waitErr != nil {
 			return nil, waitErr
 		}
+	case !namespaceOwnedBy(existing, component):
+		// Don't adopt a namespace we didn't create.
+		return nil, errors.New(errors.ErrCodeConflict, fmt.Sprintf(
+			"namespace %q already exists without the expected %s=%s,%s=%s labels; refusing to adopt a namespace this package did not create",
+			namespace, labels.ManagedBy, labels.ValueValidator, labels.Component, component))
 	default:
-		// Already exists and is usable — nothing to do.
+		// Already exists, owned by us, and usable. Nothing to do.
 		return existing, nil
 	}
 
@@ -2050,7 +2055,18 @@ func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.
 	if err != nil {
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read namespace created by a concurrent caller", err)
 	}
+	if !namespaceOwnedBy(winner, component) {
+		return nil, errors.New(errors.ErrCodeConflict, fmt.Sprintf(
+			"namespace %q was created by a concurrent caller without the expected %s=%s,%s=%s labels; refusing to adopt it",
+			namespace, labels.ManagedBy, labels.ValueValidator, labels.Component, component))
+	}
 	return winner, nil
+}
+
+// namespaceOwnedBy reports whether ns carries the labels ensureNamespace
+// stamps on create for the given component.
+func namespaceOwnedBy(ns *v1.Namespace, component string) bool {
+	return ns.Labels[labels.ManagedBy] == labels.ValueValidator && ns.Labels[labels.Component] == component
 }
 
 // waitForNamespaceGone watches the given namespace until it is removed.

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1618,7 +1618,7 @@ func buildTolerations(node v1.Node) []v1.Toleration {
 // deferred cleanup in the caller always runs — even if later steps fail.
 func deployInferenceWorkload(ctx *validators.Context, config *inferenceWorkloadConfig) error {
 	// Create namespace (idempotent).
-	if _, err := ensureNamespace(ctx, config.namespace, labels.ValueInferencePerf); err != nil {
+	if _, _, err := ensureNamespace(ctx, config.namespace, labels.ValueInferencePerf); err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
 	}
 
@@ -2005,8 +2005,12 @@ func ensureHFTokenSecret(ctx *validators.Context, namespace string) error {
 //
 // Returns the resulting namespace object, UID included, so a caller
 // needing one (e.g. an owning-UID delete precondition) doesn't have to
-// issue a further Get.
-func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.Namespace, error) {
+// issue a further Get. Also returns whether this call's own Create landed,
+// as opposed to reusing an existing namespace or adopting a concurrent
+// caller's race-winning Create, so a caller that wants to roll back a
+// namespace it alone is responsible for (e.g. on a later, unrelated
+// failure) doesn't tear down one it merely adopted.
+func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.Namespace, bool, error) {
 	nsCtx, cancel := context.WithTimeout(ctx.Ctx, defaults.InferenceNamespaceTerminationWait)
 	defer cancel()
 
@@ -2017,21 +2021,21 @@ func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.
 	case apierrors.IsNotFound(err):
 		// Namespace doesn't exist — Create below will succeed.
 	case err != nil:
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to check namespace", err)
+		return nil, false, errors.Wrap(errors.ErrCodeInternal, "failed to check namespace", err)
 	case existing.DeletionTimestamp != nil:
 		slog.Info("Namespace is terminating from a prior run; waiting for full deletion",
 			"namespace", namespace)
 		if waitErr := waitForNamespaceGone(nsCtx, clients, namespace); waitErr != nil {
-			return nil, waitErr
+			return nil, false, waitErr
 		}
 	case !namespaceOwnedBy(existing, component):
 		// Don't adopt a namespace we didn't create.
-		return nil, errors.New(errors.ErrCodeConflict, fmt.Sprintf(
+		return nil, false, errors.New(errors.ErrCodeConflict, fmt.Sprintf(
 			"namespace %q already exists without the expected %s=%s,%s=%s labels; refusing to adopt a namespace this package did not create",
 			namespace, labels.ManagedBy, labels.ValueValidator, labels.Component, component))
 	default:
 		// Already exists, owned by us, and usable. Nothing to do.
-		return existing, nil
+		return existing, false, nil
 	}
 
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
@@ -2043,17 +2047,17 @@ func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.
 	}}
 	created, err := clients.Create(nsCtx, ns, metav1.CreateOptions{})
 	if err == nil {
-		return created, nil
+		return created, true, nil
 	}
 	if !apierrors.IsAlreadyExists(err) {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
+		return nil, false, errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
 	}
 	// Lost a create race to a concurrent caller. Fetch the winning object
 	// rather than returning nil, so a UID-precondition caller still gets
 	// something to pin its later delete to.
 	winner, err := clients.Get(nsCtx, namespace, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to read namespace created by a concurrent caller", err)
+		return nil, false, errors.Wrap(errors.ErrCodeInternal, "failed to read namespace created by a concurrent caller", err)
 	}
 	if winner.DeletionTimestamp != nil {
 		// Wait for the terminating winner to fully disappear, then create
@@ -2062,21 +2066,21 @@ func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.
 		slog.Info("Namespace from a concurrent create race is terminating; waiting for full deletion",
 			"namespace", namespace)
 		if waitErr := waitForNamespaceGone(nsCtx, clients, namespace); waitErr != nil {
-			return nil, waitErr
+			return nil, false, waitErr
 		}
 		created, createErr := clients.Create(nsCtx, ns, metav1.CreateOptions{})
 		if createErr != nil {
-			return nil, errors.Wrap(errors.ErrCodeInternal,
+			return nil, false, errors.Wrap(errors.ErrCodeInternal,
 				"failed to create namespace after a concurrent owner finished terminating", createErr)
 		}
-		return created, nil
+		return created, true, nil
 	}
 	if !namespaceOwnedBy(winner, component) {
-		return nil, errors.New(errors.ErrCodeConflict, fmt.Sprintf(
+		return nil, false, errors.New(errors.ErrCodeConflict, fmt.Sprintf(
 			"namespace %q was created by a concurrent caller without the expected %s=%s,%s=%s labels; refusing to adopt it",
 			namespace, labels.ManagedBy, labels.ValueValidator, labels.Component, component))
 	}
-	return winner, nil
+	return winner, false, nil
 }
 
 // namespaceOwnedBy reports whether ns carries the labels ensureNamespace

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1618,7 +1618,7 @@ func buildTolerations(node v1.Node) []v1.Toleration {
 // deferred cleanup in the caller always runs — even if later steps fail.
 func deployInferenceWorkload(ctx *validators.Context, config *inferenceWorkloadConfig) error {
 	// Create namespace (idempotent).
-	if _, err := ensureNamespace(ctx, config.namespace); err != nil {
+	if _, err := ensureNamespace(ctx, config.namespace, labels.ValueInferencePerf); err != nil {
 		return errors.Wrap(errors.ErrCodeInternal, "failed to create namespace", err)
 	}
 
@@ -1998,14 +1998,15 @@ func ensureHFTokenSecret(ctx *validators.Context, namespace string) error {
 // "... forbidden: ... because it is being terminated". Waiting here until the
 // prior Terminating instance is fully gone avoids that race.
 //
-// Stamps labels.ManagedBy so pruneStaleNCCLNamespaces can later scope its
-// sweep to namespaces this package actually created, not just ones that
-// match its naming convention.
+// Stamps labels.ManagedBy and the given component value so a stale-namespace
+// prune (see pruneStaleNCCLNamespaces) can scope its List server-side to
+// namespaces this package actually created for one specific benchmark, not
+// just ones that happen to match a naming convention.
 //
 // Returns the resulting namespace object (its UID included) so callers that
 // need one, such as an owning-UID delete precondition, don't have to issue a
 // further Get for it.
-func ensureNamespace(ctx *validators.Context, namespace string) (*v1.Namespace, error) {
+func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.Namespace, error) {
 	nsCtx, cancel := context.WithTimeout(ctx.Ctx, defaults.InferenceNamespaceTerminationWait)
 	defer cancel()
 
@@ -2029,8 +2030,11 @@ func ensureNamespace(ctx *validators.Context, namespace string) (*v1.Namespace, 
 	}
 
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name:   namespace,
-		Labels: map[string]string{labels.ManagedBy: labels.ValueValidator},
+		Name: namespace,
+		Labels: map[string]string{
+			labels.ManagedBy: labels.ValueValidator,
+			labels.Component: component,
+		},
 	}}
 	created, err := clients.Create(nsCtx, ns, metav1.CreateOptions{})
 	if err == nil {

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1998,14 +1998,14 @@ func ensureHFTokenSecret(ctx *validators.Context, namespace string) error {
 // "... forbidden: ... because it is being terminated". Waiting here until the
 // prior Terminating instance is fully gone avoids that race.
 //
-// Stamps labels.ManagedBy and the given component value so a stale-namespace
-// prune (see pruneStaleNCCLNamespaces) can scope its List server-side to
-// namespaces this package actually created for one specific benchmark, not
-// just ones that happen to match a naming convention.
+// Stamps labels.ManagedBy and the given component value so
+// pruneStaleNCCLNamespaces can scope its List server-side to namespaces
+// this package actually created for one benchmark, not just ones matching
+// a naming convention.
 //
-// Returns the resulting namespace object (its UID included) so callers that
-// need one, such as an owning-UID delete precondition, don't have to issue a
-// further Get for it.
+// Returns the resulting namespace object, UID included, so a caller
+// needing one (e.g. an owning-UID delete precondition) doesn't have to
+// issue a further Get.
 func ensureNamespace(ctx *validators.Context, namespace, component string) (*v1.Namespace, error) {
 	nsCtx, cancel := context.WithTimeout(ctx.Ctx, defaults.InferenceNamespaceTerminationWait)
 	defer cancel()

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -1846,7 +1846,8 @@ func TestEnsureHFTokenSecret(t *testing.T) {
 // TestEnsureNamespace covers namespace adoption: a fresh namespace is
 // created and labeled, an existing one is reused only if it carries our
 // ownership labels, and a create-race winner (AlreadyExists) is read back
-// and held to the same ownership check.
+// and held to the same ownership check, including waiting out a winner
+// that's already terminating.
 func TestEnsureNamespace(t *testing.T) {
 	const ns = "aicr-inference-perf-deadbeef"
 	const component = labels.ValueInferencePerf
@@ -1905,6 +1906,40 @@ func TestEnsureNamespace(t *testing.T) {
 		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
 		if _, err := ensureNamespace(ctx, ns, component); !stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
 			t.Errorf("got %v, want ErrCodeConflict", err)
+		}
+	})
+
+	t.Run("waits for a terminating create-race winner then creates its own", func(t *testing.T) {
+		client := fake.NewClientset()
+		var seeded bool
+		client.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			createAction, ok := action.(k8stesting.CreateAction)
+			obj, objOK := createAction.GetObject().(*v1.Namespace)
+			if !ok || !objOK || obj.Name != ns || seeded {
+				return false, nil, nil // seeded: the winner is gone, let the retry Create through.
+			}
+			seeded = true
+			now := metav1.Now()
+			winner := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: ns, DeletionTimestamp: &now, Finalizers: []string{"kubernetes"},
+			}}
+			if err := client.Tracker().Add(winner); err != nil {
+				return true, nil, err
+			}
+			return true, nil, apierrors.NewAlreadyExists(v1.Resource("namespaces"), ns)
+		})
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			_ = client.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+		}()
+
+		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
+		got, err := ensureNamespace(ctx, ns, component)
+		if err != nil {
+			t.Fatalf("expected the retry to succeed once the winner finished terminating, got: %v", err)
+		}
+		if got.DeletionTimestamp != nil {
+			t.Error("returned namespace is still terminating")
 		}
 	})
 }

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -1855,12 +1855,15 @@ func TestEnsureNamespace(t *testing.T) {
 	t.Run("creates a fresh namespace", func(t *testing.T) {
 		client := fake.NewClientset()
 		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
-		got, err := ensureNamespace(ctx, ns, component)
+		got, created, err := ensureNamespace(ctx, ns, component)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got.Labels[labels.ManagedBy] != labels.ValueValidator || got.Labels[labels.Component] != component {
 			t.Errorf("created namespace labels = %v, want ManagedBy/Component set", got.Labels)
+		}
+		if !created {
+			t.Error("expected created=true for a brand new namespace")
 		}
 	})
 
@@ -1870,12 +1873,15 @@ func TestEnsureNamespace(t *testing.T) {
 		}}}
 		client := fake.NewClientset(owned)
 		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
-		got, err := ensureNamespace(ctx, ns, component)
+		got, created, err := ensureNamespace(ctx, ns, component)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got.Name != ns {
 			t.Errorf("got namespace %q, want %q", got.Name, ns)
+		}
+		if created {
+			t.Error("expected created=false for a reused namespace")
 		}
 	})
 
@@ -1883,7 +1889,7 @@ func TestEnsureNamespace(t *testing.T) {
 		foreign := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
 		client := fake.NewClientset(foreign)
 		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
-		if _, err := ensureNamespace(ctx, ns, component); !stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
+		if _, _, err := ensureNamespace(ctx, ns, component); !stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
 			t.Errorf("got %v, want ErrCodeConflict", err)
 		}
 	})
@@ -1904,8 +1910,38 @@ func TestEnsureNamespace(t *testing.T) {
 			return true, nil, apierrors.NewAlreadyExists(v1.Resource("namespaces"), ns)
 		})
 		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
-		if _, err := ensureNamespace(ctx, ns, component); !stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
+		if _, _, err := ensureNamespace(ctx, ns, component); !stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
 			t.Errorf("got %v, want ErrCodeConflict", err)
+		}
+	})
+
+	t.Run("adopts an owned create-race winner without claiming to have created it", func(t *testing.T) {
+		client := fake.NewClientset()
+		client.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			createAction, ok := action.(k8stesting.CreateAction)
+			obj, objOK := createAction.GetObject().(*v1.Namespace)
+			if !ok || !objOK || obj.Name != ns {
+				return false, nil, nil
+			}
+			// A concurrent caller using the same labels won the race.
+			winner := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, Labels: map[string]string{
+				labels.ManagedBy: labels.ValueValidator, labels.Component: component,
+			}}}
+			if err := client.Tracker().Add(winner); err != nil {
+				return true, nil, err
+			}
+			return true, nil, apierrors.NewAlreadyExists(v1.Resource("namespaces"), ns)
+		})
+		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
+		got, created, err := ensureNamespace(ctx, ns, component)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != ns {
+			t.Errorf("got namespace %q, want %q", got.Name, ns)
+		}
+		if created {
+			t.Error("expected created=false: a concurrent caller's Create won the race, not ours")
 		}
 	})
 
@@ -1934,12 +1970,15 @@ func TestEnsureNamespace(t *testing.T) {
 		}()
 
 		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
-		got, err := ensureNamespace(ctx, ns, component)
+		got, created, err := ensureNamespace(ctx, ns, component)
 		if err != nil {
 			t.Fatalf("expected the retry to succeed once the winner finished terminating, got: %v", err)
 		}
 		if got.DeletionTimestamp != nil {
 			t.Error("returned namespace is still terminating")
+		}
+		if !created {
+			t.Error("expected created=true: our own Create landed after the prior winner finished terminating")
 		}
 	})
 }

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	validatorv1 "github.com/NVIDIA/aicr/pkg/validator/v1"
 	"github.com/NVIDIA/aicr/validators"
 	"github.com/NVIDIA/aicr/validators/internal/allocmode"
@@ -1838,6 +1839,72 @@ func TestEnsureHFTokenSecret(t *testing.T) {
 		}
 		if _, err := client.CoreV1().Secrets(ns).Get(context.Background(), hfTokenSecretName, metav1.GetOptions{}); err == nil {
 			t.Error("stale HF token secret should be deleted when HF_TOKEN is unset")
+		}
+	})
+}
+
+// TestEnsureNamespace covers namespace adoption: a fresh namespace is
+// created and labeled, an existing one is reused only if it carries our
+// ownership labels, and a create-race winner (AlreadyExists) is read back
+// and held to the same ownership check.
+func TestEnsureNamespace(t *testing.T) {
+	const ns = "aicr-inference-perf-deadbeef"
+	const component = labels.ValueInferencePerf
+
+	t.Run("creates a fresh namespace", func(t *testing.T) {
+		client := fake.NewClientset()
+		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
+		got, err := ensureNamespace(ctx, ns, component)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Labels[labels.ManagedBy] != labels.ValueValidator || got.Labels[labels.Component] != component {
+			t.Errorf("created namespace labels = %v, want ManagedBy/Component set", got.Labels)
+		}
+	})
+
+	t.Run("reuses an existing namespace it owns", func(t *testing.T) {
+		owned := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, Labels: map[string]string{
+			labels.ManagedBy: labels.ValueValidator, labels.Component: component,
+		}}}
+		client := fake.NewClientset(owned)
+		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
+		got, err := ensureNamespace(ctx, ns, component)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != ns {
+			t.Errorf("got namespace %q, want %q", got.Name, ns)
+		}
+	})
+
+	t.Run("refuses to adopt an existing namespace it doesn't own", func(t *testing.T) {
+		foreign := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+		client := fake.NewClientset(foreign)
+		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
+		if _, err := ensureNamespace(ctx, ns, component); !stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
+			t.Errorf("got %v, want ErrCodeConflict", err)
+		}
+	})
+
+	t.Run("refuses to adopt an unowned create-race winner", func(t *testing.T) {
+		client := fake.NewClientset()
+		client.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			createAction, ok := action.(k8stesting.CreateAction)
+			obj, objOK := createAction.GetObject().(*v1.Namespace)
+			if !ok || !objOK || obj.Name != ns {
+				return false, nil, nil
+			}
+			// A concurrent, unrelated caller won the race to create ns first.
+			winner := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+			if err := client.Tracker().Add(winner); err != nil {
+				return true, nil, err
+			}
+			return true, nil, apierrors.NewAlreadyExists(v1.Resource("namespaces"), ns)
+		})
+		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
+		if _, err := ensureNamespace(ctx, ns, component); !stderrors.Is(err, errors.New(errors.ErrCodeConflict, "")) {
+			t.Errorf("got %v, want ErrCodeConflict", err)
 		}
 	})
 }

--- a/validators/performance/inference_perf_test.go
+++ b/validators/performance/inference_perf_test.go
@@ -1981,6 +1981,30 @@ func TestEnsureNamespace(t *testing.T) {
 			t.Error("expected created=true: our own Create landed after the prior winner finished terminating")
 		}
 	})
+
+	t.Run("waits for a pre-existing terminating namespace then creates its own", func(t *testing.T) {
+		now := metav1.Now()
+		terminating := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: ns, DeletionTimestamp: &now, Finalizers: []string{"kubernetes"},
+		}}
+		client := fake.NewClientset(terminating)
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			_ = client.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+		}()
+
+		ctx := &validators.Context{Ctx: context.Background(), Clientset: client}
+		got, created, err := ensureNamespace(ctx, ns, component)
+		if err != nil {
+			t.Fatalf("expected creation to succeed once the terminating namespace finished deleting, got: %v", err)
+		}
+		if got.Labels[labels.ManagedBy] != labels.ValueValidator || got.Labels[labels.Component] != component {
+			t.Errorf("created namespace labels = %v, want ManagedBy/Component set", got.Labels)
+		}
+		if !created {
+			t.Error("expected created=true: our own Create landed after the pre-existing namespace finished terminating")
+		}
+	})
 }
 
 // TestBuildAIPerfJob_EnvOverrides verifies the AICR_INFERENCE_PERF_* knobs flow

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1508,6 +1508,14 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 		if err := client.Delete(applyCtx, obj.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to delete stale resource for recreate", err)
 		}
+		// Delete only stamps DeletionTimestamp while a controller-serviced
+		// finalizer (Trainer v2 / JobSet ownership) is still clearing.
+		// Recreating immediately would race it and hit AlreadyExists again,
+		// defeating the same-run retry-after-hard-kill path this exists for.
+		if err := waitForResourceGone(applyCtx, client, obj.GetName()); err != nil {
+			return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
+				"failed waiting for stale resource to finish deleting before recreate")
+		}
 		obj.SetResourceVersion("")
 		if _, err := client.Create(applyCtx, obj, metav1.CreateOptions{}); err != nil {
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to recreate resource", err)
@@ -1524,6 +1532,49 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to update resource", err)
 	}
 	return nil
+}
+
+// waitForResourceGone watches a namespaced resource by name until it's
+// removed, mirroring waitForNamespaceGone for the dynamic client. Used by
+// createUnstructured to wait out a finalizer-held delete before recreating.
+func waitForResourceGone(ctx context.Context, client dynamic.ResourceInterface, name string) error {
+	watcher, err := client.Watch(ctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + name,
+	})
+	if err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to watch resource deletion", err)
+	}
+	defer watcher.Stop()
+
+	if _, getErr := client.Get(ctx, name, metav1.GetOptions{}); apierrors.IsNotFound(getErr) {
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
+				"timed out waiting for resource to be fully deleted", ctx.Err())
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return aicrErrors.Wrap(aicrErrors.ErrCodeTimeout,
+						"timed out waiting for resource to be fully deleted", ctxErr)
+				}
+				// Watch channel closed without cancellation. Re-Get before
+				// failing, since the resource may have been deleted during
+				// the closure window (apiserver hiccup, rolling restart).
+				if _, getErr := client.Get(ctx, name, metav1.GetOptions{}); apierrors.IsNotFound(getErr) {
+					return nil
+				}
+				return aicrErrors.New(aicrErrors.ErrCodeUnavailable,
+					"resource watch channel closed before deletion observed")
+			}
+			if event.Type == watch.Deleted {
+				return nil
+			}
+		}
+	}
 }
 
 // platformWorkerScheduling returns the default nodeSelector and tolerations

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -2413,16 +2413,20 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 // order. It deletes the per-run namespace first (cascading its
 // TrainJob/TrainingRuntime/ComputeDomain/RoCE-claim CRs), then, only on the
 // self-install fallback path, the Kubeflow Trainer installation itself.
-// The order matters. deleteTrainer removes the Trainer controller and its
-// CRDs, and doing that first would strand the namespace's own CRs'
-// controller-serviced finalizers, hanging the namespace in Terminating.
+// The order matters, deleteTrainer removes the Trainer controller and its
+// CRDs, which would strand the namespace's own CRs' finalizers if it ran
+// first. Trainer teardown only runs if the namespace delete succeeded,
+// since those CRs may otherwise still exist.
 //
 // benchErr is the check's result so far. A cleanup failure only overrides
 // a nil benchErr, never masking a real benchmark failure (see
 // foldCleanupError).
 func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interface, namespace string, uid types.UID, installedResources []trainerResourceRef, benchErr error) error {
-	err := foldCleanupError(benchErr, cleanupNCCLResources(clientset, namespace, uid),
-		"NCCL benchmark succeeded but NCCL resource cleanup failed")
+	nsErr := cleanupNCCLResources(clientset, namespace, uid)
+	err := foldCleanupError(benchErr, nsErr, "NCCL benchmark succeeded but NCCL resource cleanup failed")
+	if nsErr != nil {
+		return err
+	}
 	if len(installedResources) > 0 {
 		err = foldCleanupError(err, deleteTrainer(dynamicClient, installedResources),
 			"NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -631,7 +631,10 @@ func generateExecutionID() string {
 // claimNCCLExecutionLock's own takeover does. Renewing either succeeds,
 // proving nothing raced it, or loses to a Conflict, proving a takeover
 // already happened, in which case cleanup must not touch the namespace. A
-// missing lock has nothing left to protect and reports true.
+// missing lock reports false rather than true. It could mean this holder's
+// own lock was never created, but it could just as easily mean a replacement
+// is about to claim it, and treating the ambiguous case as authorization to
+// proceed risks deleting or mutating that replacement's live resources.
 //
 // Also used mid-run, right before mutating this namespace's fixed-name
 // resources, to revalidate a holder whose earlier pre-pod steps (Trainer
@@ -644,7 +647,7 @@ func ncclExecutionLockHeldBy(ctx context.Context, clientset kubernetes.Interface
 	leaseClient := clientset.CoordinationV1().Leases(namespace)
 	lease, err := leaseClient.Get(getCtx, ncclRunLockName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		return true, nil
+		return false, nil
 	}
 	if err != nil {
 		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check NCCL benchmark execution lock", err)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -609,6 +609,33 @@ func rollbackNCCLNamespace(clientset kubernetes.Interface, namespace string, uid
 	}
 }
 
+// releaseNCCLExecutionLockIfHeldBy best-effort deletes namespace's execution
+// lock, but only if it's still named holderID as the current holder.
+// pruneStaleNCCLNamespaces calls this when its own namespace delete fails
+// transiently. Left in place, the fence Lease it just claimed would
+// otherwise sit there until it ages past NCCLExecutionLockStaleAge, failing
+// a same-run retry closed for up to that long. Checking the holder first,
+// rather than deleting outright, keeps this from removing a legitimate
+// claim that lands in between.
+func releaseNCCLExecutionLockIfHeldBy(ctx context.Context, clientset kubernetes.Interface, namespace, holderID string) {
+	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	leaseClient := clientset.CoordinationV1().Leases(namespace)
+	lease, err := leaseClient.Get(getCtx, ncclRunLockName, metav1.GetOptions{})
+	if err != nil {
+		return // Gone, or unreadable; nothing this call can safely remove.
+	}
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != holderID {
+		return // Already taken over by someone else; not ours to remove.
+	}
+	if delErr := leaseClient.Delete(getCtx, ncclRunLockName, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{ResourceVersion: &lease.ResourceVersion},
+	}); delErr != nil && !apierrors.IsNotFound(delErr) {
+		slog.Warn("Failed to release an orphaned NCCL benchmark execution lock after a failed namespace delete",
+			"namespace", namespace, "error", delErr)
+	}
+}
+
 // generateExecutionID returns a fresh random identifier for one execution,
 // distinct from AICR_RUN_ID so two invocations sharing a run ID still get
 // different lock holder identities.
@@ -733,7 +760,8 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		// or freshly-won lock fails this with ErrCodeConflict. The
 		// namespace delete cascades this pruner's own claim away with
 		// everything else, so it never lingers.
-		if _, claimErr := claimNCCLExecutionLock(ctx, clientset, ns.Name); claimErr != nil {
+		holderID, claimErr := claimNCCLExecutionLock(ctx, clientset, ns.Name)
+		if claimErr != nil {
 			if stderrors.Is(claimErr, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
 				slog.Info("Skipping stale NCCL benchmark namespace prune: namespace has a live execution lock",
 					"namespace", ns.Name)
@@ -753,6 +781,11 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		delCancel()
 		if delErr != nil && !apierrors.IsNotFound(delErr) {
 			slog.Warn("Failed to delete stale NCCL benchmark namespace", "namespace", ns.Name, "error", delErr)
+			// The claim above just fenced this namespace off. Left in
+			// place after a failed delete, that Lease would otherwise
+			// block a legitimate same-run retry closed until it goes
+			// stale on its own.
+			releaseNCCLExecutionLockIfHeldBy(ctx, clientset, ns.Name, holderID)
 			otherNamespacesRemain = true
 			continue
 		}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -32,6 +32,7 @@ import (
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	k8spod "github.com/NVIDIA/aicr/pkg/k8s/pod"
 	"github.com/NVIDIA/aicr/pkg/recipe"
+	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	"github.com/NVIDIA/aicr/validators"
 	"github.com/NVIDIA/aicr/validators/helper"
 	"github.com/NVIDIA/aicr/validators/internal/gkenet"
@@ -553,21 +554,30 @@ func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interf
 // killed standalone run instead orphans a namespace under a different random
 // suffix that no future run will ever name again, so nothing else reclaims it.
 //
+// Scoped server-side to labels.ManagedBy=aicr-validator, the label
+// ensureNamespace stamps on creation, so name shape and age alone never
+// qualify an unrelated namespace for deletion.
+//
 // Deletion is fire-and-forget: this only issues the Delete call and moves on,
 // it never waits for the namespace to fully terminate, so it adds no
-// wall-clock cost to the run in progress. currentNamespace and anything
-// younger than defaults.NCCLStaleNamespacePruneAge are left alone, so a
-// namespace still owned by an in-progress sibling variant is never touched.
-// An aged namespace that still has a live pod is also left alone, using the
-// same verifyNCCLNamespaceNotLive occupancy check the adoption gate uses, in
-// case some other execution has simply run long. Listing or deleting
-// failures are logged and otherwise ignored. This is opportunistic cleanup,
-// not something a benchmark run should ever fail for.
+// wall-clock cost to the run in progress. The delete carries a UID
+// precondition pinned to the instance this List observed, so a same-named
+// namespace recreated by someone else in between is left alone.
+// currentNamespace and anything younger than
+// defaults.NCCLStaleNamespacePruneAge are left alone, so a namespace still
+// owned by an in-progress sibling variant is never touched. An aged
+// namespace that still has a live pod is also left alone, using the same
+// verifyNCCLNamespaceNotLive occupancy check the adoption gate uses, in case
+// some other execution has simply run long. Listing or deleting failures are
+// logged and otherwise ignored. This is opportunistic cleanup, not something
+// a benchmark run should ever fail for.
 func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interface, currentNamespace string) {
 	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
 
-	namespaces, err := clientset.CoreV1().Namespaces().List(listCtx, metav1.ListOptions{})
+	namespaces, err := clientset.CoreV1().Namespaces().List(listCtx, metav1.ListOptions{
+		LabelSelector: labels.ManagedBy + "=" + labels.ValueValidator,
+	})
 	if err != nil {
 		slog.Warn("Failed to list namespaces for stale NCCL benchmark namespace prune", "error", err)
 		return
@@ -591,7 +601,10 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		}
 
 		delCtx, delCancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
-		delErr := clientset.CoreV1().Namespaces().Delete(delCtx, ns.Name, metav1.DeleteOptions{})
+		uid := ns.UID
+		delErr := clientset.CoreV1().Namespaces().Delete(delCtx, ns.Name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &uid},
+		})
 		delCancel()
 		if delErr != nil && !apierrors.IsNotFound(delErr) {
 			slog.Warn("Failed to delete stale NCCL benchmark namespace", "namespace", ns.Name, "error", delErr)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -705,6 +705,9 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 			continue
 		}
 		if ns.DeletionTimestamp != nil {
+			// Still terminating. Its TrainJob/TrainingRuntime CRs need the
+			// Trainer controller alive to clear their finalizers.
+			otherNamespacesRemain = true
 			continue
 		}
 		if time.Since(ns.CreationTimestamp.Time) < defaults.NCCLStaleNamespacePruneAge {
@@ -752,6 +755,9 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		}
 		slog.Info("Deleted stale NCCL benchmark namespace left behind by an interrupted run",
 			"namespace", ns.Name, "age", time.Since(ns.CreationTimestamp.Time).Round(time.Minute))
+		// The delete was accepted, but its cascade still needs the Trainer
+		// controller to service the namespace's CRs' finalizers.
+		otherNamespacesRemain = true
 	}
 
 	reapOrphanedTrainerInstall(ctx, clientset, dynamicClient, otherNamespacesRemain)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -63,6 +63,14 @@ const (
 	// ncclTrainingRuntimeName is the name of the TrainingRuntime resource.
 	// Must stay in sync with runtime.yaml.
 	ncclTrainingRuntimeName = "nccl-all-reduce-runtime"
+
+	// ncclWorkloadNamespacePrefix is the base for the per-run benchmark
+	// namespace (see runNCCLTrainJob). Isolating each run in its own
+	// namespace, the same pattern inferenceWorkloadNamespacePrefix uses,
+	// means the fixed resource names below never collide across concurrent
+	// or crashed runs: uniqueness only has to hold within a namespace, and
+	// cleanup is a single namespace delete instead of per-resource tracking.
+	ncclWorkloadNamespacePrefix = "aicr-nccl-perf"
 )
 
 // skipMsg* are the constraint-result strings returned when the NCCL check cannot
@@ -485,6 +493,26 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 
 	dynamicClient := ctx.DynamicClient
 
+	// Isolate this run in its own namespace, the same pattern
+	// inferenceWorkloadConfig uses (see deriveRunID/ensureNamespace): every
+	// fixed resource name below only has to be unique within it, so two
+	// concurrent (or one crashed, one retried) aicr validate runs can never
+	// collide, adopt, or delete each other's resources — no lock required.
+	gpuConfig.Namespace = fmt.Sprintf("%s-%s", ncclWorkloadNamespacePrefix, deriveRunID())
+	if err = ensureNamespace(ctx, gpuConfig.Namespace); err != nil {
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace", err)
+	}
+
+	// Clean up the per-run namespace (and everything created in it) on every
+	// exit path from here on, including a failed Trainer install below.
+	// NotFound-tolerant, so running it after an early/partial-apply failure is
+	// safe. A cleanup failure only overrides a nil benchErr — see
+	// foldCleanupError — so it never masks a real benchmark failure.
+	defer func() {
+		err = foldCleanupError(err, cleanupNCCLResources(ctx.Clientset, gpuConfig.Namespace),
+			"NCCL benchmark succeeded but NCCL resource cleanup failed")
+	}()
+
 	// Ensure a usable Kubeflow Trainer. Whether an incomplete installation is a
 	// failure or something to install over is decided by the recipe, not by what
 	// happens to be on the cluster: a recipe that ships the component must have a
@@ -499,20 +527,10 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	}
 	if len(installedResources) > 0 {
 		defer func() {
-			err = foldCleanupError(err, deleteTrainer(dynamicClient, installedResources))
+			err = foldCleanupError(err, deleteTrainer(dynamicClient, installedResources),
+				"NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
 		}()
 	}
-
-	// Clean up NCCL resources on every exit path. Registered after the trainer
-	// install block but before the apply: defers run LIFO, so this runs *before*
-	// the conditional deleteTrainer above — the NCCL TrainJob/TrainingRuntime CRs
-	// are deleted while their CRDs still exist, rather than relying on CRD-delete
-	// cascade GC. Registering it before applyNCCLResources still guarantees a
-	// partial-apply failure (e.g. the RoCE claim is created, then the runtime or
-	// TrainJob apply fails) doesn't leak nccl-roce-rct into the persistent, reused
-	// validation namespace. cleanupNCCLResources is NotFound-tolerant for every
-	// resource it deletes, so running it after an early failure is safe.
-	defer cleanupNCCLResources(dynamicClient, gpuConfig.Namespace)
 
 	// Apply runtime and trainjob resources. Propagate an inner code rather than
 	// forcing ErrCodeInternal — a recipe-supplied runtime that fails to render is
@@ -523,7 +541,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 
 	podHelper := &helper.PodLifecycle{
 		ClientSet: ctx.Clientset,
-		Namespace: ctx.Namespace,
+		Namespace: gpuConfig.Namespace,
 	}
 
 	// Wait for launcher pod and get logs.
@@ -540,8 +558,11 @@ type gpuConfiguration struct {
 	WorkerCount     int
 	GPUCountPerNode int
 	TotalGPUCount   int
-	Namespace       string
-	Nodes           []v1.Node
+	// Namespace is the per-run benchmark namespace; unset by determineGPUConfig
+	// and filled in by runNCCLTrainJob once it derives one (see
+	// ncclWorkloadNamespacePrefix).
+	Namespace string
+	Nodes     []v1.Node
 }
 
 // parseThreshold extracts the numeric threshold value from a constraint value.
@@ -761,7 +782,6 @@ func determineGPUConfig(ctx *validators.Context, service recipe.CriteriaServiceT
 		WorkerCount:     len(targetNodes),
 		GPUCountPerNode: gpuCountPerNode,
 		TotalGPUCount:   totalGPUs,
-		Namespace:       ctx.Namespace,
 		Nodes:           targetNodes,
 	}, nil
 }
@@ -936,10 +956,10 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	if err != nil {
 		return err
 	}
-	if err := applyNCCLWorkerScheduling(runtimeObj, effectiveNodeSelector, effectiveTolerations); err != nil {
+	if err = applyNCCLWorkerScheduling(runtimeObj, effectiveNodeSelector, effectiveTolerations); err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply NCCL worker scheduling", err)
 	}
-	if err := createUnstructured(ctx.Ctx, dynamicClient, trainingRuntimeGVR, config.Namespace, runtimeObj); err != nil {
+	if err = createUnstructured(ctx.Ctx, dynamicClient, trainingRuntimeGVR, config.Namespace, runtimeObj); err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply training runtime", err)
 	}
 	slog.Info("Applied TrainingRuntime", "service", service)
@@ -947,7 +967,7 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	// Wait for the runtime to be visible to the Trainer admission webhook.
 	// The webhook validates that the referenced runtime exists before allowing
 	// TrainJob creation; without this wait we hit a race condition.
-	if err := waitForTrainingRuntime(ctx.Ctx, dynamicClient, config.Namespace); err != nil {
+	if err = waitForTrainingRuntime(ctx.Ctx, dynamicClient, config.Namespace); err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "TrainingRuntime not ready", err)
 	}
 
@@ -960,10 +980,10 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	// runtime: IMEX/ComputeDomain wiring is part of the fabric contract the
 	// runtime owns, so it must declare any ComputeDomain/ResourceClaim it needs.
 	if customRuntime == "" && variant == variantNVLS {
-		if err := applyNCCLComputeDomain(ctx.Ctx, dynamicClient, config.Namespace); err != nil {
+		if err = applyNCCLComputeDomain(ctx.Ctx, dynamicClient, config.Namespace); err != nil {
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to apply ComputeDomain", err)
 		}
-		if err := waitForIMEXClaimTemplate(ctx.Ctx, dynamicClient, config.Namespace); err != nil {
+		if err = waitForIMEXClaimTemplate(ctx.Ctx, dynamicClient, config.Namespace); err != nil {
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "IMEX ResourceClaimTemplate not ready", err)
 		}
 	}
@@ -975,7 +995,7 @@ func applyNCCLResources(ctx *validators.Context, dynamicClient dynamic.Interface
 	// rejected with "TrainingRuntime not found". applyTrainJobWithRetry retries
 	// on exactly that denial until the webhook cache catches up.
 	trainjobPath := filepath.Join("testdata", "trainjob.yaml")
-	if err := applyTrainJobWithRetry(ctx.Ctx, dynamicClient, config.Namespace, trainjobPath, templateData); err != nil {
+	if err = applyTrainJobWithRetry(ctx.Ctx, dynamicClient, config.Namespace, trainjobPath, templateData); err != nil {
 		return err
 	}
 	slog.Info("Applied TrainJob")
@@ -1114,7 +1134,10 @@ func applyNCCLComputeDomain(ctx context.Context, dynamicClient dynamic.Interface
 
 	// AlreadyExists: fetch the current resourceVersion and Update in place.
 	// Required because Update rejects an empty resourceVersion to prevent
-	// lost updates.
+	// lost updates. Adopting an existing ComputeDomain here is intentional:
+	// it's how a stale one left by a prior run under this same per-run
+	// namespace (e.g. a retry reusing AICR_RUN_ID after a hard kill before
+	// cleanup ran) gets reclaimed instead of failing with AlreadyExists.
 	existing, err := client.Get(applyCtx, ncclComputeDomainName, metav1.GetOptions{})
 	if err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get existing ComputeDomain", err)
@@ -1307,12 +1330,12 @@ func renderYAMLTemplate(content string, data map[string]string) (*unstructured.U
 	return obj, nil
 }
 
-// createUnstructured creates a namespaced resource from an unstructured object with a timeout.
+// createUnstructured creates a namespaced resource from an unstructured object
+// with a timeout.
 func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
 	applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
-	_, err := dynamicClient.Resource(gvr).Namespace(namespace).Create(applyCtx, obj, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := dynamicClient.Resource(gvr).Namespace(namespace).Create(applyCtx, obj, metav1.CreateOptions{}); err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create resource", err)
 	}
 	return nil
@@ -1512,7 +1535,7 @@ func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.Pod
 	launcherPod, err := waitForPodByLabelSelector(
 		ctx.Ctx,
 		ctx.Clientset,
-		ctx.Namespace,
+		podHelper.Namespace,
 		fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s,jobset.sigs.k8s.io/replicatedjob-name=launcher", ncclTrainJobName),
 		defaults.NCCLLauncherPodTimeout,
 	)
@@ -1564,14 +1587,14 @@ func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.Pod
 		// the pod object and survives the container GC that GetPodLogs loses to.
 		// Either way the fetchNote reason is preserved in the payload.
 		if launcherLogs == "" {
-			if term := launcherTerminationTail(ctx.Ctx, ctx.Clientset, ctx.Namespace, launcherPod.Name); term != "" {
+			if term := launcherTerminationTail(ctx.Ctx, ctx.Clientset, podHelper.Namespace, launcherPod.Name); term != "" {
 				launcherLogs = fmt.Sprintf("<%s; container termination-message tail follows>\n%s",
 					fetchNote, tailLines(term, maxDiagLogLines))
 			} else {
 				launcherLogs = fmt.Sprintf("<%s; no termination message captured>", fetchNote)
 			}
 		}
-		workerDiag := collectNCCLWorkerDiagnostics(ctx.Ctx, ctx.Clientset, ctx.Namespace)
+		workerDiag := collectNCCLWorkerDiagnostics(ctx.Ctx, ctx.Clientset, podHelper.Namespace)
 
 		// Surface the diagnostics via slog, not just the return value: every
 		// caller on this error path (runNCCLTrainJob, validateNcclAllReduceBw,
@@ -1607,7 +1630,7 @@ func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.Pod
 	// rotation-proof source of truth while the streamed log remains available for
 	// transport verification and diagnostics. Empty for launchers that don't write
 	// results there (other platforms), leaving behavior unchanged.
-	term := launcherTerminationTail(ctx.Ctx, ctx.Clientset, ctx.Namespace, launcherPod.Name)
+	term := launcherTerminationTail(ctx.Ctx, ctx.Clientset, podHelper.Namespace, launcherPod.Name)
 	if term != "" {
 		slog.Info("Appending launcher termination message (rotation-proof results)", "termBytes", len(term))
 	}
@@ -2082,66 +2105,53 @@ func verifyTransportFromLogs(logs string, variant ncclVariant) error {
 	}
 }
 
-// cleanupNCCLResources removes the trainjob, runtime, and (if present) the
-// ComputeDomain CR using the dynamic client. Deleting the ComputeDomain
-// cascades to its auto-generated ResourceClaimTemplate via the DRA driver;
-// NotFound on the ComputeDomain is expected for the default/NET variants
-// and is logged at debug rather than error.
-func cleanupNCCLResources(dynamicClient dynamic.Interface, namespace string) {
-	slog.Info("Cleaning up NCCL test resources...")
+// cleanupNCCLResources deletes the per-run benchmark namespace, cascading
+// away the trainjob, runtime, and (if present) the ComputeDomain and RoCE
+// ResourceClaimTemplate CRs this run created in it, mirroring
+// cleanupInferenceWorkload's pattern for the sibling inference-perf check.
+// Since runNCCLTrainJob gives every run its own namespace (see
+// ncclWorkloadNamespacePrefix), there is no shared state to pin deletes
+// against: nothing else ever lives in this namespace.
+//
+// Namespaces().Delete only starts asynchronous deletion. It returns as soon
+// as the delete is accepted, not once the namespace (and the
+// ComputeDomain/ResourceClaimTemplate/TrainJob finalizers cascading through
+// it) is actually gone. Waiting here for the deletion to finish, via the
+// same waitForNamespaceGone helper ensureNamespace already uses on the
+// create side for exactly this reason (see its doc comment), means a
+// successful benchmark can't report clean teardown while resources are
+// still leaking.
+//
+// Unlike cleanupInferenceWorkload, a delete failure here is returned rather
+// than only logged, so foldCleanupError can still fail an otherwise-passing
+// check on it. NotFound is tolerated (nothing to clean up).
+func cleanupNCCLResources(clientset kubernetes.Interface, namespace string) error {
+	slog.Info("Cleaning up NCCL test resources...", "namespace", namespace)
 
-	cleanupCtx, cancel := context.WithTimeout(context.Background(), defaults.DiagnosticTimeout)
+	deleteCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 	defer cancel()
 
-	// Delete trainjob. NotFound is expected and logged at debug: this runs as a
-	// deferred cleanup registered before the apply, so an early/partial-apply
-	// failure (or the install-trainer path, where deleteTrainer may already have
-	// cascade-removed the CRs) legitimately leaves no TrainJob to delete.
-	err := dynamicClient.Resource(trainJobGVR).Namespace(namespace).Delete(cleanupCtx, ncclTrainJobName, metav1.DeleteOptions{})
-	switch {
-	case err == nil:
-		slog.Info("Deleted TrainJob")
-	case apierrors.IsNotFound(err):
-		slog.Debug("TrainJob not present, skipping", "name", ncclTrainJobName)
-	default:
-		slog.Warn("failed to delete TrainJob", "error", err)
+	nsClient := clientset.CoreV1().Namespaces()
+	err := nsClient.Delete(deleteCtx, namespace, metav1.DeleteOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			slog.Info("NCCL benchmark namespace already gone", "namespace", namespace)
+			return nil
+		}
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("failed to delete NCCL benchmark namespace %q", namespace), err)
 	}
 
-	// Delete runtime. NotFound is expected and logged at debug (see TrainJob above).
-	err = dynamicClient.Resource(trainingRuntimeGVR).Namespace(namespace).Delete(cleanupCtx, ncclTrainingRuntimeName, metav1.DeleteOptions{})
-	switch {
-	case err == nil:
-		slog.Info("Deleted TrainingRuntime")
-	case apierrors.IsNotFound(err):
-		slog.Debug("TrainingRuntime not present, skipping", "name", ncclTrainingRuntimeName)
-	default:
-		slog.Warn("failed to delete TrainingRuntime", "error", err)
+	// Same bound as ensureNamespace's wait on the create side (see
+	// defaults.InferenceNamespaceTerminationWait doc comment). This cascade
+	// is the same finalizer chain, just observed from the delete side.
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), defaults.InferenceNamespaceTerminationWait)
+	defer waitCancel()
+	if err := waitForNamespaceGone(waitCtx, nsClient, namespace); err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("NCCL benchmark namespace %q did not finish terminating", namespace), err)
 	}
 
-	// Delete ComputeDomain if this was the NVLS variant. NotFound is the
-	// expected path for default/NET and is ignored here; other errors bubble
-	// up as a warning because the RCT and IMEX daemons otherwise leak.
-	err = dynamicClient.Resource(computeDomainGVR).Namespace(namespace).Delete(cleanupCtx, ncclComputeDomainName, metav1.DeleteOptions{})
-	switch {
-	case err == nil:
-		slog.Info("Deleted ComputeDomain")
-	case apierrors.IsNotFound(err):
-		slog.Debug("ComputeDomain not present (non-NVLS variant), skipping", "name", ncclComputeDomainName)
-	default:
-		slog.Warn("failed to delete ComputeDomain", "error", err, "name", ncclComputeDomainName)
-	}
-
-	// Delete the RoCE ResourceClaimTemplate (RoCE NET variant only). The
-	// validator namespace is persistent and reused across runs, so leaving it
-	// behind makes the next RoCE run fail with AlreadyExists when
-	// applyNCCLResources re-creates it. NotFound is expected for EFA/NVLS runs.
-	err = dynamicClient.Resource(resourceClaimTemplateGVR).Namespace(namespace).Delete(cleanupCtx, ncclRoceClaimName, metav1.DeleteOptions{})
-	switch {
-	case err == nil:
-		slog.Info("Deleted RoCE ResourceClaimTemplate", "name", ncclRoceClaimName)
-	case apierrors.IsNotFound(err):
-		slog.Debug("RoCE ResourceClaimTemplate not present (non-RoCE variant), skipping", "name", ncclRoceClaimName)
-	default:
-		slog.Warn("failed to delete RoCE ResourceClaimTemplate", "error", err, "name", ncclRoceClaimName)
-	}
+	slog.Info("Deleted NCCL benchmark namespace", "namespace", namespace)
+	return nil
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -2198,13 +2198,17 @@ func verifyTransportFromLogs(logs string, variant ncclVariant) error {
 // ComputeDomain/ResourceClaimTemplate/TrainJob finalizers cascading through
 // it) is actually gone. Waiting here for the deletion to finish, via the
 // same waitForNamespaceGone helper ensureNamespace already uses on the
-// create side for exactly this reason (see its doc comment), means a
-// successful benchmark can't report clean teardown while resources are
-// still leaking.
+// create side for exactly this reason (see its doc comment), gives teardown
+// observability in the common case. But the wait itself only ever logs on
+// timeout (see below). Once Delete is accepted, cascading GC completes
+// server-side regardless of whether we wait for it here, and NVLS runs'
+// ComputeDomain/ResourceClaimTemplate DRA/IMEX finalizers can legitimately
+// outlast the wait bound on the dual-fabric GB200 path.
 //
-// Unlike cleanupInferenceWorkload, a delete failure here is returned rather
-// than only logged, so foldCleanupError can still fail an otherwise-passing
-// check on it. NotFound is tolerated (nothing to clean up).
+// Unlike cleanupInferenceWorkload, a Delete call failure itself is returned
+// rather than only logged, so foldCleanupError can still fail an
+// otherwise-passing check on it. That is the actual "did cleanup happen"
+// signal. NotFound is tolerated (nothing to clean up).
 //
 // uid pins the delete to the exact namespace instance runNCCLTrainJob
 // created or reclaimed: if that instance was deleted and a different one
@@ -2231,12 +2235,18 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 
 	// Same bound as ensureNamespace's wait on the create side (see
 	// defaults.InferenceNamespaceTerminationWait doc comment). This cascade
-	// is the same finalizer chain, just observed from the delete side.
+	// is the same finalizer chain, just observed from the delete side. Only
+	// logged on timeout, not returned: the Delete call above already
+	// succeeded, so a slow-but-real teardown (e.g. NVLS's DRA/IMEX
+	// finalizers) must not fail an otherwise-passing benchmark just because
+	// this observability wait ran out first.
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), defaults.InferenceNamespaceTerminationWait)
 	defer waitCancel()
 	if err := waitForNamespaceGone(waitCtx, nsClient, namespace); err != nil {
-		return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
-			fmt.Sprintf("NCCL benchmark namespace %q did not finish terminating", namespace))
+		slog.Warn("NCCL benchmark namespace did not finish terminating within the wait bound, "+
+			"deletion was accepted and its cascading GC continues in the background",
+			"namespace", namespace, "error", err)
+		return nil
 	}
 
 	slog.Info("Deleted NCCL benchmark namespace", "namespace", namespace)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1459,12 +1459,16 @@ func renderYAMLTemplate(content string, data map[string]string) (*unstructured.U
 // createUnstructured creates a namespaced resource from an unstructured object
 // with a timeout.
 // createUnstructured creates obj. If a fixed-name resource with that
-// GVR/name already exists, it reclaims it by updating it in place. Both
-// callers (TrainingRuntime, TrainJob) use fixed names inside the caller's
-// per-run namespace, so an AlreadyExists here only happens on a same-run
-// retry after a hard kill left it behind; reclaiming it, the same way
-// applyNCCLComputeDomain already does for ComputeDomain, lets that retry
-// recover instead of failing.
+// GVR/name already exists, it reclaims it so a same-run retry after a hard
+// kill can recover instead of failing on AlreadyExists.
+//
+// TrainJob reclaims by delete-then-recreate rather than update. Kubeflow
+// Trainer treats most of its spec as immutable once created and rejects an
+// in-place update to those fields, and even a permitted update would not
+// make the controller recreate the underlying JobSet/pods, which is what a
+// stale TrainJob left behind by a hard kill actually needs. Every other
+// caller (TrainingRuntime) reclaims by updating in place, the same way
+// applyNCCLComputeDomain already does for ComputeDomain.
 func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
 	applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -1474,6 +1478,17 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 		return nil
 	} else if !apierrors.IsAlreadyExists(err) {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create resource", err)
+	}
+
+	if gvr == trainJobGVR {
+		if err := client.Delete(applyCtx, obj.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to delete stale resource for recreate", err)
+		}
+		obj.SetResourceVersion("")
+		if _, err := client.Create(applyCtx, obj, metav1.CreateOptions{}); err != nil {
+			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to recreate resource", err)
+		}
+		return nil
 	}
 
 	existing, err := client.Get(applyCtx, obj.GetName(), metav1.GetOptions{})

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -615,8 +615,14 @@ func generateExecutionID() string {
 // proving nothing raced it, or loses to a Conflict, proving a takeover
 // already happened, in which case cleanup must not touch the namespace. A
 // missing lock has nothing left to protect and reports true.
-func ncclExecutionLockHeldBy(clientset kubernetes.Interface, namespace, holderID string) (bool, error) {
-	getCtx, cancel := context.WithTimeout(context.Background(), defaults.DiagnosticTimeout)
+//
+// Also used mid-run, right before mutating this namespace's fixed-name
+// resources, to revalidate a holder whose earlier pre-pod steps (Trainer
+// install, resource apply) ran long enough for a same-run retry to take the
+// lock over. The renewal doubles as a heartbeat in that case, since
+// succeeding extends the caller's own claim by another NCCLExecutionLockStaleAge.
+func ncclExecutionLockHeldBy(ctx context.Context, clientset kubernetes.Interface, namespace, holderID string) (bool, error) {
+	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
 	leaseClient := clientset.CoordinationV1().Leases(namespace)
 	lease, err := leaseClient.Get(getCtx, ncclRunLockName, metav1.GetOptions{})
@@ -798,6 +804,20 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 		ctx.Clientset.Discovery(), recipeDeclaresTrainer)
 	if err != nil {
 		return "", err
+	}
+
+	// Trainer install can run long enough for the execution lock to go stale
+	// and be taken over by a same-run retry. Revalidate (and renew)
+	// ownership before mutating this namespace's fixed-name resources, so a
+	// resumed caller that's since been superseded fails closed instead of
+	// updating or recreating the new holder's resources.
+	held, err := ncclExecutionLockHeldBy(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace, holderID)
+	if err != nil {
+		return "", err
+	}
+	if !held {
+		return "", aicrErrors.New(aicrErrors.ErrCodeConflict,
+			fmt.Sprintf("NCCL benchmark execution lock for namespace %q was taken over by another execution; refusing to proceed", gpuConfig.Namespace))
 	}
 
 	// Apply runtime and trainjob resources. Propagate an inner code rather than
@@ -2576,7 +2596,7 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 // a nil benchErr, never masking a real benchmark failure (see
 // foldCleanupError).
 func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interface, namespace string, uid types.UID, holderID string, installedResources []trainerResourceRef, benchErr error) error {
-	held, lockErr := ncclExecutionLockHeldBy(clientset, namespace, holderID)
+	held, lockErr := ncclExecutionLockHeldBy(context.Background(), clientset, namespace, holderID)
 	if lockErr != nil {
 		return foldCleanupError(benchErr, lockErr, "NCCL benchmark succeeded but its execution lock could not be checked")
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -2702,11 +2702,50 @@ func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interf
 		return err
 	}
 	if len(installedResources) > 0 {
-		if trainerErr := deleteTrainer(dynamicClient, installedResources); trainerErr != nil {
+		// A concurrent run with a different AICR_RUN_ID gets its own
+		// namespace, but the two can still share this same self-installed
+		// Trainer: ensureTrainerInstalled's reuse path returns no
+		// resources for the peer, so only this run's cleanup ever sees
+		// installedResources non-empty. Deleting Trainer here regardless
+		// of that peer would fail its still-running TrainJob out from
+		// under it. On a List failure, leave Trainer installed rather
+		// than risk deleting it out from under a peer this call could
+		// not rule out.
+		othersRemain, listErr := otherNCCLNamespacesExist(context.Background(), clientset, namespace)
+		if listErr != nil {
+			slog.Warn("Failed to check for other NCCL benchmark namespaces; leaving Trainer installed for a later cleanup",
+				"namespace", namespace, "error", listErr)
+		} else if othersRemain {
+			slog.Info("Other NCCL benchmark namespaces remain; leaving the self-installed Trainer for a later cleanup",
+				"namespace", namespace)
+		} else if trainerErr := deleteTrainer(dynamicClient, installedResources); trainerErr != nil {
 			err = foldCleanupError(err, trainerErr, "NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
 		} else {
 			removeTrainerInstallManifestEntries(context.Background(), clientset, installedResources)
 		}
 	}
 	return err
+}
+
+// otherNCCLNamespacesExist reports whether any AICR-owned NCCL benchmark
+// namespace other than namespace currently exists. cleanupNCCLRun checks
+// this before eagerly deleting a self-installed Trainer, since a
+// concurrent run with a different run ID can share that same install and
+// still be using it.
+func otherNCCLNamespacesExist(ctx context.Context, clientset kubernetes.Interface, namespace string) (bool, error) {
+	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	namespaces, err := clientset.CoreV1().Namespaces().List(listCtx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+			labels.ManagedBy, labels.ValueValidator, labels.Component, labels.ValueNCCLPerf),
+	})
+	if err != nil {
+		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to list NCCL benchmark namespaces", err)
+	}
+	for _, ns := range namespaces.Items {
+		if ns.Name != namespace {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -604,20 +604,41 @@ func generateExecutionID() string {
 	return hex.EncodeToString(buf)
 }
 
-// ncclExecutionLockHeldBy reports whether namespace's execution lock still
-// names holderID as the current holder. A missing lock has nothing left to
-// protect and reports true.
+// ncclExecutionLockHeldBy confirms namespace's execution lock still names
+// holderID as the current holder, and renews it in the same call. A plain
+// read-only check here would leave a gap between the read and
+// cleanupNCCLResources's delete for a takeover to land in: both executions
+// would then share the same namespace UID, and the stale holder's delete
+// would remove the new holder's live namespace. Renewing pinned to the
+// resourceVersion just read closes that gap the same way
+// claimNCCLExecutionLock's own takeover does. Renewing either succeeds,
+// proving nothing raced it, or loses to a Conflict, proving a takeover
+// already happened, in which case cleanup must not touch the namespace. A
+// missing lock has nothing left to protect and reports true.
 func ncclExecutionLockHeldBy(clientset kubernetes.Interface, namespace, holderID string) (bool, error) {
 	getCtx, cancel := context.WithTimeout(context.Background(), defaults.DiagnosticTimeout)
 	defer cancel()
-	lease, err := clientset.CoordinationV1().Leases(namespace).Get(getCtx, ncclRunLockName, metav1.GetOptions{})
+	leaseClient := clientset.CoordinationV1().Leases(namespace)
+	lease, err := leaseClient.Get(getCtx, ncclRunLockName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return true, nil
 	}
 	if err != nil {
 		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check NCCL benchmark execution lock", err)
 	}
-	return lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity == holderID, nil
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != holderID {
+		return false, nil
+	}
+
+	now := metav1.NewMicroTime(time.Now())
+	lease.Spec.RenewTime = &now
+	if _, err := leaseClient.Update(getCtx, lease, metav1.UpdateOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			return false, nil
+		}
+		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to renew NCCL benchmark execution lock before cleanup", err)
+	}
+	return true, nil
 }
 
 // pruneStaleNCCLNamespaces best-effort deletes aicr-nccl-perf-* namespaces

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -562,14 +562,21 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	}
 	namespaceUID := nsObj.UID
 
-	// Clean up the per-run namespace (and everything created in it) on every
-	// exit path from here on, including a failed Trainer install below.
-	// NotFound-tolerant, so running it after an early/partial-apply failure is
-	// safe. A cleanup failure only overrides a nil benchErr — see
-	// foldCleanupError — so it never masks a real benchmark failure.
+	// Clean up everything this run created, on every exit path from here on
+	// (including a failed Trainer install below), via a single defer
+	// registered before installedResources is even known. installedResources
+	// is read by closure once cleanupNCCLRun actually runs, so this defer
+	// covers both an early ensureTrainerInstalled failure (installedResources
+	// still nil) and the normal success path. Two separately registered
+	// defers would run in LIFO order instead, tearing down the (self-install
+	// fallback only) Trainer controller and its TrainJob/TrainingRuntime CRDs
+	// *before* the namespace's own TrainJob/TrainingRuntime CRs are deleted.
+	// That can leave those CRs' controller-serviced finalizers stuck forever
+	// and hang the namespace in Terminating. See cleanupNCCLRun for the
+	// enforced order.
+	var installedResources []trainerResourceRef
 	defer func() {
-		err = foldCleanupError(err, cleanupNCCLResources(ctx.Clientset, gpuConfig.Namespace, namespaceUID),
-			"NCCL benchmark succeeded but NCCL resource cleanup failed")
+		err = cleanupNCCLRun(ctx.Clientset, dynamicClient, gpuConfig.Namespace, namespaceUID, installedResources, err)
 	}()
 
 	// Ensure a usable Kubeflow Trainer. Whether an incomplete installation is a
@@ -579,16 +586,10 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// installs an ephemeral fixture only when nothing is. Anything we install is
 	// ours to clean up after the test completes.
 	recipeDeclaresTrainer := validators.RecipeDeclares(ctx, kubeflowTrainerComponent)
-	installedResources, err := ensureTrainerInstalled(ctx.Ctx, dynamicClient,
+	installedResources, err = ensureTrainerInstalled(ctx.Ctx, dynamicClient,
 		ctx.Clientset.Discovery(), recipeDeclaresTrainer)
 	if err != nil {
 		return "", err
-	}
-	if len(installedResources) > 0 {
-		defer func() {
-			err = foldCleanupError(err, deleteTrainer(dynamicClient, installedResources),
-				"NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
-		}()
 	}
 
 	// Apply runtime and trainjob resources. Propagate an inner code rather than
@@ -2240,4 +2241,27 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 
 	slog.Info("Deleted NCCL benchmark namespace", "namespace", namespace)
 	return nil
+}
+
+// cleanupNCCLRun tears down everything runNCCLTrainJob created for this run,
+// in a fixed order. It deletes the per-run namespace first (and the
+// TrainJob/TrainingRuntime/ComputeDomain/RoCE-claim CRs cascading through
+// it). Only on the self-install fallback path, where installedResources is
+// non-empty, does it then tear down the Kubeflow Trainer installation
+// itself. That order is required, not cosmetic. deleteTrainer removes the
+// Trainer controller and its TrainJob/TrainingRuntime CRDs, so tearing it
+// down before the namespace's own CRs are deleted would leave those CRs'
+// controller-serviced finalizers with nothing left to clear them, hanging
+// the namespace in Terminating until cleanupNCCLResources's wait times out.
+// benchErr is the check's result so far. A cleanup failure only overrides a
+// nil benchErr, so it never masks a real benchmark failure. See
+// foldCleanupError.
+func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interface, namespace string, uid types.UID, installedResources []trainerResourceRef, benchErr error) error {
+	err := foldCleanupError(benchErr, cleanupNCCLResources(clientset, namespace, uid),
+		"NCCL benchmark succeeded but NCCL resource cleanup failed")
+	if len(installedResources) > 0 {
+		err = foldCleanupError(err, deleteTrainer(dynamicClient, installedResources),
+			"NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
+	}
+	return err
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -731,6 +731,11 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 	// namespace could still depend on Trainer.
 	otherNamespacesRemain := false
 	for _, ns := range namespaces.Items {
+		if err := ctx.Err(); err != nil {
+			// Canceled mid-sweep. Stop issuing more calls for the
+			// remaining namespaces instead of letting each one fail in turn.
+			return
+		}
 		if ns.Name == currentNamespace {
 			continue
 		}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -67,25 +67,18 @@ const (
 	ncclTrainingRuntimeName = "nccl-all-reduce-runtime"
 
 	// ncclWorkloadNamespacePrefix is the base for the per-run, per-variant
-	// benchmark namespace (see ncclRunNamespace). Isolating each run in its
-	// own namespace, the same pattern inferenceWorkloadNamespacePrefix uses,
-	// means the fixed resource names below never collide across concurrent
-	// or crashed runs: uniqueness only has to hold within a namespace, and
-	// cleanup is a single namespace delete instead of per-resource tracking.
+	// benchmark namespace (see ncclRunNamespace), the same isolation pattern
+	// inferenceWorkloadNamespacePrefix uses so fixed resource names never
+	// collide across concurrent or crashed runs, and cleanup is one
+	// namespace delete instead of per-resource tracking.
 	ncclWorkloadNamespacePrefix = "aicr-nccl-perf"
 )
 
 // ncclRunNamespace derives the per-run, per-variant benchmark namespace.
-// deriveRunID is deterministic per AICR_RUN_ID, and all three catalog checks
-// (nccl-all-reduce-bw, -net, -nvls) share one AICR_RUN_ID within a single
-// aicr validate invocation. Folding the variant into the name, rather than
-// relying on deriveRunID's suffix alone, keeps each check's namespace, and
-// the fixed resource names inside it, unique from its siblings too. That
-// only matters once those checks can run concurrently (see pkg/validator's
-// TODO(perf) to parallelize intra-phase entries). Today they run serially
-// and each fully drains its namespace before the next starts, but this is
-// free to bake in now, before a future change to that ordering would
-// otherwise let two variants adopt, and delete, each other's namespace.
+// All three catalog checks share one AICR_RUN_ID per invocation, so folding
+// the variant into the name keeps each check's namespace, and its fixed
+// resource names, unique from its siblings once they can run concurrently
+// (see pkg/validator's TODO(perf)).
 func ncclRunNamespace(variant ncclVariant) string {
 	variantLabel := string(variant)
 	if variantLabel == "" {
@@ -507,15 +500,11 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 
 // verifyNCCLNamespaceNotLive fails closed if the given, already-fetched NCCL
 // namespace is not terminating and still has a non-terminal
-// (Pending/Running/Unknown) pod in it. deriveRunID is deterministic per
-// AICR_RUN_ID, so an existing, non-terminating instance is expected on a
-// same-run retry after a hard kill, but only once the prior execution has
-// actually stopped. A live pod means some other execution (a genuinely
-// concurrent run of the same AICR_RUN_ID, or the rare random-suffix
-// collision) still owns this namespace, so adopting it would let this run
-// create fixed-name resources into, and its cleanup later delete, a
-// namespace another run is actively using. A nil ns (namespace doesn't exist,
-// or ensureNamespace just created it fresh) is not an error here.
+// (Pending/Running/Unknown) pod in it. A live pod means some other
+// execution (a genuinely concurrent run, or a rare random-suffix collision)
+// still owns this namespace, so adopting it would let this run's
+// fixed-name resources collide with a namespace another run is actively
+// using. A nil ns (doesn't exist, or just created fresh) is not an error.
 func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interface, ns *v1.Namespace) error {
 	if ns == nil || ns.DeletionTimestamp != nil {
 		// Doesn't exist, or already terminating from a prior cleanup;
@@ -542,34 +531,25 @@ func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interf
 }
 
 // pruneStaleNCCLNamespaces best-effort deletes aicr-nccl-perf-* namespaces
-// left behind by a standalone (no AICR_RUN_ID) aicr validate process killed
-// before its own deferred cleanup ran. The Job path does not need this: its
-// run ID is deterministic, so ensureNamespace/verifyNCCLNamespaceNotLive
-// already reclaim a stale instance of the SAME namespace on the next run. A
-// killed standalone run instead orphans a namespace under a different random
-// suffix that no future run will ever name again, so nothing else reclaims it.
+// left behind by a standalone (no AICR_RUN_ID) run killed before its own
+// deferred cleanup ran. The Job path doesn't need this. Its deterministic
+// run ID lets ensureNamespace/verifyNCCLNamespaceNotLive reclaim a stale
+// namespace on the next run, but a killed standalone run orphans one under
+// a random suffix no future run will ever name again.
 //
 // Scoped server-side to labels.ManagedBy=aicr-validator plus
-// labels.Component=nccl-perf, the labels ensureNamespace stamps on creation,
-// so this only ever sees namespaces this package itself created. That also
-// means the match no longer depends on ncclWorkloadNamespacePrefix staying
-// in sync with the namespace-naming logic: a label tied to what created the
-// object can't drift out of sync with itself the way a name-prefix constant
-// duplicated at two call sites could.
+// labels.Component=nccl-perf, so this only sees namespaces this package
+// created, decoupled from ncclWorkloadNamespacePrefix staying in sync with
+// the naming logic.
 //
-// Deletion is fire-and-forget: this only issues the Delete call and moves on,
-// it never waits for the namespace to fully terminate, so it adds no
-// wall-clock cost to the run in progress. The delete carries a UID
-// precondition pinned to the instance this List observed, so a same-named
-// namespace recreated by someone else in between is left alone.
-// currentNamespace and anything younger than
-// defaults.NCCLStaleNamespacePruneAge are left alone, so a namespace still
-// owned by an in-progress sibling variant is never touched. An aged
-// namespace that still has a live pod is also left alone, using the same
-// verifyNCCLNamespaceNotLive occupancy check the adoption gate uses, in case
-// some other execution has simply run long. Listing or deleting failures are
-// logged and otherwise ignored. This is opportunistic cleanup, not something
-// a benchmark run should ever fail for.
+// Fire-and-forget. It deletes and moves on without waiting for
+// termination, pinning a UID precondition to the instance this List
+// observed so a same-named namespace recreated in between is left alone.
+// currentNamespace, anything younger than
+// defaults.NCCLStaleNamespacePruneAge, and any aged namespace still holding
+// a live pod (via verifyNCCLNamespaceNotLive) are left alone too. Failures
+// are logged and ignored, since this is opportunistic cleanup a benchmark
+// run should never fail for.
 func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interface, currentNamespace string) {
 	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -624,16 +604,13 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	dynamicClient := ctx.DynamicClient
 
 	// Isolate this run in its own namespace, the same pattern
-	// inferenceWorkloadConfig uses (see deriveRunID/ensureNamespace): every
-	// fixed resource name below only has to be unique within it, so a
-	// crashed-then-retried aicr validate run (same AICR_RUN_ID, same derived
-	// name) reclaims its own leftovers instead of colliding. That name is
-	// deterministic, though, so before proceeding into an already-existing,
-	// non-terminating instance of it we must prove no other execution is
-	// still live under it. Otherwise we could steal or later delete a
-	// genuinely concurrent run's namespace. ensureNamespace's own decision to
-	// reuse an existing namespace isn't itself unsafe, so the liveness check
-	// can run on the object it returns rather than needing its own fetch.
+	// inferenceWorkloadConfig uses (see deriveRunID/ensureNamespace). Fixed
+	// resource names only need to be unique within it, so a crashed-then-
+	// retried run reclaims its own leftovers instead of colliding. The name
+	// is deterministic, so before reusing an existing, non-terminating
+	// instance, verifyNCCLNamespaceNotLive confirms no other execution is
+	// still live under it (running on the object ensureNamespace already
+	// returned, needing no separate fetch).
 	gpuConfig.Namespace = ncclRunNamespace(variant)
 	pruneStaleNCCLNamespaces(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
 	nsObj, err := ensureNamespace(ctx, gpuConfig.Namespace, labels.ValueNCCLPerf)
@@ -651,18 +628,13 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// flight).
 	namespaceUID := nsObj.UID
 
-	// Clean up everything this run created, on every exit path from here on
-	// (including a failed Trainer install below), via a single defer
-	// registered before installedResources is even known. installedResources
-	// is read by closure once cleanupNCCLRun actually runs, so this defer
-	// covers both an early ensureTrainerInstalled failure (installedResources
-	// still nil) and the normal success path. Two separately registered
-	// defers would run in LIFO order instead, tearing down the (self-install
-	// fallback only) Trainer controller and its TrainJob/TrainingRuntime CRDs
-	// *before* the namespace's own TrainJob/TrainingRuntime CRs are deleted.
-	// That can leave those CRs' controller-serviced finalizers stuck forever
-	// and hang the namespace in Terminating. See cleanupNCCLRun for the
-	// enforced order.
+	// Clean up everything this run created on every exit path, via a single
+	// defer registered before installedResources is even known (it's read
+	// by closure once cleanupNCCLRun runs). Two separate defers would
+	// instead run LIFO, tearing down the Trainer controller and its CRDs
+	// before the namespace's own TrainJob/TrainingRuntime CRs, leaving
+	// their finalizers stuck and the namespace hung in Terminating. See
+	// cleanupNCCLRun for the enforced order.
 	var installedResources []trainerResourceRef
 	defer func() {
 		err = cleanupNCCLRun(ctx.Clientset, dynamicClient, gpuConfig.Namespace, namespaceUID, installedResources, err)
@@ -707,9 +679,9 @@ type gpuConfiguration struct {
 	WorkerCount     int
 	GPUCountPerNode int
 	TotalGPUCount   int
-	// Namespace is the per-run benchmark namespace; unset by determineGPUConfig
-	// and filled in by runNCCLTrainJob once it derives one (see
-	// ncclWorkloadNamespacePrefix).
+	// Namespace is the per-run benchmark namespace. Unset by
+	// determineGPUConfig, and filled in by runNCCLTrainJob once it derives
+	// one (see ncclWorkloadNamespacePrefix).
 	Namespace string
 	Nodes     []v1.Node
 }
@@ -1282,11 +1254,11 @@ func applyNCCLComputeDomain(ctx context.Context, dynamicClient dynamic.Interface
 	}
 
 	// AlreadyExists: fetch the current resourceVersion and Update in place.
-	// Required because Update rejects an empty resourceVersion to prevent
-	// lost updates. Adopting an existing ComputeDomain here is intentional:
-	// it's how a stale one left by a prior run under this same per-run
-	// namespace (e.g. a retry reusing AICR_RUN_ID after a hard kill before
-	// cleanup ran) gets reclaimed instead of failing with AlreadyExists.
+	// Required because Update rejects an empty resourceVersion. Adopting an
+	// existing ComputeDomain here is intentional, since it's how a stale
+	// one left by a prior run (e.g. a retry reusing AICR_RUN_ID after a
+	// hard kill before cleanup ran) gets reclaimed instead of failing with
+	// AlreadyExists.
 	existing, err := client.Get(applyCtx, ncclComputeDomainName, metav1.GetOptions{})
 	if err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get existing ComputeDomain", err)
@@ -1479,19 +1451,17 @@ func renderYAMLTemplate(content string, data map[string]string) (*unstructured.U
 	return obj, nil
 }
 
-// createUnstructured creates a namespaced resource from an unstructured object
-// with a timeout.
-// createUnstructured creates obj. If a fixed-name resource with that
-// GVR/name already exists, it reclaims it so a same-run retry after a hard
-// kill can recover instead of failing on AlreadyExists.
+// createUnstructured creates obj, a namespaced resource, with a timeout. If
+// a fixed-name resource with that GVR/name already exists, it reclaims it
+// so a same-run retry after a hard kill can recover instead of failing on
+// AlreadyExists.
 //
-// TrainJob reclaims by delete-then-recreate rather than update. Kubeflow
-// Trainer treats most of its spec as immutable once created and rejects an
-// in-place update to those fields, and even a permitted update would not
-// make the controller recreate the underlying JobSet/pods, which is what a
-// stale TrainJob left behind by a hard kill actually needs. Every other
-// caller (TrainingRuntime) reclaims by updating in place, the same way
-// applyNCCLComputeDomain already does for ComputeDomain.
+// TrainJob reclaims by delete-then-recreate rather than update, since
+// Kubeflow Trainer treats most of its spec as immutable and an update
+// wouldn't make the controller recreate the underlying JobSet/pods anyway,
+// which is what a stale TrainJob actually needs. Every other caller
+// (TrainingRuntime) reclaims by updating in place, like
+// applyNCCLComputeDomain does for ComputeDomain.
 func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
 	applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -1506,13 +1476,13 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 	if gvr == trainJobGVR {
 		// Pin the delete to the object actually observed here, not just its
 		// name. Create's AlreadyExists above only proves something existed
-		// at that instant; without a UID precondition a delete-by-name in
+		// at that instant. Without a UID precondition, a delete-by-name in
 		// the gap since could remove a same-named TrainJob that a distinct
 		// execution created in between, rather than failing the delete.
 		stale, err := client.Get(applyCtx, obj.GetName(), metav1.GetOptions{})
 		switch {
 		case apierrors.IsNotFound(err):
-			// Already gone since the AlreadyExists above; nothing to delete.
+			// Already gone since the AlreadyExists above. Nothing to delete.
 		case err != nil:
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get stale resource for recreate", err)
 		default:
@@ -2254,14 +2224,12 @@ func waitForPodByLabelSelector(ctx context.Context, clientset kubernetes.Interfa
 			if !ok {
 				continue
 			}
-			// A Deleted event, or a pod already terminating/terminal, is not
-			// a match: a retry that recreates the workload under the same
-			// label selector (e.g. TrainJob admission retry) can fire a
-			// Deleted event for the stale pod before the replacement's
-			// Added event arrives. Returning it here would hand the caller
-			// a pod that is already gone. Keep waiting for the replacement
-			// instead, matching the same non-terminal, non-deleting filter
-			// newestRunnablePod uses on the re-List recovery path below.
+			// A Deleted event, or a pod already terminating/terminal, isn't
+			// a match. A recreated workload (e.g. a TrainJob admission
+			// retry) can fire a Deleted event for the stale pod before the
+			// replacement's Added event arrives, so keep waiting for the
+			// replacement, matching the filter newestRunnablePod uses on
+			// its re-List recovery path.
 			isTerminal := pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
 			if event.Type == watch.Deleted || pod.DeletionTimestamp != nil || isTerminal {
 				continue
@@ -2373,39 +2341,25 @@ func verifyTransportFromLogs(logs string, variant ncclVariant) error {
 
 // cleanupNCCLResources deletes the per-run benchmark namespace, cascading
 // away the trainjob, runtime, and (if present) the ComputeDomain and RoCE
-// ResourceClaimTemplate CRs this run created in it, mirroring
-// cleanupInferenceWorkload's pattern for the sibling inference-perf check.
-// Since runNCCLTrainJob gives every run its own namespace (see
-// ncclWorkloadNamespacePrefix), there is no shared state to pin deletes
-// against: nothing else ever lives in this namespace.
+// ResourceClaimTemplate CRs it created, mirroring cleanupInferenceWorkload's
+// pattern. Nothing else ever shares this namespace, so there's no shared
+// state to pin deletes against.
 //
-// Namespaces().Delete only starts asynchronous deletion. It returns as soon
-// as the delete is accepted, not once the namespace (and the
-// ComputeDomain/ResourceClaimTemplate/TrainJob finalizers cascading through
-// it) is actually gone. Waiting here for the deletion to finish, via the
-// same waitForNamespaceGone helper ensureNamespace already uses on the
-// create side for exactly this reason (see its doc comment), gives teardown
-// observability in the common case. But the wait itself only ever logs on
-// timeout (see below). Once Delete is accepted, cascading GC completes
-// server-side regardless of whether we wait for it here, and NVLS runs'
-// ComputeDomain/ResourceClaimTemplate DRA/IMEX finalizers can legitimately
-// outlast the wait bound on the dual-fabric GB200 path.
+// Delete only starts asynchronous deletion, so this waits via
+// waitForNamespaceGone for teardown observability, but only logs on
+// timeout rather than failing. Cascading GC completes server-side
+// regardless, and NVLS's DRA/IMEX finalizers can legitimately outlast the
+// wait bound on the dual-fabric GB200 path.
 //
-// Unlike cleanupInferenceWorkload, a Delete call failure itself is returned
-// rather than only logged, so foldCleanupError can still fail an
-// otherwise-passing check on it. That is the actual "did cleanup happen"
-// signal. NotFound is tolerated (nothing to clean up).
+// Unlike cleanupInferenceWorkload, a Delete failure is itself returned, not
+// just logged, so foldCleanupError can still fail an otherwise-passing
+// check on it, the real "did cleanup happen" signal. NotFound is tolerated.
 //
 // uid pins the delete to the exact namespace instance runNCCLTrainJob
-// created or reclaimed: if that instance was deleted and a different one
-// recreated under the same name in the meantime, the UID precondition makes
-// this delete fail instead of silently removing the new (not ours) instance.
-// uid must be non-empty. An empty Preconditions.UID is still an exact-match
-// precondition against the real namespace's (never-empty) UID, so it would
-// only ever fail the delete outright on a real apiserver, but the fake
-// client used in tests ignores delete preconditions entirely and would
-// silently proceed. Reject it explicitly rather than depend on that
-// difference to catch a caller bug.
+// created or reclaimed, so a recreated same-named namespace is left alone
+// instead of silently deleted. It must be non-empty, since the fake client
+// used in tests ignores delete preconditions and would otherwise silently
+// proceed on a caller bug that drops the UID.
 func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid types.UID) error {
 	if uid == "" {
 		return aicrErrors.New(aicrErrors.ErrCodeInternal,
@@ -2430,10 +2384,8 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 			fmt.Sprintf("failed to delete NCCL benchmark namespace %q", namespace), err)
 	}
 
-	// Same bound as ensureNamespace's wait on the create side (see
-	// defaults.InferenceNamespaceTerminationWait doc comment). This cascade
-	// is the same finalizer chain, just observed from the delete side. Only
-	// logged on timeout, not returned: the Delete call above already
+	// Same bound as ensureNamespace's wait on the create side. Only logged
+	// on timeout, not returned, since the Delete call above already
 	// succeeded, so a slow-but-real teardown (e.g. NVLS's DRA/IMEX
 	// finalizers) must not fail an otherwise-passing benchmark just because
 	// this observability wait ran out first.
@@ -2450,19 +2402,17 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 	return nil
 }
 
-// cleanupNCCLRun tears down everything runNCCLTrainJob created for this run,
-// in a fixed order. It deletes the per-run namespace first (and the
-// TrainJob/TrainingRuntime/ComputeDomain/RoCE-claim CRs cascading through
-// it). Only on the self-install fallback path, where installedResources is
-// non-empty, does it then tear down the Kubeflow Trainer installation
-// itself. That order is required, not cosmetic. deleteTrainer removes the
-// Trainer controller and its TrainJob/TrainingRuntime CRDs, so tearing it
-// down before the namespace's own CRs are deleted would leave those CRs'
-// controller-serviced finalizers with nothing left to clear them, hanging
-// the namespace in Terminating until cleanupNCCLResources's wait times out.
-// benchErr is the check's result so far. A cleanup failure only overrides a
-// nil benchErr, so it never masks a real benchmark failure. See
-// foldCleanupError.
+// cleanupNCCLRun tears down everything runNCCLTrainJob created, in a fixed
+// order. It deletes the per-run namespace first (cascading its
+// TrainJob/TrainingRuntime/ComputeDomain/RoCE-claim CRs), then, only on the
+// self-install fallback path, the Kubeflow Trainer installation itself.
+// The order matters. deleteTrainer removes the Trainer controller and its
+// CRDs, and doing that first would strand the namespace's own CRs'
+// controller-serviced finalizers, hanging the namespace in Terminating.
+//
+// benchErr is the check's result so far. A cleanup failure only overrides
+// a nil benchErr, never masking a real benchmark failure (see
+// foldCleanupError).
 func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interface, namespace string, uid types.UID, installedResources []trainerResourceRef, benchErr error) error {
 	err := foldCleanupError(benchErr, cleanupNCCLResources(clientset, namespace, uid),
 		"NCCL benchmark succeeded but NCCL resource cleanup failed")

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1243,7 +1243,10 @@ func applyTrainJobWithRetry(ctx context.Context, dynamicClient dynamic.Interface
 	attempt := 0
 	for {
 		attempt++
-		createErr := createUnstructured(retryCtx, dynamicClient, trainJobGVR, namespace, obj)
+		// ctx, not retryCtx, so the reclaim wait inside createUnstructured
+		// gets its own NCCLResourceRecreateWait budget instead of retryCtx's
+		// shorter one. The retry loop itself still stays bounded below.
+		createErr := createUnstructured(ctx, dynamicClient, trainJobGVR, namespace, obj)
 		if createErr == nil {
 			if attempt > 1 {
 				slog.Info("TrainJob created after Trainer webhook cache caught up to the TrainingRuntime",

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -40,6 +40,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -484,6 +485,47 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	return actualValue, passed, nil
 }
 
+// verifyNCCLNamespaceNotLive fails closed if the per-run NCCL namespace
+// already exists, is not terminating, and still has a non-terminal
+// (Pending/Running/Unknown) pod in it. deriveRunID is deterministic per
+// AICR_RUN_ID, so an existing, non-terminating instance is expected on a
+// same-run retry after a hard kill, but only once the prior execution has
+// actually stopped. A live pod means some other execution (a genuinely
+// concurrent run of the same AICR_RUN_ID, or the rare random-suffix
+// collision) still owns this namespace, so adopting it would let this run
+// create fixed-name resources into, and its cleanup later delete, a
+// namespace another run is actively using. NotFound is not an error here:
+// ensureNamespace creates it fresh in that case.
+func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
+	ns, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+		return nil
+	case err != nil:
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check NCCL benchmark namespace", err)
+	case ns.DeletionTimestamp != nil:
+		// Already terminating from a prior cleanup; ensureNamespace waits
+		// for it to fully disappear before recreating it.
+		return nil
+	}
+
+	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	pods, err := clientset.CoreV1().Pods(namespace).List(listCtx, metav1.ListOptions{})
+	if err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			"failed to check NCCL benchmark namespace for a live execution", err)
+	}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
+			return aicrErrors.New(aicrErrors.ErrCodeConflict,
+				fmt.Sprintf("NCCL benchmark namespace %q already exists with a live pod %q from another execution; refusing to adopt it",
+					namespace, pod.Name))
+		}
+	}
+	return nil
+}
+
 // runNCCLTrainJob runs the NCCL all-reduce benchmark using Kubeflow TrainJob + MPI.
 // It applies the per-platform TrainingRuntime and shared TrainJob, waits for the launcher
 // pod to complete, and returns the benchmark logs.
@@ -495,13 +537,30 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 
 	// Isolate this run in its own namespace, the same pattern
 	// inferenceWorkloadConfig uses (see deriveRunID/ensureNamespace): every
-	// fixed resource name below only has to be unique within it, so two
-	// concurrent (or one crashed, one retried) aicr validate runs can never
-	// collide, adopt, or delete each other's resources — no lock required.
+	// fixed resource name below only has to be unique within it, so a
+	// crashed-then-retried aicr validate run (same AICR_RUN_ID, same derived
+	// name) reclaims its own leftovers instead of colliding. That name is
+	// deterministic, though, so before adopting an already-existing,
+	// non-terminating instance of it we must prove no other execution is
+	// still live under it. Otherwise we could steal or later delete a
+	// genuinely concurrent run's namespace.
 	gpuConfig.Namespace = fmt.Sprintf("%s-%s", ncclWorkloadNamespacePrefix, deriveRunID())
+	if err = verifyNCCLNamespaceNotLive(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace); err != nil {
+		return "", err
+	}
 	if err = ensureNamespace(ctx, gpuConfig.Namespace); err != nil {
 		return "", aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace")
 	}
+
+	// Pin the namespace instance we just created/reclaimed by UID so the
+	// deferred delete below can never remove a different namespace object
+	// that came to exist under this same name afterward (e.g. deleted and
+	// recreated by an unrelated run while this one was in flight).
+	nsObj, getErr := ctx.Clientset.CoreV1().Namespaces().Get(ctx.Ctx, gpuConfig.Namespace, metav1.GetOptions{})
+	if getErr != nil {
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read NCCL benchmark namespace after creation", getErr)
+	}
+	namespaceUID := nsObj.UID
 
 	// Clean up the per-run namespace (and everything created in it) on every
 	// exit path from here on, including a failed Trainer install below.
@@ -509,7 +568,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// safe. A cleanup failure only overrides a nil benchErr — see
 	// foldCleanupError — so it never masks a real benchmark failure.
 	defer func() {
-		err = foldCleanupError(err, cleanupNCCLResources(ctx.Clientset, gpuConfig.Namespace),
+		err = foldCleanupError(err, cleanupNCCLResources(ctx.Clientset, gpuConfig.Namespace, namespaceUID),
 			"NCCL benchmark succeeded but NCCL resource cleanup failed")
 	}()
 
@@ -1332,11 +1391,31 @@ func renderYAMLTemplate(content string, data map[string]string) (*unstructured.U
 
 // createUnstructured creates a namespaced resource from an unstructured object
 // with a timeout.
+// createUnstructured creates obj. If a fixed-name resource with that
+// GVR/name already exists, it reclaims it by updating it in place. Both
+// callers (TrainingRuntime, TrainJob) use fixed names inside the caller's
+// per-run namespace, so an AlreadyExists here only happens on a same-run
+// retry after a hard kill left it behind; reclaiming it, the same way
+// applyNCCLComputeDomain already does for ComputeDomain, lets that retry
+// recover instead of failing.
 func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
 	applyCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
-	if _, err := dynamicClient.Resource(gvr).Namespace(namespace).Create(applyCtx, obj, metav1.CreateOptions{}); err != nil {
+
+	client := dynamicClient.Resource(gvr).Namespace(namespace)
+	if _, err := client.Create(applyCtx, obj, metav1.CreateOptions{}); err == nil {
+		return nil
+	} else if !apierrors.IsAlreadyExists(err) {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create resource", err)
+	}
+
+	existing, err := client.Get(applyCtx, obj.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get existing resource for update", err)
+	}
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	if _, err := client.Update(applyCtx, obj, metav1.UpdateOptions{}); err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to update resource", err)
 	}
 	return nil
 }
@@ -2125,14 +2204,21 @@ func verifyTransportFromLogs(logs string, variant ncclVariant) error {
 // Unlike cleanupInferenceWorkload, a delete failure here is returned rather
 // than only logged, so foldCleanupError can still fail an otherwise-passing
 // check on it. NotFound is tolerated (nothing to clean up).
-func cleanupNCCLResources(clientset kubernetes.Interface, namespace string) error {
+//
+// uid pins the delete to the exact namespace instance runNCCLTrainJob
+// created or reclaimed: if that instance was deleted and a different one
+// recreated under the same name in the meantime, the UID precondition makes
+// this delete fail instead of silently removing the new (not ours) instance.
+func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid types.UID) error {
 	slog.Info("Cleaning up NCCL test resources...", "namespace", namespace)
 
 	deleteCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)
 	defer cancel()
 
 	nsClient := clientset.CoreV1().Namespaces()
-	err := nsClient.Delete(deleteCtx, namespace, metav1.DeleteOptions{})
+	err := nsClient.Delete(deleteCtx, namespace, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &uid},
+	})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			slog.Info("NCCL benchmark namespace already gone", "namespace", namespace)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -916,7 +916,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	}
 
 	// Wait for launcher pod and get logs.
-	logs, err = waitForLauncherPodAndGetLogs(ctx, podHelper)
+	logs, err = waitForLauncherPodAndGetLogs(ctx, podHelper, holderID)
 	if err != nil {
 		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get launcher logs", err)
 	}
@@ -2014,7 +2014,7 @@ func nestedMap(m map[string]any, keys ...string) (map[string]any, bool) {
 }
 
 // waitForLauncherPodAndGetLogs waits for the launcher pod to be created and retrieves logs
-func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.PodLifecycle) (string, error) {
+func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.PodLifecycle, holderID string) (string, error) {
 	slog.Info("Waiting for launcher pod to be created...")
 
 	// Wait for launcher pod to be created (pattern: nccl-all-reduce-tj-launcher-*)
@@ -2033,6 +2033,21 @@ func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.Pod
 
 	// Wait for pod to complete using helper method
 	err = podHelper.WaitForPodSuccess(ctx.Ctx, launcherPod, defaults.NCCLTrainJobTimeout)
+
+	// This wait can run past NCCLExecutionLockStaleAge with no renewal. A
+	// live pod protects this namespace from a same-run retry on its own,
+	// but that ends the moment it goes terminal. Renew right here, before
+	// the diagnostic gathering below adds more unrenewed time, so a retry
+	// can't take the lock while cleanup still has work to do.
+	held, lockErr := ncclExecutionLockHeldBy(ctx.Ctx, ctx.Clientset, podHelper.Namespace, holderID)
+	if lockErr != nil {
+		return "", lockErr
+	}
+	if !held {
+		return "", aicrErrors.New(aicrErrors.ErrCodeConflict,
+			fmt.Sprintf("NCCL benchmark execution lock for namespace %q was taken over by another execution; refusing to proceed", podHelper.Namespace))
+	}
+
 	if err != nil {
 		// Get logs even if pod failed for debugging. Surface (not discard) a
 		// log-fetch error: an empty launcher log with no explanation is exactly

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -2321,7 +2321,18 @@ func verifyTransportFromLogs(logs string, variant ncclVariant) error {
 // created or reclaimed: if that instance was deleted and a different one
 // recreated under the same name in the meantime, the UID precondition makes
 // this delete fail instead of silently removing the new (not ours) instance.
+// uid must be non-empty. An empty Preconditions.UID is still an exact-match
+// precondition against the real namespace's (never-empty) UID, so it would
+// only ever fail the delete outright on a real apiserver, but the fake
+// client used in tests ignores delete preconditions entirely and would
+// silently proceed. Reject it explicitly rather than depend on that
+// difference to catch a caller bug.
 func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid types.UID) error {
+	if uid == "" {
+		return aicrErrors.New(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("refusing to delete NCCL benchmark namespace %q without an owning UID", namespace))
+	}
+
 	slog.Info("Cleaning up NCCL test resources...", "namespace", namespace)
 
 	deleteCtx, cancel := context.WithTimeout(context.Background(), defaults.K8sCleanupTimeout)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -775,7 +775,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// returned, needing no separate fetch).
 	gpuConfig.Namespace = ncclRunNamespace(variant)
 	pruneStaleNCCLNamespaces(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
-	nsObj, err := ensureNamespace(ctx, gpuConfig.Namespace, labels.ValueNCCLPerf)
+	nsObj, nsCreated, err := ensureNamespace(ctx, gpuConfig.Namespace, labels.ValueNCCLPerf)
 	if err != nil {
 		return "", aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace")
 	}
@@ -788,12 +788,14 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// closed instead of sharing the namespace.
 	holderID, err := claimNCCLExecutionLock(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
 	if err != nil {
-		// The cleanup defer below isn't registered yet, so a namespace
-		// ensureNamespace just created or reclaimed would otherwise leak
-		// until the next run's prune sweep. Roll it back now, unless a
-		// concurrent caller won the claim instead, since that namespace is
+		// The cleanup defer below isn't registered yet, so a namespace this
+		// call alone just created would otherwise leak until the next run's
+		// prune sweep. Roll it back now, but only the one we created. A
+		// reused or concurrently-adopted namespace (nsCreated false) may
+		// hold another execution's leftovers worth reclaiming later, and a
+		// concurrent caller's conflicting claim means that namespace is
 		// legitimately theirs, not ours to remove.
-		if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		if nsCreated && !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
 			rollbackNCCLNamespace(ctx.Clientset, gpuConfig.Namespace, nsObj.UID)
 		}
 		return "", err

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -737,6 +737,11 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 			return
 		}
 		if ns.Name == currentNamespace {
+			// This namespace existing at all means this run, or a peer
+			// sharing the same deterministic name, may still need
+			// Trainer. Reaping it out from under a live peer would fail
+			// that peer's in-flight TrainJob.
+			otherNamespacesRemain = true
 			continue
 		}
 		if ns.DeletionTimestamp != nil {

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -2380,6 +2380,13 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 			slog.Info("NCCL benchmark namespace already gone", "namespace", namespace)
 			return nil
 		}
+		if apierrors.IsConflict(err) {
+			// UID precondition mismatch. The namespace we created is
+			// already gone and a different one holds the name, so
+			// nothing this run owns leaked.
+			slog.Info("NCCL benchmark namespace was already replaced", "namespace", namespace)
+			return nil
+		}
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
 			fmt.Sprintf("failed to delete NCCL benchmark namespace %q", namespace), err)
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1761,6 +1761,14 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 	}
 
 	existing, err := client.Get(applyCtx, obj.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// Deleted between the AlreadyExists above and this Get. Create
+		// fresh instead of failing on a race a plain Create would win.
+		if _, createErr := client.Create(applyCtx, obj, metav1.CreateOptions{}); createErr != nil {
+			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to recreate resource", createErr)
+		}
+		return nil
+	}
 	if err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get existing resource for update", err)
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -65,14 +65,33 @@ const (
 	// Must stay in sync with runtime.yaml.
 	ncclTrainingRuntimeName = "nccl-all-reduce-runtime"
 
-	// ncclWorkloadNamespacePrefix is the base for the per-run benchmark
-	// namespace (see runNCCLTrainJob). Isolating each run in its own
-	// namespace, the same pattern inferenceWorkloadNamespacePrefix uses,
+	// ncclWorkloadNamespacePrefix is the base for the per-run, per-variant
+	// benchmark namespace (see ncclRunNamespace). Isolating each run in its
+	// own namespace, the same pattern inferenceWorkloadNamespacePrefix uses,
 	// means the fixed resource names below never collide across concurrent
 	// or crashed runs: uniqueness only has to hold within a namespace, and
 	// cleanup is a single namespace delete instead of per-resource tracking.
 	ncclWorkloadNamespacePrefix = "aicr-nccl-perf"
 )
+
+// ncclRunNamespace derives the per-run, per-variant benchmark namespace.
+// deriveRunID is deterministic per AICR_RUN_ID, and all three catalog checks
+// (nccl-all-reduce-bw, -net, -nvls) share one AICR_RUN_ID within a single
+// aicr validate invocation. Folding the variant into the name, rather than
+// relying on deriveRunID's suffix alone, keeps each check's namespace, and
+// the fixed resource names inside it, unique from its siblings too. That
+// only matters once those checks can run concurrently (see pkg/validator's
+// TODO(perf) to parallelize intra-phase entries). Today they run serially
+// and each fully drains its namespace before the next starts, but this is
+// free to bake in now, before a future change to that ordering would
+// otherwise let two variants adopt, and delete, each other's namespace.
+func ncclRunNamespace(variant ncclVariant) string {
+	variantLabel := string(variant)
+	if variantLabel == "" {
+		variantLabel = "default"
+	}
+	return fmt.Sprintf("%s-%s-%s", ncclWorkloadNamespacePrefix, variantLabel, deriveRunID())
+}
 
 // skipMsg* are the constraint-result strings returned when the NCCL check cannot
 // run. The "skipped " prefix is contractual: nccl_all_reduce_bw.go:78 dispatches
@@ -544,7 +563,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// non-terminating instance of it we must prove no other execution is
 	// still live under it. Otherwise we could steal or later delete a
 	// genuinely concurrent run's namespace.
-	gpuConfig.Namespace = fmt.Sprintf("%s-%s", ncclWorkloadNamespacePrefix, deriveRunID())
+	gpuConfig.Namespace = ncclRunNamespace(variant)
 	if err = verifyNCCLNamespaceNotLive(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace); err != nil {
 		return "", err
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -542,11 +542,8 @@ const ncclRunLockName = "aicr-nccl-run-lock"
 // claimNCCLExecutionLock atomically admits exactly one execution into
 // namespace, closing the race where two callers (e.g. sharing one
 // AICR_RUN_ID) both pass verifyNCCLNamespaceNotLive before either creates a
-// pod. A missing Lease is claimed by Create, which only one caller can win.
-// An existing Lease is claimed by Update pinned to the resourceVersion just
-// read, so a racing takeover also loses to a Conflict, unless it was
-// renewed within NCCLExecutionLockStaleAge, in which case it's still live
-// and returns ErrCodeConflict instead.
+// pod. A stale, unrenewed lock past NCCLExecutionLockStaleAge can still be
+// taken over by a new caller.
 //
 // The returned holder ID is fresh per call, so cleanupNCCLRun can tell
 // whether it still holds the lock before deleting anything.
@@ -566,6 +563,7 @@ func claimNCCLExecutionLock(ctx context.Context, clientset kubernetes.Interface,
 			AcquireTime: &now, RenewTime: &now,
 		},
 	}
+	// A missing Lease is claimed by Create, which only one racing caller can win.
 	if _, err := leaseClient.Create(claimCtx, lease, metav1.CreateOptions{}); err == nil {
 		return holderID, nil
 	} else if !apierrors.IsAlreadyExists(err) {
@@ -583,6 +581,8 @@ func claimNCCLExecutionLock(ctx context.Context, clientset kubernetes.Interface,
 
 	existing.Spec.HolderIdentity, existing.Spec.LeaseDurationSeconds = &holderID, &leaseDurationSeconds
 	existing.Spec.AcquireTime, existing.Spec.RenewTime = &now, &now
+	// An existing Lease is claimed by Update pinned to the resourceVersion
+	// just read, so a racing takeover here also loses to a Conflict.
 	if _, err := leaseClient.Update(claimCtx, existing, metav1.UpdateOptions{}); err != nil {
 		if apierrors.IsConflict(err) {
 			return "", aicrErrors.New(aicrErrors.ErrCodeConflict,
@@ -609,14 +609,14 @@ func rollbackNCCLNamespace(clientset kubernetes.Interface, namespace string, uid
 	}
 }
 
-// releaseNCCLExecutionLockIfHeldBy best-effort deletes namespace's execution
-// lock, but only if it's still named holderID as the current holder.
+// releaseNCCLExecutionLockIfHeldBy best-effort deletes namespace's
+// execution lock, but only if holderID is still the current holder.
 // pruneStaleNCCLNamespaces calls this when its own namespace delete fails
-// transiently. Left in place, the fence Lease it just claimed would
-// otherwise sit there until it ages past NCCLExecutionLockStaleAge, failing
-// a same-run retry closed for up to that long. Checking the holder first,
-// rather than deleting outright, keeps this from removing a legitimate
-// claim that lands in between.
+// transiently, since the fence Lease it just claimed would otherwise sit
+// there until it ages past NCCLExecutionLockStaleAge, failing a same-run
+// retry closed for that long. Checking the holder first, instead of
+// deleting outright, avoids removing a legitimate claim that lands in
+// between.
 func releaseNCCLExecutionLockIfHeldBy(ctx context.Context, clientset kubernetes.Interface, namespace, holderID string) {
 	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -648,26 +648,21 @@ func generateExecutionID() string {
 	return hex.EncodeToString(buf)
 }
 
-// ncclExecutionLockHeldBy confirms namespace's execution lock still names
-// holderID as the current holder, and renews it in the same call. A plain
-// read-only check here would leave a gap between the read and
-// cleanupNCCLResources's delete for a takeover to land in: both executions
-// would then share the same namespace UID, and the stale holder's delete
-// would remove the new holder's live namespace. Renewing pinned to the
-// resourceVersion just read closes that gap the same way
-// claimNCCLExecutionLock's own takeover does. Renewing either succeeds,
-// proving nothing raced it, or loses to a Conflict, proving a takeover
-// already happened, in which case cleanup must not touch the namespace. A
-// missing lock reports false rather than true. It could mean this holder's
-// own lock was never created, but it could just as easily mean a replacement
-// is about to claim it, and treating the ambiguous case as authorization to
-// proceed risks deleting or mutating that replacement's live resources.
+// ncclExecutionLockHeldBy reports whether namespace's execution lock still
+// names holderID as the current holder, renewing it as part of the same
+// call. Renewing, rather than a plain read, closes the gap where a
+// takeover could land between this check and a subsequent delete, letting
+// the stale holder's delete remove the new holder's live namespace.
 //
-// Also used mid-run, right before mutating this namespace's fixed-name
-// resources, to revalidate a holder whose earlier pre-pod steps (Trainer
-// install, resource apply) ran long enough for a same-run retry to take the
-// lock over. The renewal doubles as a heartbeat in that case, since
-// succeeding extends the caller's own claim by another NCCLExecutionLockStaleAge.
+// A missing lock reports false, not true, since that could equally mean a
+// replacement is about to claim it, and treating the ambiguous case as
+// authorization to proceed risks deleting or mutating that replacement's
+// live resources.
+//
+// Called both right before cleanup's delete and mid-run before mutating
+// this namespace's fixed-name resources, where the renewal also acts as a
+// heartbeat, extending the caller's own claim by another
+// NCCLExecutionLockStaleAge.
 func ncclExecutionLockHeldBy(ctx context.Context, clientset kubernetes.Interface, namespace, holderID string) (bool, error) {
 	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -685,6 +680,9 @@ func ncclExecutionLockHeldBy(ctx context.Context, clientset kubernetes.Interface
 
 	now := metav1.NewMicroTime(time.Now())
 	lease.Spec.RenewTime = &now
+	// Pinned to the resourceVersion just read, so this either succeeds,
+	// proving nothing raced it, or loses to a Conflict, proving a takeover
+	// already happened.
 	if _, err := leaseClient.Update(getCtx, lease, metav1.UpdateOptions{}); err != nil {
 		if apierrors.IsConflict(err) {
 			return false, nil
@@ -696,24 +694,19 @@ func ncclExecutionLockHeldBy(ctx context.Context, clientset kubernetes.Interface
 
 // pruneStaleNCCLNamespaces best-effort deletes aicr-nccl-perf-* namespaces
 // left behind by a standalone (no AICR_RUN_ID) run killed before its own
-// deferred cleanup ran. The Job path doesn't need this. Its deterministic
-// run ID lets ensureNamespace/verifyNCCLNamespaceNotLive reclaim a stale
-// namespace on the next run, but a killed standalone run orphans one under
-// a random suffix no future run will ever name again.
+// deferred cleanup ran. The Job path doesn't need this, since its
+// deterministic run ID lets ensureNamespace/verifyNCCLNamespaceNotLive
+// reclaim a stale namespace on the next run, but a killed standalone run
+// orphans one under a random suffix no future run will ever name again.
 //
-// Scoped server-side to labels.ManagedBy=aicr-validator plus
-// labels.Component=nccl-perf, so this only sees namespaces this package
-// created, decoupled from ncclWorkloadNamespacePrefix staying in sync with
-// the naming logic.
-//
-// Fire-and-forget. It deletes and moves on without waiting for
-// termination, pinning a UID precondition to the instance this List
-// observed so a same-named namespace recreated in between is left alone.
-// currentNamespace, anything younger than
-// defaults.NCCLStaleNamespacePruneAge, and any aged namespace still holding
-// a live pod (via verifyNCCLNamespaceNotLive) are left alone too. Failures
-// are logged and ignored, since this is opportunistic cleanup a benchmark
-// run should never fail for.
+// Scoped server-side to labels.ManagedBy and labels.Component, so this only
+// sees namespaces this package created, decoupled from
+// ncclWorkloadNamespacePrefix staying in sync with the naming logic.
+// currentNamespace, anything too young, and anything still live are left
+// alone (see the checks below). Fire-and-forget: it deletes and moves on
+// without waiting for termination, and failures are logged and ignored,
+// since this is opportunistic cleanup a benchmark run should never fail
+// for.
 func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interface, dynamicClient dynamic.Interface, currentNamespace string) {
 	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -785,6 +778,8 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 
 		delCtx, delCancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 		uid := ns.UID
+		// Pinned to the UID this List observed, so a same-named namespace
+		// recreated in between is left alone rather than deleted.
 		delErr := clientset.CoreV1().Namespaces().Delete(delCtx, ns.Name, metav1.DeleteOptions{
 			Preconditions: &metav1.Preconditions{UID: &uid},
 		})
@@ -2013,7 +2008,11 @@ func nestedMap(m map[string]any, keys ...string) (map[string]any, bool) {
 	return current, true
 }
 
-// waitForLauncherPodAndGetLogs waits for the launcher pod to be created and retrieves logs
+// waitForLauncherPodAndGetLogs waits for the launcher pod to be created,
+// waits for it to complete, and returns its logs. Revalidates that
+// holderID still holds the namespace's execution lock right after the pod
+// goes terminal, since a live pod only protects the namespace from a
+// same-run retry while it's still running.
 func waitForLauncherPodAndGetLogs(ctx *validators.Context, podHelper *helper.PodLifecycle, holderID string) (string, error) {
 	slog.Info("Waiting for launcher pod to be created...")
 
@@ -2625,23 +2624,19 @@ func verifyTransportFromLogs(logs string, variant ncclVariant) error {
 // pattern. Nothing else ever shares this namespace, so there's no shared
 // state to pin deletes against.
 //
-// Delete only starts asynchronous deletion, so this waits via
-// waitForNamespaceGone for teardown observability, but only logs on
-// timeout rather than failing. Cascading GC completes server-side
-// regardless, and NVLS's DRA/IMEX finalizers can legitimately outlast the
-// wait bound on the dual-fabric GB200 path.
-//
 // Unlike cleanupInferenceWorkload, a Delete failure is itself returned, not
 // just logged, so foldCleanupError can still fail an otherwise-passing
-// check on it, the real "did cleanup happen" signal. NotFound is tolerated.
+// check on it. NotFound is tolerated.
 //
 // uid pins the delete to the exact namespace instance runNCCLTrainJob
 // created or reclaimed, so a recreated same-named namespace is left alone
-// instead of silently deleted. It must be non-empty, since the fake client
-// used in tests ignores delete preconditions and would otherwise silently
-// proceed on a caller bug that drops the UID.
+// instead of silently deleted (see the check below for why it must be
+// non-empty).
 func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid types.UID) error {
 	if uid == "" {
+		// Required, not just preferred: the fake client used in tests
+		// ignores delete preconditions and would otherwise silently
+		// proceed on a caller bug that drops the UID.
 		return aicrErrors.New(aicrErrors.ErrCodeInternal,
 			fmt.Sprintf("refusing to delete NCCL benchmark namespace %q without an owning UID", namespace))
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -664,25 +664,6 @@ func ncclExecutionLockHeldBy(ctx context.Context, clientset kubernetes.Interface
 	return true, nil
 }
 
-// ncclExecutionLockIsLive reports whether namespace's execution lock exists
-// and was renewed within NCCLExecutionLockStaleAge. An admitted execution
-// can hold a fresh lock with no pod yet, still installing Trainer or
-// applying resources, so pruneStaleNCCLNamespaces checks this alongside pod
-// occupancy instead of treating a podless namespace as unclaimed. A missing
-// lock is not live.
-func ncclExecutionLockIsLive(ctx context.Context, clientset kubernetes.Interface, namespace string) (bool, error) {
-	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
-	defer cancel()
-	lease, err := clientset.CoordinationV1().Leases(namespace).Get(getCtx, ncclRunLockName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return false, nil
-	}
-	if err != nil {
-		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check NCCL benchmark execution lock", err)
-	}
-	return lease.Spec.RenewTime != nil && time.Since(lease.Spec.RenewTime.Time) < defaults.NCCLExecutionLockStaleAge, nil
-}
-
 // pruneStaleNCCLNamespaces best-effort deletes aicr-nccl-perf-* namespaces
 // left behind by a standalone (no AICR_RUN_ID) run killed before its own
 // deferred cleanup ran. The Job path doesn't need this. Its deterministic
@@ -731,13 +712,21 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 				"namespace", ns.Name, "reason", liveErr)
 			continue
 		}
-		if leaseLive, leaseErr := ncclExecutionLockIsLive(ctx, clientset, ns.Name); leaseErr != nil {
-			slog.Warn("Skipping stale NCCL benchmark namespace prune: failed to check its execution lock",
-				"namespace", ns.Name, "error", leaseErr)
-			continue
-		} else if leaseLive {
-			slog.Info("Skipping stale NCCL benchmark namespace prune: namespace has a live execution lock",
-				"namespace", ns.Name)
+		// A plain read here, checked then acted on moments later, would
+		// leave a gap for a legitimate claim to land in before the delete
+		// below runs. Claiming the lock atomically proves nothing currently
+		// holds it and fences off a claim landing in that gap, since a live
+		// or freshly-won lock fails this with ErrCodeConflict. The
+		// namespace delete cascades this pruner's own claim away with
+		// everything else, so it never lingers.
+		if _, claimErr := claimNCCLExecutionLock(ctx, clientset, ns.Name); claimErr != nil {
+			if stderrors.Is(claimErr, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+				slog.Info("Skipping stale NCCL benchmark namespace prune: namespace has a live execution lock",
+					"namespace", ns.Name)
+			} else {
+				slog.Warn("Skipping stale NCCL benchmark namespace prune: failed to claim its execution lock",
+					"namespace", ns.Name, "error", claimErr)
+			}
 			continue
 		}
 

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1500,8 +1500,24 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 	}
 
 	if gvr == trainJobGVR {
-		if err := client.Delete(applyCtx, obj.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to delete stale resource for recreate", err)
+		// Pin the delete to the object actually observed here, not just its
+		// name. Create's AlreadyExists above only proves something existed
+		// at that instant; without a UID precondition a delete-by-name in
+		// the gap since could remove a same-named TrainJob that a distinct
+		// execution created in between, rather than failing the delete.
+		stale, err := client.Get(applyCtx, obj.GetName(), metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			// Already gone since the AlreadyExists above; nothing to delete.
+		case err != nil:
+			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to get stale resource for recreate", err)
+		default:
+			uid := stale.GetUID()
+			if err := client.Delete(applyCtx, obj.GetName(), metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{UID: &uid},
+			}); err != nil && !apierrors.IsNotFound(err) {
+				return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to delete stale resource for recreate", err)
+			}
 		}
 		// Delete only stamps DeletionTimestamp while a controller-serviced
 		// finalizer (Trainer v2 / JobSet ownership) is still clearing.

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -2692,11 +2692,12 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 // cleanupNCCLRun tears down everything runNCCLTrainJob created, in a fixed
 // order. It skips cleanup entirely if holderID no longer holds the
 // namespace's execution lock, since another execution has since taken it
-// over. Otherwise it deletes the per-run namespace first (cascading its
-// TrainJob/TrainingRuntime/ComputeDomain/RoCE-claim CRs), then, only on the
-// self-install fallback path, the Kubeflow Trainer installation, whose
-// removal would otherwise strand those CRs' finalizers if it ran first.
-// Trainer teardown only runs if the namespace delete succeeded.
+// over, or if that can't be confirmed either way. Otherwise it deletes the
+// per-run namespace first (cascading its TrainJob/TrainingRuntime/
+// ComputeDomain/RoCE-claim CRs), then, only on the self-install fallback
+// path, the Kubeflow Trainer installation, whose removal would otherwise
+// strand those CRs' finalizers if it ran first. Trainer teardown only runs
+// if the namespace delete succeeded.
 //
 // benchErr is the check's result so far. A cleanup failure only overrides
 // a nil benchErr, never masking a real benchmark failure (see
@@ -2704,7 +2705,14 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interface, namespace string, uid types.UID, holderID string, installedResources []trainerResourceRef, benchErr error) error {
 	held, lockErr := ncclExecutionLockHeldBy(context.Background(), clientset, namespace, holderID)
 	if lockErr != nil {
-		return foldCleanupError(benchErr, lockErr, "NCCL benchmark succeeded but its execution lock could not be checked")
+		// A transient read failure here (an apiserver blip, a timeout) is not
+		// proof the lock was actually taken over, but it's not proof it
+		// wasn't either. Treat it the same as a confirmed loss below rather
+		// than fail an otherwise-passing benchmark over a flaky lease read,
+		// or risk deleting a peer's live resources on a guess.
+		slog.Warn("Failed to verify the NCCL benchmark execution lock is still held; skipping cleanup",
+			"namespace", namespace, "error", lockErr)
+		return benchErr
 	}
 	if !held {
 		slog.Warn("NCCL benchmark execution lock was taken over by another execution; skipping cleanup", "namespace", namespace)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1595,12 +1595,16 @@ func createUnstructured(ctx context.Context, dynamicClient dynamic.Interface, gv
 		// finalizer (Trainer v2 / JobSet ownership) is still clearing.
 		// Recreating immediately would race it and hit AlreadyExists again,
 		// defeating the same-run retry-after-hard-kill path this exists for.
-		if err := waitForResourceGone(applyCtx, client, obj.GetName()); err != nil {
+		// A finalizer can outlast applyCtx's short DiagnosticTimeout, so the
+		// wait and the recreate that depends on it get their own bound.
+		waitCtx, waitCancel := context.WithTimeout(ctx, defaults.NCCLResourceRecreateWait)
+		defer waitCancel()
+		if err := waitForResourceGone(waitCtx, client, obj.GetName()); err != nil {
 			return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
 				"failed waiting for stale resource to finish deleting before recreate")
 		}
 		obj.SetResourceVersion("")
-		if _, err := client.Create(applyCtx, obj, metav1.CreateOptions{}); err != nil {
+		if _, err := client.Create(waitCtx, obj, metav1.CreateOptions{}); err != nil {
 			return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to recreate resource", err)
 		}
 		return nil

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -641,6 +641,25 @@ func ncclExecutionLockHeldBy(clientset kubernetes.Interface, namespace, holderID
 	return true, nil
 }
 
+// ncclExecutionLockIsLive reports whether namespace's execution lock exists
+// and was renewed within NCCLExecutionLockStaleAge. An admitted execution
+// can hold a fresh lock with no pod yet, still installing Trainer or
+// applying resources, so pruneStaleNCCLNamespaces checks this alongside pod
+// occupancy instead of treating a podless namespace as unclaimed. A missing
+// lock is not live.
+func ncclExecutionLockIsLive(ctx context.Context, clientset kubernetes.Interface, namespace string) (bool, error) {
+	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	lease, err := clientset.CoordinationV1().Leases(namespace).Get(getCtx, ncclRunLockName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check NCCL benchmark execution lock", err)
+	}
+	return lease.Spec.RenewTime != nil && time.Since(lease.Spec.RenewTime.Time) < defaults.NCCLExecutionLockStaleAge, nil
+}
+
 // pruneStaleNCCLNamespaces best-effort deletes aicr-nccl-perf-* namespaces
 // left behind by a standalone (no AICR_RUN_ID) run killed before its own
 // deferred cleanup ran. The Job path doesn't need this. Its deterministic
@@ -687,6 +706,15 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		if liveErr := verifyNCCLNamespaceNotLive(ctx, clientset, &ns); liveErr != nil {
 			slog.Info("Skipping stale NCCL benchmark namespace prune: namespace still has a live pod",
 				"namespace", ns.Name, "reason", liveErr)
+			continue
+		}
+		if leaseLive, leaseErr := ncclExecutionLockIsLive(ctx, clientset, ns.Name); leaseErr != nil {
+			slog.Warn("Skipping stale NCCL benchmark namespace prune: failed to check its execution lock",
+				"namespace", ns.Name, "error", leaseErr)
+			continue
+		} else if leaseLive {
+			slog.Info("Skipping stale NCCL benchmark namespace prune: namespace has a live execution lock",
+				"namespace", ns.Name)
 			continue
 		}
 

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -558,8 +558,11 @@ func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interf
 // wall-clock cost to the run in progress. currentNamespace and anything
 // younger than defaults.NCCLStaleNamespacePruneAge are left alone, so a
 // namespace still owned by an in-progress sibling variant is never touched.
-// Listing or deleting failures are logged and otherwise ignored: this is
-// opportunistic cleanup, not something a benchmark run should ever fail for.
+// An aged namespace that still has a live pod is also left alone, using the
+// same verifyNCCLNamespaceNotLive occupancy check the adoption gate uses, in
+// case some other execution has simply run long. Listing or deleting
+// failures are logged and otherwise ignored. This is opportunistic cleanup,
+// not something a benchmark run should ever fail for.
 func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interface, currentNamespace string) {
 	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -576,6 +579,14 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 			continue
 		}
 		if ns.DeletionTimestamp != nil || time.Since(ns.CreationTimestamp.Time) < defaults.NCCLStaleNamespacePruneAge {
+			continue
+		}
+		// An aged namespace can still belong to a live execution that has
+		// simply run long. Reuse the same occupancy check the adoption gate
+		// uses rather than deleting on age alone.
+		if liveErr := verifyNCCLNamespaceNotLive(ctx, clientset, ns.Name); liveErr != nil {
+			slog.Info("Skipping stale NCCL benchmark namespace prune: namespace still has a live pod",
+				"namespace", ns.Name, "reason", liveErr)
 			continue
 		}
 

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -505,8 +505,8 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 	return actualValue, passed, nil
 }
 
-// verifyNCCLNamespaceNotLive fails closed if the per-run NCCL namespace
-// already exists, is not terminating, and still has a non-terminal
+// verifyNCCLNamespaceNotLive fails closed if the given, already-fetched NCCL
+// namespace is not terminating and still has a non-terminal
 // (Pending/Running/Unknown) pod in it. deriveRunID is deterministic per
 // AICR_RUN_ID, so an existing, non-terminating instance is expected on a
 // same-run retry after a hard kill, but only once the prior execution has
@@ -514,24 +514,19 @@ func validateNcclAllReduceBw(ctx *validators.Context, constraint recipe.Constrai
 // concurrent run of the same AICR_RUN_ID, or the rare random-suffix
 // collision) still owns this namespace, so adopting it would let this run
 // create fixed-name resources into, and its cleanup later delete, a
-// namespace another run is actively using. NotFound is not an error here:
-// ensureNamespace creates it fresh in that case.
-func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
-	ns, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-	switch {
-	case apierrors.IsNotFound(err):
-		return nil
-	case err != nil:
-		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check NCCL benchmark namespace", err)
-	case ns.DeletionTimestamp != nil:
-		// Already terminating from a prior cleanup; ensureNamespace waits
-		// for it to fully disappear before recreating it.
+// namespace another run is actively using. A nil ns (namespace doesn't exist,
+// or ensureNamespace just created it fresh) is not an error here.
+func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interface, ns *v1.Namespace) error {
+	if ns == nil || ns.DeletionTimestamp != nil {
+		// Doesn't exist, or already terminating from a prior cleanup;
+		// ensureNamespace creates it fresh / waits for it to fully
+		// disappear before recreating it. Either way, nothing to check yet.
 		return nil
 	}
 
 	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
-	pods, err := clientset.CoreV1().Pods(namespace).List(listCtx, metav1.ListOptions{})
+	pods, err := clientset.CoreV1().Pods(ns.Name).List(listCtx, metav1.ListOptions{})
 	if err != nil {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
 			"failed to check NCCL benchmark namespace for a live execution", err)
@@ -540,7 +535,7 @@ func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interf
 		if pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
 			return aicrErrors.New(aicrErrors.ErrCodeConflict,
 				fmt.Sprintf("NCCL benchmark namespace %q already exists with a live pod %q from another execution; refusing to adopt it",
-					namespace, pod.Name))
+					ns.Name, pod.Name))
 		}
 	}
 	return nil
@@ -594,7 +589,7 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		// An aged namespace can still belong to a live execution that has
 		// simply run long. Reuse the same occupancy check the adoption gate
 		// uses rather than deleting on age alone.
-		if liveErr := verifyNCCLNamespaceNotLive(ctx, clientset, ns.Name); liveErr != nil {
+		if liveErr := verifyNCCLNamespaceNotLive(ctx, clientset, &ns); liveErr != nil {
 			slog.Info("Skipping stale NCCL benchmark namespace prune: namespace still has a live pod",
 				"namespace", ns.Name, "reason", liveErr)
 			continue
@@ -629,27 +624,27 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// fixed resource name below only has to be unique within it, so a
 	// crashed-then-retried aicr validate run (same AICR_RUN_ID, same derived
 	// name) reclaims its own leftovers instead of colliding. That name is
-	// deterministic, though, so before adopting an already-existing,
+	// deterministic, though, so before proceeding into an already-existing,
 	// non-terminating instance of it we must prove no other execution is
 	// still live under it. Otherwise we could steal or later delete a
-	// genuinely concurrent run's namespace.
+	// genuinely concurrent run's namespace. ensureNamespace's own decision to
+	// reuse an existing namespace isn't itself unsafe, so the liveness check
+	// can run on the object it returns rather than needing its own fetch.
 	gpuConfig.Namespace = ncclRunNamespace(variant)
 	pruneStaleNCCLNamespaces(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
-	if err = verifyNCCLNamespaceNotLive(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace); err != nil {
-		return "", err
-	}
-	if err = ensureNamespace(ctx, gpuConfig.Namespace); err != nil {
+	nsObj, err := ensureNamespace(ctx, gpuConfig.Namespace)
+	if err != nil {
 		return "", aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace")
 	}
-
-	// Pin the namespace instance we just created/reclaimed by UID so the
-	// deferred delete below can never remove a different namespace object
-	// that came to exist under this same name afterward (e.g. deleted and
-	// recreated by an unrelated run while this one was in flight).
-	nsObj, getErr := ctx.Clientset.CoreV1().Namespaces().Get(ctx.Ctx, gpuConfig.Namespace, metav1.GetOptions{})
-	if getErr != nil {
-		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read NCCL benchmark namespace after creation", getErr)
+	if err = verifyNCCLNamespaceNotLive(ctx.Ctx, ctx.Clientset, nsObj); err != nil {
+		return "", err
 	}
+
+	// Pin the namespace instance ensureNamespace just created or reclaimed by
+	// UID so the deferred delete below can never remove a different
+	// namespace object that came to exist under this same name afterward
+	// (e.g. deleted and recreated by an unrelated run while this one was in
+	// flight).
 	namespaceUID := nsObj.UID
 
 	// Clean up everything this run created, on every exit path from here on

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -544,7 +544,7 @@ const ncclRunLockName = "aicr-nccl-run-lock"
 // pod. A missing Lease is claimed by Create, which only one caller can win.
 // An existing Lease is claimed by Update pinned to the resourceVersion just
 // read, so a racing takeover also loses to a Conflict, unless it was
-// renewed within NCCLStaleNamespacePruneAge, in which case it's still live
+// renewed within NCCLExecutionLockStaleAge, in which case it's still live
 // and returns ErrCodeConflict instead.
 //
 // The returned holder ID is fresh per call, so cleanupNCCLRun can tell
@@ -552,7 +552,7 @@ const ncclRunLockName = "aicr-nccl-run-lock"
 func claimNCCLExecutionLock(ctx context.Context, clientset kubernetes.Interface, namespace string) (string, error) {
 	holderID := generateExecutionID()
 	now := metav1.NewMicroTime(time.Now())
-	leaseDurationSeconds := int32(defaults.NCCLStaleNamespacePruneAge.Seconds())
+	leaseDurationSeconds := int32(defaults.NCCLExecutionLockStaleAge.Seconds())
 
 	claimCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
@@ -575,7 +575,7 @@ func claimNCCLExecutionLock(ctx context.Context, clientset kubernetes.Interface,
 	if err != nil {
 		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read NCCL benchmark execution lock", err)
 	}
-	if existing.Spec.RenewTime != nil && time.Since(existing.Spec.RenewTime.Time) < defaults.NCCLStaleNamespacePruneAge {
+	if existing.Spec.RenewTime != nil && time.Since(existing.Spec.RenewTime.Time) < defaults.NCCLExecutionLockStaleAge {
 		return "", aicrErrors.New(aicrErrors.ErrCodeConflict,
 			fmt.Sprintf("NCCL benchmark namespace %q is claimed by another execution; refusing to proceed", namespace))
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -500,7 +500,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// collide, adopt, or delete each other's resources — no lock required.
 	gpuConfig.Namespace = fmt.Sprintf("%s-%s", ncclWorkloadNamespacePrefix, deriveRunID())
 	if err = ensureNamespace(ctx, gpuConfig.Namespace); err != nil {
-		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace", err)
+		return "", aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace")
 	}
 
 	// Clean up the per-run namespace (and everything created in it) on every
@@ -2148,8 +2148,8 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string) erro
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), defaults.InferenceNamespaceTerminationWait)
 	defer waitCancel()
 	if err := waitForNamespaceGone(waitCtx, nsClient, namespace); err != nil {
-		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
-			fmt.Sprintf("NCCL benchmark namespace %q did not finish terminating", namespace), err)
+		return aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("NCCL benchmark namespace %q did not finish terminating", namespace))
 	}
 
 	slog.Info("Deleted NCCL benchmark namespace", "namespace", namespace)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -684,7 +684,7 @@ func ncclExecutionLockHeldBy(ctx context.Context, clientset kubernetes.Interface
 // a live pod (via verifyNCCLNamespaceNotLive) are left alone too. Failures
 // are logged and ignored, since this is opportunistic cleanup a benchmark
 // run should never fail for.
-func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interface, currentNamespace string) {
+func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interface, dynamicClient dynamic.Interface, currentNamespace string) {
 	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
 	defer cancel()
 
@@ -697,11 +697,18 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		return
 	}
 
+	// Feeds reapOrphanedTrainerInstall below. Only reap once no other
+	// namespace could still depend on Trainer.
+	otherNamespacesRemain := false
 	for _, ns := range namespaces.Items {
 		if ns.Name == currentNamespace {
 			continue
 		}
-		if ns.DeletionTimestamp != nil || time.Since(ns.CreationTimestamp.Time) < defaults.NCCLStaleNamespacePruneAge {
+		if ns.DeletionTimestamp != nil {
+			continue
+		}
+		if time.Since(ns.CreationTimestamp.Time) < defaults.NCCLStaleNamespacePruneAge {
+			otherNamespacesRemain = true
 			continue
 		}
 		// An aged namespace can still belong to a live execution that has
@@ -710,6 +717,7 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		if liveErr := verifyNCCLNamespaceNotLive(ctx, clientset, &ns); liveErr != nil {
 			slog.Info("Skipping stale NCCL benchmark namespace prune: namespace still has a live pod",
 				"namespace", ns.Name, "reason", liveErr)
+			otherNamespacesRemain = true
 			continue
 		}
 		// A plain read here, checked then acted on moments later, would
@@ -727,6 +735,7 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 				slog.Warn("Skipping stale NCCL benchmark namespace prune: failed to claim its execution lock",
 					"namespace", ns.Name, "error", claimErr)
 			}
+			otherNamespacesRemain = true
 			continue
 		}
 
@@ -738,11 +747,14 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 		delCancel()
 		if delErr != nil && !apierrors.IsNotFound(delErr) {
 			slog.Warn("Failed to delete stale NCCL benchmark namespace", "namespace", ns.Name, "error", delErr)
+			otherNamespacesRemain = true
 			continue
 		}
 		slog.Info("Deleted stale NCCL benchmark namespace left behind by an interrupted run",
 			"namespace", ns.Name, "age", time.Since(ns.CreationTimestamp.Time).Round(time.Minute))
 	}
+
+	reapOrphanedTrainerInstall(ctx, clientset, dynamicClient, otherNamespacesRemain)
 }
 
 // runNCCLTrainJob runs the NCCL all-reduce benchmark using Kubeflow TrainJob + MPI.
@@ -763,7 +775,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// still live under it (running on the object ensureNamespace already
 	// returned, needing no separate fetch).
 	gpuConfig.Namespace = ncclRunNamespace(variant)
-	pruneStaleNCCLNamespaces(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
+	pruneStaleNCCLNamespaces(ctx.Ctx, ctx.Clientset, dynamicClient, gpuConfig.Namespace)
 	nsObj, nsCreated, err := ensureNamespace(ctx, gpuConfig.Namespace, labels.ValueNCCLPerf)
 	if err != nil {
 		return "", aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace")
@@ -820,6 +832,9 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 		ctx.Clientset.Discovery(), recipeDeclaresTrainer)
 	if err != nil {
 		return "", err
+	}
+	if len(installedResources) > 0 {
+		persistTrainerInstallManifest(ctx.Ctx, ctx.Clientset, installedResources)
 	}
 
 	// Trainer install can run long enough for the execution lock to go stale
@@ -2627,8 +2642,11 @@ func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interf
 		return err
 	}
 	if len(installedResources) > 0 {
-		err = foldCleanupError(err, deleteTrainer(dynamicClient, installedResources),
-			"NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
+		if trainerErr := deleteTrainer(dynamicClient, installedResources); trainerErr != nil {
+			err = foldCleanupError(err, trainerErr, "NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
+		} else {
+			removeTrainerInstallManifestEntries(context.Background(), clientset, installedResources)
+		}
 	}
 	return err
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -592,6 +593,22 @@ func claimNCCLExecutionLock(ctx context.Context, clientset kubernetes.Interface,
 	return holderID, nil
 }
 
+// rollbackNCCLNamespace best-effort deletes namespace, pinned to uid, after
+// claimNCCLExecutionLock fails before the cleanup defer is registered.
+// Errors are only logged. This is a leak-avoidance nicety, not correctness
+// critical, since pruneStaleNCCLNamespaces reclaims an orphaned namespace on
+// a later run regardless.
+func rollbackNCCLNamespace(clientset kubernetes.Interface, namespace string, uid types.UID) {
+	delCtx, cancel := context.WithTimeout(context.Background(), defaults.DiagnosticTimeout)
+	defer cancel()
+	if err := clientset.CoreV1().Namespaces().Delete(delCtx, namespace, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &uid},
+	}); err != nil && !apierrors.IsNotFound(err) {
+		slog.Warn("Failed to roll back NCCL benchmark namespace after execution lock admission failed",
+			"namespace", namespace, "error", err)
+	}
+}
+
 // generateExecutionID returns a fresh random identifier for one execution,
 // distinct from AICR_RUN_ID so two invocations sharing a run ID still get
 // different lock holder identities.
@@ -771,6 +788,14 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// closed instead of sharing the namespace.
 	holderID, err := claimNCCLExecutionLock(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
 	if err != nil {
+		// The cleanup defer below isn't registered yet, so a namespace
+		// ensureNamespace just created or reclaimed would otherwise leak
+		// until the next run's prune sweep. Roll it back now, unless a
+		// concurrent caller won the claim instead, since that namespace is
+		// legitimately theirs, not ours to remove.
+		if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+			rollbackNCCLNamespace(ctx.Clientset, gpuConfig.Namespace, nsObj.UID)
+		}
 		return "", err
 	}
 

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -880,7 +880,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// installs an ephemeral fixture only when nothing is. Anything we install is
 	// ours to clean up after the test completes.
 	recipeDeclaresTrainer := validators.RecipeDeclares(ctx, kubeflowTrainerComponent)
-	installedResources, err = ensureTrainerInstalled(ctx.Ctx, dynamicClient,
+	installedResources, err = ensureTrainerInstalled(ctx.Ctx, dynamicClient, ctx.Clientset,
 		ctx.Clientset.Discovery(), recipeDeclaresTrainer)
 	if err != nil {
 		return "", err

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -2105,8 +2105,11 @@ func waitForTrainingRuntime(ctx context.Context, dynamicClient dynamic.Interface
 	}
 }
 
-// waitForPodByLabelSelector waits for a pod matching the label selector to be created.
-// Uses the Watch API for efficiency instead of polling.
+// waitForPodByLabelSelector waits for a pod matching the label selector to be
+// created. Uses the Watch API for efficiency instead of polling. Skips
+// Deleted events and pods that are already terminating or terminal, so a
+// retry that recreates the workload under the same label selector doesn't
+// return a stale pod that no longer exists.
 func waitForPodByLabelSelector(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector string, timeout time.Duration) (*v1.Pod, error) {
 	slog.Info("Watching for pod with selector", "selector", labelSelector)
 
@@ -2144,6 +2147,18 @@ func waitForPodByLabelSelector(ctx context.Context, clientset kubernetes.Interfa
 			}
 			pod, ok := event.Object.(*v1.Pod)
 			if !ok {
+				continue
+			}
+			// A Deleted event, or a pod already terminating/terminal, is not
+			// a match: a retry that recreates the workload under the same
+			// label selector (e.g. TrainJob admission retry) can fire a
+			// Deleted event for the stale pod before the replacement's
+			// Added event arrives. Returning it here would hand the caller
+			// a pod that is already gone. Keep waiting for the replacement
+			// instead, matching the same non-terminal, non-deleting filter
+			// newestRunnablePod uses on the re-List recovery path below.
+			isTerminal := pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
+			if event.Type == watch.Deleted || pod.DeletionTimestamp != nil || isTerminal {
 				continue
 			}
 			slog.Info("Found launcher pod", "name", pod.Name)

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -545,6 +545,52 @@ func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interf
 	return nil
 }
 
+// pruneStaleNCCLNamespaces best-effort deletes aicr-nccl-perf-* namespaces
+// left behind by a standalone (no AICR_RUN_ID) aicr validate process killed
+// before its own deferred cleanup ran. The Job path does not need this: its
+// run ID is deterministic, so ensureNamespace/verifyNCCLNamespaceNotLive
+// already reclaim a stale instance of the SAME namespace on the next run. A
+// killed standalone run instead orphans a namespace under a different random
+// suffix that no future run will ever name again, so nothing else reclaims it.
+//
+// Deletion is fire-and-forget: this only issues the Delete call and moves on,
+// it never waits for the namespace to fully terminate, so it adds no
+// wall-clock cost to the run in progress. currentNamespace and anything
+// younger than defaults.NCCLStaleNamespacePruneAge are left alone, so a
+// namespace still owned by an in-progress sibling variant is never touched.
+// Listing or deleting failures are logged and otherwise ignored: this is
+// opportunistic cleanup, not something a benchmark run should ever fail for.
+func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interface, currentNamespace string) {
+	listCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+
+	namespaces, err := clientset.CoreV1().Namespaces().List(listCtx, metav1.ListOptions{})
+	if err != nil {
+		slog.Warn("Failed to list namespaces for stale NCCL benchmark namespace prune", "error", err)
+		return
+	}
+
+	staleNamePrefix := ncclWorkloadNamespacePrefix + "-"
+	for _, ns := range namespaces.Items {
+		if ns.Name == currentNamespace || !strings.HasPrefix(ns.Name, staleNamePrefix) {
+			continue
+		}
+		if ns.DeletionTimestamp != nil || time.Since(ns.CreationTimestamp.Time) < defaults.NCCLStaleNamespacePruneAge {
+			continue
+		}
+
+		delCtx, delCancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+		delErr := clientset.CoreV1().Namespaces().Delete(delCtx, ns.Name, metav1.DeleteOptions{})
+		delCancel()
+		if delErr != nil && !apierrors.IsNotFound(delErr) {
+			slog.Warn("Failed to delete stale NCCL benchmark namespace", "namespace", ns.Name, "error", delErr)
+			continue
+		}
+		slog.Info("Deleted stale NCCL benchmark namespace left behind by an interrupted run",
+			"namespace", ns.Name, "age", time.Since(ns.CreationTimestamp.Time).Round(time.Minute))
+	}
+}
+
 // runNCCLTrainJob runs the NCCL all-reduce benchmark using Kubeflow TrainJob + MPI.
 // It applies the per-platform TrainingRuntime and shared TrainJob, waits for the launcher
 // pod to complete, and returns the benchmark logs.
@@ -564,6 +610,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// still live under it. Otherwise we could steal or later delete a
 	// genuinely concurrent run's namespace.
 	gpuConfig.Namespace = ncclRunNamespace(variant)
+	pruneStaleNCCLNamespaces(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
 	if err = verifyNCCLNamespaceNotLive(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace); err != nil {
 		return "", err
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -549,9 +549,13 @@ func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interf
 // killed standalone run instead orphans a namespace under a different random
 // suffix that no future run will ever name again, so nothing else reclaims it.
 //
-// Scoped server-side to labels.ManagedBy=aicr-validator, the label
-// ensureNamespace stamps on creation, so name shape and age alone never
-// qualify an unrelated namespace for deletion.
+// Scoped server-side to labels.ManagedBy=aicr-validator plus
+// labels.Component=nccl-perf, the labels ensureNamespace stamps on creation,
+// so this only ever sees namespaces this package itself created. That also
+// means the match no longer depends on ncclWorkloadNamespacePrefix staying
+// in sync with the namespace-naming logic: a label tied to what created the
+// object can't drift out of sync with itself the way a name-prefix constant
+// duplicated at two call sites could.
 //
 // Deletion is fire-and-forget: this only issues the Delete call and moves on,
 // it never waits for the namespace to fully terminate, so it adds no
@@ -571,16 +575,16 @@ func pruneStaleNCCLNamespaces(ctx context.Context, clientset kubernetes.Interfac
 	defer cancel()
 
 	namespaces, err := clientset.CoreV1().Namespaces().List(listCtx, metav1.ListOptions{
-		LabelSelector: labels.ManagedBy + "=" + labels.ValueValidator,
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+			labels.ManagedBy, labels.ValueValidator, labels.Component, labels.ValueNCCLPerf),
 	})
 	if err != nil {
 		slog.Warn("Failed to list namespaces for stale NCCL benchmark namespace prune", "error", err)
 		return
 	}
 
-	staleNamePrefix := ncclWorkloadNamespacePrefix + "-"
 	for _, ns := range namespaces.Items {
-		if ns.Name == currentNamespace || !strings.HasPrefix(ns.Name, staleNamePrefix) {
+		if ns.Name == currentNamespace {
 			continue
 		}
 		if ns.DeletionTimestamp != nil || time.Since(ns.CreationTimestamp.Time) < defaults.NCCLStaleNamespacePruneAge {
@@ -632,7 +636,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// can run on the object it returns rather than needing its own fetch.
 	gpuConfig.Namespace = ncclRunNamespace(variant)
 	pruneStaleNCCLNamespaces(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
-	nsObj, err := ensureNamespace(ctx, gpuConfig.Namespace)
+	nsObj, err := ensureNamespace(ctx, gpuConfig.Namespace, labels.ValueNCCLPerf)
 	if err != nil {
 		return "", aicrErrors.PropagateOrWrap(err, aicrErrors.ErrCodeInternal, "failed to create NCCL benchmark namespace")
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -16,6 +16,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -36,6 +39,7 @@ import (
 	"github.com/NVIDIA/aicr/validators"
 	"github.com/NVIDIA/aicr/validators/helper"
 	"github.com/NVIDIA/aicr/validators/internal/gkenet"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -530,6 +534,92 @@ func verifyNCCLNamespaceNotLive(ctx context.Context, clientset kubernetes.Interf
 	return nil
 }
 
+// ncclRunLockName is the Lease that admits exactly one execution into a
+// per-run NCCL namespace at a time.
+const ncclRunLockName = "aicr-nccl-run-lock"
+
+// claimNCCLExecutionLock atomically admits exactly one execution into
+// namespace, closing the race where two callers (e.g. sharing one
+// AICR_RUN_ID) both pass verifyNCCLNamespaceNotLive before either creates a
+// pod. A missing Lease is claimed by Create, which only one caller can win.
+// An existing Lease is claimed by Update pinned to the resourceVersion just
+// read, so a racing takeover also loses to a Conflict, unless it was
+// renewed within NCCLStaleNamespacePruneAge, in which case it's still live
+// and returns ErrCodeConflict instead.
+//
+// The returned holder ID is fresh per call, so cleanupNCCLRun can tell
+// whether it still holds the lock before deleting anything.
+func claimNCCLExecutionLock(ctx context.Context, clientset kubernetes.Interface, namespace string) (string, error) {
+	holderID := generateExecutionID()
+	now := metav1.NewMicroTime(time.Now())
+	leaseDurationSeconds := int32(defaults.NCCLStaleNamespacePruneAge.Seconds())
+
+	claimCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	leaseClient := clientset.CoordinationV1().Leases(namespace)
+
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: namespace},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: &holderID, LeaseDurationSeconds: &leaseDurationSeconds,
+			AcquireTime: &now, RenewTime: &now,
+		},
+	}
+	if _, err := leaseClient.Create(claimCtx, lease, metav1.CreateOptions{}); err == nil {
+		return holderID, nil
+	} else if !apierrors.IsAlreadyExists(err) {
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to claim NCCL benchmark execution lock", err)
+	}
+
+	existing, err := leaseClient.Get(claimCtx, ncclRunLockName, metav1.GetOptions{})
+	if err != nil {
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read NCCL benchmark execution lock", err)
+	}
+	if existing.Spec.RenewTime != nil && time.Since(existing.Spec.RenewTime.Time) < defaults.NCCLStaleNamespacePruneAge {
+		return "", aicrErrors.New(aicrErrors.ErrCodeConflict,
+			fmt.Sprintf("NCCL benchmark namespace %q is claimed by another execution; refusing to proceed", namespace))
+	}
+
+	existing.Spec.HolderIdentity, existing.Spec.LeaseDurationSeconds = &holderID, &leaseDurationSeconds
+	existing.Spec.AcquireTime, existing.Spec.RenewTime = &now, &now
+	if _, err := leaseClient.Update(claimCtx, existing, metav1.UpdateOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			return "", aicrErrors.New(aicrErrors.ErrCodeConflict,
+				fmt.Sprintf("NCCL benchmark namespace %q was claimed by a concurrent execution; refusing to proceed", namespace))
+		}
+		return "", aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to take over an abandoned NCCL benchmark execution lock", err)
+	}
+	return holderID, nil
+}
+
+// generateExecutionID returns a fresh random identifier for one execution,
+// distinct from AICR_RUN_ID so two invocations sharing a run ID still get
+// different lock holder identities.
+func generateExecutionID() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		sum := sha256.Sum256(fmt.Appendf(nil, "%d", time.Now().UnixNano()))
+		return hex.EncodeToString(sum[:8])
+	}
+	return hex.EncodeToString(buf)
+}
+
+// ncclExecutionLockHeldBy reports whether namespace's execution lock still
+// names holderID as the current holder. A missing lock has nothing left to
+// protect and reports true.
+func ncclExecutionLockHeldBy(clientset kubernetes.Interface, namespace, holderID string) (bool, error) {
+	getCtx, cancel := context.WithTimeout(context.Background(), defaults.DiagnosticTimeout)
+	defer cancel()
+	lease, err := clientset.CoordinationV1().Leases(namespace).Get(getCtx, ncclRunLockName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to check NCCL benchmark execution lock", err)
+	}
+	return lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity == holderID, nil
+}
+
 // pruneStaleNCCLNamespaces best-effort deletes aicr-nccl-perf-* namespaces
 // left behind by a standalone (no AICR_RUN_ID) run killed before its own
 // deferred cleanup ran. The Job path doesn't need this. Its deterministic
@@ -621,6 +711,14 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 		return "", err
 	}
 
+	// Two callers can still both pass the check above before either creates
+	// a pod. Claim exclusive ownership atomically so the loser fails
+	// closed instead of sharing the namespace.
+	holderID, err := claimNCCLExecutionLock(ctx.Ctx, ctx.Clientset, gpuConfig.Namespace)
+	if err != nil {
+		return "", err
+	}
+
 	// Pin the namespace instance ensureNamespace just created or reclaimed by
 	// UID so the deferred delete below can never remove a different
 	// namespace object that came to exist under this same name afterward
@@ -637,7 +735,7 @@ func runNCCLTrainJob(ctx *validators.Context, gpuConfig *gpuConfiguration,
 	// cleanupNCCLRun for the enforced order.
 	var installedResources []trainerResourceRef
 	defer func() {
-		err = cleanupNCCLRun(ctx.Clientset, dynamicClient, gpuConfig.Namespace, namespaceUID, installedResources, err)
+		err = cleanupNCCLRun(ctx.Clientset, dynamicClient, gpuConfig.Namespace, namespaceUID, holderID, installedResources, err)
 	}()
 
 	// Ensure a usable Kubeflow Trainer. Whether an incomplete installation is a
@@ -2410,18 +2508,27 @@ func cleanupNCCLResources(clientset kubernetes.Interface, namespace string, uid 
 }
 
 // cleanupNCCLRun tears down everything runNCCLTrainJob created, in a fixed
-// order. It deletes the per-run namespace first (cascading its
+// order. It skips cleanup entirely if holderID no longer holds the
+// namespace's execution lock, since another execution has since taken it
+// over. Otherwise it deletes the per-run namespace first (cascading its
 // TrainJob/TrainingRuntime/ComputeDomain/RoCE-claim CRs), then, only on the
-// self-install fallback path, the Kubeflow Trainer installation itself.
-// The order matters, deleteTrainer removes the Trainer controller and its
-// CRDs, which would strand the namespace's own CRs' finalizers if it ran
-// first. Trainer teardown only runs if the namespace delete succeeded,
-// since those CRs may otherwise still exist.
+// self-install fallback path, the Kubeflow Trainer installation, whose
+// removal would otherwise strand those CRs' finalizers if it ran first.
+// Trainer teardown only runs if the namespace delete succeeded.
 //
 // benchErr is the check's result so far. A cleanup failure only overrides
 // a nil benchErr, never masking a real benchmark failure (see
 // foldCleanupError).
-func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interface, namespace string, uid types.UID, installedResources []trainerResourceRef, benchErr error) error {
+func cleanupNCCLRun(clientset kubernetes.Interface, dynamicClient dynamic.Interface, namespace string, uid types.UID, holderID string, installedResources []trainerResourceRef, benchErr error) error {
+	held, lockErr := ncclExecutionLockHeldBy(clientset, namespace, holderID)
+	if lockErr != nil {
+		return foldCleanupError(benchErr, lockErr, "NCCL benchmark succeeded but its execution lock could not be checked")
+	}
+	if !held {
+		slog.Warn("NCCL benchmark execution lock was taken over by another execution; skipping cleanup", "namespace", namespace)
+		return benchErr
+	}
+
 	nsErr := cleanupNCCLResources(clientset, namespace, uid)
 	err := foldCleanupError(benchErr, nsErr, "NCCL benchmark succeeded but NCCL resource cleanup failed")
 	if nsErr != nil {

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -575,10 +575,53 @@ func TestRunNCCLTrainJob_RefusesLiveForeignNamespace(t *testing.T) {
 	}
 }
 
-// TestCreateUnstructured_ReclaimsStaleResource is the regression guard for
-// the MAJOR finding that a same-run retry could hit AlreadyExists on stale
-// fixed-name TrainingRuntime/TrainJob resources instead of recovering.
-func TestCreateUnstructured_ReclaimsStaleResource(t *testing.T) {
+// TestCreateUnstructured_ReclaimsStaleResource_UpdatesInPlace is the
+// regression guard for the MAJOR finding that a same-run retry could hit
+// AlreadyExists on a stale fixed-name TrainingRuntime instead of recovering.
+func TestCreateUnstructured_ReclaimsStaleResource_UpdatesInPlace(t *testing.T) {
+	const ns = "aicr-nccl-bench-deadbeef"
+	listKinds := map[schema.GroupVersionResource]string{trainingRuntimeGVR: "TrainingRuntimeList"}
+
+	stale := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": trainingRuntimeGVR.GroupVersion().String(),
+		"kind":       "TrainingRuntime",
+		"metadata": map[string]interface{}{
+			"name":            ncclTrainingRuntimeName,
+			"namespace":       ns,
+			"resourceVersion": "1",
+		},
+		"spec": map[string]interface{}{"stale": true},
+	}}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, stale)
+
+	fresh := stale.DeepCopy()
+	fresh.SetResourceVersion("")
+	if err := unstructured.SetNestedField(fresh.Object, false, "spec", "stale"); err != nil {
+		t.Fatalf("SetNestedField: %v", err)
+	}
+
+	if err := createUnstructured(context.Background(), dynamicClient, trainingRuntimeGVR, ns, fresh); err != nil {
+		t.Fatalf("createUnstructured() on an AlreadyExists fixed-name resource = %v, want reclaim via update", err)
+	}
+
+	got, err := dynamicClient.Resource(trainingRuntimeGVR).Namespace(ns).Get(context.Background(), ncclTrainingRuntimeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get() after reclaim: %v", err)
+	}
+	if staleVal, _, _ := unstructured.NestedBool(got.Object, "spec", "stale"); staleVal {
+		t.Error("reclaimed resource still has the stale prior-run spec, update did not apply")
+	}
+}
+
+// TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates is the
+// regression guard for the finding that reclaiming a stale TrainJob by
+// updating it in place does not actually recover a same-run retry. Kubeflow
+// Trainer treats most of the TrainJob spec as immutable once created and
+// rejects an in-place update to those fields, and even a permitted update
+// would not make the controller recreate the underlying JobSet/pods a
+// hard-killed run left behind. TrainJob must be reclaimed by delete then
+// recreate instead.
+func TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates(t *testing.T) {
 	const ns = "aicr-nccl-bench-deadbeef"
 	listKinds := map[schema.GroupVersionResource]string{trainJobGVR: "TrainJobList"}
 
@@ -594,6 +637,16 @@ func TestCreateUnstructured_ReclaimsStaleResource(t *testing.T) {
 	}}
 	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, stale)
 
+	var order []string
+	dynamicClient.PrependReactor("delete", "trainjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		order = append(order, "delete")
+		return false, nil, nil // let the default reactor perform the real delete too.
+	})
+	dynamicClient.PrependReactor("create", "trainjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		order = append(order, "create")
+		return false, nil, nil
+	})
+
 	fresh := stale.DeepCopy()
 	fresh.SetResourceVersion("")
 	if err := unstructured.SetNestedField(fresh.Object, false, "spec", "stale"); err != nil {
@@ -601,7 +654,13 @@ func TestCreateUnstructured_ReclaimsStaleResource(t *testing.T) {
 	}
 
 	if err := createUnstructured(context.Background(), dynamicClient, trainJobGVR, ns, fresh); err != nil {
-		t.Fatalf("createUnstructured() on an AlreadyExists fixed-name resource = %v, want reclaim via update", err)
+		t.Fatalf("createUnstructured() on an AlreadyExists TrainJob = %v, want reclaim via delete-then-recreate", err)
+	}
+
+	// The first "create" is createUnstructured's own initial attempt, which
+	// hits AlreadyExists and triggers the delete-then-recreate path below.
+	if want := []string{"create", "delete", "create"}; len(order) != len(want) || order[0] != want[0] || order[1] != want[1] || order[2] != want[2] {
+		t.Fatalf("expected the stale TrainJob to be deleted then recreated, got call order %v, want %v", order, want)
 	}
 
 	got, err := dynamicClient.Resource(trainJobGVR).Namespace(ns).Get(context.Background(), ncclTrainJobName, metav1.GetOptions{})
@@ -609,6 +668,6 @@ func TestCreateUnstructured_ReclaimsStaleResource(t *testing.T) {
 		t.Fatalf("Get() after reclaim: %v", err)
 	}
 	if staleVal, _, _ := unstructured.NestedBool(got.Object, "spec", "stale"); staleVal {
-		t.Error("reclaimed resource still has the stale prior-run spec; update did not apply")
+		t.Error("reclaimed TrainJob still has the stale prior-run spec, recreate did not apply")
 	}
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -618,6 +618,35 @@ func TestPruneStaleNCCLNamespaces_OwnDeleteBlocksTrainerReap(t *testing.T) {
 	}
 }
 
+// TestPruneStaleNCCLNamespaces_LiveCurrentNamespaceBlocksTrainerReap checks
+// that a live current namespace blocks Trainer reaping, even though prune's
+// delete path never touches it. A retry sharing the same deterministic
+// namespace name as a still-running peer must not reap Trainer out from
+// under that peer's in-flight TrainJob.
+func TestPruneStaleNCCLNamespaces_LiveCurrentNamespaceBlocksTrainerReap(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	currentNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-currentrun", CreationTimestamp: old,
+		Labels: map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf},
+	}}
+	livePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: currentNS.Name},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	client := fake.NewClientset(currentNS, livePod)
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+	backdateTrainerInstallManifest(t, client)
+
+	pruneStaleNCCLNamespaces(context.Background(), client, newTrainerFakeClient(), currentNS.Name)
+
+	if _, resources, _ := loadTrainerInstallManifest(context.Background(), client); resources == nil {
+		t.Error("expected the Trainer install manifest to survive while the current namespace is live")
+	}
+}
+
 // TestPruneStaleNCCLNamespaces_SkipsDeleteOnConcurrentClaim checks that
 // prune backs off if a caller claims the namespace's lock in the instant
 // between prune's own liveness check and its delete, instead of deleting

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -358,6 +359,62 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 		if !names[keep] {
 			t.Errorf("expected namespace %q to be left alone, but it was deleted", keep)
 		}
+	}
+}
+
+// TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher is the regression
+// guard for the finding that any watch event, including a Deleted event for a
+// stale pod, was returned as-is. applyNCCLResources's TrainJob admission
+// retry (see TrainJobAdmissionRetryTimeout) can recreate the launcher under
+// the same label selector: the stale launcher's Deleted event must be
+// skipped so the wait continues until the replacement's Added event arrives.
+func TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	const selector = "jobset.sigs.k8s.io/jobset-name=nccl-all-reduce-tj,jobset.sigs.k8s.io/replicatedjob-name=launcher"
+
+	clientset := fake.NewClientset()
+	fakeWatch := watch.NewFake()
+	clientset.PrependWatchReactor("pods", k8stesting.DefaultWatchReactor(fakeWatch, nil))
+
+	staleLauncher := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nccl-all-reduce-tj-launcher-0", Namespace: ns,
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:        []string{"kubernetes"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	replacementLauncher := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "nccl-all-reduce-tj-launcher-1", Namespace: ns},
+		Status:     corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	type waitResult struct {
+		pod *corev1.Pod
+		err error
+	}
+	resultCh := make(chan waitResult, 1)
+	go func() {
+		pod, err := waitForPodByLabelSelector(context.Background(), clientset, ns, selector, 5*time.Second)
+		resultCh <- waitResult{pod, err}
+	}()
+
+	// Give the goroutine above time to establish its watch before pushing
+	// events into it.
+	time.Sleep(50 * time.Millisecond)
+	fakeWatch.Delete(staleLauncher)
+	fakeWatch.Add(replacementLauncher)
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			t.Fatalf("waitForPodByLabelSelector failed: %v", res.err)
+		}
+		if res.pod.Name != replacementLauncher.Name {
+			t.Fatalf("expected the replacement launcher %q, got %q", replacementLauncher.Name, res.pod.Name)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForPodByLabelSelector did not return after the replacement launcher appeared")
 	}
 }
 

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -543,7 +543,7 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 
 	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS,
 		unlabeledMatchingNS, otherComponentNS, liveAgedNS, liveAgedPod, admittedPodlessNS, admittedLease)
-	pruneStaleNCCLNamespaces(context.Background(), client, currentNS.Name)
+	pruneStaleNCCLNamespaces(context.Background(), client, newTrainerFakeClient(), currentNS.Name)
 
 	remaining, err := client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -592,7 +592,7 @@ func TestPruneStaleNCCLNamespaces_SkipsDeleteOnConcurrentClaim(t *testing.T) {
 		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "coordination.k8s.io", Resource: "leases"}, ncclRunLockName)
 	})
 
-	pruneStaleNCCLNamespaces(context.Background(), client, "some-other-namespace")
+	pruneStaleNCCLNamespaces(context.Background(), client, newTrainerFakeClient(), "some-other-namespace")
 
 	if _, err := client.CoreV1().Namespaces().Get(context.Background(), targetNS.Name, metav1.GetOptions{}); err != nil {
 		t.Errorf("namespace was deleted despite a concurrent caller claiming its lock first: %v", err)

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -285,6 +285,65 @@ func TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace(t *testing.T) {
 	}
 }
 
+// TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer is the regression guard for
+// the reversed-defer-order finding on the self-install fallback path
+// (installedResources non-empty): deleteTrainer removes the Trainer
+// controller and its TrainJob/TrainingRuntime CRDs, so running it before the
+// namespace's own TrainJob/TrainingRuntime CRs are deleted can leave those
+// CRs' controller-serviced finalizers stuck forever. cleanupNCCLRun must
+// always delete the namespace first.
+func TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	dynamicClient := newTrainerFakeClient()
+
+	var order []string
+	clientset.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		order = append(order, "namespace")
+		return false, nil, nil // let the default reactor perform the actual delete too.
+	})
+	dynamicClient.PrependReactor("delete", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		order = append(order, "trainer")
+		return false, nil, nil
+	})
+
+	resources := []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	}
+
+	if err := cleanupNCCLRun(clientset, dynamicClient, ns, "", resources, nil); err != nil {
+		t.Fatalf("cleanupNCCLRun failed: %v", err)
+	}
+
+	if len(order) != 2 || order[0] != "namespace" || order[1] != "trainer" {
+		t.Fatalf("expected namespace delete before trainer delete, got order %v", order)
+	}
+}
+
+// TestCleanupNCCLRun_PropagatesTrainerCleanupFailure verifies a Trainer
+// teardown failure on the self-install fallback path still fails the check,
+// not just the namespace half of cleanup.
+func TestCleanupNCCLRun_PropagatesTrainerCleanupFailure(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	dynamicClient := newTrainerFakeClient()
+	dynamicClient.PrependReactor("delete", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "deployments"}, trainerControllerDeployment, nil)
+	})
+
+	resources := []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	}
+
+	err := cleanupNCCLRun(clientset, dynamicClient, ns, "", resources, nil)
+	if err == nil {
+		t.Fatal("expected the Trainer teardown failure to fail the check, got nil")
+	}
+	if !strings.Contains(err.Error(), trainerControllerDeployment) {
+		t.Errorf("expected error to name the failed resource %q, got: %v", trainerControllerDeployment, err)
+	}
+}
+
 // TestVerifyNCCLNamespaceNotLive covers the ownership gate that decides
 // whether an already-existing per-run namespace is safe to adopt. Regression
 // guard for the MAJOR finding that silently reusing any active namespace let

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -565,6 +565,59 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	}
 }
 
+// TestPruneStaleNCCLNamespaces_TerminatingNamespaceBlocksTrainerReap checks
+// that a namespace still cascading its own deletion holds back Trainer
+// reaping. Its TrainJob/TrainingRuntime CRs still need the Trainer
+// controller alive to clear their finalizers.
+func TestPruneStaleNCCLNamespaces_TerminatingNamespaceBlocksTrainerReap(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	terminatingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-cafef00d", CreationTimestamp: old,
+		Labels:            map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf},
+		DeletionTimestamp: &metav1.Time{Time: time.Now()}, Finalizers: []string{"kubernetes"},
+	}}
+
+	client := fake.NewClientset(terminatingNS)
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+	backdateTrainerInstallManifest(t, client)
+
+	pruneStaleNCCLNamespaces(context.Background(), client, newTrainerFakeClient(), "aicr-nccl-perf-default-currentrun")
+
+	if _, resources, _ := loadTrainerInstallManifest(context.Background(), client); resources == nil {
+		t.Error("expected the Trainer install manifest to survive while a namespace is still terminating")
+	}
+}
+
+// TestPruneStaleNCCLNamespaces_OwnDeleteBlocksTrainerReap checks that a
+// namespace this sweep just deleted also holds back Trainer reaping in the
+// same pass. The delete only starts the cascade, and the accepted
+// namespace's TrainJob/TrainingRuntime CRs still need Trainer alive to
+// clear their finalizers.
+func TestPruneStaleNCCLNamespaces_OwnDeleteBlocksTrainerReap(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	staleNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-deadbeef", CreationTimestamp: old,
+		Labels: map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf},
+	}}
+
+	client := fake.NewClientset(staleNS)
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+	backdateTrainerInstallManifest(t, client)
+
+	pruneStaleNCCLNamespaces(context.Background(), client, newTrainerFakeClient(), "aicr-nccl-perf-default-currentrun")
+
+	if _, err := client.CoreV1().Namespaces().Get(context.Background(), staleNS.Name, metav1.GetOptions{}); err == nil {
+		t.Fatalf("expected %q to be deleted by this sweep", staleNS.Name)
+	}
+	if _, resources, _ := loadTrainerInstallManifest(context.Background(), client); resources == nil {
+		t.Error("expected the Trainer install manifest to survive: the delete only started the cascade")
+	}
+}
+
 // TestPruneStaleNCCLNamespaces_SkipsDeleteOnConcurrentClaim checks that
 // prune backs off if a caller claims the namespace's lock in the instant
 // between prune's own liveness check and its delete, instead of deleting

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	stderrors "errors"
-	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -31,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -285,6 +285,31 @@ func TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace(t *testing.T) {
 	}
 }
 
+// TestNCCLRunNamespace_VariesByVariant is the regression guard for the
+// finding that all three catalog checks (nccl-all-reduce-bw, -net, -nvls)
+// share one AICR_RUN_ID within a single aicr validate invocation, so
+// deriveRunID's suffix alone would give them the identical namespace name.
+// Today that is safe because the checks run serially and cleanup fully
+// drains each namespace before the next starts, but folding the variant
+// into the name removes the dependency on that ordering, which pkg/validator
+// has a TODO to parallelize.
+func TestNCCLRunNamespace_VariesByVariant(t *testing.T) {
+	t.Setenv("AICR_RUN_ID", "test-run-id")
+
+	seen := map[string]ncclVariant{}
+	for _, variant := range []ncclVariant{variantDefault, variantNET, variantNVLS} {
+		ns := ncclRunNamespace(variant)
+		if owner, ok := seen[ns]; ok {
+			t.Fatalf("variant %q and %q derived the same namespace %q", owner, variant, ns)
+		}
+		seen[ns] = variant
+
+		if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+			t.Errorf("namespace %q for variant %q is not a valid DNS-1123 label: %v", ns, variant, errs)
+		}
+	}
+}
+
 // TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer is the regression guard for
 // the reversed-defer-order finding on the self-install fallback path
 // (installedResources non-empty): deleteTrainer removes the Trainer
@@ -406,7 +431,7 @@ func TestVerifyNCCLNamespaceNotLive(t *testing.T) {
 // still-running execution owns.
 func TestRunNCCLTrainJob_RefusesLiveForeignNamespace(t *testing.T) {
 	t.Setenv("AICR_RUN_ID", "test-run-id")
-	ns := fmt.Sprintf("%s-%s", ncclWorkloadNamespacePrefix, deriveRunID())
+	ns := ncclRunNamespace(variantDefault)
 
 	clientset := fake.NewClientset(
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -1105,6 +1105,49 @@ func TestCleanupNCCLRun_MissingLeaseSkipsDelete(t *testing.T) {
 	}
 }
 
+// TestCleanupNCCLRun_LockCheckErrorSkipsCleanupWithoutFailingBenchmark checks
+// that a lock-check error at cleanup is treated like a confirmed takeover,
+// skipping cleanup without failing a benchmark that already passed.
+func TestCleanupNCCLRun_LockCheckErrorSkipsCleanupWithoutFailingBenchmark(t *testing.T) {
+	benchFailure := aicrErrors.New(aicrErrors.ErrCodeInternal, "benchmark already failed")
+	tests := []struct {
+		name       string
+		benchErr   error
+		wantErrNil bool
+	}{
+		{"passing benchmark stays passing", nil, true},
+		{"failing benchmark keeps its own error", benchFailure, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const ns = "aicr-nccl-perf-deadbeef"
+			holder := testHolderID
+			clientset := fake.NewClientset(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}},
+				&coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+					Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder},
+				},
+			)
+			dynamicClient := newTrainerFakeClient()
+			clientset.PrependReactor("get", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewServiceUnavailable("apiserver unavailable")
+			})
+
+			err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, testHolderID, nil, tt.benchErr)
+			if tt.wantErrNil && err != nil {
+				t.Errorf("expected a transient lock-check error not to fail an otherwise-passing benchmark, got: %v", err)
+			}
+			if !tt.wantErrNil && !stderrors.Is(err, benchFailure) {
+				t.Errorf("expected the original benchmark failure to survive, got: %v", err)
+			}
+			if _, err := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); err != nil {
+				t.Errorf("expected the namespace to survive a lock-check error, got: %v", err)
+			}
+		})
+	}
+}
+
 // TestNcclExecutionLockHeldBy_ExpiredHolderCannotResumeAfterTakeover checks
 // that a holder whose lock went stale and was taken over by another caller
 // is correctly told it no longer holds the lock.

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	"github.com/NVIDIA/aicr/validators"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -322,41 +323,50 @@ func TestNCCLRunNamespace_VariesByVariant(t *testing.T) {
 	}
 }
 
-// TestPruneStaleNCCLNamespaces is the regression guard for the low-priority
-// orphan-namespace nit: a standalone run killed before its own deferred
-// cleanup leaves an aicr-nccl-perf-* namespace under a random suffix nothing
-// else will ever reclaim. The prune must delete only namespaces that are all
-// of: name-matching, old enough to rule out an in-progress sibling variant,
-// not already terminating, and not the namespace this run is about to use.
+// TestPruneStaleNCCLNamespaces is the regression guard for the ownership
+// finding. Name, age, and pod occupancy alone must never qualify a namespace
+// for deletion. The prune must delete only namespaces that are all of:
+// labeled as ours (see ensureNamespace's labels.ManagedBy stamp),
+// name-matching, old enough to rule out an in-progress sibling variant, not
+// already terminating, and not the namespace this run is about to use.
+// unlabeledMatchingNS is the case that would have been wrongly deleted
+// before the fix.
 func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
 	young := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+	ownedLabels := map[string]string{labels.ManagedBy: labels.ValueValidator}
 
 	staleNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: "aicr-nccl-perf-default-deadbeef", CreationTimestamp: old,
+		Name: "aicr-nccl-perf-default-deadbeef", CreationTimestamp: old, Labels: ownedLabels,
 	}}
 	youngNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: "aicr-nccl-perf-default-abad1dea", CreationTimestamp: young,
+		Name: "aicr-nccl-perf-default-abad1dea", CreationTimestamp: young, Labels: ownedLabels,
 	}}
 	currentNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: "aicr-nccl-perf-default-currentrun", CreationTimestamp: old,
+		Name: "aicr-nccl-perf-default-currentrun", CreationTimestamp: old, Labels: ownedLabels,
 	}}
 	terminatingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: "aicr-nccl-perf-default-cafef00d", CreationTimestamp: old,
+		Name: "aicr-nccl-perf-default-cafef00d", CreationTimestamp: old, Labels: ownedLabels,
 		DeletionTimestamp: &metav1.Time{Time: time.Now()}, Finalizers: []string{"kubernetes"},
 	}}
 	unrelatedNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "some-other-namespace", CreationTimestamp: old,
 	}}
+	// Matches the name prefix, is old enough, and has no live pod. Without
+	// the ownership label check, the pre-fix prune would have deleted it.
+	unlabeledMatchingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-notours", CreationTimestamp: old,
+	}}
 	liveAgedNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: "aicr-nccl-perf-default-livebeef", CreationTimestamp: old,
+		Name: "aicr-nccl-perf-default-livebeef", CreationTimestamp: old, Labels: ownedLabels,
 	}}
 	liveAgedPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: liveAgedNS.Name},
 		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 
-	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS, liveAgedNS, liveAgedPod)
+	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS,
+		unlabeledMatchingNS, liveAgedNS, liveAgedPod)
 	pruneStaleNCCLNamespaces(context.Background(), client, currentNS.Name)
 
 	remaining, err := client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
@@ -371,7 +381,8 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	if names[staleNS.Name] {
 		t.Errorf("expected stale namespace %q to be deleted", staleNS.Name)
 	}
-	for _, keep := range []string{youngNS.Name, currentNS.Name, terminatingNS.Name, unrelatedNS.Name, liveAgedNS.Name} {
+	for _, keep := range []string{youngNS.Name, currentNS.Name, terminatingNS.Name, unrelatedNS.Name,
+		unlabeledMatchingNS.Name, liveAgedNS.Name} {
 		if !names[keep] {
 			t.Errorf("expected namespace %q to be left alone, but it was deleted", keep)
 		}

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -1063,6 +1063,97 @@ func TestNcclExecutionLockHeldBy_LosesRaceToTakeover(t *testing.T) {
 	}
 }
 
+// TestClaimNCCLExecutionLock_CreateError checks that a Create failure other
+// than AlreadyExists surfaces as an error, instead of falling through to the
+// takeover path meant for an existing Lease.
+func TestClaimNCCLExecutionLock_CreateError(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset()
+	clientset.PrependReactor("create", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver unavailable")
+	})
+
+	if _, err := claimNCCLExecutionLock(context.Background(), clientset, ns); err == nil {
+		t.Fatal("expected a Create failure to surface as an error")
+	}
+}
+
+// TestClaimNCCLExecutionLock_UpdateError checks that a CAS-Update failure
+// other than a Conflict surfaces as an error, not the same ErrCodeConflict a
+// losing takeover gets.
+func TestClaimNCCLExecutionLock_UpdateError(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	staleHolder := "stale-holder"
+	staleRenew := metav1.NewMicroTime(time.Now().Add(-2 * defaults.NCCLExecutionLockStaleAge))
+	clientset := fake.NewClientset(&coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &staleHolder, RenewTime: &staleRenew},
+	})
+	clientset.PrependReactor("update", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver unavailable")
+	})
+
+	_, err := claimNCCLExecutionLock(context.Background(), clientset, ns)
+	if err == nil {
+		t.Fatal("expected an Update failure to surface as an error")
+	}
+	if stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		t.Errorf("expected a plain Update failure, not ErrCodeConflict, got: %v", err)
+	}
+}
+
+// TestNcclExecutionLockHeldBy_GetError checks that a Lease read failure
+// other than NotFound surfaces as an error, instead of being treated the
+// same as a missing lock.
+func TestNcclExecutionLockHeldBy_GetError(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset()
+	clientset.PrependReactor("get", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver unavailable")
+	})
+
+	if _, err := ncclExecutionLockHeldBy(context.Background(), clientset, ns, testHolderID); err == nil {
+		t.Fatal("expected a Lease read failure to surface as an error")
+	}
+}
+
+// TestNcclExecutionLockHeldBy_RenewError checks that a renew failure other
+// than a Conflict surfaces as an error, instead of quietly reporting the
+// lock as not held.
+func TestNcclExecutionLockHeldBy_RenewError(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	holder := testHolderID
+	clientset := fake.NewClientset(&coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder},
+	})
+	clientset.PrependReactor("update", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver unavailable")
+	})
+
+	if _, err := ncclExecutionLockHeldBy(context.Background(), clientset, ns, testHolderID); err == nil {
+		t.Fatal("expected a renew failure to surface as an error")
+	}
+}
+
+// TestRollbackNCCLNamespace_ToleratesDeleteFailure checks that a rollback
+// delete failure is only logged, not propagated. This is a leak-avoidance
+// nicety, not correctness-critical, since pruneStaleNCCLNamespaces reclaims
+// an orphaned namespace on a later run regardless.
+func TestRollbackNCCLNamespace_ToleratesDeleteFailure(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
+	clientset.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, ns, nil)
+	})
+
+	rollbackNCCLNamespace(clientset, ns, testNamespaceUID) // must not panic
+
+	if _, err := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the namespace to survive a failed rollback delete, got: %v", err)
+	}
+}
+
 // raceClaimNCCLExecutionLock calls claimNCCLExecutionLock concurrently from
 // n goroutines against the same namespace and returns the winning holder
 // IDs and the errors from the rest.
@@ -1158,6 +1249,26 @@ func TestVerifyNCCLNamespaceNotLive(t *testing.T) {
 				t.Errorf("expected ErrCodeConflict, got %v", err)
 			}
 		})
+	}
+}
+
+// TestVerifyNCCLNamespaceNotLive_ListError checks that a Pods().List
+// failure surfaces as a plain error, instead of being treated the same as
+// an empty, safe-to-adopt namespace.
+func TestVerifyNCCLNamespaceNotLive_ListError(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	activeNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+	client := fake.NewClientset(activeNS)
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver unavailable")
+	})
+
+	err := verifyNCCLNamespaceNotLive(context.Background(), client, activeNS)
+	if err == nil {
+		t.Fatal("expected a Pods().List failure to surface as an error")
+	}
+	if stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		t.Errorf("expected a plain read failure, not ErrCodeConflict, got: %v", err)
 	}
 }
 

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	stderrors "errors"
 	"log/slog"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	"github.com/NVIDIA/aicr/validators"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -473,7 +477,7 @@ func TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer(t *testing.T) {
 		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
 	}
 
-	if err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, resources, nil); err != nil {
+	if err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, testHolderID, resources, nil); err != nil {
 		t.Fatalf("cleanupNCCLRun failed: %v", err)
 	}
 
@@ -497,7 +501,7 @@ func TestCleanupNCCLRun_PropagatesTrainerCleanupFailure(t *testing.T) {
 		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
 	}
 
-	err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, resources, nil)
+	err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, testHolderID, resources, nil)
 	if err == nil {
 		t.Fatal("expected the Trainer teardown failure to fail the check, got nil")
 	}
@@ -527,12 +531,126 @@ func TestCleanupNCCLRun_SkipsTrainerTeardownOnNamespaceDeleteFailure(t *testing.
 		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
 	}
 
-	err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, resources, nil)
+	err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, testHolderID, resources, nil)
 	if err == nil {
 		t.Fatal("expected the namespace delete failure to fail the check, got nil")
 	}
 	if trainerDeleted {
 		t.Error("expected Trainer teardown to be skipped after the namespace delete failed, but deleteTrainer ran")
+	}
+}
+
+// TestClaimNCCLExecutionLock_ConcurrentCallersOneWins verifies that when
+// several callers race to claim a namespace with no existing lock, exactly
+// one wins and the rest get ErrCodeConflict.
+func TestClaimNCCLExecutionLock_ConcurrentCallersOneWins(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset()
+	holders, errs := raceClaimNCCLExecutionLock(clientset, ns, 8)
+
+	if len(holders) != 1 {
+		t.Fatalf("expected exactly one winner, got %d: %v", len(holders), holders)
+	}
+	assertAllConflict(t, errs, 7)
+}
+
+// TestClaimNCCLExecutionLock_ConcurrentTakeoverOneWins verifies that when
+// several callers race to take over an abandoned lock, exactly one wins and
+// the rest get ErrCodeConflict, instead of all of them proceeding. The
+// fake ObjectTracker doesn't enforce optimistic concurrency on Update, so a
+// reactor emulates the real apiserver's resourceVersion check.
+func TestClaimNCCLExecutionLock_ConcurrentTakeoverOneWins(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	oldHolder := "stale-holder"
+	oldRenew := metav1.NewMicroTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	clientset := fake.NewClientset(&coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns, ResourceVersion: "1"},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: &oldHolder,
+			RenewTime:      &oldRenew,
+		},
+	})
+
+	var (
+		mu        sync.Mutex
+		currentRV = 1
+	)
+	clientset.PrependReactor("update", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		lease := action.(k8stesting.UpdateAction).GetObject().(*coordinationv1.Lease)
+		mu.Lock()
+		defer mu.Unlock()
+		if lease.ResourceVersion != strconv.Itoa(currentRV) {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "coordination.k8s.io", Resource: "leases"},
+				ncclRunLockName, stderrors.New("resourceVersion mismatch"))
+		}
+		currentRV++
+		return true, lease, nil
+	})
+
+	holders, errs := raceClaimNCCLExecutionLock(clientset, ns, 8)
+
+	if len(holders) != 1 {
+		t.Fatalf("expected exactly one winner, got %d: %v", len(holders), holders)
+	}
+	assertAllConflict(t, errs, 7)
+}
+
+// TestClaimNCCLExecutionLock_RefusesLiveLease verifies a lock renewed
+// recently is treated as a live execution's claim, not taken over.
+func TestClaimNCCLExecutionLock_RefusesLiveLease(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	liveHolder := "live-holder"
+	liveRenew := metav1.NewMicroTime(time.Now())
+	clientset := fake.NewClientset(&coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: &liveHolder,
+			RenewTime:      &liveRenew,
+		},
+	})
+
+	if _, err := claimNCCLExecutionLock(context.Background(), clientset, ns); !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		t.Errorf("expected ErrCodeConflict against a live lease, got: %v", err)
+	}
+}
+
+// raceClaimNCCLExecutionLock calls claimNCCLExecutionLock concurrently from
+// n goroutines against the same namespace and returns the winning holder
+// IDs and the errors from the rest.
+func raceClaimNCCLExecutionLock(clientset kubernetes.Interface, namespace string, n int) (holders []string, errs []error) {
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			holderID, err := claimNCCLExecutionLock(context.Background(), clientset, namespace)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				holders = append(holders, holderID)
+			}
+		}()
+	}
+	wg.Wait()
+	return holders, errs
+}
+
+// assertAllConflict fails the test unless errs has wantCount entries, all
+// ErrCodeConflict.
+func assertAllConflict(t *testing.T, errs []error, wantCount int) {
+	t.Helper()
+	if len(errs) != wantCount {
+		t.Fatalf("expected %d losing callers, got %d: %v", wantCount, len(errs), errs)
+	}
+	for _, err := range errs {
+		if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+			t.Errorf("expected ErrCodeConflict for a losing caller, got: %v", err)
+		}
 	}
 }
 

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -17,15 +17,21 @@ package main
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
 
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/validators"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -276,5 +282,141 @@ func TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace(t *testing.T) {
 
 	if _, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), gpuConfig.Namespace, metav1.GetOptions{}); !apierrors.IsNotFound(getErr) {
 		t.Errorf("namespace %q was not cleaned up after Trainer install failure: get err = %v", gpuConfig.Namespace, getErr)
+	}
+}
+
+// TestVerifyNCCLNamespaceNotLive covers the ownership gate that decides
+// whether an already-existing per-run namespace is safe to adopt. Regression
+// guard for the MAJOR finding that silently reusing any active namespace let
+// a retry collide with (and later delete) a still-live execution's
+// resources.
+func TestVerifyNCCLNamespaceNotLive(t *testing.T) {
+	const ns = "aicr-nccl-bench-deadbeef"
+	terminatingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              ns,
+		DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+		Finalizers:        []string{"kubernetes"},
+	}}
+	activeNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+	livePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: ns},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	terminalPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: ns},
+		Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+
+	tests := []struct {
+		name    string
+		objs    []runtime.Object
+		wantErr bool
+	}{
+		{name: "namespace does not exist yet", objs: nil, wantErr: false},
+		{name: "namespace terminating from a prior cleanup", objs: []runtime.Object{terminatingNS}, wantErr: false},
+		{name: "namespace active with no pods (empty stale leftover)", objs: []runtime.Object{activeNS}, wantErr: false},
+		{
+			name:    "namespace active with only terminal pods (stale same-run resources)",
+			objs:    []runtime.Object{activeNS, terminalPod},
+			wantErr: false,
+		},
+		{
+			name:    "namespace active with a live pod (foreign/concurrent execution)",
+			objs:    []runtime.Object{activeNS, livePod},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientset(tt.objs...)
+			err := verifyNCCLNamespaceNotLive(context.Background(), client, ns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("verifyNCCLNamespaceNotLive() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+				t.Errorf("expected ErrCodeConflict, got %v", err)
+			}
+		})
+	}
+}
+
+// TestRunNCCLTrainJob_RefusesLiveForeignNamespace is the end-to-end
+// regression guard for the same MAJOR finding: a retry with the same
+// AICR_RUN_ID (or a rare random-suffix collision) must not silently adopt,
+// and must never let its deferred cleanup delete, a namespace a different,
+// still-running execution owns.
+func TestRunNCCLTrainJob_RefusesLiveForeignNamespace(t *testing.T) {
+	t.Setenv("AICR_RUN_ID", "test-run-id")
+	ns := fmt.Sprintf("%s-%s", ncclWorkloadNamespacePrefix, deriveRunID())
+
+	clientset := fake.NewClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: ns},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	)
+	vctx := &validators.Context{
+		Ctx:           context.Background(),
+		Clientset:     clientset,
+		DynamicClient: newTrainerFakeClient(),
+	}
+	gpuConfig := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 4, TotalGPUCount: 8}
+
+	_, err := runNCCLTrainJob(vctx, gpuConfig, "", "", variantDefault, fabricEFA, "")
+	if err == nil {
+		t.Fatal("expected a conflict error for a live foreign namespace, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		t.Errorf("expected ErrCodeConflict, got %v", err)
+	}
+
+	nsAfter, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("foreign namespace was removed (or errored reading it back) instead of left alone: %v", getErr)
+	}
+	if nsAfter.DeletionTimestamp != nil {
+		t.Error("foreign namespace was marked for deletion; cleanup must never touch a namespace it doesn't own")
+	}
+	if _, getErr := clientset.CoreV1().Pods(ns).Get(context.Background(), "launcher-0", metav1.GetOptions{}); getErr != nil {
+		t.Errorf("foreign execution's live pod was removed: %v", getErr)
+	}
+}
+
+// TestCreateUnstructured_ReclaimsStaleResource is the regression guard for
+// the MAJOR finding that a same-run retry could hit AlreadyExists on stale
+// fixed-name TrainingRuntime/TrainJob resources instead of recovering.
+func TestCreateUnstructured_ReclaimsStaleResource(t *testing.T) {
+	const ns = "aicr-nccl-bench-deadbeef"
+	listKinds := map[schema.GroupVersionResource]string{trainJobGVR: "TrainJobList"}
+
+	stale := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": trainJobGVR.GroupVersion().String(),
+		"kind":       "TrainJob",
+		"metadata": map[string]interface{}{
+			"name":            ncclTrainJobName,
+			"namespace":       ns,
+			"resourceVersion": "1",
+		},
+		"spec": map[string]interface{}{"stale": true},
+	}}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, stale)
+
+	fresh := stale.DeepCopy()
+	fresh.SetResourceVersion("")
+	if err := unstructured.SetNestedField(fresh.Object, false, "spec", "stale"); err != nil {
+		t.Fatalf("SetNestedField: %v", err)
+	}
+
+	if err := createUnstructured(context.Background(), dynamicClient, trainJobGVR, ns, fresh); err != nil {
+		t.Fatalf("createUnstructured() on an AlreadyExists fixed-name resource = %v, want reclaim via update", err)
+	}
+
+	got, err := dynamicClient.Resource(trainJobGVR).Namespace(ns).Get(context.Background(), ncclTrainJobName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get() after reclaim: %v", err)
+	}
+	if staleVal, _, _ := unstructured.NestedBool(got.Object, "spec", "stale"); staleVal {
+		t.Error("reclaimed resource still has the stale prior-run spec; update did not apply")
 	}
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -1244,6 +1244,49 @@ func TestCreateUnstructured_ReclaimsStaleResource_UpdatesInPlace(t *testing.T) {
 	}
 }
 
+// TestCreateUnstructured_RecreatesAfterNotFoundRace checks that a resource
+// deleted between the AlreadyExists Create and the follow-up Get falls
+// through to a fresh Create, instead of surfacing that race as a spurious
+// internal error.
+func TestCreateUnstructured_RecreatesAfterNotFoundRace(t *testing.T) {
+	const ns = "aicr-nccl-bench-deadbeef"
+	listKinds := map[schema.GroupVersionResource]string{trainingRuntimeGVR: "TrainingRuntimeList"}
+
+	stale := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": trainingRuntimeGVR.GroupVersion().String(),
+		"kind":       "TrainingRuntime",
+		"metadata": map[string]interface{}{
+			"name":            ncclTrainingRuntimeName,
+			"namespace":       ns,
+			"resourceVersion": "1",
+		},
+	}}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, stale)
+
+	var raced bool
+	dynamicClient.PrependReactor("get", "trainingruntimes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if raced {
+			return false, nil, nil // second Get, from the fallback Create's caller, uses the default reactor.
+		}
+		raced = true
+		if err := dynamicClient.Tracker().Delete(trainingRuntimeGVR, ns, ncclTrainingRuntimeName); err != nil {
+			return true, nil, err
+		}
+		return true, nil, apierrors.NewNotFound(trainingRuntimeGVR.GroupResource(), ncclTrainingRuntimeName)
+	})
+
+	fresh := stale.DeepCopy()
+	fresh.SetResourceVersion("")
+
+	if err := createUnstructured(context.Background(), dynamicClient, trainingRuntimeGVR, ns, fresh); err != nil {
+		t.Fatalf("createUnstructured() after a NotFound race = %v, want a fresh Create", err)
+	}
+
+	if _, err := dynamicClient.Resource(trainingRuntimeGVR).Namespace(ns).Get(context.Background(), ncclTrainingRuntimeName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected the resource to exist after the fallback Create: %v", err)
+	}
+}
+
 // TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates is the
 // regression guard for the finding that reclaiming a stale TrainJob by
 // updating it in place does not recover a same-run retry (see

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -21,7 +21,9 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/validators"
 	corev1 "k8s.io/api/core/v1"
@@ -306,6 +308,55 @@ func TestNCCLRunNamespace_VariesByVariant(t *testing.T) {
 
 		if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
 			t.Errorf("namespace %q for variant %q is not a valid DNS-1123 label: %v", ns, variant, errs)
+		}
+	}
+}
+
+// TestPruneStaleNCCLNamespaces is the regression guard for the low-priority
+// orphan-namespace nit: a standalone run killed before its own deferred
+// cleanup leaves an aicr-nccl-perf-* namespace under a random suffix nothing
+// else will ever reclaim. The prune must delete only namespaces that are all
+// of: name-matching, old enough to rule out an in-progress sibling variant,
+// not already terminating, and not the namespace this run is about to use.
+func TestPruneStaleNCCLNamespaces(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	young := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+
+	staleNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-deadbeef", CreationTimestamp: old,
+	}}
+	youngNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-abad1dea", CreationTimestamp: young,
+	}}
+	currentNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-currentrun", CreationTimestamp: old,
+	}}
+	terminatingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-cafef00d", CreationTimestamp: old,
+		DeletionTimestamp: &metav1.Time{Time: time.Now()}, Finalizers: []string{"kubernetes"},
+	}}
+	unrelatedNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "some-other-namespace", CreationTimestamp: old,
+	}}
+
+	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS)
+	pruneStaleNCCLNamespaces(context.Background(), client, currentNS.Name)
+
+	remaining, err := client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list namespaces after sweep: %v", err)
+	}
+	names := map[string]bool{}
+	for _, ns := range remaining.Items {
+		names[ns.Name] = true
+	}
+
+	if names[staleNS.Name] {
+		t.Errorf("expected stale namespace %q to be deleted", staleNS.Name)
+	}
+	for _, keep := range []string{youngNS.Name, currentNS.Name, terminatingNS.Name, unrelatedNS.Name} {
+		if !names[keep] {
+			t.Errorf("expected namespace %q to be left alone, but it was deleted", keep)
 		}
 	}
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -714,6 +714,46 @@ func TestPruneStaleNCCLNamespaces_ReleasesLockOnFailedDelete(t *testing.T) {
 	}
 }
 
+// TestPruneStaleNCCLNamespaces_StopsOnContextCancelMidSweep checks that a
+// context canceled partway through the sweep stops it from issuing calls
+// for the remaining namespaces, instead of continuing regardless.
+func TestPruneStaleNCCLNamespaces_StopsOnContextCancelMidSweep(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	ownedLabels := map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf}
+	nsA := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-aaaaaaaa", CreationTimestamp: old, Labels: ownedLabels,
+	}}
+	nsB := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-bbbbbbbb", CreationTimestamp: old, Labels: ownedLabels,
+	}}
+
+	client := fake.NewClientset(nsA, nsB)
+	ctx, cancel := context.WithCancel(context.Background())
+	var podListCalls, nsDeleteCalls int
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		podListCalls++
+		if podListCalls == 1 {
+			// Cancel partway through processing the first namespace, before
+			// the loop reaches the second.
+			cancel()
+		}
+		return false, nil, nil
+	})
+	client.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		nsDeleteCalls++
+		return false, nil, nil
+	})
+
+	pruneStaleNCCLNamespaces(ctx, client, newTrainerFakeClient(), "aicr-nccl-perf-default-currentrun")
+
+	if podListCalls != 1 {
+		t.Errorf("expected the sweep to stop after checking one namespace's pods, checked %d", podListCalls)
+	}
+	if nsDeleteCalls != 1 {
+		t.Errorf("expected exactly one namespace deleted before the canceled context stopped the sweep, got %d", nsDeleteCalls)
+	}
+}
+
 // TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher is the regression
 // guard for the finding that any watch event, including a Deleted event for a
 // stale pod, was returned as-is. applyNCCLResources's TrainJob admission

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -747,7 +747,9 @@ func TestRunNCCLTrainJob_RefusesLiveForeignNamespace(t *testing.T) {
 	ns := ncclRunNamespace(variantDefault)
 
 	clientset := fake.NewClientset(
-		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, Labels: map[string]string{
+			labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf,
+		}}},
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: ns},
 			Status:     corev1.PodStatus{Phase: corev1.PodRunning},

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -397,6 +397,37 @@ func TestRunNCCLTrainJob_RollsBackNamespaceOnLeaseAdmissionFailure(t *testing.T)
 	}
 }
 
+// TestRunNCCLTrainJob_KeepsReusedNamespaceOnLeaseAdmissionFailure checks
+// that the rollback added for a failed Lease claim does not fire for a
+// namespace ensureNamespace reused rather than created, since it may hold
+// another execution's leftovers worth reclaiming on a later retry.
+func TestRunNCCLTrainJob_KeepsReusedNamespaceOnLeaseAdmissionFailure(t *testing.T) {
+	t.Setenv("AICR_RUN_ID", "test-run-id")
+	ns := ncclRunNamespace(variantDefault)
+
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID, Labels: map[string]string{
+		labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf,
+	}}})
+	clientset.PrependReactor("create", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "coordination.k8s.io", Resource: "leases"},
+			ncclRunLockName, nil)
+	})
+
+	vctx := &validators.Context{
+		Ctx:           context.Background(),
+		Clientset:     clientset,
+		DynamicClient: newTrainerFakeClient(),
+	}
+	gpuConfig := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 4, TotalGPUCount: 8}
+
+	if _, err := runNCCLTrainJob(vctx, gpuConfig, "", "", variantDefault, fabricEFA, ""); err == nil {
+		t.Fatal("expected an error from the failed Lease claim, got nil")
+	}
+	if _, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); getErr != nil {
+		t.Errorf("reused namespace was rolled back after an unrelated Lease claim failure: %v", getErr)
+	}
+}
+
 // TestRunNCCLTrainJob_KeepsNamespaceOnConcurrentClaimConflict checks that
 // the rollback added for a failed Lease claim does not fire when the claim
 // failed because a concurrent caller already holds the lock, since that

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -698,3 +698,102 @@ func TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates(t *testing
 		t.Error("reclaimed TrainJob still has the stale prior-run spec, recreate did not apply")
 	}
 }
+
+// countDeleteActions counts "delete" actions recorded for the given
+// resource. Actions() is the fake client's own call history, so this reads
+// real counts without a separate counter.
+func countDeleteActions(actions []k8stesting.Action, resource string) int {
+	n := 0
+	for _, a := range actions {
+		if a.GetVerb() == "delete" && a.GetResource().Resource == resource {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCreateUnstructured_WaitsForFinalizerHeldTrainJobBeforeRecreate is the
+// regression guard for the finalizer-race finding. Delete only stamps
+// DeletionTimestamp while a Trainer v2 / JobSet ownership finalizer is still
+// clearing, so an immediate Create would hit AlreadyExists again. Before the
+// fix, createUnstructured issued Create immediately after Delete with no
+// wait in between.
+func TestCreateUnstructured_WaitsForFinalizerHeldTrainJobBeforeRecreate(t *testing.T) {
+	const ns = "aicr-nccl-bench-deadbeef"
+	const holdFinalizer = 200 * time.Millisecond
+	listKinds := map[schema.GroupVersionResource]string{trainJobGVR: "TrainJobList"}
+
+	stale := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": trainJobGVR.GroupVersion().String(),
+		"kind":       "TrainJob",
+		"metadata": map[string]interface{}{
+			"name":            ncclTrainJobName,
+			"namespace":       ns,
+			"resourceVersion": "1",
+		},
+		"spec": map[string]interface{}{"stale": true},
+	}}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, stale)
+
+	dynamicClient.PrependReactor("delete", "trainjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		// Branch on the object's own DeletionTimestamp, not an invocation
+		// counter, matching how a real apiserver decides. This also avoids
+		// calling Actions() from inside a reactor, which deadlocks. Invokes
+		// holds the Fake's write lock for the whole reactor chain, and
+		// Actions() takes that same lock to read.
+		existing, getErr := dynamicClient.Tracker().Get(trainJobGVR, ns, ncclTrainJobName)
+		obj, ok := existing.(*unstructured.Unstructured)
+		if getErr == nil && ok && obj.GetDeletionTimestamp() == nil {
+			// On the first delete, simulate a still-cascading finalizer by
+			// stamping DeletionTimestamp via the tracker instead of
+			// actually removing the object, then accept the request
+			// (handled=true, err=nil) as a real apiserver would.
+			held := obj.DeepCopy()
+			held.SetFinalizers([]string{"trainer.kubeflow.org/finalizer"})
+			now := metav1.Now()
+			held.SetDeletionTimestamp(&now)
+			if err := dynamicClient.Tracker().Update(trainJobGVR, held, ns); err != nil {
+				return true, nil, err
+			}
+			return true, nil, nil
+		}
+		// Already marked for deletion. The goroutine below fires this once
+		// the "finalizer" clears, so let the default reactor delete it for
+		// real, which emits the watch.Deleted event waitForResourceGone is
+		// blocked on.
+		return false, nil, nil
+	})
+
+	// Captured before the goroutine launches, so elapsed below can't dip
+	// under holdFinalizer merely because the goroutine's sleep started
+	// first.
+	start := time.Now()
+	go func() {
+		time.Sleep(holdFinalizer)
+		_ = dynamicClient.Resource(trainJobGVR).Namespace(ns).Delete(context.Background(), ncclTrainJobName, metav1.DeleteOptions{})
+	}()
+
+	fresh := stale.DeepCopy()
+	fresh.SetResourceVersion("")
+	if err := unstructured.SetNestedField(fresh.Object, false, "spec", "stale"); err != nil {
+		t.Fatalf("SetNestedField: %v", err)
+	}
+
+	if err := createUnstructured(context.Background(), dynamicClient, trainJobGVR, ns, fresh); err != nil {
+		t.Fatalf("createUnstructured() should succeed once the finalizer clears, got: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// A delete count of 2 alone doesn't prove the wait blocked. The
+	// goroutine above fires the second delete unconditionally at
+	// t=holdFinalizer regardless of what createUnstructured does. The
+	// elapsed-time check below is the real guard. A pre-fix immediate
+	// recreate would hit AlreadyExists and fail before that goroutine ever
+	// ran, with the delete count still at 1.
+	if got := countDeleteActions(dynamicClient.Actions(), "trainjobs"); got < 2 {
+		t.Fatalf("expected createUnstructured to observe the stale TrainJob still present and wait for a second delete, got %d delete call(s)", got)
+	}
+	if elapsed < holdFinalizer {
+		t.Errorf("createUnstructured recreated after %v, want it to have blocked at least %v for the finalizer to clear", elapsed, holdFinalizer)
+	}
+}

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -361,6 +361,76 @@ func TestRunNCCLTrainJob_AbortsIfExecutionLockLostBeforeApply(t *testing.T) {
 	}
 }
 
+// TestRunNCCLTrainJob_RollsBackNamespaceOnLeaseAdmissionFailure checks that
+// a namespace ensureNamespace just created is deleted again if claiming the
+// execution lock fails for a reason other than a concurrent caller already
+// holding it, so a standalone run doesn't leak a namespace on every retry.
+func TestRunNCCLTrainJob_RollsBackNamespaceOnLeaseAdmissionFailure(t *testing.T) {
+	clientset := fake.NewClientset()
+	clientset.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if ns, ok := action.(k8stesting.CreateAction).GetObject().(*corev1.Namespace); ok && ns.UID == "" {
+			ns.UID = testNamespaceUID
+		}
+		return false, nil, nil
+	})
+	clientset.PrependReactor("create", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "coordination.k8s.io", Resource: "leases"},
+			ncclRunLockName, nil)
+	})
+
+	vctx := &validators.Context{
+		Ctx:           context.Background(),
+		Clientset:     clientset,
+		DynamicClient: newTrainerFakeClient(),
+	}
+	gpuConfig := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 4, TotalGPUCount: 8}
+
+	_, err := runNCCLTrainJob(vctx, gpuConfig, "", "", variantDefault, fabricEFA, "")
+	if err == nil {
+		t.Fatal("expected an error from the failed Lease claim, got nil")
+	}
+	if gpuConfig.Namespace == "" {
+		t.Fatal("gpuConfig.Namespace was never set; ensureNamespace apparently wasn't reached")
+	}
+	if _, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), gpuConfig.Namespace, metav1.GetOptions{}); !apierrors.IsNotFound(getErr) {
+		t.Errorf("namespace %q was not rolled back after the Lease claim failed: get err = %v", gpuConfig.Namespace, getErr)
+	}
+}
+
+// TestRunNCCLTrainJob_KeepsNamespaceOnConcurrentClaimConflict checks that
+// the rollback added for a failed Lease claim does not fire when the claim
+// failed because a concurrent caller already holds the lock, since that
+// namespace belongs to them, not to this caller.
+func TestRunNCCLTrainJob_KeepsNamespaceOnConcurrentClaimConflict(t *testing.T) {
+	t.Setenv("AICR_RUN_ID", "test-run-id")
+	ns := ncclRunNamespace(variantDefault)
+	concurrentHolder := "concurrent-holder"
+	liveRenew := metav1.NewMicroTime(time.Now())
+	clientset := fake.NewClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID, Labels: map[string]string{
+			labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf,
+		}}},
+		&coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &concurrentHolder, RenewTime: &liveRenew},
+		},
+	)
+	vctx := &validators.Context{
+		Ctx:           context.Background(),
+		Clientset:     clientset,
+		DynamicClient: newTrainerFakeClient(),
+	}
+	gpuConfig := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 4, TotalGPUCount: 8}
+
+	_, err := runNCCLTrainJob(vctx, gpuConfig, "", "", variantDefault, fabricEFA, "")
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		t.Fatalf("expected ErrCodeConflict, got %v", err)
+	}
+	if _, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); getErr != nil {
+		t.Errorf("namespace was rolled back even though a concurrent caller holds the lock: %v", getErr)
+	}
+}
+
 // TestNCCLRunNamespace_VariesByVariant is the regression guard for the
 // finding that all three catalog checks share one AICR_RUN_ID per
 // invocation, so deriveRunID's suffix alone would give them the identical

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -370,9 +370,20 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: liveAgedNS.Name},
 		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
 	}
+	// Aged past the prune age and podless, but admitted moments ago, still
+	// installing Trainer or applying resources.
+	admittedPodlessNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-admitted", CreationTimestamp: old, Labels: ownedLabels,
+	}}
+	admittedHolder := "admitted-holder"
+	freshRenew := metav1.NewMicroTime(time.Now())
+	admittedLease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: admittedPodlessNS.Name},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &admittedHolder, RenewTime: &freshRenew},
+	}
 
 	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS,
-		unlabeledMatchingNS, otherComponentNS, liveAgedNS, liveAgedPod)
+		unlabeledMatchingNS, otherComponentNS, liveAgedNS, liveAgedPod, admittedPodlessNS, admittedLease)
 	pruneStaleNCCLNamespaces(context.Background(), client, currentNS.Name)
 
 	remaining, err := client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
@@ -388,7 +399,7 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 		t.Errorf("expected stale namespace %q to be deleted", staleNS.Name)
 	}
 	for _, keep := range []string{youngNS.Name, currentNS.Name, terminatingNS.Name, unrelatedNS.Name,
-		unlabeledMatchingNS.Name, otherComponentNS.Name, liveAgedNS.Name} {
+		unlabeledMatchingNS.Name, otherComponentNS.Name, liveAgedNS.Name, admittedPodlessNS.Name} {
 		if !names[keep] {
 			t.Errorf("expected namespace %q to be left alone, but it was deleted", keep)
 		}

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -339,8 +339,15 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	unrelatedNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "some-other-namespace", CreationTimestamp: old,
 	}}
+	liveAgedNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-livebeef", CreationTimestamp: old,
+	}}
+	liveAgedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "launcher-0", Namespace: liveAgedNS.Name},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
 
-	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS)
+	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS, liveAgedNS, liveAgedPod)
 	pruneStaleNCCLNamespaces(context.Background(), client, currentNS.Name)
 
 	remaining, err := client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
@@ -355,7 +362,7 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	if names[staleNS.Name] {
 		t.Errorf("expected stale namespace %q to be deleted", staleNS.Name)
 	}
-	for _, keep := range []string{youngNS.Name, currentNS.Name, terminatingNS.Name, unrelatedNS.Name} {
+	for _, keep := range []string{youngNS.Name, currentNS.Name, terminatingNS.Name, unrelatedNS.Name, liveAgedNS.Name} {
 		if !names[keep] {
 			t.Errorf("expected namespace %q to be left alone, but it was deleted", keep)
 		}

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -867,6 +867,47 @@ func TestCleanupNCCLRun_SkipsTrainerTeardownOnNamespaceDeleteFailure(t *testing.
 	}
 }
 
+// TestCleanupNCCLRun_SkipsTrainerTeardownWhenOtherNCCLNamespaceExists checks
+// that cleanupNCCLRun leaves a self-installed Trainer alone while another
+// AICR-owned NCCL benchmark namespace exists. A concurrent run using a
+// different AICR_RUN_ID gets its own namespace but can still be using this
+// same shared Trainer install, since ensureTrainerInstalled's reuse path
+// returns no resources for that peer to track and delete on its own.
+func TestCleanupNCCLRun_SkipsTrainerTeardownWhenOtherNCCLNamespaceExists(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	peerNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "aicr-nccl-perf-other-cafef00d",
+		Labels: map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf},
+	}}
+	holder := testHolderID
+	clientset := fake.NewClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}},
+		peerNS,
+		&coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder},
+		},
+	)
+	dynamicClient := newTrainerFakeClient(readyTrainerDeployment())
+
+	resources := []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	}
+	persistTrainerInstallManifest(context.Background(), clientset, resources)
+
+	if err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, testHolderID, resources, nil); err != nil {
+		t.Fatalf("cleanupNCCLRun failed: %v", err)
+	}
+
+	if _, err := dynamicClient.Resource(trainerDeploymentGVR).Namespace(trainerNamespace).
+		Get(context.Background(), trainerControllerDeployment, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the Trainer Deployment to survive while a peer namespace exists: %v", err)
+	}
+	if _, got, _ := loadTrainerInstallManifest(context.Background(), clientset); got == nil {
+		t.Error("expected the Trainer install manifest to survive while a peer namespace exists")
+	}
+}
+
 // TestClaimNCCLExecutionLock_ConcurrentCallersOneWins verifies that when
 // several callers race to claim a namespace with no existing lock, exactly
 // one wins and the rest get ErrCodeConflict.

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -699,6 +700,80 @@ func TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates(t *testing
 	}
 	if staleVal, _, _ := unstructured.NestedBool(got.Object, "spec", "stale"); staleVal {
 		t.Error("reclaimed TrainJob still has the stale prior-run spec, recreate did not apply")
+	}
+}
+
+// TestCreateUnstructured_TrainJobUIDMismatchPreventsDelete verifies the
+// reclaim delete is pinned to the TrainJob actually observed, not just its
+// name. It simulates the race the precondition guards against: a concurrent
+// execution deletes and recreates the same-named TrainJob (a new UID) in the
+// gap between createUnstructured's own Get and its Delete call. A "get"
+// reactor hands back that now-stale, already-observed UID exactly once, so
+// the Delete's precondition no longer matches what the tracker actually
+// holds. client-go's fake ObjectTracker ignores Delete preconditions
+// entirely, so a second reactor emulates the real apiserver's precondition
+// check to prove the mismatch surfaces as an error instead of deleting the
+// replacement regardless.
+func TestCreateUnstructured_TrainJobUIDMismatchPreventsDelete(t *testing.T) {
+	const ns = "aicr-nccl-bench-deadbeef"
+	const observedUID = types.UID("observed-before-replace")
+	const actualUID = types.UID("actual-owner-after-replace")
+	listKinds := map[schema.GroupVersionResource]string{trainJobGVR: "TrainJobList"}
+
+	stale := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": trainJobGVR.GroupVersion().String(),
+		"kind":       "TrainJob",
+		"metadata": map[string]interface{}{
+			"name":            ncclTrainJobName,
+			"namespace":       ns,
+			"uid":             string(actualUID),
+			"resourceVersion": "1",
+		},
+		"spec": map[string]interface{}{"stale": true},
+	}}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, stale)
+
+	getObservedStaleUID := true
+	dynamicClient.PrependReactor("get", "trainjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if !getObservedStaleUID {
+			return false, nil, nil
+		}
+		getObservedStaleUID = false
+		observed := stale.DeepCopy()
+		observed.SetUID(observedUID)
+		return true, observed, nil
+	})
+	dynamicClient.PrependReactor("delete", "trainjobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		if !ok {
+			return false, nil, nil
+		}
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if preconditions == nil || preconditions.UID == nil || *preconditions.UID == actualUID {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewConflict(trainJobGVR.GroupResource(), ncclTrainJobName,
+			stderrors.New("uid in precondition does not match uid in record"))
+	})
+
+	fresh := stale.DeepCopy()
+	fresh.SetUID("")
+	fresh.SetResourceVersion("")
+	if err := unstructured.SetNestedField(fresh.Object, false, "spec", "stale"); err != nil {
+		t.Fatalf("SetNestedField: %v", err)
+	}
+
+	err := createUnstructured(context.Background(), dynamicClient, trainJobGVR, ns, fresh)
+	if err == nil {
+		t.Fatal("expected a conflict error for a mismatched owning UID, got nil")
+	}
+
+	got, getErr := dynamicClient.Resource(trainJobGVR).Namespace(ns).Get(context.Background(), ncclTrainJobName, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("TrainJob should be left alone on a UID mismatch, got err=%v", getErr)
+	}
+	if staleVal, _, _ := unstructured.NestedBool(got.Object, "spec", "stale"); !staleVal {
+		t.Error("TrainJob was replaced despite the UID mismatch")
 	}
 }
 

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -21,10 +21,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/validators"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestEmitDiagnosticBlock(t *testing.T) {
@@ -241,5 +244,37 @@ func TestCollectNCCLWorkerDiagnostics(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace is the regression
+// guard for the namespace-cleanup defer's registration point: it must be
+// registered right after ensureNamespace succeeds, not after
+// ensureTrainerInstalled, or a Trainer-install failure returns before the
+// defer is ever registered and leaks the per-run namespace forever.
+func TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace(t *testing.T) {
+	dynamicClient := newTrainerFakeClient(completeTrainerInstall()...)
+	dynamicClient.PrependReactor("get", resourceCRDs, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
+	})
+
+	clientset := fake.NewClientset()
+	vctx := &validators.Context{
+		Ctx:           context.Background(),
+		Clientset:     clientset,
+		DynamicClient: dynamicClient,
+	}
+	gpuConfig := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 4, TotalGPUCount: 8}
+
+	_, err := runNCCLTrainJob(vctx, gpuConfig, "", "", variantDefault, fabricEFA, "")
+	if err == nil {
+		t.Fatal("expected an error from the failed Trainer install probe, got nil")
+	}
+	if gpuConfig.Namespace == "" {
+		t.Fatal("gpuConfig.Namespace was never set; ensureNamespace apparently wasn't reached")
+	}
+
+	if _, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), gpuConfig.Namespace, metav1.GetOptions{}); !apierrors.IsNotFound(getErr) {
+		t.Errorf("namespace %q was not cleaned up after Trainer install failure: get err = %v", gpuConfig.Namespace, getErr)
 	}
 }

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -506,6 +506,36 @@ func TestCleanupNCCLRun_PropagatesTrainerCleanupFailure(t *testing.T) {
 	}
 }
 
+// TestCleanupNCCLRun_SkipsTrainerTeardownOnNamespaceDeleteFailure verifies
+// that cleanupNCCLRun skips Trainer teardown, and fails the check, when the
+// namespace delete itself fails.
+func TestCleanupNCCLRun_SkipsTrainerTeardownOnNamespaceDeleteFailure(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
+	dynamicClient := newTrainerFakeClient()
+
+	clientset.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, ns, nil)
+	})
+	trainerDeleted := false
+	dynamicClient.PrependReactor("delete", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		trainerDeleted = true
+		return false, nil, nil
+	})
+
+	resources := []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	}
+
+	err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, resources, nil)
+	if err == nil {
+		t.Fatal("expected the namespace delete failure to fail the check, got nil")
+	}
+	if trainerDeleted {
+		t.Error("expected Trainer teardown to be skipped after the namespace delete failed, but deleteTrainer ran")
+	}
+}
+
 // TestVerifyNCCLNamespaceNotLive covers the ownership gate that decides
 // whether an already-existing per-run namespace is safe to adopt. Regression
 // guard for the MAJOR finding that silently reusing any active namespace let

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -528,19 +528,22 @@ func TestVerifyNCCLNamespaceNotLive(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		nsArg   *corev1.Namespace
 		objs    []runtime.Object
 		wantErr bool
 	}{
-		{name: "namespace does not exist yet", objs: nil, wantErr: false},
-		{name: "namespace terminating from a prior cleanup", objs: []runtime.Object{terminatingNS}, wantErr: false},
-		{name: "namespace active with no pods (empty stale leftover)", objs: []runtime.Object{activeNS}, wantErr: false},
+		{name: "namespace does not exist yet", nsArg: nil, objs: nil, wantErr: false},
+		{name: "namespace terminating from a prior cleanup", nsArg: terminatingNS, objs: []runtime.Object{terminatingNS}, wantErr: false},
+		{name: "namespace active with no pods (empty stale leftover)", nsArg: activeNS, objs: []runtime.Object{activeNS}, wantErr: false},
 		{
 			name:    "namespace active with only terminal pods (stale same-run resources)",
+			nsArg:   activeNS,
 			objs:    []runtime.Object{activeNS, terminalPod},
 			wantErr: false,
 		},
 		{
 			name:    "namespace active with a live pod (foreign/concurrent execution)",
+			nsArg:   activeNS,
 			objs:    []runtime.Object{activeNS, livePod},
 			wantErr: true,
 		},
@@ -548,7 +551,7 @@ func TestVerifyNCCLNamespaceNotLive(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewClientset(tt.objs...)
-			err := verifyNCCLNamespaceNotLive(context.Background(), client, ns)
+			err := verifyNCCLNamespaceNotLive(context.Background(), client, tt.nsArg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("verifyNCCLNamespaceNotLive() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -565,6 +565,40 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	}
 }
 
+// TestPruneStaleNCCLNamespaces_SkipsDeleteOnConcurrentClaim checks that
+// prune backs off if a caller claims the namespace's lock in the instant
+// between prune's own liveness check and its delete, instead of deleting
+// out from under a claim that didn't exist yet when prune first looked.
+func TestPruneStaleNCCLNamespaces_SkipsDeleteOnConcurrentClaim(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	ownedLabels := map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf}
+	targetNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-raced", CreationTimestamp: old, Labels: ownedLabels,
+	}}
+
+	client := fake.NewClientset(targetNS)
+	client.PrependReactor("create", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		// A caller wins the claim moments after prune's own check found no
+		// lease at all, racing prune's own claim attempt on the same Create.
+		rivalHolder := "rival-holder"
+		renew := metav1.NewMicroTime(time.Now())
+		rival := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: action.GetNamespace()},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &rivalHolder, RenewTime: &renew},
+		}
+		if err := client.Tracker().Add(rival); err != nil {
+			return true, nil, err
+		}
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "coordination.k8s.io", Resource: "leases"}, ncclRunLockName)
+	})
+
+	pruneStaleNCCLNamespaces(context.Background(), client, "some-other-namespace")
+
+	if _, err := client.CoreV1().Namespaces().Get(context.Background(), targetNS.Name, metav1.GetOptions{}); err != nil {
+		t.Errorf("namespace was deleted despite a concurrent caller claiming its lock first: %v", err)
+	}
+}
+
 // TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher is the regression
 // guard for the finding that any watch event, including a Deleted event for a
 // stale pod, was returned as-is. applyNCCLResources's TrainJob admission

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -29,6 +29,7 @@ import (
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	"github.com/NVIDIA/aicr/validators"
+	"github.com/NVIDIA/aicr/validators/helper"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -766,6 +767,72 @@ func TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("waitForPodByLabelSelector did not return after the replacement launcher appeared")
+	}
+}
+
+// TestWaitForLauncherPodAndGetLogs_TakenOverLockFailsClosed checks that a
+// lock lost while the pod ran is caught right after it goes terminal,
+// instead of being left until cleanup runs minutes later. A live pod
+// already blocks a same-run retry on its own, but that protection ends
+// once the pod finishes, so ownership needs revalidating here.
+func TestWaitForLauncherPodAndGetLogs_TakenOverLockFailsClosed(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	launcherLabels := map[string]string{
+		"jobset.sigs.k8s.io/jobset-name":        "nccl-all-reduce-tj",
+		"jobset.sigs.k8s.io/replicatedjob-name": "launcher",
+	}
+	launcherPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "nccl-all-reduce-tj-launcher-0", Namespace: ns, Labels: launcherLabels},
+		Status:     corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	otherHolder := "some-other-holder"
+	clientset := fake.NewClientset(launcherPod, &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &otherHolder},
+	})
+	fakeWatch := watch.NewFake()
+	clientset.PrependWatchReactor("pods", k8stesting.DefaultWatchReactor(fakeWatch, nil))
+
+	// Flip the tracked pod to Succeeded up front, since
+	// waitForPodByLabelSelector only reads phase off the watch event below.
+	// WaitForPodSuccess re-Gets by name afterward and sees this update
+	// directly, no second watch needed.
+	succeeded := launcherPod.DeepCopy()
+	succeeded.Status.Phase = corev1.PodSucceeded
+	if _, err := clientset.CoreV1().Pods(ns).Update(context.Background(), succeeded, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to mark launcher pod succeeded: %v", err)
+	}
+
+	podHelper := &helper.PodLifecycle{ClientSet: clientset, Namespace: ns}
+	ctx := &validators.Context{Ctx: context.Background(), Clientset: clientset}
+
+	type waitResult struct {
+		logs string
+		err  error
+	}
+	resultCh := make(chan waitResult, 1)
+	go func() {
+		logs, err := waitForLauncherPodAndGetLogs(ctx, podHelper, testHolderID)
+		resultCh <- waitResult{logs, err}
+	}()
+
+	// Give the goroutine above time to establish its watch, then hand it the
+	// launcher pod. Its phase here only needs to pass the non-terminal
+	// filter, the state that actually matters was already set above.
+	time.Sleep(50 * time.Millisecond)
+	fakeWatch.Add(launcherPod)
+
+	select {
+	case res := <-resultCh:
+		if res.logs != "" {
+			t.Errorf("expected no logs once the lock was taken over, got %q", res.logs)
+		}
+		if !stderrors.Is(res.err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+			t.Errorf("expected ErrCodeConflict for a taken-over lock, got: %v", res.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForLauncherPodAndGetLogs did not return")
 	}
 }
 

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -639,6 +639,75 @@ func TestClaimNCCLExecutionLock_ReclaimsWellBeforeNamespacePruneAge(t *testing.T
 	}
 }
 
+// TestNcclExecutionLockHeldBy_LosesRaceToTakeover verifies that a takeover
+// landing between ncclExecutionLockHeldBy's read and its renewal makes it
+// report the lock not held, instead of the stale holder's cleanup going on
+// to delete the new holder's live namespace. A reactor on the Lease Get
+// applies a rival takeover to the tracker before returning the stale
+// holder's view, then a second reactor emulates the apiserver's
+// resourceVersion check the fake ObjectTracker skips on Update, so the
+// renewal that follows the Get sees the same conflict a real cluster would.
+func TestNcclExecutionLockHeldBy_LosesRaceToTakeover(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	holderA, holderB := "holder-a", "holder-b"
+	leaseGVR := coordinationv1.SchemeGroupVersion.WithResource("leases")
+	clientset := fake.NewClientset(&coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns, ResourceVersion: "1"},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holderA},
+	})
+
+	var (
+		mu        sync.Mutex
+		currentRV = 1
+		tookOver  bool
+	)
+	clientset.PrependReactor("get", "leases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if tookOver {
+			return false, nil, nil
+		}
+		tookOver = true
+		// Return this caller its stale, pre-takeover view...
+		staleView := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns, ResourceVersion: "1"},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holderA},
+		}
+		// ...while a rival's takeover lands underneath it, the interleaving
+		// this test exists to prove ncclExecutionLockHeldBy's renewal
+		// detects instead of proceeding on the stale view.
+		renew := metav1.NewMicroTime(time.Now())
+		currentRV++
+		rival := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns, ResourceVersion: strconv.Itoa(currentRV)},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holderB, RenewTime: &renew},
+		}
+		if err := clientset.Tracker().Update(leaseGVR, rival, ns); err != nil {
+			return true, nil, err
+		}
+		return true, staleView, nil
+	})
+	clientset.PrependReactor("update", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		lease := action.(k8stesting.UpdateAction).GetObject().(*coordinationv1.Lease)
+		mu.Lock()
+		defer mu.Unlock()
+		if lease.ResourceVersion != strconv.Itoa(currentRV) {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "coordination.k8s.io", Resource: "leases"},
+				ncclRunLockName, stderrors.New("resourceVersion mismatch"))
+		}
+		currentRV++
+		return true, lease, nil
+	})
+
+	held, err := ncclExecutionLockHeldBy(clientset, ns, holderA)
+	if err != nil {
+		t.Fatalf("ncclExecutionLockHeldBy() error = %v", err)
+	}
+	if held {
+		t.Error("expected the renewal to lose the race to the takeover and report the lock not held")
+	}
+}
+
 // raceClaimNCCLExecutionLock calls claimNCCLExecutionLock concurrently from
 // n goroutines against the same namespace and returns the winning holder
 // IDs and the errors from the rest.

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -562,7 +562,7 @@ func TestClaimNCCLExecutionLock_ConcurrentCallersOneWins(t *testing.T) {
 func TestClaimNCCLExecutionLock_ConcurrentTakeoverOneWins(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	oldHolder := "stale-holder"
-	oldRenew := metav1.NewMicroTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	oldRenew := metav1.NewMicroTime(time.Now().Add(-2 * defaults.NCCLExecutionLockStaleAge))
 	clientset := fake.NewClientset(&coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns, ResourceVersion: "1"},
 		Spec: coordinationv1.LeaseSpec{
@@ -611,6 +611,31 @@ func TestClaimNCCLExecutionLock_RefusesLiveLease(t *testing.T) {
 
 	if _, err := claimNCCLExecutionLock(context.Background(), clientset, ns); !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
 		t.Errorf("expected ErrCodeConflict against a live lease, got: %v", err)
+	}
+}
+
+// TestClaimNCCLExecutionLock_ReclaimsWellBeforeNamespacePruneAge verifies a
+// retry after a hard kill reclaims its dead lock promptly, well under
+// NCCLStaleNamespacePruneAge, not after waiting out that much longer age.
+func TestClaimNCCLExecutionLock_ReclaimsWellBeforeNamespacePruneAge(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	deadHolder := "dead-holder"
+	deadRenew := metav1.NewMicroTime(time.Now().Add(-2 * defaults.NCCLExecutionLockStaleAge))
+	if time.Since(deadRenew.Time) >= defaults.NCCLStaleNamespacePruneAge {
+		t.Fatalf("test fixture is not a useful regression guard: 2x NCCLExecutionLockStaleAge "+
+			"(%s ago) already exceeds NCCLStaleNamespacePruneAge (%s)",
+			time.Since(deadRenew.Time), defaults.NCCLStaleNamespacePruneAge)
+	}
+	clientset := fake.NewClientset(&coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: &deadHolder,
+			RenewTime:      &deadRenew,
+		},
+	})
+
+	if _, err := claimNCCLExecutionLock(context.Background(), clientset, ns); err != nil {
+		t.Errorf("expected the dead holder's lock to be reclaimed, got: %v", err)
 	}
 }
 

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -335,7 +335,7 @@ func TestNCCLRunNamespace_VariesByVariant(t *testing.T) {
 func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
 	young := metav1.NewTime(time.Now().Add(-1 * time.Minute))
-	ownedLabels := map[string]string{labels.ManagedBy: labels.ValueValidator}
+	ownedLabels := map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf}
 
 	staleNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "aicr-nccl-perf-default-deadbeef", CreationTimestamp: old, Labels: ownedLabels,
@@ -358,6 +358,13 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	unlabeledMatchingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "aicr-nccl-perf-default-notours", CreationTimestamp: old,
 	}}
+	// Also matches the name prefix and is AICR-managed, but for a different
+	// component. Proves the List selector, not name shape, decides scope:
+	// the Go-side loop no longer filters by prefix at all.
+	otherComponentNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-notmine", CreationTimestamp: old,
+		Labels: map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueInferencePerf},
+	}}
 	liveAgedNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "aicr-nccl-perf-default-livebeef", CreationTimestamp: old, Labels: ownedLabels,
 	}}
@@ -367,7 +374,7 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	}
 
 	client := fake.NewClientset(staleNS, youngNS, currentNS, terminatingNS, unrelatedNS,
-		unlabeledMatchingNS, liveAgedNS, liveAgedPod)
+		unlabeledMatchingNS, otherComponentNS, liveAgedNS, liveAgedPod)
 	pruneStaleNCCLNamespaces(context.Background(), client, currentNS.Name)
 
 	remaining, err := client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
@@ -383,7 +390,7 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 		t.Errorf("expected stale namespace %q to be deleted", staleNS.Name)
 	}
 	for _, keep := range []string{youngNS.Name, currentNS.Name, terminatingNS.Name, unrelatedNS.Name,
-		unlabeledMatchingNS.Name, liveAgedNS.Name} {
+		unlabeledMatchingNS.Name, otherComponentNS.Name, liveAgedNS.Name} {
 		if !names[keep] {
 			t.Errorf("expected namespace %q to be left alone, but it was deleted", keep)
 		}

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -652,6 +652,38 @@ func TestPruneStaleNCCLNamespaces_SkipsDeleteOnConcurrentClaim(t *testing.T) {
 	}
 }
 
+// TestPruneStaleNCCLNamespaces_ReleasesLockOnFailedDelete checks that a
+// transient namespace-delete failure releases the fence Lease prune just
+// claimed, instead of leaving it to block a same-run retry closed until it
+// ages out on its own.
+func TestPruneStaleNCCLNamespaces_ReleasesLockOnFailedDelete(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
+	ownedLabels := map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf}
+	targetNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "aicr-nccl-perf-default-flaky", CreationTimestamp: old, Labels: ownedLabels,
+	}}
+
+	client := fake.NewClientset(targetNS)
+	client.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver unavailable")
+	})
+
+	pruneStaleNCCLNamespaces(context.Background(), client, newTrainerFakeClient(), "some-other-namespace")
+
+	if _, err := client.CoreV1().Namespaces().Get(context.Background(), targetNS.Name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected the namespace to survive a failed delete: %v", err)
+	}
+	if _, err := client.CoordinationV1().Leases(targetNS.Name).Get(context.Background(), ncclRunLockName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("expected the fence Lease to be released after the failed delete, got: %v", err)
+	}
+
+	// A same-run retry must be able to claim it immediately, not fail
+	// closed until NCCLExecutionLockStaleAge passes.
+	if _, err := claimNCCLExecutionLock(context.Background(), client, targetNS.Name); err != nil {
+		t.Errorf("expected a retry to claim the released lock immediately, got: %v", err)
+	}
+}
+
 // TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher is the regression
 // guard for the finding that any watch event, including a Deleted event for a
 // stale pod, was returned as-is. applyNCCLResources's TrainJob admission

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -717,7 +717,10 @@ func TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher(t *testing.T) {
 // always delete the namespace first.
 func TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
-	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
+	clientset := fake.NewClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}},
+		testHeldLease(ns),
+	)
 	dynamicClient := newTrainerFakeClient()
 
 	var order []string
@@ -748,7 +751,10 @@ func TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer(t *testing.T) {
 // not just the namespace half of cleanup.
 func TestCleanupNCCLRun_PropagatesTrainerCleanupFailure(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
-	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
+	clientset := fake.NewClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}},
+		testHeldLease(ns),
+	)
 	dynamicClient := newTrainerFakeClient()
 	dynamicClient.PrependReactor("delete", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "deployments"}, trainerControllerDeployment, nil)
@@ -772,7 +778,10 @@ func TestCleanupNCCLRun_PropagatesTrainerCleanupFailure(t *testing.T) {
 // namespace delete itself fails.
 func TestCleanupNCCLRun_SkipsTrainerTeardownOnNamespaceDeleteFailure(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
-	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
+	clientset := fake.NewClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}},
+		testHeldLease(ns),
+	)
 	dynamicClient := newTrainerFakeClient()
 
 	clientset.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
@@ -893,6 +902,37 @@ func TestClaimNCCLExecutionLock_ReclaimsWellBeforeNamespacePruneAge(t *testing.T
 
 	if _, err := claimNCCLExecutionLock(context.Background(), clientset, ns); err != nil {
 		t.Errorf("expected the dead holder's lock to be reclaimed, got: %v", err)
+	}
+}
+
+// TestNcclExecutionLockHeldBy_MissingLeaseFailsClosed checks that a missing
+// Lease reports the lock not held, not held by default.
+func TestNcclExecutionLockHeldBy_MissingLeaseFailsClosed(t *testing.T) {
+	clientset := fake.NewClientset()
+
+	held, err := ncclExecutionLockHeldBy(context.Background(), clientset, "aicr-nccl-perf-deadbeef", testHolderID)
+	if err != nil {
+		t.Fatalf("ncclExecutionLockHeldBy() error = %v", err)
+	}
+	if held {
+		t.Error("expected a missing Lease to report the lock not held")
+	}
+}
+
+// TestCleanupNCCLRun_MissingLeaseSkipsDelete checks that cleanupNCCLRun
+// leaves the namespace alone, instead of deleting it, when its Lease is
+// missing.
+func TestCleanupNCCLRun_MissingLeaseSkipsDelete(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
+	dynamicClient := newTrainerFakeClient()
+
+	if err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, testHolderID, nil, nil); err != nil {
+		t.Fatalf("cleanupNCCLRun failed: %v", err)
+	}
+
+	if _, err := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the namespace to survive a missing Lease, got: %v", err)
 	}
 }
 

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -259,7 +259,7 @@ func TestCollectNCCLWorkerDiagnostics(t *testing.T) {
 }
 
 // TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace is the regression
-// guard for the namespace-cleanup defer's registration point: it must be
+// guard for the namespace-cleanup defer's registration point. It must be
 // registered right after ensureNamespace succeeds, not after
 // ensureTrainerInstalled, or a Trainer-install failure returns before the
 // defer is ever registered and leaks the per-run namespace forever.
@@ -300,13 +300,9 @@ func TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace(t *testing.T) {
 }
 
 // TestNCCLRunNamespace_VariesByVariant is the regression guard for the
-// finding that all three catalog checks (nccl-all-reduce-bw, -net, -nvls)
-// share one AICR_RUN_ID within a single aicr validate invocation, so
-// deriveRunID's suffix alone would give them the identical namespace name.
-// Today that is safe because the checks run serially and cleanup fully
-// drains each namespace before the next starts, but folding the variant
-// into the name removes the dependency on that ordering, which pkg/validator
-// has a TODO to parallelize.
+// finding that all three catalog checks share one AICR_RUN_ID per
+// invocation, so deriveRunID's suffix alone would give them the identical
+// namespace name. Folding the variant into the name keeps them distinct.
 func TestNCCLRunNamespace_VariesByVariant(t *testing.T) {
 	t.Setenv("AICR_RUN_ID", "test-run-id")
 
@@ -325,12 +321,10 @@ func TestNCCLRunNamespace_VariesByVariant(t *testing.T) {
 }
 
 // TestPruneStaleNCCLNamespaces is the regression guard for the ownership
-// finding. Name, age, and pod occupancy alone must never qualify a namespace
-// for deletion. The prune must delete only namespaces that are all of:
-// labeled as ours (see ensureNamespace's labels.ManagedBy stamp),
-// name-matching, old enough to rule out an in-progress sibling variant, not
-// already terminating, and not the namespace this run is about to use.
-// unlabeledMatchingNS is the case that would have been wrongly deleted
+// finding. Only a namespace labeled ours, old enough to rule out an
+// in-progress sibling variant, not already terminating, and not the one
+// this run is about to use may be deleted. unlabeledMatchingNS and
+// otherComponentNS are the cases that would have been wrongly deleted
 // before the fix.
 func TestPruneStaleNCCLNamespaces(t *testing.T) {
 	old := metav1.NewTime(time.Now().Add(-2 * defaults.NCCLStaleNamespacePruneAge))
@@ -401,7 +395,7 @@ func TestPruneStaleNCCLNamespaces(t *testing.T) {
 // guard for the finding that any watch event, including a Deleted event for a
 // stale pod, was returned as-is. applyNCCLResources's TrainJob admission
 // retry (see TrainJobAdmissionRetryTimeout) can recreate the launcher under
-// the same label selector: the stale launcher's Deleted event must be
+// the same label selector, and the stale launcher's Deleted event must be
 // skipped so the wait continues until the replacement's Added event arrives.
 func TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
@@ -571,7 +565,7 @@ func TestVerifyNCCLNamespaceNotLive(t *testing.T) {
 }
 
 // TestRunNCCLTrainJob_RefusesLiveForeignNamespace is the end-to-end
-// regression guard for the same MAJOR finding: a retry with the same
+// regression guard for the same MAJOR finding. A retry with the same
 // AICR_RUN_ID (or a rare random-suffix collision) must not silently adopt,
 // and must never let its deferred cleanup delete, a namespace a different,
 // still-running execution owns.
@@ -653,12 +647,9 @@ func TestCreateUnstructured_ReclaimsStaleResource_UpdatesInPlace(t *testing.T) {
 
 // TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates is the
 // regression guard for the finding that reclaiming a stale TrainJob by
-// updating it in place does not actually recover a same-run retry. Kubeflow
-// Trainer treats most of the TrainJob spec as immutable once created and
-// rejects an in-place update to those fields, and even a permitted update
-// would not make the controller recreate the underlying JobSet/pods a
-// hard-killed run left behind. TrainJob must be reclaimed by delete then
-// recreate instead.
+// updating it in place does not recover a same-run retry (see
+// createUnstructured's doc comment for why). It must be reclaimed by
+// delete then recreate instead.
 func TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates(t *testing.T) {
 	const ns = "aicr-nccl-bench-deadbeef"
 	listKinds := map[schema.GroupVersionResource]string{trainJobGVR: "TrainJobList"}
@@ -712,15 +703,12 @@ func TestCreateUnstructured_ReclaimsStaleTrainJob_DeletesAndRecreates(t *testing
 
 // TestCreateUnstructured_TrainJobUIDMismatchPreventsDelete verifies the
 // reclaim delete is pinned to the TrainJob actually observed, not just its
-// name. It simulates the race the precondition guards against: a concurrent
-// execution deletes and recreates the same-named TrainJob (a new UID) in the
-// gap between createUnstructured's own Get and its Delete call. A "get"
-// reactor hands back that now-stale, already-observed UID exactly once, so
-// the Delete's precondition no longer matches what the tracker actually
-// holds. client-go's fake ObjectTracker ignores Delete preconditions
-// entirely, so a second reactor emulates the real apiserver's precondition
-// check to prove the mismatch surfaces as an error instead of deleting the
-// replacement regardless.
+// name. A "get" reactor hands back a stale, already-observed UID once,
+// simulating a concurrent delete-and-recreate in the gap between
+// createUnstructured's own Get and Delete. client-go's fake ObjectTracker
+// ignores Delete preconditions, so a second reactor emulates the real
+// apiserver's precondition check to prove the UID mismatch surfaces as an
+// error instead of deleting the replacement regardless.
 func TestCreateUnstructured_TrainJobUIDMismatchPreventsDelete(t *testing.T) {
 	const ns = "aicr-nccl-bench-deadbeef"
 	const observedUID = types.UID("observed-before-replace")

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -303,6 +303,64 @@ func TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace(t *testing.T) {
 	}
 }
 
+// TestRunNCCLTrainJob_AbortsIfExecutionLockLostBeforeApply checks that if
+// another caller takes the execution lock over while Trainer install is
+// running, runNCCLTrainJob aborts instead of applying resources under a
+// lock it no longer holds. The reactor takes the lock over on the first
+// Lease read after the initial claim.
+func TestRunNCCLTrainJob_AbortsIfExecutionLockLostBeforeApply(t *testing.T) {
+	dynamicClient := newTrainerFakeClient(completeTrainerInstall()...)
+	runtimeApplied := false
+	dynamicClient.PrependReactor("create", "trainingruntimes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		runtimeApplied = true
+		return false, nil, nil
+	})
+	clientset := fake.NewClientset()
+	clientset.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if ns, ok := action.(k8stesting.CreateAction).GetObject().(*corev1.Namespace); ok && ns.UID == "" {
+			ns.UID = testNamespaceUID
+		}
+		return false, nil, nil
+	})
+
+	leaseGVR := coordinationv1.SchemeGroupVersion.WithResource("leases")
+	var takenOver bool
+	clientset.PrependReactor("get", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if takenOver {
+			return false, nil, nil
+		}
+		takenOver = true
+		rivalHolder := "rival-holder"
+		renew := metav1.NewMicroTime(time.Now())
+		rival := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: action.GetNamespace(), ResourceVersion: "999"},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &rivalHolder, RenewTime: &renew},
+		}
+		if err := clientset.Tracker().Update(leaseGVR, rival, action.GetNamespace()); err != nil {
+			return true, nil, err
+		}
+		return false, nil, nil // let the default reactor return the now-updated (rival) object
+	})
+
+	vctx := &validators.Context{
+		Ctx:           context.Background(),
+		Clientset:     clientset,
+		DynamicClient: dynamicClient,
+	}
+	gpuConfig := &gpuConfiguration{WorkerCount: 2, GPUCountPerNode: 4, TotalGPUCount: 8}
+
+	_, err := runNCCLTrainJob(vctx, gpuConfig, "", "", variantDefault, fabricEFA, "")
+	if err == nil {
+		t.Fatal("expected a conflict error when the execution lock was taken over before apply, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeConflict, "")) {
+		t.Errorf("expected ErrCodeConflict, got %v", err)
+	}
+	if runtimeApplied {
+		t.Error("expected no TrainingRuntime to be applied after losing the execution lock")
+	}
+}
+
 // TestNCCLRunNamespace_VariesByVariant is the regression guard for the
 // finding that all three catalog checks share one AICR_RUN_ID per
 // invocation, so deriveRunID's suffix alone would give them the identical
@@ -650,6 +708,32 @@ func TestClaimNCCLExecutionLock_ReclaimsWellBeforeNamespacePruneAge(t *testing.T
 	}
 }
 
+// TestNcclExecutionLockHeldBy_ExpiredHolderCannotResumeAfterTakeover checks
+// that a holder whose lock went stale and was taken over by another caller
+// is correctly told it no longer holds the lock.
+func TestNcclExecutionLockHeldBy_ExpiredHolderCannotResumeAfterTakeover(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	pausedHolder := "paused-holder"
+	staleRenew := metav1.NewMicroTime(time.Now().Add(-2 * defaults.NCCLExecutionLockStaleAge))
+	clientset := fake.NewClientset(&coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: ns},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &pausedHolder, RenewTime: &staleRenew},
+	})
+
+	newHolder, err := claimNCCLExecutionLock(context.Background(), clientset, ns)
+	if err != nil {
+		t.Fatalf("expected the stale lock to be taken over, got: %v", err)
+	}
+
+	held, err := ncclExecutionLockHeldBy(context.Background(), clientset, ns, pausedHolder)
+	if err != nil {
+		t.Fatalf("ncclExecutionLockHeldBy() error = %v", err)
+	}
+	if held {
+		t.Errorf("expected paused holder %q to no longer hold the lock after %q took it over", pausedHolder, newHolder)
+	}
+}
+
 // TestNcclExecutionLockHeldBy_LosesRaceToTakeover verifies that a takeover
 // landing between ncclExecutionLockHeldBy's read and its renewal makes it
 // report the lock not held, instead of the stale holder's cleanup going on
@@ -710,7 +794,7 @@ func TestNcclExecutionLockHeldBy_LosesRaceToTakeover(t *testing.T) {
 		return true, lease, nil
 	})
 
-	held, err := ncclExecutionLockHeldBy(clientset, ns, holderA)
+	held, err := ncclExecutionLockHeldBy(context.Background(), clientset, ns, holderA)
 	if err != nil {
 		t.Fatalf("ncclExecutionLockHeldBy() error = %v", err)
 	}

--- a/validators/performance/nccl_all_reduce_bw_constraint_test.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint_test.go
@@ -268,6 +268,15 @@ func TestRunNCCLTrainJob_TrainerInstallFailureCleansUpNamespace(t *testing.T) {
 	})
 
 	clientset := fake.NewClientset()
+	// A real apiserver always stamps a UID on create. The fake tracker
+	// doesn't, so mimic it here since cleanupNCCLResources now requires one
+	// to authorize its delete (see testNamespaceUID).
+	clientset.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if ns, ok := action.(k8stesting.CreateAction).GetObject().(*corev1.Namespace); ok && ns.UID == "" {
+			ns.UID = testNamespaceUID
+		}
+		return false, nil, nil
+	})
 	vctx := &validators.Context{
 		Ctx:           context.Background(),
 		Clientset:     clientset,
@@ -434,7 +443,7 @@ func TestWaitForPodByLabelSelector_IgnoresStaleDeletedLauncher(t *testing.T) {
 // always delete the namespace first.
 func TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
-	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
 	dynamicClient := newTrainerFakeClient()
 
 	var order []string
@@ -451,7 +460,7 @@ func TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer(t *testing.T) {
 		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
 	}
 
-	if err := cleanupNCCLRun(clientset, dynamicClient, ns, "", resources, nil); err != nil {
+	if err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, resources, nil); err != nil {
 		t.Fatalf("cleanupNCCLRun failed: %v", err)
 	}
 
@@ -465,7 +474,7 @@ func TestCleanupNCCLRun_DeletesNamespaceBeforeTrainer(t *testing.T) {
 // not just the namespace half of cleanup.
 func TestCleanupNCCLRun_PropagatesTrainerCleanupFailure(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
-	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	clientset := fake.NewClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
 	dynamicClient := newTrainerFakeClient()
 	dynamicClient.PrependReactor("delete", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "deployments"}, trainerControllerDeployment, nil)
@@ -475,7 +484,7 @@ func TestCleanupNCCLRun_PropagatesTrainerCleanupFailure(t *testing.T) {
 		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
 	}
 
-	err := cleanupNCCLRun(clientset, dynamicClient, ns, "", resources, nil)
+	err := cleanupNCCLRun(clientset, dynamicClient, ns, testNamespaceUID, resources, nil)
 	if err == nil {
 		t.Fatal("expected the Trainer teardown failure to fail the check, got nil")
 	}

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
@@ -121,6 +122,12 @@ func TestCreateOrUpdateFromTemplate_RoCEClaimIdempotent(t *testing.T) {
 	}
 }
 
+// testNamespaceUID is the owning UID used across cleanupNCCLResources tests
+// that seed a namespace. A real namespace always has one, and
+// cleanupNCCLResources now refuses to delete without one (see
+// TestCleanupNCCLResources_RejectsEmptyUID).
+const testNamespaceUID = types.UID("test-owner-uid")
+
 // TestCleanupNCCLResources_ToleratesMissing verifies the deferred cleanup is
 // safe to run after an early/partial-apply failure: with no namespace ever
 // created, deleting it must be treated as success (NotFound-tolerant), not
@@ -128,7 +135,7 @@ func TestCreateOrUpdateFromTemplate_RoCEClaimIdempotent(t *testing.T) {
 func TestCleanupNCCLResources_ToleratesMissing(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	fakeClient := fake.NewClientset()
-	if err := cleanupNCCLResources(fakeClient, ns, ""); err != nil {
+	if err := cleanupNCCLResources(fakeClient, ns, testNamespaceUID); err != nil {
 		t.Fatalf("cleanup of a namespace that was never created should not error, got: %v", err)
 	}
 }
@@ -140,9 +147,9 @@ func TestCleanupNCCLResources_ToleratesMissing(t *testing.T) {
 // tracking required since nothing else ever shares this namespace.
 func TestCleanupNCCLResources_DeletesNamespace(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
-	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
 
-	if err := cleanupNCCLResources(fakeClient, ns, ""); err != nil {
+	if err := cleanupNCCLResources(fakeClient, ns, testNamespaceUID); err != nil {
 		t.Fatalf("cleanup should not error, got: %v", err)
 	}
 
@@ -157,17 +164,72 @@ func TestCleanupNCCLResources_DeletesNamespace(t *testing.T) {
 // still fail an otherwise-passing check on it.
 func TestCleanupNCCLResources_ReturnsErrorOnDeleteFailure(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
-	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
 	fakeClient.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
 	})
 
-	err := cleanupNCCLResources(fakeClient, ns, "")
+	err := cleanupNCCLResources(fakeClient, ns, testNamespaceUID)
 	if err == nil {
 		t.Fatal("expected an error from a non-NotFound namespace delete failure, got nil")
 	}
 	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeInternal, "")) {
 		t.Errorf("got %v, want an ErrCodeInternal-wrapped delete failure", err)
+	}
+}
+
+// TestCleanupNCCLResources_RejectsEmptyUID is the regression guard for the
+// hardening finding that an empty owning UID must be rejected outright.
+// Against a real apiserver an empty Preconditions.UID would fail the delete
+// anyway (it is still an exact-match check, and a real namespace's UID is
+// never empty), but the fake client used in the other tests here ignores
+// delete preconditions entirely and would silently proceed, masking a
+// caller bug that drops the UID.
+func TestCleanupNCCLResources_RejectsEmptyUID(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
+
+	err := cleanupNCCLResources(fakeClient, ns, "")
+	if err == nil {
+		t.Fatal("expected an error for an empty owning UID, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeInternal, "")) {
+		t.Errorf("got %v, want an ErrCodeInternal error", err)
+	}
+	if _, getErr := fakeClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); getErr != nil {
+		t.Errorf("namespace should be left alone when the UID check is rejected, got err=%v", getErr)
+	}
+}
+
+// TestCleanupNCCLResources_UIDMismatchPreventsDelete verifies the ownership
+// precondition against a UID mismatch. client-go's fake ObjectTracker
+// ignores Delete preconditions entirely, so this reactor emulates the real
+// apiserver's UID precondition check (see cleanupNCCLResources's doc
+// comment) to prove a mismatch actually surfaces as an error instead of the
+// namespace being deleted regardless.
+func TestCleanupNCCLResources_UIDMismatchPreventsDelete(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	const actualUID = types.UID("actual-owner-uid")
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: actualUID}})
+	fakeClient.PrependReactor("delete", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		if !ok {
+			return false, nil, nil
+		}
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if preconditions == nil || preconditions.UID == nil || *preconditions.UID == actualUID {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewConflict(v1.Resource("namespaces"), ns,
+			stderrors.New("uid in precondition does not match uid in record"))
+	})
+
+	err := cleanupNCCLResources(fakeClient, ns, "wrong-uid")
+	if err == nil {
+		t.Fatal("expected a conflict error for a mismatched owning UID, got nil")
+	}
+	if _, getErr := fakeClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); getErr != nil {
+		t.Errorf("namespace should be left alone on a UID mismatch, got err=%v", getErr)
 	}
 }
 
@@ -182,7 +244,7 @@ func TestCleanupNCCLResources_ReturnsErrorOnDeleteFailure(t *testing.T) {
 func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	const holdFinalizer = 200 * time.Millisecond
-	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
 	nsGVR := v1.SchemeGroupVersion.WithResource("namespaces")
 
 	var deleteCalls int32
@@ -196,6 +258,7 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 			now := metav1.Now()
 			held := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
 				Name:              ns,
+				UID:               testNamespaceUID,
 				Finalizers:        []string{"kubernetes"},
 				DeletionTimestamp: &now,
 			}}
@@ -220,7 +283,7 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 		_ = fakeClient.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
 	}()
 
-	if err := cleanupNCCLResources(fakeClient, ns, ""); err != nil {
+	if err := cleanupNCCLResources(fakeClient, ns, testNamespaceUID); err != nil {
 		t.Fatalf("cleanup should succeed once the finalizer clears, got: %v", err)
 	}
 	elapsed := time.Since(start)

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -127,6 +127,11 @@ func TestCreateOrUpdateFromTemplate_RoCEClaimIdempotent(t *testing.T) {
 // TestCleanupNCCLResources_RejectsEmptyUID).
 const testNamespaceUID = types.UID("test-owner-uid")
 
+// testHolderID is the execution lock holder ID used across cleanupNCCLRun
+// tests that don't seed a Lease. ncclExecutionLockHeldBy treats a missing
+// Lease as nothing left to protect, so any value works here.
+const testHolderID = "test-holder-id"
+
 // TestCleanupNCCLResources_ToleratesMissing verifies the deferred cleanup is
 // safe to run after an early/partial-apply failure. With no namespace ever
 // created, deleting it must be treated as success (NotFound-tolerant), not

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -16,10 +16,15 @@ package main
 
 import (
 	"context"
+	stderrors "errors"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/validators"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,11 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
-// ncclGVRListKinds maps every GVR cleanupNCCLResources / applyNCCLResources
-// touch to a fake list kind, so the dynamic fake client can serve Create/Get/
-// Update/Delete for these CRDs without a real REST mapper.
+// ncclGVRListKinds maps every GVR applyNCCLResources touches to a fake list
+// kind, so the dynamic fake client can serve Create/Get/Update for these CRDs
+// without a real REST mapper.
 var ncclGVRListKinds = map[schema.GroupVersionResource]string{
 	resourceClaimTemplateGVR: "ResourceClaimTemplateList",
 	trainJobGVR:              "TrainJobList",
@@ -115,47 +122,139 @@ func TestCreateOrUpdateFromTemplate_RoCEClaimIdempotent(t *testing.T) {
 }
 
 // TestCleanupNCCLResources_ToleratesMissing verifies the deferred cleanup is
-// safe to run after an early/partial-apply failure: with no resources present,
-// every Delete hits NotFound and the function must complete without panicking.
+// safe to run after an early/partial-apply failure: with no namespace ever
+// created, deleting it must be treated as success (NotFound-tolerant), not
+// an error.
 func TestCleanupNCCLResources_ToleratesMissing(t *testing.T) {
-	const ns = "aicr-validation"
-	// No objects seeded — every Delete returns NotFound.
-	fakeClient := newFakeDynamicClient()
-	cleanupNCCLResources(fakeClient, ns)
-
-	// Cleanup must tolerate the absence, not resurrect anything.
-	_, err := fakeClient.Resource(resourceClaimTemplateGVR).Namespace(ns).
-		Get(context.Background(), ncclRoceClaimName, metav1.GetOptions{})
-	if !apierrors.IsNotFound(err) {
-		t.Fatalf("claim should remain absent after cleanup of empty namespace, got err=%v", err)
+	const ns = "aicr-nccl-perf-deadbeef"
+	fakeClient := fake.NewClientset()
+	if err := cleanupNCCLResources(fakeClient, ns); err != nil {
+		t.Fatalf("cleanup of a namespace that was never created should not error, got: %v", err)
 	}
 }
 
-// TestCleanupNCCLResources_DeletesRoCEClaim verifies the happy path: a RoCE
-// claim left in the persistent namespace is deleted by cleanup, so the next run
-// does not collide with it.
-func TestCleanupNCCLResources_DeletesRoCEClaim(t *testing.T) {
-	const ns = "aicr-validation"
+// TestCleanupNCCLResources_DeletesNamespace verifies the happy path: the
+// per-run namespace this run created is deleted, cascading away everything
+// created in it (TrainJob, TrainingRuntime, ComputeDomain, RoCE claim) via
+// ordinary Kubernetes namespace garbage collection, with no per-resource
+// tracking required since nothing else ever shares this namespace.
+func TestCleanupNCCLResources_DeletesNamespace(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 
-	claim := &unstructured.Unstructured{}
-	claim.SetAPIVersion("resource.k8s.io/v1")
-	claim.SetKind("ResourceClaimTemplate")
-	claim.SetName(ncclRoceClaimName)
-	claim.SetNamespace(ns)
-
-	fakeClient := newFakeDynamicClient(claim)
-
-	// Sanity: the claim exists before cleanup.
-	if _, err := fakeClient.Resource(resourceClaimTemplateGVR).Namespace(ns).
-		Get(context.Background(), ncclRoceClaimName, metav1.GetOptions{}); err != nil {
-		t.Fatalf("precondition: claim should exist before cleanup: %v", err)
+	if err := cleanupNCCLResources(fakeClient, ns); err != nil {
+		t.Fatalf("cleanup should not error, got: %v", err)
 	}
 
-	cleanupNCCLResources(fakeClient, ns)
+	if _, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("namespace should be deleted after cleanup, got err=%v", err)
+	}
+}
 
-	_, err := fakeClient.Resource(resourceClaimTemplateGVR).Namespace(ns).
-		Get(context.Background(), ncclRoceClaimName, metav1.GetOptions{})
-	if !apierrors.IsNotFound(err) {
-		t.Fatalf("claim should be deleted after cleanup, got err=%v", err)
+// TestCleanupNCCLResources_ReturnsErrorOnDeleteFailure verifies a delete
+// failure that is not NotFound (e.g. a transient apiserver error) is
+// returned to the caller instead of only logged, so foldCleanupError can
+// still fail an otherwise-passing check on it.
+func TestCleanupNCCLResources_ReturnsErrorOnDeleteFailure(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	fakeClient.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
+	})
+
+	err := cleanupNCCLResources(fakeClient, ns)
+	if err == nil {
+		t.Fatal("expected an error from a non-NotFound namespace delete failure, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeInternal, "")) {
+		t.Errorf("got %v, want an ErrCodeInternal-wrapped delete failure", err)
+	}
+}
+
+// TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace is the regression
+// guard for the wait-for-termination fix: a namespace whose first delete
+// only stamps a DeletionTimestamp (finalizers still cascading, as the
+// ComputeDomain/ResourceClaimTemplate CRs this namespace can hold commonly
+// do) must not be reported as cleaned up until it actually disappears.
+// Before this fix, cleanupNCCLResources returned nil as soon as the first
+// Delete call was accepted, even though the namespace, and everything
+// still finalizing inside it, was still there.
+func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	const holdFinalizer = 200 * time.Millisecond
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	nsGVR := v1.SchemeGroupVersion.WithResource("namespaces")
+
+	var deleteCalls int32
+	fakeClient.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if atomic.AddInt32(&deleteCalls, 1) == 1 {
+			// First delete: simulate a still-cascading finalizer by stamping
+			// DeletionTimestamp via the tracker directly instead of actually
+			// removing the object, then tell the caller the delete request
+			// was accepted (handled=true, err=nil), matching what a real
+			// apiserver does for a namespace with finalizers.
+			now := metav1.Now()
+			held := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name:              ns,
+				Finalizers:        []string{"kubernetes"},
+				DeletionTimestamp: &now,
+			}}
+			if err := fakeClient.Tracker().Update(nsGVR, held, ""); err != nil {
+				return true, nil, err
+			}
+			return true, nil, nil
+		}
+		// Second delete (fired by the goroutine below once the "finalizer"
+		// clears): let the default reactor perform the real delete, which
+		// also emits the watch.Deleted event waitForNamespaceGone is
+		// blocked on.
+		return false, nil, nil
+	})
+
+	go func() {
+		time.Sleep(holdFinalizer)
+		_ = fakeClient.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+	}()
+
+	start := time.Now()
+	if err := cleanupNCCLResources(fakeClient, ns); err != nil {
+		t.Fatalf("cleanup should succeed once the finalizer clears, got: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if got := atomic.LoadInt32(&deleteCalls); got < 2 {
+		t.Fatalf("expected cleanup to observe the namespace still present and wait for a second delete, got %d delete call(s)", got)
+	}
+	if elapsed < holdFinalizer {
+		t.Errorf("cleanup returned after %v, want it to have blocked at least %v for the finalizer to clear (it returned before the namespace actually disappeared)", elapsed, holdFinalizer)
+	}
+}
+
+// TestWaitForNamespaceGone_TimesOutWhenNeverDeleted is the regression guard
+// for the "wait boundedly, then fail" half of the fix: if a namespace's
+// finalizers never clear within the caller's deadline, the wait must return
+// a timeout error rather than either hang indefinitely or (the pre-fix
+// cleanupNCCLResources behavior this mirrors) silently report success while
+// the namespace is still there. Calls waitForNamespaceGone directly with a
+// short local context so the test doesn't have to wait out
+// cleanupNCCLResources's real 5-minute production timeout.
+func TestWaitForNamespaceGone_TimesOutWhenNeverDeleted(t *testing.T) {
+	const ns = "aicr-nccl-perf-deadbeef"
+	now := metav1.Now()
+	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              ns,
+		Finalizers:        []string{"kubernetes"},
+		DeletionTimestamp: &now,
+	}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := waitForNamespaceGone(ctx, fakeClient.CoreV1().Namespaces(), ns)
+	if err == nil {
+		t.Fatal("expected a timeout error waiting for a namespace that never finishes terminating, got nil")
+	}
+	if !stderrors.Is(err, aicrErrors.New(aicrErrors.ErrCodeTimeout, "")) {
+		t.Errorf("got %v, want an ErrCodeTimeout-wrapped wait failure", err)
 	}
 }

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -128,7 +128,7 @@ func TestCreateOrUpdateFromTemplate_RoCEClaimIdempotent(t *testing.T) {
 func TestCleanupNCCLResources_ToleratesMissing(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	fakeClient := fake.NewClientset()
-	if err := cleanupNCCLResources(fakeClient, ns); err != nil {
+	if err := cleanupNCCLResources(fakeClient, ns, ""); err != nil {
 		t.Fatalf("cleanup of a namespace that was never created should not error, got: %v", err)
 	}
 }
@@ -142,7 +142,7 @@ func TestCleanupNCCLResources_DeletesNamespace(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 
-	if err := cleanupNCCLResources(fakeClient, ns); err != nil {
+	if err := cleanupNCCLResources(fakeClient, ns, ""); err != nil {
 		t.Fatalf("cleanup should not error, got: %v", err)
 	}
 
@@ -162,7 +162,7 @@ func TestCleanupNCCLResources_ReturnsErrorOnDeleteFailure(t *testing.T) {
 		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
 	})
 
-	err := cleanupNCCLResources(fakeClient, ns)
+	err := cleanupNCCLResources(fakeClient, ns, "")
 	if err == nil {
 		t.Fatal("expected an error from a non-NotFound namespace delete failure, got nil")
 	}
@@ -217,7 +217,7 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 	}()
 
 	start := time.Now()
-	if err := cleanupNCCLResources(fakeClient, ns); err != nil {
+	if err := cleanupNCCLResources(fakeClient, ns, ""); err != nil {
 		t.Fatalf("cleanup should succeed once the finalizer clears, got: %v", err)
 	}
 	elapsed := time.Since(start)

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	stderrors "errors"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -247,36 +246,33 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
 	nsGVR := v1.SchemeGroupVersion.WithResource("namespaces")
 
-	var deleteCalls int32
 	fakeClient.PrependReactor("delete", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
-		if atomic.AddInt32(&deleteCalls, 1) == 1 {
-			// First delete: simulate a still-cascading finalizer by stamping
-			// DeletionTimestamp via the tracker directly instead of actually
-			// removing the object, then tell the caller the delete request
-			// was accepted (handled=true, err=nil), matching what a real
-			// apiserver does for a namespace with finalizers.
+		// Branch on the DeletionTimestamp, not a counter, matching how a
+		// real apiserver decides.
+		existing, getErr := fakeClient.Tracker().Get(nsGVR, "", ns)
+		obj, ok := existing.(*v1.Namespace)
+		if getErr == nil && ok && obj.DeletionTimestamp == nil {
+			// On the first delete, simulate a still-cascading finalizer by
+			// stamping DeletionTimestamp instead of removing the object,
+			// then accept the request as a real apiserver would.
+			held := obj.DeepCopy()
+			held.Finalizers = []string{"kubernetes"}
 			now := metav1.Now()
-			held := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
-				Name:              ns,
-				UID:               testNamespaceUID,
-				Finalizers:        []string{"kubernetes"},
-				DeletionTimestamp: &now,
-			}}
+			held.DeletionTimestamp = &now
 			if err := fakeClient.Tracker().Update(nsGVR, held, ""); err != nil {
 				return true, nil, err
 			}
 			return true, nil, nil
 		}
-		// Second delete (fired by the goroutine below once the "finalizer"
-		// clears): let the default reactor perform the real delete, which
-		// also emits the watch.Deleted event waitForNamespaceGone is
+		// Already marked for deletion. The goroutine below fires this once
+		// the "finalizer" clears, so let the default reactor delete it for
+		// real, emitting the watch.Deleted event waitForNamespaceGone is
 		// blocked on.
 		return false, nil, nil
 	})
 
-	// Captured before the goroutine launches, so elapsed below can't dip
-	// under holdFinalizer merely because the goroutine's sleep started
-	// before start was assigned.
+	// Captured before the goroutine launches so elapsed can't dip under
+	// holdFinalizer from a head start.
 	start := time.Now()
 	go func() {
 		time.Sleep(holdFinalizer)
@@ -288,13 +284,11 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	// deleteCalls reaching 2 alone doesn't prove cleanup blocked. The
-	// goroutine above fires the second delete unconditionally at t=200ms
-	// regardless of what cleanupNCCLResources does. The elapsed-time check
-	// below is the real guard. A pre-fix early return (reporting success as
-	// soon as the first Delete call was accepted) would hit it at ~0ms,
-	// with deleteCalls still at 1.
-	if got := atomic.LoadInt32(&deleteCalls); got < 2 {
+	// A delete count of 2 alone doesn't prove cleanup blocked. The
+	// goroutine fires the second delete unconditionally at t=200ms. The
+	// elapsed-time check below is the real guard. A pre-fix early return
+	// would hit it at ~0ms with the count still at 1.
+	if got := countDeleteActions(fakeClient.Actions(), "namespaces"); got < 2 {
 		t.Fatalf("expected cleanup to observe the namespace still present and wait for a second delete, got %d delete call(s)", got)
 	}
 	if elapsed < holdFinalizer {

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -211,17 +211,26 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 		return false, nil, nil
 	})
 
+	// Captured before the goroutine launches, so elapsed below can't dip
+	// under holdFinalizer merely because the goroutine's sleep started
+	// before start was assigned.
+	start := time.Now()
 	go func() {
 		time.Sleep(holdFinalizer)
 		_ = fakeClient.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
 	}()
 
-	start := time.Now()
 	if err := cleanupNCCLResources(fakeClient, ns, ""); err != nil {
 		t.Fatalf("cleanup should succeed once the finalizer clears, got: %v", err)
 	}
 	elapsed := time.Since(start)
 
+	// deleteCalls reaching 2 alone doesn't prove cleanup blocked. The
+	// goroutine above fires the second delete unconditionally at t=200ms
+	// regardless of what cleanupNCCLResources does. The elapsed-time check
+	// below is the real guard. A pre-fix early return (reporting success as
+	// soon as the first Delete call was accepted) would hit it at ~0ms,
+	// with deleteCalls still at 1.
 	if got := atomic.LoadInt32(&deleteCalls); got < 2 {
 		t.Fatalf("expected cleanup to observe the namespace still present and wait for a second delete, got %d delete call(s)", got)
 	}

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -198,11 +198,10 @@ func TestCleanupNCCLResources_RejectsEmptyUID(t *testing.T) {
 	}
 }
 
-// TestCleanupNCCLResources_UIDMismatchPreventsDelete verifies the ownership
-// precondition against a UID mismatch. client-go's fake ObjectTracker
-// ignores Delete preconditions, so this reactor emulates the real
-// apiserver's check to prove a mismatch surfaces as an error instead of
-// deleting the namespace regardless.
+// TestCleanupNCCLResources_UIDMismatchPreventsDelete verifies a UID
+// mismatch is treated like NotFound, not a cleanup failure. client-go's
+// fake ObjectTracker ignores Delete preconditions, so this reactor emulates
+// the real apiserver's check.
 func TestCleanupNCCLResources_UIDMismatchPreventsDelete(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	const actualUID = types.UID("actual-owner-uid")
@@ -220,9 +219,8 @@ func TestCleanupNCCLResources_UIDMismatchPreventsDelete(t *testing.T) {
 			stderrors.New("uid in precondition does not match uid in record"))
 	})
 
-	err := cleanupNCCLResources(fakeClient, ns, "wrong-uid")
-	if err == nil {
-		t.Fatal("expected a conflict error for a mismatched owning UID, got nil")
+	if err := cleanupNCCLResources(fakeClient, ns, "wrong-uid"); err != nil {
+		t.Fatalf("expected a UID mismatch to be treated as already-replaced, got err=%v", err)
 	}
 	if _, getErr := fakeClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{}); getErr != nil {
 		t.Errorf("namespace should be left alone on a UID mismatch, got err=%v", getErr)

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -23,6 +23,7 @@ import (
 
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/validators"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,9 +129,20 @@ func TestCreateOrUpdateFromTemplate_RoCEClaimIdempotent(t *testing.T) {
 const testNamespaceUID = types.UID("test-owner-uid")
 
 // testHolderID is the execution lock holder ID used across cleanupNCCLRun
-// tests that don't seed a Lease. ncclExecutionLockHeldBy treats a missing
-// Lease as nothing left to protect, so any value works here.
+// tests. Pair it with testHeldLease so ncclExecutionLockHeldBy finds a live
+// Lease naming this holder, rather than failing closed on one that's missing.
 const testHolderID = "test-holder-id"
+
+// testHeldLease returns a Lease naming testHolderID as the current holder
+// of namespace's execution lock, for tests that exercise cleanupNCCLRun
+// without covering the lock check itself.
+func testHeldLease(namespace string) *coordinationv1.Lease {
+	holder := testHolderID
+	return &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: ncclRunLockName, Namespace: namespace},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder},
+	}
+}
 
 // TestCleanupNCCLResources_ToleratesMissing verifies the deferred cleanup is
 // safe to run after an early/partial-apply failure. With no namespace ever

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -302,14 +302,14 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 	}
 }
 
-// TestWaitForNamespaceGone_TimesOutWhenNeverDeleted is the regression guard
-// for the "wait boundedly, then fail" half of the fix: if a namespace's
-// finalizers never clear within the caller's deadline, the wait must return
-// a timeout error rather than either hang indefinitely or (the pre-fix
-// cleanupNCCLResources behavior this mirrors) silently report success while
-// the namespace is still there. Calls waitForNamespaceGone directly with a
-// short local context so the test doesn't have to wait out
-// cleanupNCCLResources's real 5-minute production timeout.
+// TestWaitForNamespaceGone_TimesOutWhenNeverDeleted guards the bounded-wait
+// contract of waitForNamespaceGone itself. If a namespace's finalizers never
+// clear within the caller's deadline, the wait must return an ErrCodeTimeout
+// error rather than hang indefinitely. cleanupNCCLResources deliberately
+// only logs this timeout and returns nil, so a slow-but-real teardown does
+// not fail an otherwise-passing benchmark. Calls waitForNamespaceGone
+// directly with a short local context so the test doesn't have to wait out
+// the real 5-minute production bound.
 func TestWaitForNamespaceGone_TimesOutWhenNeverDeleted(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	now := metav1.Now()

--- a/validators/performance/nccl_roce_apply_test.go
+++ b/validators/performance/nccl_roce_apply_test.go
@@ -128,7 +128,7 @@ func TestCreateOrUpdateFromTemplate_RoCEClaimIdempotent(t *testing.T) {
 const testNamespaceUID = types.UID("test-owner-uid")
 
 // TestCleanupNCCLResources_ToleratesMissing verifies the deferred cleanup is
-// safe to run after an early/partial-apply failure: with no namespace ever
+// safe to run after an early/partial-apply failure. With no namespace ever
 // created, deleting it must be treated as success (NotFound-tolerant), not
 // an error.
 func TestCleanupNCCLResources_ToleratesMissing(t *testing.T) {
@@ -139,7 +139,7 @@ func TestCleanupNCCLResources_ToleratesMissing(t *testing.T) {
 	}
 }
 
-// TestCleanupNCCLResources_DeletesNamespace verifies the happy path: the
+// TestCleanupNCCLResources_DeletesNamespace verifies the happy path. The
 // per-run namespace this run created is deleted, cascading away everything
 // created in it (TrainJob, TrainingRuntime, ComputeDomain, RoCE claim) via
 // ordinary Kubernetes namespace garbage collection, with no per-resource
@@ -178,12 +178,10 @@ func TestCleanupNCCLResources_ReturnsErrorOnDeleteFailure(t *testing.T) {
 }
 
 // TestCleanupNCCLResources_RejectsEmptyUID is the regression guard for the
-// hardening finding that an empty owning UID must be rejected outright.
-// Against a real apiserver an empty Preconditions.UID would fail the delete
-// anyway (it is still an exact-match check, and a real namespace's UID is
-// never empty), but the fake client used in the other tests here ignores
-// delete preconditions entirely and would silently proceed, masking a
-// caller bug that drops the UID.
+// hardening finding that an empty owning UID must be rejected outright,
+// since the fake client used in the other tests here ignores Delete
+// preconditions entirely and would silently proceed on a caller bug that
+// drops the UID.
 func TestCleanupNCCLResources_RejectsEmptyUID(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	fakeClient := fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, UID: testNamespaceUID}})
@@ -202,10 +200,9 @@ func TestCleanupNCCLResources_RejectsEmptyUID(t *testing.T) {
 
 // TestCleanupNCCLResources_UIDMismatchPreventsDelete verifies the ownership
 // precondition against a UID mismatch. client-go's fake ObjectTracker
-// ignores Delete preconditions entirely, so this reactor emulates the real
-// apiserver's UID precondition check (see cleanupNCCLResources's doc
-// comment) to prove a mismatch actually surfaces as an error instead of the
-// namespace being deleted regardless.
+// ignores Delete preconditions, so this reactor emulates the real
+// apiserver's check to prove a mismatch surfaces as an error instead of
+// deleting the namespace regardless.
 func TestCleanupNCCLResources_UIDMismatchPreventsDelete(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	const actualUID = types.UID("actual-owner-uid")
@@ -233,13 +230,11 @@ func TestCleanupNCCLResources_UIDMismatchPreventsDelete(t *testing.T) {
 }
 
 // TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace is the regression
-// guard for the wait-for-termination fix: a namespace whose first delete
-// only stamps a DeletionTimestamp (finalizers still cascading, as the
-// ComputeDomain/ResourceClaimTemplate CRs this namespace can hold commonly
-// do) must not be reported as cleaned up until it actually disappears.
-// Before this fix, cleanupNCCLResources returned nil as soon as the first
-// Delete call was accepted, even though the namespace, and everything
-// still finalizing inside it, was still there.
+// guard for the wait-for-termination fix. A namespace whose first delete
+// only stamps a DeletionTimestamp (finalizers still cascading) must not be
+// reported as cleaned up until it actually disappears. Before this fix,
+// cleanupNCCLResources returned nil as soon as the first Delete call was
+// accepted.
 func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	const holdFinalizer = 200 * time.Millisecond
@@ -297,13 +292,11 @@ func TestCleanupNCCLResources_WaitsForFinalizerHeldNamespace(t *testing.T) {
 }
 
 // TestWaitForNamespaceGone_TimesOutWhenNeverDeleted guards the bounded-wait
-// contract of waitForNamespaceGone itself. If a namespace's finalizers never
-// clear within the caller's deadline, the wait must return an ErrCodeTimeout
-// error rather than hang indefinitely. cleanupNCCLResources deliberately
-// only logs this timeout and returns nil, so a slow-but-real teardown does
-// not fail an otherwise-passing benchmark. Calls waitForNamespaceGone
-// directly with a short local context so the test doesn't have to wait out
-// the real 5-minute production bound.
+// contract of waitForNamespaceGone itself. If finalizers never clear within
+// the deadline, it must return ErrCodeTimeout rather than hang indefinitely
+// (cleanupNCCLResources itself only logs this and returns nil). Calls it
+// directly with a short local context to avoid the real 5-minute
+// production bound.
 func TestWaitForNamespaceGone_TimesOutWhenNeverDeleted(t *testing.T) {
 	const ns = "aicr-nccl-perf-deadbeef"
 	now := metav1.Now()

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -212,7 +212,7 @@ func TestFoldCleanupError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := foldCleanupError(tt.bench, tt.cleanup)
+			got := foldCleanupError(tt.bench, tt.cleanup, "NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
 			if tt.want == nil {
 				if got != nil {
 					t.Fatalf("got %v, want nil", got)
@@ -231,7 +231,7 @@ func TestFoldCleanupError(t *testing.T) {
 func TestFoldCleanupError_PreservesCleanupCode(t *testing.T) {
 	cleanupErr := aicrErrors.New(aicrErrors.ErrCodeUnavailable, "apiserver is down")
 
-	got := foldCleanupError(nil, cleanupErr)
+	got := foldCleanupError(nil, cleanupErr, "fallback message")
 	if !stderrors.Is(got, aicrErrors.New(aicrErrors.ErrCodeUnavailable, "")) {
 		t.Errorf("cleanup error code was flattened: %v", got)
 	}

--- a/validators/performance/trainer_ensure_test.go
+++ b/validators/performance/trainer_ensure_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -36,7 +37,7 @@ import (
 func TestEnsureTrainerInstalled_CompleteInstallIsLeftAlone(t *testing.T) {
 	client := newTrainerFakeClient(completeTrainerInstall()...)
 
-	refs, err := ensureTrainerInstalled(context.Background(), client, nil, false)
+	refs, err := ensureTrainerInstalled(context.Background(), client, fake.NewClientset(), nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -83,7 +84,7 @@ func TestEnsureTrainerInstalled_WaitsOnDiscoveredControllerName(t *testing.T) {
 		return false, nil, nil
 	})
 
-	refs, err := ensureTrainerInstalled(ctx, client, nil, false)
+	refs, err := ensureTrainerInstalled(ctx, client, fake.NewClientset(), nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error waiting on the discovered controller %q (polled %v): %v",
 			discoveredName, polled, err)
@@ -128,7 +129,7 @@ func TestEnsureTrainerInstalled_WaitsForPreexistingController(t *testing.T) {
 	})
 	defer cancel()
 
-	refs, err := ensureTrainerInstalled(ctx, client, nil, false)
+	refs, err := ensureTrainerInstalled(ctx, client, fake.NewClientset(), nil, false)
 	if err == nil {
 		t.Fatal("expected a not-ready pre-existing controller to fail, got nil error")
 	}
@@ -158,7 +159,7 @@ func TestEnsureTrainerInstalled_RefusesToInstallOverForeignNamespace(t *testing.
 			trainerValidatingWebhookName, "kubeflow"),
 	)
 
-	refs, err := ensureTrainerInstalled(context.Background(), client, nil, false)
+	refs, err := ensureTrainerInstalled(context.Background(), client, fake.NewClientset(), nil, false)
 	if err == nil {
 		t.Fatal("expected the installer to refuse installing over an installation in another namespace")
 	}
@@ -182,7 +183,7 @@ func TestEnsureTrainerInstalled_PreservesProbeErrorCode(t *testing.T) {
 		return true, nil, apierrors.NewServiceUnavailable("apiserver is down")
 	})
 
-	_, err := ensureTrainerInstalled(context.Background(), client, nil, false)
+	_, err := ensureTrainerInstalled(context.Background(), client, fake.NewClientset(), nil, false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -285,7 +286,7 @@ func TestEnsureTrainerInstalled_RecipeDrivenLifecycle(t *testing.T) {
 			defer withShortTrainerWait(t)()
 			client := newTrainerFakeClient(tt.objects...)
 
-			refs, err := ensureTrainerInstalled(context.Background(), client, nil, tt.declared)
+			refs, err := ensureTrainerInstalled(context.Background(), client, fake.NewClientset(), nil, tt.declared)
 
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
@@ -417,7 +418,7 @@ func TestEnsureTrainerInstalled_DeclaredRolloutDoesNotFallThrough(t *testing.T) 
 	// machine with egress a fall-through would download tens of megabytes first. The
 	// assertions below are what catch it — no error, no claimed resources, and a
 	// probe count proving the wait was entered.
-	refs, err := ensureTrainerInstalled(context.Background(), client, nil, true)
+	refs, err := ensureTrainerInstalled(context.Background(), client, fake.NewClientset(), nil, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/validators/performance/trainer_install_manifest_test.go
+++ b/validators/performance/trainer_install_manifest_test.go
@@ -22,8 +22,24 @@ import (
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+// backdateTrainerInstallManifest rewrites the persisted manifest's
+// CreationTimestamp so reapOrphanedTrainerInstall treats it as abandoned
+// rather than possibly mid-install.
+func backdateTrainerInstallManifest(t *testing.T, client kubernetes.Interface) {
+	t.Helper()
+	cm, err := client.CoreV1().ConfigMaps(trainerNamespace).Get(context.Background(), trainerInstallManifestName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to fetch the manifest to backdate it: %v", err)
+	}
+	cm.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * defaults.NCCLExecutionLockStaleAge))
+	if _, err := client.CoreV1().ConfigMaps(trainerNamespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to backdate the manifest: %v", err)
+	}
+}
 
 // TestTrainerInstallManifest_RoundTrips checks that a persisted manifest can
 // be read back with the same resource list, and that deleting it leaves
@@ -205,14 +221,7 @@ func TestReapOrphanedTrainerInstall_ReapsStaleAbandonedInstall(t *testing.T) {
 	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
 		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
 	})
-	cm, err := client.CoreV1().ConfigMaps(trainerNamespace).Get(context.Background(), trainerInstallManifestName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to fetch the manifest to backdate it: %v", err)
-	}
-	cm.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * defaults.NCCLExecutionLockStaleAge))
-	if _, err := client.CoreV1().ConfigMaps(trainerNamespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
-		t.Fatalf("failed to backdate the manifest: %v", err)
-	}
+	backdateTrainerInstallManifest(t, client)
 
 	reapOrphanedTrainerInstall(context.Background(), client, dynamicClient, false)
 

--- a/validators/performance/trainer_install_manifest_test.go
+++ b/validators/performance/trainer_install_manifest_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -80,6 +81,23 @@ func TestLoadTrainerInstallManifest_MissingIsNil(t *testing.T) {
 	}
 	if cm != nil || resources != nil {
 		t.Errorf("loadTrainerInstallManifest() = (%v, %v), want (nil, nil)", cm, resources)
+	}
+}
+
+// TestLoadTrainerInstallManifest_MissingDataKeyIsEmpty checks that a
+// ConfigMap present without the resources key reports an empty list instead
+// of a decode error, so it does not permanently block orphan reaping.
+func TestLoadTrainerInstallManifest_MissingDataKeyIsEmpty(t *testing.T) {
+	client := fake.NewClientset(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: trainerInstallManifestName, Namespace: trainerNamespace,
+	}})
+
+	cm, resources, err := loadTrainerInstallManifest(context.Background(), client)
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", err)
+	}
+	if cm == nil || resources != nil {
+		t.Errorf("loadTrainerInstallManifest() = (%v, %v), want (non-nil, nil)", cm, resources)
 	}
 }
 

--- a/validators/performance/trainer_install_manifest_test.go
+++ b/validators/performance/trainer_install_manifest_test.go
@@ -296,6 +296,8 @@ func TestTrustworthyTrainerResourceRefs(t *testing.T) {
 			GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: "a"}, false},
 		{"namespace outside trainerNamespace is rejected", trainerResourceRef{
 			GVR: trainerDeploymentGVR, Namespace: "other", Name: "a", UID: testNamespaceUID}, false},
+		{"cluster-scoped kind outside the allowlist is rejected", trainerResourceRef{
+			GVR: trainerServiceGVR, Name: "a", UID: testNamespaceUID}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -353,5 +355,29 @@ func TestReapOrphanedTrainerInstall_RejectsEntryOutsideNamespace(t *testing.T) {
 	if _, err := dynamicClient.Resource(trainerDeploymentGVR).Namespace(otherNamespace).
 		Get(context.Background(), "someone-elses-deployment", metav1.GetOptions{}); err != nil {
 		t.Errorf("expected the out-of-namespace resource to survive: %v", err)
+	}
+}
+
+// TestReapOrphanedTrainerInstall_RejectsUntrustedClusterScopedKind checks
+// that a manifest entry naming a cluster-scoped kind outside
+// trustedClusterScopedTrainerGVRs is left alone instead of deleted. The
+// Trainer overlay never produces such a kind at cluster scope, so an entry
+// like this can only be a tampered or corrupted manifest.
+func TestReapOrphanedTrainerInstall_RejectsUntrustedClusterScopedKind(t *testing.T) {
+	client := fake.NewClientset()
+	victim := newTestObject("v1", "Service", "", "someone-elses-service")
+	victim.SetUID(testNamespaceUID)
+	dynamicClient := newTrainerFakeClient(victim)
+
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: trainerServiceGVR, Name: "someone-elses-service", UID: testNamespaceUID},
+	})
+	backdateTrainerInstallManifest(t, client)
+
+	reapOrphanedTrainerInstall(context.Background(), client, dynamicClient, false)
+
+	if _, err := dynamicClient.Resource(trainerServiceGVR).
+		Get(context.Background(), "someone-elses-service", metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the untrusted cluster-scoped resource to survive: %v", err)
 	}
 }

--- a/validators/performance/trainer_install_manifest_test.go
+++ b/validators/performance/trainer_install_manifest_test.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestTrainerInstallManifest_RoundTrips checks that a persisted manifest can
+// be read back with the same resource list, and that deleting it leaves
+// nothing behind.
+func TestTrainerInstallManifest_RoundTrips(t *testing.T) {
+	client := fake.NewClientset()
+	resources := []trainerResourceRef{
+		{GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	}
+
+	persistTrainerInstallManifest(context.Background(), client, resources)
+
+	_, got, err := loadTrainerInstallManifest(context.Background(), client)
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Name != trainerControllerDeployment {
+		t.Errorf("loadTrainerInstallManifest() = %v, want the persisted resource back", got)
+	}
+
+	deleteTrainerInstallManifest(context.Background(), client)
+	cm, _, err := loadTrainerInstallManifest(context.Background(), client)
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() after delete error = %v", err)
+	}
+	if cm != nil {
+		t.Error("expected the manifest to be gone after deleteTrainerInstallManifest")
+	}
+}
+
+// TestLoadTrainerInstallManifest_MissingIsNil checks that a namespace with no
+// manifest reports nothing tracked instead of an error.
+func TestLoadTrainerInstallManifest_MissingIsNil(t *testing.T) {
+	cm, resources, err := loadTrainerInstallManifest(context.Background(), fake.NewClientset())
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", err)
+	}
+	if cm != nil || resources != nil {
+		t.Errorf("loadTrainerInstallManifest() = (%v, %v), want (nil, nil)", cm, resources)
+	}
+}
+
+// TestPersistTrainerInstallManifest_MergesConcurrentInstall checks that a
+// second install's manifest write merges with, rather than overwrites, one
+// already persisted by a concurrent installer.
+func TestPersistTrainerInstallManifest_MergesConcurrentInstall(t *testing.T) {
+	client := fake.NewClientset()
+	deploymentGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	first := []trainerResourceRef{{GVR: deploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment}}
+	second := []trainerResourceRef{{GVR: deploymentGVR, Namespace: trainerNamespace, Name: jobSetControllerDeployment}}
+
+	persistTrainerInstallManifest(context.Background(), client, first)
+	persistTrainerInstallManifest(context.Background(), client, second)
+
+	_, got, err := loadTrainerInstallManifest(context.Background(), client)
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected both installers' resources to be tracked, got %v", got)
+	}
+}
+
+// TestRemoveTrainerInstallManifestEntries_LeavesConcurrentInstallTracked
+// checks that removing one run's own resources from the manifest preserves
+// a concurrent installer's entries, rather than wiping the whole manifest.
+func TestRemoveTrainerInstallManifestEntries_LeavesConcurrentInstallTracked(t *testing.T) {
+	client := fake.NewClientset()
+	deploymentGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	ours := []trainerResourceRef{{GVR: deploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment}}
+	theirs := []trainerResourceRef{{GVR: deploymentGVR, Namespace: trainerNamespace, Name: jobSetControllerDeployment}}
+
+	persistTrainerInstallManifest(context.Background(), client, ours)
+	persistTrainerInstallManifest(context.Background(), client, theirs)
+
+	removeTrainerInstallManifestEntries(context.Background(), client, ours)
+
+	_, got, err := loadTrainerInstallManifest(context.Background(), client)
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Name != jobSetControllerDeployment {
+		t.Errorf("removeTrainerInstallManifestEntries() left %v, want only the other installer's resource", got)
+	}
+}
+
+// TestRemoveTrainerInstallManifestEntries_DeletesWhenEmpty checks that the
+// manifest is deleted once removing a run's resources leaves nothing behind.
+func TestRemoveTrainerInstallManifestEntries_DeletesWhenEmpty(t *testing.T) {
+	client := fake.NewClientset()
+	resources := []trainerResourceRef{
+		{GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	}
+	persistTrainerInstallManifest(context.Background(), client, resources)
+
+	removeTrainerInstallManifestEntries(context.Background(), client, resources)
+
+	cm, _, err := loadTrainerInstallManifest(context.Background(), client)
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", err)
+	}
+	if cm != nil {
+		t.Error("expected the manifest to be deleted once empty")
+	}
+}
+
+// TestRemoveTrainerInstallManifestEntries_MissingIsNoOp checks that removing
+// from a manifest that does not exist does not error or create one.
+func TestRemoveTrainerInstallManifestEntries_MissingIsNoOp(t *testing.T) {
+	client := fake.NewClientset()
+	removeTrainerInstallManifestEntries(context.Background(), client, []trainerResourceRef{
+		{GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+
+	cm, _, err := loadTrainerInstallManifest(context.Background(), client)
+	if err != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", err)
+	}
+	if cm != nil {
+		t.Error("expected no manifest to be created")
+	}
+}
+
+// TestReapOrphanedTrainerInstall_SkipsWhenOtherNamespacesRemain checks that
+// reaping is skipped while another NCCL benchmark namespace might still
+// depend on Trainer, even if a manifest is present.
+func TestReapOrphanedTrainerInstall_SkipsWhenOtherNamespacesRemain(t *testing.T) {
+	client := fake.NewClientset()
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+
+	reapOrphanedTrainerInstall(context.Background(), client, newTrainerFakeClient(), true)
+
+	if _, got, _ := loadTrainerInstallManifest(context.Background(), client); got == nil {
+		t.Error("expected the manifest to survive while other namespaces remain")
+	}
+}
+
+// TestReapOrphanedTrainerInstall_SkipsFreshManifest checks that a manifest
+// younger than NCCLExecutionLockStaleAge is left alone, since it may belong
+// to an install still in progress rather than an abandoned one.
+func TestReapOrphanedTrainerInstall_SkipsFreshManifest(t *testing.T) {
+	client := fake.NewClientset()
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+	// The fake tracker, unlike a real apiserver, does not auto-stamp
+	// CreationTimestamp on Create, so it is set explicitly here.
+	cm, err := client.CoreV1().ConfigMaps(trainerNamespace).Get(context.Background(), trainerInstallManifestName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to fetch the manifest to stamp it: %v", err)
+	}
+	cm.CreationTimestamp = metav1.Now()
+	if _, err := client.CoreV1().ConfigMaps(trainerNamespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to stamp the manifest: %v", err)
+	}
+
+	reapOrphanedTrainerInstall(context.Background(), client, newTrainerFakeClient(), false)
+
+	if _, got, _ := loadTrainerInstallManifest(context.Background(), client); got == nil {
+		t.Error("expected a fresh manifest to survive reap")
+	}
+}
+
+// TestReapOrphanedTrainerInstall_ReapsStaleAbandonedInstall checks that a
+// stale manifest with no other namespaces around gets its Trainer resources
+// deleted and the manifest cleared, closing the leak an abandoned install
+// would otherwise leave behind.
+func TestReapOrphanedTrainerInstall_ReapsStaleAbandonedInstall(t *testing.T) {
+	client := fake.NewClientset()
+	dynamicClient := newTrainerFakeClient(readyTrainerDeployment())
+
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+	cm, err := client.CoreV1().ConfigMaps(trainerNamespace).Get(context.Background(), trainerInstallManifestName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to fetch the manifest to backdate it: %v", err)
+	}
+	cm.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * defaults.NCCLExecutionLockStaleAge))
+	if _, err := client.CoreV1().ConfigMaps(trainerNamespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to backdate the manifest: %v", err)
+	}
+
+	reapOrphanedTrainerInstall(context.Background(), client, dynamicClient, false)
+
+	if _, err := dynamicClient.Resource(trainerDeploymentGVR).Namespace(trainerNamespace).
+		Get(context.Background(), trainerControllerDeployment, metav1.GetOptions{}); err == nil {
+		t.Error("expected the orphaned Trainer Deployment to be deleted")
+	}
+	if _, got, _ := loadTrainerInstallManifest(context.Background(), client); got != nil {
+		t.Error("expected the manifest to be deleted once the install was reaped")
+	}
+}

--- a/validators/performance/trainer_install_manifest_test.go
+++ b/validators/performance/trainer_install_manifest_test.go
@@ -83,6 +83,32 @@ func TestLoadTrainerInstallManifest_MissingIsNil(t *testing.T) {
 	}
 }
 
+// TestMergeTrainerResourceRefs_PreservesOrder checks that the merged list
+// keeps a's, then b's, first-seen order with a duplicate updated in place.
+// deleteTrainer tears down in reverse list order, so a random order here
+// could delete a CRD or webhook before its controller.
+func TestMergeTrainerResourceRefs_PreservesOrder(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	ref := func(name string) trainerResourceRef {
+		return trainerResourceRef{GVR: gvr, Namespace: trainerNamespace, Name: name}
+	}
+
+	a := []trainerResourceRef{ref("crd"), ref("webhook"), ref("controller")}
+	b := []trainerResourceRef{ref("controller"), ref("service")}
+
+	got := mergeTrainerResourceRefs(a, b)
+
+	want := []string{"crd", "webhook", "controller", "service"}
+	if len(got) != len(want) {
+		t.Fatalf("mergeTrainerResourceRefs() = %v, want %d entries", got, len(want))
+	}
+	for i, name := range want {
+		if got[i].Name != name {
+			t.Errorf("entry %d = %q, want %q (full: %v)", i, got[i].Name, name, got)
+		}
+	}
+}
+
 // TestPersistTrainerInstallManifest_MergesConcurrentInstall checks that a
 // second install's manifest write merges with, rather than overwrites, one
 // already persisted by a concurrent installer.

--- a/validators/performance/trainer_install_manifest_test.go
+++ b/validators/performance/trainer_install_manifest_test.go
@@ -260,10 +260,12 @@ func TestReapOrphanedTrainerInstall_SkipsFreshManifest(t *testing.T) {
 // would otherwise leave behind.
 func TestReapOrphanedTrainerInstall_ReapsStaleAbandonedInstall(t *testing.T) {
 	client := fake.NewClientset()
-	dynamicClient := newTrainerFakeClient(readyTrainerDeployment())
+	deployment := readyTrainerDeployment()
+	deployment.SetUID(testNamespaceUID)
+	dynamicClient := newTrainerFakeClient(deployment)
 
 	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
-		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment, UID: testNamespaceUID},
 	})
 	backdateTrainerInstallManifest(t, client)
 
@@ -275,5 +277,81 @@ func TestReapOrphanedTrainerInstall_ReapsStaleAbandonedInstall(t *testing.T) {
 	}
 	if _, got, _ := loadTrainerInstallManifest(context.Background(), client); got != nil {
 		t.Error("expected the manifest to be deleted once the install was reaped")
+	}
+}
+
+// TestTrustworthyTrainerResourceRefs checks which manifest entries are kept
+// versus dropped, independent of the reap flow around it.
+func TestTrustworthyTrainerResourceRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  trainerResourceRef
+		want bool
+	}{
+		{"namespaced with UID is trusted", trainerResourceRef{
+			GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: "a", UID: testNamespaceUID}, true},
+		{"cluster-scoped with UID is trusted", trainerResourceRef{
+			GVR: trainerCRDGVR, Name: "a", UID: testNamespaceUID}, true},
+		{"missing UID is rejected", trainerResourceRef{
+			GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: "a"}, false},
+		{"namespace outside trainerNamespace is rejected", trainerResourceRef{
+			GVR: trainerDeploymentGVR, Namespace: "other", Name: "a", UID: testNamespaceUID}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trustworthyTrainerResourceRefs([]trainerResourceRef{tt.ref})
+			if (len(got) == 1) != tt.want {
+				t.Errorf("trustworthyTrainerResourceRefs(%+v) = %v, want kept=%v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReapOrphanedTrainerInstall_RejectsEntryWithoutUID checks that a
+// manifest entry with no recorded UID is left alone instead of deleted. The
+// manifest ConfigMap is writable by anyone with access to trainerNamespace,
+// and a delete with no UID precondition would remove whatever currently
+// holds that name, not necessarily what this run installed.
+func TestReapOrphanedTrainerInstall_RejectsEntryWithoutUID(t *testing.T) {
+	client := fake.NewClientset()
+	deployment := readyTrainerDeployment()
+	deployment.SetUID(testNamespaceUID)
+	dynamicClient := newTrainerFakeClient(deployment)
+
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: trainerNamespace, Name: trainerControllerDeployment},
+	})
+	backdateTrainerInstallManifest(t, client)
+
+	reapOrphanedTrainerInstall(context.Background(), client, dynamicClient, false)
+
+	if _, err := dynamicClient.Resource(trainerDeploymentGVR).Namespace(trainerNamespace).
+		Get(context.Background(), trainerControllerDeployment, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the Deployment to survive a UID-less manifest entry: %v", err)
+	}
+}
+
+// TestReapOrphanedTrainerInstall_RejectsEntryOutsideNamespace checks that a
+// manifest entry naming a namespace other than trainerNamespace is left
+// alone instead of deleted. A legitimate self-install never creates a
+// namespaced resource anywhere else, so such an entry can only be a
+// tampered or corrupted manifest.
+func TestReapOrphanedTrainerInstall_RejectsEntryOutsideNamespace(t *testing.T) {
+	client := fake.NewClientset()
+	const otherNamespace = "unrelated-namespace"
+	victim := newTestObject("apps/v1", "Deployment", otherNamespace, "someone-elses-deployment")
+	victim.SetUID(testNamespaceUID)
+	dynamicClient := newTrainerFakeClient(victim)
+
+	persistTrainerInstallManifest(context.Background(), client, []trainerResourceRef{
+		{GVR: trainerDeploymentGVR, Namespace: otherNamespace, Name: "someone-elses-deployment", UID: testNamespaceUID},
+	})
+	backdateTrainerInstallManifest(t, client)
+
+	reapOrphanedTrainerInstall(context.Background(), client, dynamicClient, false)
+
+	if _, err := dynamicClient.Resource(trainerDeploymentGVR).Namespace(otherNamespace).
+		Get(context.Background(), "someone-elses-deployment", metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the out-of-namespace resource to survive: %v", err)
 	}
 }

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -828,14 +828,14 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 	}
 }
 
-// foldCleanupError decides the check's verdict when teardown fails. A cleanup
-// failure leaks cluster-scoped CRDs, RBAC, and webhook configurations (or, for
-// the NCCL resource cleanup caller, poisons the next run's fixed-named
-// resources) that would silently break a later run, so it fails an
-// otherwise-passing check, but it never masks a real benchmark failure,
-// which is always the more useful signal. fallbackMsg is used only when
-// cleanupErr isn't already a *StructuredError (PropagateOrWrap preserves an
-// existing one's own message/code as-is).
+// foldCleanupError decides the check's verdict when teardown fails. A
+// cleanup failure leaks cluster-scoped CRDs, RBAC, and webhook
+// configurations (or, for the NCCL resource cleanup caller, poisons the
+// next run's fixed-named resources), so it fails an otherwise-passing
+// check without masking a real benchmark failure, the more useful signal.
+// fallbackMsg is used only when cleanupErr isn't already a
+// *StructuredError (PropagateOrWrap preserves an existing one's own
+// message/code as-is).
 func foldCleanupError(benchErr, cleanupErr error, fallbackMsg string) error {
 	if cleanupErr == nil || benchErr != nil {
 		return benchErr
@@ -995,12 +995,12 @@ func newTrainerInstallManifestConfigMap(resources []trainerResourceRef) (*corev1
 
 // persistTrainerInstallManifest durably records a fresh self-install's
 // resources, so reapOrphanedTrainerInstall can find and remove them if the
-// installing caller never reaches its own cleanup. Failures are logged and
-// swallowed. The caller's own cleanup path still works either way.
+// installing caller never reaches its own cleanup. Failures are only
+// logged, since the caller's own cleanup path still works either way.
 //
-// A concurrent installer's Create can lose to this one with AlreadyExists, so
-// the two lists are merged, retrying on conflict, instead of one overwriting
-// the other.
+// A concurrent installer's Create can lose to this one with AlreadyExists,
+// so the two lists are merged instead of one overwriting the other,
+// retrying on conflict.
 func persistTrainerInstallManifest(ctx context.Context, clientset kubernetes.Interface, resources []trainerResourceRef) {
 	cm, buildErr := newTrainerInstallManifestConfigMap(resources)
 	if buildErr != nil {
@@ -1098,7 +1098,7 @@ func deleteTrainerInstallManifest(ctx context.Context, clientset kubernetes.Inte
 // the persisted manifest, deleting it only once nothing remains. A
 // concurrent installer's resources may still be listed, so a full delete
 // here would drop them from tracking even though none were removed. A
-// missing manifest is a no-op. Retries on conflict.
+// missing manifest is a no-op, and conflicts are retried.
 func removeTrainerInstallManifestEntries(ctx context.Context, clientset kubernetes.Interface, resources []trainerResourceRef) {
 	toRemove := make(map[trainerResourceKey]bool, len(resources))
 	for _, ref := range resources {

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -264,6 +264,15 @@ var (
 	trainerMutatingWebhookGVR = schema.GroupVersionResource{
 		Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations",
 	}
+	trainerClusterRoleGVR = schema.GroupVersionResource{
+		Group: apiGroupRBAC, Version: "v1", Resource: "clusterroles",
+	}
+	trainerClusterRoleBindingGVR = schema.GroupVersionResource{
+		Group: apiGroupRBAC, Version: "v1", Resource: "clusterrolebindings",
+	}
+	trainerNamespaceGVR = schema.GroupVersionResource{
+		Version: "v1", Resource: "namespaces",
+	}
 
 	// requiredTrainerCRDs are the CRDs a usable Trainer install implies: the two the
 	// benchmark consumes directly, plus JobSet, which TrainJobs are executed as.
@@ -1171,15 +1180,31 @@ func reapOrphanedTrainerInstall(ctx context.Context, clientset kubernetes.Interf
 	deleteTrainerInstallManifest(ctx, clientset)
 }
 
+// trustedClusterScopedTrainerGVRs is every cluster-scoped GVR the Trainer
+// kustomize overlay can legitimately produce (see decodeTrainerObjects and
+// the manifest set built from trainerKustomizePath). Confines
+// trustworthyTrainerResourceRefs's cluster-scoped path to exactly these
+// kinds, so a manifest entry cannot name some unrelated cluster-scoped
+// resource, such as a Namespace this package never installed.
+var trustedClusterScopedTrainerGVRs = map[schema.GroupVersionResource]bool{
+	trainerCRDGVR:                true,
+	trainerValidatingWebhookGVR:  true,
+	trainerMutatingWebhookGVR:    true,
+	trainerClusterRoleGVR:        true,
+	trainerClusterRoleBindingGVR: true,
+	trainerNamespaceGVR:          true,
+}
+
 // trustworthyTrainerResourceRefs drops manifest entries reapOrphanedTrainerInstall
 // must not delete unconditionally. The manifest is a ConfigMap anyone with
 // write access to trainerNamespace can edit, and deleteTrainerResource skips
-// its UID delete precondition when UID is empty, so an entry with no UID, or
-// naming a namespace outside this install's own, could point a cluster-scoped
-// delete at any resource on the cluster. Every entry this package itself
-// persists always carries the real UID it got back from Create and stays
-// within trainerNamespace or cluster scope, so a rejected entry here is
-// never a legitimate one.
+// its UID delete precondition when UID is empty, so an entry with no UID, a
+// namespace outside this install's own, or a cluster-scoped kind this
+// package never installs could point a delete at any resource on the
+// cluster. Every entry this package itself persists always carries the real
+// UID it got back from Create and stays within trainerNamespace or one of
+// trustedClusterScopedTrainerGVRs, so a rejected entry here is never a
+// legitimate one.
 func trustworthyTrainerResourceRefs(resources []trainerResourceRef) []trainerResourceRef {
 	trusted := make([]trainerResourceRef, 0, len(resources))
 	for _, ref := range resources {
@@ -1188,8 +1213,14 @@ func trustworthyTrainerResourceRefs(resources []trainerResourceRef) []trainerRes
 				"resource", ref.String())
 			continue
 		}
-		if ref.Namespace != "" && ref.Namespace != trainerNamespace {
-			slog.Warn("Refusing to reap a Trainer install manifest entry outside the expected namespace",
+		if ref.Namespace != "" {
+			if ref.Namespace != trainerNamespace {
+				slog.Warn("Refusing to reap a Trainer install manifest entry outside the expected namespace",
+					"resource", ref.String())
+				continue
+			}
+		} else if !trustedClusterScopedTrainerGVRs[ref.GVR] {
+			slog.Warn("Refusing to reap a Trainer install manifest entry with an unexpected cluster-scoped resource type",
 				"resource", ref.String())
 			continue
 		}

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -580,7 +580,7 @@ func trainerResourceClient(dynamicClient dynamic.Interface,
 // happens to be on the cluster. Execution still differs across the undeclared rows —
 // a pre-existing Trainer is reused, an absent one is installed — which is why the
 // earlier "behaves identically regardless of live state" wording was withdrawn.
-func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface,
+func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface, clientset kubernetes.Interface,
 	discoveryClient discovery.DiscoveryInterface, recipeDeclaresTrainer bool) ([]trainerResourceRef, error) {
 
 	install, installed, err := isTrainerInstalled(ctx, dynamicClient)
@@ -637,7 +637,7 @@ func ensureTrainerInstalled(ctx context.Context, dynamicClient dynamic.Interface
 		slog.Info("Kubeflow Trainer not found or incomplete, installing...")
 		// installTrainer rolls back its own resources on failure, so there is
 		// nothing to clean up on the error path.
-		created, installErr := installTrainer(ctx, dynamicClient, discoveryClient)
+		created, installErr := installTrainer(ctx, dynamicClient, clientset, discoveryClient)
 		if installErr != nil {
 			return nil, aicrErrors.PropagateOrWrap(installErr, aicrErrors.ErrCodeInternal,
 				"failed to install Kubeflow Trainer")
@@ -841,7 +841,9 @@ func foldCleanupError(benchErr, cleanupErr error, fallbackMsg string) error {
 // Installation is transactional: on success it returns the resources it created so
 // the caller can defer deleteTrainer for cleanup; on any failure it rolls those
 // resources back itself and returns none.
-func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discoveryClient discovery.DiscoveryInterface) ([]trainerResourceRef, error) {
+func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, clientset kubernetes.Interface,
+	discoveryClient discovery.DiscoveryInterface) ([]trainerResourceRef, error) {
+
 	slog.Info("Downloading Kubeflow Trainer archive", "url", trainerArchiveURL)
 
 	extractedDir, cleanup, err := downloadAndExtractGitHubArchive(ctx, trainerArchiveURL)
@@ -873,7 +875,7 @@ func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discov
 	// Build a REST mapper from live discovery so we can resolve GVK → GVR for each resource.
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
 
-	return installTrainerResources(ctx, dynamicClient, mapper, objs)
+	return installTrainerResources(ctx, dynamicClient, clientset, mapper, objs)
 }
 
 // decodeTrainerObjects converts kustomize build output into unstructured objects,
@@ -936,10 +938,10 @@ func decodeTrainerObjects(resources []*resource.Resource) ([]*unstructured.Unstr
 // On success it returns the resources it created, for the caller to delete once
 // the benchmark finishes. On failure it returns no resources: rollback already
 // removed them, so the caller has nothing left to clean up.
-func installTrainerResources(ctx context.Context, dynamicClient dynamic.Interface,
+func installTrainerResources(ctx context.Context, dynamicClient dynamic.Interface, clientset kubernetes.Interface,
 	mapper apimeta.RESTMapper, objs []*unstructured.Unstructured) ([]trainerResourceRef, error) {
 
-	created, err := applyTrainerResources(ctx, dynamicClient, mapper, objs)
+	created, err := applyTrainerResources(ctx, dynamicClient, clientset, mapper, objs)
 	if err == nil {
 		// No discovered name here: these objects were just applied from the overlay,
 		// so the controller carries its fixed self-install name.
@@ -1275,7 +1277,7 @@ func findDeploymentByLabels(ctx context.Context, dynamicClient dynamic.Interface
 // The returned list holds only the resources this call actually created. Objects
 // that were already present are updated but deliberately excluded, so a rollback
 // never deletes a Trainer another owner installed.
-func applyTrainerResources(ctx context.Context, dynamicClient dynamic.Interface,
+func applyTrainerResources(ctx context.Context, dynamicClient dynamic.Interface, clientset kubernetes.Interface,
 	mapper apimeta.RESTMapper, objs []*unstructured.Unstructured) ([]trainerResourceRef, error) {
 
 	attemptID, err := newInstallAttemptID()
@@ -1326,6 +1328,11 @@ func applyTrainerResources(ctx context.Context, dynamicClient dynamic.Interface,
 		case err == nil:
 			ref.UID = createdObj.GetUID()
 			created = append(created, ref)
+			// Persisted as each resource is created, not once the whole
+			// install returns. A kill in between would leave this on the
+			// cluster with no record for reapOrphanedTrainerInstall to
+			// find, leaking it indefinitely.
+			persistTrainerInstallManifest(ctx, clientset, []trainerResourceRef{ref})
 			slog.Info("Applied Trainer resource", "kind", gvk.Kind, "name", ref.Name, "namespace", ref.Namespace)
 		case k8serrors.IsAlreadyExists(err):
 			// Enforce current resource state even when left from a prior partial
@@ -1342,6 +1349,11 @@ func applyTrainerResources(ctx context.Context, dynamicClient dynamic.Interface,
 			// cannot remove it and we leak exactly what this change exists to stop.
 			if claimed, ok := claimAmbiguousCreate(ctx, client, ref, attemptID, err); ok {
 				created = append(created, claimed)
+				// ctx may itself be the reason Create was ambiguous, so
+				// persisting under it here risks silently skipping the
+				// write. A fresh context keeps this claimed resource's
+				// record from leaking untracked.
+				persistTrainerInstallManifest(context.Background(), clientset, []trainerResourceRef{claimed}) //nolint:contextcheck
 			}
 			return created, aicrErrors.Wrap(trainerAPIErrorCode(err),
 				fmt.Sprintf("failed to create %s %q", gvk.Kind, ref.Name), err)

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +36,7 @@ import (
 	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/validator/labels"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -45,6 +47,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/kustomize/api/krusty"
@@ -164,6 +167,14 @@ const (
 	// production registry. The same tag (e.g. v0.11.0) exists here, so rewriting the repo
 	// prefix is sufficient to make the controller pullable.
 	jobSetPromotedImageRepo = "registry.k8s.io/jobset/jobset"
+
+	// trainerInstallManifestName is a ConfigMap in trainerNamespace recording a
+	// self-install's resource list, durably, so reapOrphanedTrainerInstall can
+	// still find and remove it if the installer never reaches its own cleanup.
+	trainerInstallManifestName = "aicr-trainer-self-install-manifest"
+
+	// trainerInstallManifestKey holds the JSON-encoded []trainerResourceRef.
+	trainerInstallManifestKey = "resources"
 )
 
 // controllerTolerateAll lets a Trainer/JobSet controller-manager Deployment
@@ -942,6 +953,209 @@ func installTrainerResources(ctx context.Context, dynamicClient dynamic.Interfac
 	}
 
 	return created, nil
+}
+
+// trainerResourceKey identifies one tracked resource for manifest merge and
+// removal, regardless of kind.
+type trainerResourceKey struct {
+	gvr             schema.GroupVersionResource
+	namespace, name string
+}
+
+func trainerResourceKeyOf(ref trainerResourceRef) trainerResourceKey {
+	return trainerResourceKey{ref.GVR, ref.Namespace, ref.Name}
+}
+
+// newTrainerInstallManifestConfigMap encodes resources into a fresh manifest object.
+func newTrainerInstallManifestConfigMap(resources []trainerResourceRef) (*corev1.ConfigMap, error) {
+	data, err := json.Marshal(resources)
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      trainerInstallManifestName,
+			Namespace: trainerNamespace,
+			Labels:    map[string]string{labels.ManagedBy: labels.ValueValidator, labels.Component: labels.ValueNCCLPerf},
+		},
+		Data: map[string]string{trainerInstallManifestKey: string(data)},
+	}, nil
+}
+
+// persistTrainerInstallManifest durably records a fresh self-install's
+// resources, so reapOrphanedTrainerInstall can find and remove them if the
+// installing caller never reaches its own cleanup. Failures are logged and
+// swallowed. The caller's own cleanup path still works either way.
+//
+// A concurrent installer's Create can lose to this one with AlreadyExists, so
+// the two lists are merged, retrying on conflict, instead of one overwriting
+// the other.
+func persistTrainerInstallManifest(ctx context.Context, clientset kubernetes.Interface, resources []trainerResourceRef) {
+	cm, buildErr := newTrainerInstallManifestConfigMap(resources)
+	if buildErr != nil {
+		slog.Warn("Failed to encode Trainer install manifest", "error", buildErr)
+		return
+	}
+
+	putCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	if _, err := clientset.CoreV1().ConfigMaps(trainerNamespace).Create(putCtx, cm, metav1.CreateOptions{}); err == nil {
+		return
+	} else if !k8serrors.IsAlreadyExists(err) {
+		slog.Warn("Failed to persist Trainer install manifest", "error", err)
+		return
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existingCM, existing, loadErr := loadTrainerInstallManifest(ctx, clientset)
+		if loadErr != nil {
+			return loadErr
+		}
+		if existingCM == nil {
+			// Deleted between the failed Create above and this read. Recreate it
+			// with just this installer's own resources.
+			_, createErr := clientset.CoreV1().ConfigMaps(trainerNamespace).Create(putCtx, cm, metav1.CreateOptions{})
+			return createErr
+		}
+		merged, mergeErr := json.Marshal(mergeTrainerResourceRefs(existing, resources))
+		if mergeErr != nil {
+			return mergeErr
+		}
+		existingCM.Data = map[string]string{trainerInstallManifestKey: string(merged)}
+		_, updateErr := clientset.CoreV1().ConfigMaps(trainerNamespace).Update(putCtx, existingCM, metav1.UpdateOptions{})
+		return updateErr
+	})
+	if err != nil {
+		slog.Warn("Failed to merge Trainer install manifest with a concurrent installer's", "error", err)
+	}
+}
+
+// mergeTrainerResourceRefs unions two resource lists by GVR/namespace/name,
+// keeping b's entry on a duplicate.
+func mergeTrainerResourceRefs(a, b []trainerResourceRef) []trainerResourceRef {
+	byKey := make(map[trainerResourceKey]trainerResourceRef, len(a)+len(b))
+	for _, ref := range a {
+		byKey[trainerResourceKeyOf(ref)] = ref
+	}
+	for _, ref := range b {
+		byKey[trainerResourceKeyOf(ref)] = ref
+	}
+	merged := make([]trainerResourceRef, 0, len(byKey))
+	for _, ref := range byKey {
+		merged = append(merged, ref)
+	}
+	return merged
+}
+
+// loadTrainerInstallManifest reads back a persisted self-install manifest. A
+// missing ConfigMap means nothing is tracked, and both return values are nil.
+func loadTrainerInstallManifest(ctx context.Context, clientset kubernetes.Interface) (*corev1.ConfigMap, []trainerResourceRef, error) {
+	getCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	cm, err := clientset.CoreV1().ConfigMaps(trainerNamespace).Get(getCtx, trainerInstallManifestName, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read Trainer install manifest", err)
+	}
+	var resources []trainerResourceRef
+	if err := json.Unmarshal([]byte(cm.Data[trainerInstallManifestKey]), &resources); err != nil {
+		return cm, nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to decode Trainer install manifest", err)
+	}
+	return cm, resources, nil
+}
+
+// deleteTrainerInstallManifest best-effort removes the manifest once its
+// resources are gone, so a future run's prune sweep no longer finds it.
+func deleteTrainerInstallManifest(ctx context.Context, clientset kubernetes.Interface) {
+	delCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	err := clientset.CoreV1().ConfigMaps(trainerNamespace).Delete(delCtx, trainerInstallManifestName, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		slog.Warn("Failed to delete Trainer install manifest", "error", err)
+	}
+}
+
+// removeTrainerInstallManifestEntries removes this run's own resources from
+// the persisted manifest, deleting it only once nothing remains. A
+// concurrent installer's resources may still be listed, so a full delete
+// here would drop them from tracking even though none were removed. A
+// missing manifest is a no-op. Retries on conflict.
+func removeTrainerInstallManifestEntries(ctx context.Context, clientset kubernetes.Interface, resources []trainerResourceRef) {
+	toRemove := make(map[trainerResourceKey]bool, len(resources))
+	for _, ref := range resources {
+		toRemove[trainerResourceKeyOf(ref)] = true
+	}
+
+	opCtx, cancel := context.WithTimeout(ctx, defaults.DiagnosticTimeout)
+	defer cancel()
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, existing, loadErr := loadTrainerInstallManifest(ctx, clientset)
+		if loadErr != nil {
+			return loadErr
+		}
+		if cm == nil {
+			return nil
+		}
+
+		remaining := make([]trainerResourceRef, 0, len(existing))
+		for _, ref := range existing {
+			if !toRemove[trainerResourceKeyOf(ref)] {
+				remaining = append(remaining, ref)
+			}
+		}
+		if len(remaining) == 0 {
+			delErr := clientset.CoreV1().ConfigMaps(trainerNamespace).Delete(opCtx, trainerInstallManifestName,
+				metav1.DeleteOptions{Preconditions: &metav1.Preconditions{ResourceVersion: &cm.ResourceVersion}})
+			if k8serrors.IsNotFound(delErr) {
+				return nil
+			}
+			return delErr
+		}
+
+		data, marshalErr := json.Marshal(remaining)
+		if marshalErr != nil {
+			return marshalErr
+		}
+		cm.Data = map[string]string{trainerInstallManifestKey: string(data)}
+		_, updateErr := clientset.CoreV1().ConfigMaps(trainerNamespace).Update(opCtx, cm, metav1.UpdateOptions{})
+		return updateErr
+	})
+	if err != nil {
+		slog.Warn("Failed to remove this run's entries from the Trainer install manifest", "error", err)
+	}
+}
+
+// reapOrphanedTrainerInstall best-effort deletes a self-installed Trainer
+// abandoned when its installer lost the execution lock before reaching its
+// own cleanup. otherNamespacesRemain means another execution might still
+// depend on Trainer, so reaping is skipped. A manifest younger than
+// NCCLExecutionLockStaleAge might still be mid-install, so that's skipped too.
+func reapOrphanedTrainerInstall(ctx context.Context, clientset kubernetes.Interface, dynamicClient dynamic.Interface, otherNamespacesRemain bool) {
+	if otherNamespacesRemain {
+		return
+	}
+	cm, resources, err := loadTrainerInstallManifest(ctx, clientset)
+	if err != nil {
+		slog.Warn("Failed to check for an orphaned Trainer install", "error", err)
+		return
+	}
+	if cm == nil {
+		return
+	}
+	if time.Since(cm.CreationTimestamp.Time) < defaults.NCCLExecutionLockStaleAge {
+		return
+	}
+
+	// deleteTrainer's own retries use a fresh background context per call,
+	// same as its other callers.
+	if err := deleteTrainer(dynamicClient, resources); err != nil { //nolint:contextcheck
+		slog.Warn("Failed to reap an orphaned Trainer install", "error", err)
+		return
+	}
+	slog.Info("Reaped a Trainer install orphaned by an abandoned execution")
+	deleteTrainerInstallManifest(ctx, clientset)
 }
 
 // waitForTrainerReady blocks until a freshly applied Trainer is usable: the CRDs

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -1031,17 +1031,19 @@ func persistTrainerInstallManifest(ctx context.Context, clientset kubernetes.Int
 }
 
 // mergeTrainerResourceRefs unions two resource lists by GVR/namespace/name,
-// keeping b's entry on a duplicate.
+// keeping b's entry on a duplicate. Preserves a's, then b's, first-seen
+// order, since deleteTrainer tears down in reverse list order and a random
+// map order could delete a CRD or webhook before its controller.
 func mergeTrainerResourceRefs(a, b []trainerResourceRef) []trainerResourceRef {
-	byKey := make(map[trainerResourceKey]trainerResourceRef, len(a)+len(b))
-	for _, ref := range a {
-		byKey[trainerResourceKeyOf(ref)] = ref
-	}
-	for _, ref := range b {
-		byKey[trainerResourceKeyOf(ref)] = ref
-	}
-	merged := make([]trainerResourceRef, 0, len(byKey))
-	for _, ref := range byKey {
+	index := make(map[trainerResourceKey]int, len(a)+len(b))
+	merged := make([]trainerResourceRef, 0, len(a)+len(b))
+	for _, ref := range append(append([]trainerResourceRef{}, a...), b...) {
+		key := trainerResourceKeyOf(ref)
+		if i, seen := index[key]; seen {
+			merged[i] = ref
+			continue
+		}
+		index[key] = len(merged)
 		merged = append(merged, ref)
 	}
 	return merged

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -1061,8 +1061,12 @@ func loadTrainerInstallManifest(ctx context.Context, clientset kubernetes.Interf
 	if err != nil {
 		return nil, nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to read Trainer install manifest", err)
 	}
+	raw, ok := cm.Data[trainerInstallManifestKey]
+	if !ok || raw == "" {
+		return cm, nil, nil
+	}
 	var resources []trainerResourceRef
-	if err := json.Unmarshal([]byte(cm.Data[trainerInstallManifestKey]), &resources); err != nil {
+	if err := json.Unmarshal([]byte(raw), &resources); err != nil {
 		return cm, nil, aicrErrors.Wrap(aicrErrors.ErrCodeInternal, "failed to decode Trainer install manifest", err)
 	}
 	return cm, resources, nil

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -1156,6 +1156,11 @@ func reapOrphanedTrainerInstall(ctx context.Context, clientset kubernetes.Interf
 		return
 	}
 
+	resources = trustworthyTrainerResourceRefs(resources)
+	if len(resources) == 0 {
+		return
+	}
+
 	// deleteTrainer's own retries use a fresh background context per call,
 	// same as its other callers.
 	if err := deleteTrainer(dynamicClient, resources); err != nil { //nolint:contextcheck
@@ -1164,6 +1169,33 @@ func reapOrphanedTrainerInstall(ctx context.Context, clientset kubernetes.Interf
 	}
 	slog.Info("Reaped a Trainer install orphaned by an abandoned execution")
 	deleteTrainerInstallManifest(ctx, clientset)
+}
+
+// trustworthyTrainerResourceRefs drops manifest entries reapOrphanedTrainerInstall
+// must not delete unconditionally. The manifest is a ConfigMap anyone with
+// write access to trainerNamespace can edit, and deleteTrainerResource skips
+// its UID delete precondition when UID is empty, so an entry with no UID, or
+// naming a namespace outside this install's own, could point a cluster-scoped
+// delete at any resource on the cluster. Every entry this package itself
+// persists always carries the real UID it got back from Create and stays
+// within trainerNamespace or cluster scope, so a rejected entry here is
+// never a legitimate one.
+func trustworthyTrainerResourceRefs(resources []trainerResourceRef) []trainerResourceRef {
+	trusted := make([]trainerResourceRef, 0, len(resources))
+	for _, ref := range resources {
+		if ref.UID == "" {
+			slog.Warn("Refusing to reap a Trainer install manifest entry with no recorded UID",
+				"resource", ref.String())
+			continue
+		}
+		if ref.Namespace != "" && ref.Namespace != trainerNamespace {
+			slog.Warn("Refusing to reap a Trainer install manifest entry outside the expected namespace",
+				"resource", ref.String())
+			continue
+		}
+		trusted = append(trusted, ref)
+	}
+	return trusted
 }
 
 // waitForTrainerReady blocks until a freshly applied Trainer is usable: the CRDs

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -809,15 +809,18 @@ func waitForDeclaredTrainer(ctx context.Context, dynamicClient dynamic.Interface
 }
 
 // foldCleanupError decides the check's verdict when teardown fails. A cleanup
-// failure leaks cluster-scoped CRDs, RBAC, and webhook configurations that would
-// silently poison the next run, so it fails an otherwise-passing check — but it
-// never masks a real benchmark failure, which is always the more useful signal.
-func foldCleanupError(benchErr, cleanupErr error) error {
+// failure leaks cluster-scoped CRDs, RBAC, and webhook configurations (or, for
+// the NCCL resource cleanup caller, poisons the next run's fixed-named
+// resources) that would silently break a later run, so it fails an
+// otherwise-passing check, but it never masks a real benchmark failure,
+// which is always the more useful signal. fallbackMsg is used only when
+// cleanupErr isn't already a *StructuredError (PropagateOrWrap preserves an
+// existing one's own message/code as-is).
+func foldCleanupError(benchErr, cleanupErr error, fallbackMsg string) error {
 	if cleanupErr == nil || benchErr != nil {
 		return benchErr
 	}
-	return aicrErrors.PropagateOrWrap(cleanupErr, aicrErrors.ErrCodeInternal,
-		"NCCL benchmark succeeded but Kubeflow Trainer cleanup failed")
+	return aicrErrors.PropagateOrWrap(cleanupErr, aicrErrors.ErrCodeInternal, fallbackMsg)
 }
 
 // installTrainer downloads the Kubeflow Trainer v2.2.0 archive from GitHub, builds the

--- a/validators/performance/trainer_lifecycle_test.go
+++ b/validators/performance/trainer_lifecycle_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/kustomize/api/hasher"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -380,5 +381,24 @@ spec:
 
 	if _, err := decodeTrainerObjects(resources); err == nil {
 		t.Fatal("decodeTrainerObjects() expected error for a malformed tolerations field, got nil")
+	}
+}
+
+// TestNCCLExecutionLockStaleAge_CoversSelfInstallWorstCase checks that
+// NCCLExecutionLockStaleAge stays ahead of the self-install path's own
+// worst case: the archive download, then waitForTrainerReady's CRD wait
+// and its two controller-ready waits (Trainer's own controller, then
+// JobSet's), all run before runNCCLTrainJob's first post-install lock
+// renewal. A change to any of those timeouts that closes this margin
+// should fail here, rather than let a same-run retry steal the lock from
+// an install that is still in progress.
+func TestNCCLExecutionLockStaleAge_CoversSelfInstallWorstCase(t *testing.T) {
+	worstCase := defaults.NCCLTrainerArchiveDownloadTimeout +
+		defaults.TrainerCRDEstablishedTimeout +
+		2*defaults.TrainerControllerReadyTimeout
+
+	if defaults.NCCLExecutionLockStaleAge <= worstCase {
+		t.Errorf("NCCLExecutionLockStaleAge (%s) must exceed the self-install worst case (%s)",
+			defaults.NCCLExecutionLockStaleAge, worstCase)
 	}
 }

--- a/validators/performance/trainer_probe_test.go
+++ b/validators/performance/trainer_probe_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -329,7 +330,7 @@ func TestApplyTrainerResources_RefusesForeignWebhookConfig(t *testing.T) {
 			trainerValidatingWebhookConfig, trainerValidatingWebhookName),
 	}
 
-	_, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	_, err := applyTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected install to refuse overwriting a foreign webhook configuration")
 	}
@@ -362,7 +363,7 @@ func TestApplyTrainerResources_UpdatesOwnWebhookConfig(t *testing.T) {
 			trainerValidatingWebhookConfig, trainerValidatingWebhookName),
 	}
 
-	if _, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs); err != nil {
+	if _, err := applyTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs); err != nil {
 		t.Fatalf("re-applying our own webhook configuration should succeed, got: %v", err)
 	}
 }

--- a/validators/performance/trainer_rollback_test.go
+++ b/validators/performance/trainer_rollback_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -168,7 +169,7 @@ func TestInstallTrainerResources_RollsBackOnApplyFailure(t *testing.T) {
 		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
 	}
 
-	refs, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	refs, err := installTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected apply failure, got nil error")
 	}
@@ -177,6 +178,39 @@ func TestInstallTrainerResources_RollsBackOnApplyFailure(t *testing.T) {
 	}
 	if configMapExists(t, client) {
 		t.Error("ConfigMap created before the failure was not rolled back")
+	}
+}
+
+// TestApplyTrainerResources_PersistsEachCreateBeforeReturning checks that
+// each created resource lands in the manifest immediately, not only once
+// the whole install returns. A process killed right after this call must
+// not lose track of what it already created.
+func TestApplyTrainerResources_PersistsEachCreateBeforeReturning(t *testing.T) {
+	dynamicClient := newTrainerFakeClient()
+	dynamicClient.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errBoom)
+	})
+	clientset := fake.NewClientset()
+
+	objs := []*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
+		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
+	}
+
+	created, err := applyTrainerResources(context.Background(), dynamicClient, clientset, newTrainerTestMapper(), objs)
+	if err == nil {
+		t.Fatal("expected the Secret create to fail")
+	}
+	if len(created) != 1 {
+		t.Fatalf("created = %d, want 1 (the ConfigMap, before the Secret failed)", len(created))
+	}
+
+	_, recorded, loadErr := loadTrainerInstallManifest(context.Background(), clientset)
+	if loadErr != nil {
+		t.Fatalf("loadTrainerInstallManifest() error = %v", loadErr)
+	}
+	if len(recorded) != 1 || recorded[0].Name != trainerConfigMapName {
+		t.Fatalf("recorded manifest = %v, want the ConfigMap recorded before the call returned", recorded)
 	}
 }
 
@@ -195,7 +229,7 @@ func TestInstallTrainerResources_LeavesPreexistingResources(t *testing.T) {
 		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
 	}
 
-	if _, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs); err == nil {
+	if _, err := installTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs); err == nil {
 		t.Fatal("expected apply failure, got nil error")
 	}
 	if !configMapExists(t, client) {
@@ -218,7 +252,7 @@ func TestInstallTrainerResources_UpdateFailureStopsInstall(t *testing.T) {
 		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
 	}
 
-	_, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	_, err := installTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected update failure to abort installation, got nil error")
 	}
@@ -242,7 +276,7 @@ func TestInstallTrainerResources_RollsBackOnCRDEstablishTimeout(t *testing.T) {
 		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
 	}
 
-	refs, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	refs, err := installTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected CRD establishment timeout, got nil error")
 	}
@@ -272,7 +306,7 @@ func TestInstallTrainerResources_RollsBackOnControllerReadyTimeout(t *testing.T)
 	})
 	defer cancel()
 
-	refs, err := installTrainerResources(ctx, client, newTrainerTestMapper(), objs)
+	refs, err := installTrainerResources(ctx, client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected controller readiness timeout, got nil error")
 	}
@@ -298,7 +332,7 @@ func TestInstallTrainerResources_SucceedsWhenReady(t *testing.T) {
 		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
 	}
 
-	refs, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	refs, err := installTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -327,7 +361,7 @@ func TestInstallTrainerResources_CleanupFailureNamesResource(t *testing.T) {
 		newTestObject("v1", "Secret", trainerNamespace, "kubeflow-trainer-webhook-cert"),
 	}
 
-	_, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	_, err := installTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -349,7 +383,7 @@ func TestInstallTrainerResources_StopsApplyingOnCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	refs, err := installTrainerResources(ctx, client, newTrainerTestMapper(), objs)
+	refs, err := installTrainerResources(ctx, client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected canceled context to abort the install, got nil error")
 	}
@@ -456,7 +490,7 @@ func TestApplyTrainerResources_ClassifiesTransientCreateFailure(t *testing.T) {
 		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
 	}
 
-	_, err := installTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	_, err := installTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected create failure, got nil")
 	}
@@ -519,7 +553,7 @@ func TestApplyTrainerResources_ClaimsAmbiguousCreate(t *testing.T) {
 		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
 	}
 
-	created, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	created, err := applyTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected the ambiguous create to surface as an error")
 	}
@@ -573,7 +607,7 @@ func TestApplyTrainerResources_DoesNotClaimForeignObjects(t *testing.T) {
 				newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
 			}
 
-			created, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+			created, err := applyTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 			if err == nil {
 				t.Fatal("expected the create failure to surface")
 			}
@@ -592,7 +626,7 @@ func TestApplyTrainerResources_StampsCreatedObjects(t *testing.T) {
 		newTestObject("v1", "ConfigMap", trainerNamespace, trainerConfigMapName),
 	}
 
-	if _, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs); err != nil {
+	if _, err := applyTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -621,7 +655,7 @@ func TestApplyTrainerResources_RefusesToRepointForeignInstall(t *testing.T) {
 			trainerValidatingWebhookName, trainerNamespace),
 	}
 
-	_, err := applyTrainerResources(context.Background(), client, newTrainerTestMapper(), objs)
+	_, err := applyTrainerResources(context.Background(), client, fake.NewClientset(), newTrainerTestMapper(), objs)
 	if err == nil {
 		t.Fatal("expected the installer to refuse repointing another installation's webhooks")
 	}


### PR DESCRIPTION
## Summary

Give each `aicr validate` NCCL all-reduce run its own per-run, ownership-verified namespace, with atomic execution admission and ownership-scoped stale-namespace pruning, so concurrent, crashed, or retried runs can never collide, adopt, or delete each other's resources.

## Motivation / Context

The NCCL all-reduce TrainJob/TrainingRuntime/ComputeDomain/RoCE-claim resources were applied by fixed name in the shared, persistent `aicr-validation` namespace, so two concurrent `aicr validate` runs (or a crashed run and its retry) could delete or adopt each other's resources. This affects every NCCL leaf in the catalog (EFA, TCPXO, RoCE, NVLS across A100/H100/B200/GB200/GB300), not just one accelerator or fabric.

Giving each run its own namespace only pushed the same problem down a level: review found that a shared, deterministic namespace name is still safe to collide on unless ownership, liveness, and admission are all checked, and closing each finding opened up a narrower version of the same race one level deeper:

- An existing namespace with the derived name could be silently adopted (or deleted by an unrelated run's cleanup) with no ownership check.
- The stale-namespace prune swept up any namespace matching the name shape, regardless of who created it.
- Even with an ownership and liveness check, two callers could both pass it before either created a pod, and admit into the same namespace at once.
- The prior execution's cleanup could authorize a namespace delete from a read that was no longer current by the time the delete ran, letting it remove a namespace a new execution had since taken over.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`) <!-- validators/performance -->
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

**Namespace naming and ownership.** `ncclRunNamespace(variant)` folds the NCCL variant into the namespace name (`aicr-nccl-perf-<variant>-<runID>`), not just `deriveRunID()` alone, so the three catalog checks sharing one `AICR_RUN_ID` no longer derive the identical namespace. `ensureNamespace` (shared with `inference-perf`) stamps `ManagedBy`/`Component` labels on every namespace it creates and refuses to adopt an existing namespace missing them, so a name collision with something this package didn't create fails closed instead of being adopted or later deleted.

**Liveness and atomic admission.** `verifyNCCLNamespaceNotLive` fails closed with `ErrCodeConflict` if an existing, non-terminating namespace still has a non-terminal pod in it. Because that's a read check, two callers can still both pass it before either creates a pod; `claimNCCLExecutionLock` closes that gap by atomically claiming a per-namespace `Lease` right after, a missing Lease is won by `Create`, an abandoned one is taken over by `Update` pinned to the observed `resourceVersion`, so a racing claim loses to a `Conflict` and fails closed. The lease's own staleness window is a dedicated constant, `NCCLExecutionLockStaleAge` (20 minutes, sized for the self-install worst case), not the much longer `NCCLStaleNamespacePruneAge`, so a same-run retry after a hard kill isn't stuck waiting out an hour.

**Cleanup.** `cleanupNCCLRun` replaces two separately-registered defers (namespace cleanup, Trainer teardown) with one, always deleting the namespace first, since Trainer teardown removes CRDs the namespace's own CRs' finalizers depend on. It skips cleanup entirely if the lock is no longer held (another execution has taken over), and skips Trainer teardown specifically if the namespace delete itself failed. The namespace delete is UID-pinned to the instance this run created or reclaimed. The lock-held check itself (`ncclExecutionLockHeldBy`) renews the lease, pinned to the `resourceVersion` just read, instead of only reading it, closing a further gap where a takeover landing between the check and the delete could let a stale holder's cleanup remove the new holder's live namespace. `Namespaces().Delete` only starts asynchronous deletion; a post-delete wait for full termination is now only logged on timeout rather than folded into the check verdict, since the delete itself already succeeded and NVLS's DRA/IMEX finalizers can legitimately outlast the wait bound.

**Reclaiming a same-run retry's stale resources.** `createUnstructured` reclaims an `AlreadyExists` TrainingRuntime by updating it in place, and a stale TrainJob by delete-then-recreate, waiting out a controller-serviced finalizer (`waitForResourceGone`) before recreating rather than racing it. That wait gets its own `NCCLResourceRecreateWait` budget (5 minutes) derived from the caller's outer context rather than a shorter retry-loop context, so a caller-imposed retry budget can't silently cap it.

**Stale orphan cleanup.** `pruneStaleNCCLNamespaces` runs best-effort before each NCCL check, scoped server-side to the same ownership labels `ensureNamespace` stamps (not a name-prefix scan), skips a namespace that's still live (reusing `verifyNCCLNamespaceNotLive`), and UID-pins its delete, covering the case where a standalone (no `AICR_RUN_ID`) run is killed before its own deferred cleanup runs.

## Testing

```bash
make qualify
```

`make qualify` passed clean against the latest commit.

- `validators/performance`: `go test -race ./...` clean; coverage 67.1%
- `golangci-lint run -c .golangci.yaml ./validators/performance/...`: 0 issues
- Repo-wide (excluding `validators/`, per the coverage-gate carve-out): 83.2%, above the 80% threshold

Test additions cover: ownership adoption refusal and namespace label scoping, the live-pod liveness gate, atomic Lease admission under concurrent claim and concurrent takeover, refusal against a live lease, fast reclaim of a dead lease well under the namespace prune age, the takeover race between the lock-held check and its renewal, per-variant namespace naming, ownership-scoped stale-namespace pruning (including an unlabeled name-matching namespace surviving), namespace-cleanup-before-Trainer-teardown ordering, skipping Trainer teardown on a namespace delete failure, the finalizer-wait before namespace deletion, and both TrainingRuntime (update-in-place) and TrainJob (delete-and-recreate) reclaim paths.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact

This is larger in scope than "give each run its own namespace": it adds an atomic distributed lock (Kubernetes Lease) for run admission and a namespace-deleting prune sweep, both new failure surfaces even though they're confined to this one validator and extensively tested. Flagging Medium rather than Low given that scope, even though the blast radius stays inside `validators/performance` and its own `aicr-nccl-perf-*` namespaces.

**Rollout notes:** N/A — internal validator behavior only, no recipe/API/CLI surface change. Each run now creates/deletes an `aicr-nccl-perf-<variant>-<runID>` namespace instead of reusing the shared `aicr-validation` namespace; no action needed by recipe authors or operators.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed <!-- no user-facing behavior changed -->
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
