### PR TITLE
fix(validator): tolerate taints, widen Trainer readiness timeout

### DIFF
--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -667,7 +667,7 @@ const (
 
 	// TrainerControllerReadyTimeout is the time to wait for the Kubeflow Trainer
 	// controller-manager Deployment to have at least one ready replica after installation.
-	TrainerControllerReadyTimeout = 2 * time.Minute
+	TrainerControllerReadyTimeout = 3 * time.Minute
 
 	// TrainerInstallPollInterval is the sleep between checks that a
 	// recipe-declared Kubeflow Trainer installation has become complete. The

--- a/pkg/defaults/timeouts.go
+++ b/pkg/defaults/timeouts.go
@@ -666,7 +666,14 @@ const (
 	TrainerCRDEstablishedTimeout = 2 * time.Minute
 
 	// TrainerControllerReadyTimeout is the time to wait for the Kubeflow Trainer
-	// controller-manager Deployment to have at least one ready replica after installation.
+	// controller-manager Deployment to have at least one ready replica after
+	// installation. Widened from 2m to 3m: on cold start the cert-controller
+	// sidecar's webhook-cert get-or-create can race a not-yet-synced informer
+	// cache, producing a resourceVersion conflict that the sidecar's own
+	// reconcile loop retries and self-heals from unassisted. This is expected
+	// behavior under cert-controller's optimistic-concurrency retry, not a
+	// defect in Trainer or in this validator — but each retry adds latency
+	// that could otherwise push first-ready past a tighter budget.
 	TrainerControllerReadyTimeout = 3 * time.Minute
 
 	// TrainerInstallPollInterval is the sleep between checks that a

--- a/validators/performance/consts.go
+++ b/validators/performance/consts.go
@@ -21,6 +21,7 @@ const (
 	versionV1alpha1          = "v1alpha1"
 	versionV1beta1           = "v1beta1"
 	keyName                  = "name"
+	keyOperator              = "operator"
 	checkNameNCCLAllReduceBW = "nccl-all-reduce-bw"
 
 	// nodeJobName is the name of both the NCCL worker replicatedJob and its

--- a/validators/performance/inference_perf_constraint.go
+++ b/validators/performance/inference_perf_constraint.go
@@ -1823,7 +1823,7 @@ func tolerationsToUnstructured(tolerations []v1.Toleration) []any {
 	tolList := make([]any, 0, len(tolerations))
 	for _, t := range tolerations {
 		tolMap := map[string]any{
-			"operator": string(t.Operator),
+			keyOperator: string(t.Operator),
 		}
 		if t.Key != "" {
 			tolMap["key"] = t.Key

--- a/validators/performance/nccl_all_reduce_bw_constraint.go
+++ b/validators/performance/nccl_all_reduce_bw_constraint.go
@@ -1451,7 +1451,7 @@ func applyNCCLWorkerScheduling(obj *unstructured.Unstructured, nodeSelector map[
 			tolList := make([]any, 0, len(tolerations))
 			for _, t := range tolerations {
 				tolMap := map[string]any{
-					"operator": string(t.Operator),
+					keyOperator: string(t.Operator),
 				}
 				if t.Key != "" {
 					tolMap["key"] = t.Key
@@ -1479,7 +1479,7 @@ func applyNCCLWorkerScheduling(obj *unstructured.Unstructured, nodeSelector map[
 	return unstructured.SetNestedSlice(obj.Object, replicatedJobs, "spec", "template", "spec", "replicatedJobs")
 }
 
-// nestedMap navigates a chain of string keys through nested map[string]interface{} values.
+// nestedMap navigates a chain of string keys through nested map[string]any values.
 // Returns the target map and true if found, nil and false otherwise.
 func nestedMap(m map[string]any, keys ...string) (map[string]any, bool) {
 	current := m

--- a/validators/performance/nccl_test.go
+++ b/validators/performance/nccl_test.go
@@ -142,8 +142,8 @@ func TestApplyNCCLWorkerScheduling_Tolerations(t *testing.T) {
 			t.Fatalf("tolerations count = %d, want 1", len(tolsRaw))
 		}
 		tol, _ := tolsRaw[0].(map[string]any)
-		if tol["key"] != "gpu-type" || tol["value"] != "h100" || tol["effect"] != "NoSchedule" {
-			t.Errorf("toleration = %v, want gpu-type=h100:NoSchedule", tol)
+		if tol["key"] != "gpu-type" || tol["value"] != "h100" || tol["effect"] != "NoSchedule" || tol["operator"] != "Equal" {
+			t.Errorf("toleration = %v, want gpu-type=h100:NoSchedule operator=Equal", tol)
 		}
 	}
 }
@@ -209,8 +209,8 @@ func TestApplyNCCLWorkerScheduling_Both(t *testing.T) {
 			t.Fatalf("tolerations count = %d, want 1", len(tolsRaw))
 		}
 		tol, _ := tolsRaw[0].(map[string]any)
-		if tol["key"] != "custom-taint" || tol["value"] != "true" || tol["effect"] != "NoSchedule" {
-			t.Errorf("toleration = %v, want custom-taint=true:NoSchedule", tol)
+		if tol["key"] != "custom-taint" || tol["value"] != "true" || tol["effect"] != "NoSchedule" || tol["operator"] != "Equal" {
+			t.Errorf("toleration = %v, want custom-taint=true:NoSchedule operator=Equal", tol)
 		}
 	}
 }

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -32,8 +32,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/component"
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	aicrErrors "github.com/NVIDIA/aicr/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +68,11 @@ const (
 
 	// trainerControllerDeployment is the Deployment name for the Trainer controller-manager.
 	trainerControllerDeployment = "kubeflow-trainer-controller-manager"
+
+	// jobSetControllerDeployment is the JobSet controller-manager Deployment name
+	// emitted by this package's kustomize overlay (see jobSetNameLabel for why
+	// the Helm chart's release-derived name doesn't apply here).
+	jobSetControllerDeployment = "jobset-controller-manager"
 
 	// trainerControllerService is the Service fronting the controller-manager's
 	// webhook port. Without it the admission webhooks have no endpoints and every
@@ -158,6 +165,57 @@ const (
 	// prefix is sufficient to make the controller pullable.
 	jobSetPromotedImageRepo = "registry.k8s.io/jobset/jobset"
 )
+
+// controllerTolerateAll lets a Trainer/JobSet controller-manager Deployment
+// schedule on any node pool, regardless of taints. Built through
+// component.TolerationsToPodSpec, the same converter used for Helm-values
+// toleration overrides, so there is one canonical place that knows the
+// toleration-to-map shape.
+var controllerTolerateAll = tolerationsToAnySlice(
+	component.TolerationsToPodSpec([]corev1.Toleration{{Operator: corev1.TolerationOpExists}}),
+)
+
+// tolerationsToAnySlice widens []map[string]any to []any: unstructured pod
+// specs (podSpec["tolerations"]) must hold []any, not []map[string]any, to
+// match how NestedSlice reads and how JSON round-tripping serializes it.
+func tolerationsToAnySlice(tolerations []map[string]any) []any {
+	result := make([]any, len(tolerations))
+	for i, t := range tolerations {
+		result[i] = t
+	}
+	return result
+}
+
+// applyControllerTolerations stamps controllerTolerateAll onto the Trainer and
+// JobSet controller-manager Deployments' pod template, unless one already
+// declares tolerations. Scoped to those two names so an unrelated Deployment
+// in the manifest set never gets a blanket toleration it didn't ask for.
+func applyControllerTolerations(obj *unstructured.Unstructured) error {
+	if obj.GroupVersionKind().Kind != "Deployment" {
+		return nil
+	}
+	switch obj.GetName() {
+	case trainerControllerDeployment, jobSetControllerDeployment:
+	default:
+		return nil
+	}
+
+	if existing, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "tolerations"); err != nil {
+		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("failed to read tolerations from Deployment %q", obj.GetName()), err)
+	} else if found && len(existing) > 0 {
+		return nil
+	}
+
+	podSpec, found := nestedMap(obj.Object, "spec", "template", "spec")
+	if !found {
+		return aicrErrors.New(aicrErrors.ErrCodeInternal,
+			fmt.Sprintf("pod spec not found in Deployment %q", obj.GetName()))
+	}
+	podSpec["tolerations"] = controllerTolerateAll
+	slog.Info("Applying blanket toleration to controller Deployment", "name", obj.GetName())
+	return nil
+}
 
 // GVRs for the objects the Trainer lifecycle probes and waits on.
 var (
@@ -806,6 +864,9 @@ func decodeTrainerObjects(resources []*resource.Resource) ([]*unstructured.Unstr
 		}
 		if obj.GroupVersionKind().Kind == "" {
 			continue
+		}
+		if tolErr := applyControllerTolerations(obj); tolErr != nil {
+			return nil, tolErr
 		}
 		objs = append(objs, obj)
 	}

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -232,7 +232,7 @@ func applyControllerTolerations(obj *unstructured.Unstructured) error {
 			fmt.Sprintf("pod spec not found in Deployment %q", obj.GetName()))
 	}
 	podSpec["tolerations"] = cloneControllerTolerateAll()
-	slog.Info("Applying blanket toleration to controller Deployment", "name", obj.GetName())
+	slog.Info("Applying blanket toleration to controller Deployment", "name", obj.GetName(), "namespace", obj.GetNamespace())
 	return nil
 }
 

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -209,7 +209,7 @@ func cloneControllerTolerateAll() []any {
 // declares tolerations. Scoped to those two names so an unrelated Deployment
 // in the manifest set never gets a blanket toleration it didn't ask for.
 func applyControllerTolerations(obj *unstructured.Unstructured) error {
-	if obj.GroupVersionKind().Kind != "Deployment" {
+	if gvk := obj.GroupVersionKind(); gvk.Kind != "Deployment" || gvk.Group != "apps" {
 		return nil
 	}
 	switch obj.GetName() {

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -222,6 +222,7 @@ func applyControllerTolerations(obj *unstructured.Unstructured) error {
 		return aicrErrors.Wrap(aicrErrors.ErrCodeInternal,
 			fmt.Sprintf("failed to read tolerations from Deployment %q", obj.GetName()), err)
 	} else if found && len(existing) > 0 {
+		slog.Debug("Controller Deployment already declares tolerations; leaving untouched", "name", obj.GetName())
 		return nil
 	}
 

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -849,6 +849,7 @@ func installTrainer(ctx context.Context, dynamicClient dynamic.Interface, discov
 // before the first apply so a malformed manifest cannot leave a partial install.
 func decodeTrainerObjects(resources []*resource.Resource) ([]*unstructured.Unstructured, error) {
 	objs := make([]*unstructured.Unstructured, 0, len(resources))
+	seenControllers := make(map[string]bool, 2)
 	for _, res := range resources {
 		// Convert to unstructured via YAML round-trip (guarantees plain Go types).
 		yamlBytes, err := res.AsYAML()
@@ -868,7 +869,23 @@ func decodeTrainerObjects(resources []*resource.Resource) ([]*unstructured.Unstr
 		if tolErr := applyControllerTolerations(obj); tolErr != nil {
 			return nil, tolErr
 		}
+		if obj.GroupVersionKind().Kind == "Deployment" {
+			seenControllers[obj.GetName()] = true
+		}
 		objs = append(objs, obj)
+	}
+
+	// A future Trainer archive bump (or a JobSet overlay variant) that renames
+	// either controller Deployment makes applyControllerTolerations's name
+	// switch miss it silently, reverting that controller to unschedulable on
+	// an all-tainted cluster. Surface the mismatch here instead of letting it
+	// resurface only as a bare readiness timeout downstream.
+	for _, name := range []string{trainerControllerDeployment, jobSetControllerDeployment} {
+		if !seenControllers[name] {
+			slog.Warn("Expected controller Deployment not found in Trainer manifest set; "+
+				"it will not receive the blanket toleration and may be unschedulable on all-tainted clusters",
+				"deployment", name)
+		}
 	}
 	return objs, nil
 }

--- a/validators/performance/trainer_lifecycle.go
+++ b/validators/performance/trainer_lifecycle.go
@@ -186,6 +186,24 @@ func tolerationsToAnySlice(tolerations []map[string]any) []any {
 	return result
 }
 
+// cloneControllerTolerateAll returns a fresh copy of controllerTolerateAll.
+// It is stamped onto both the Trainer and JobSet Deployments, so a per-call
+// copy keeps a future in-place edit of one controller's tolerations from
+// silently corrupting the other Deployment's live object, or the shared
+// process-wide global itself.
+func cloneControllerTolerateAll() []any {
+	cloned := make([]any, len(controllerTolerateAll))
+	for i, t := range controllerTolerateAll {
+		m, _ := t.(map[string]any)
+		clonedMap := make(map[string]any, len(m))
+		for k, v := range m {
+			clonedMap[k] = v
+		}
+		cloned[i] = clonedMap
+	}
+	return cloned
+}
+
 // applyControllerTolerations stamps controllerTolerateAll onto the Trainer and
 // JobSet controller-manager Deployments' pod template, unless one already
 // declares tolerations. Scoped to those two names so an unrelated Deployment
@@ -212,7 +230,7 @@ func applyControllerTolerations(obj *unstructured.Unstructured) error {
 		return aicrErrors.New(aicrErrors.ErrCodeInternal,
 			fmt.Sprintf("pod spec not found in Deployment %q", obj.GetName()))
 	}
-	podSpec["tolerations"] = controllerTolerateAll
+	podSpec["tolerations"] = cloneControllerTolerateAll()
 	slog.Info("Applying blanket toleration to controller Deployment", "name", obj.GetName())
 	return nil
 }

--- a/validators/performance/trainer_lifecycle_test.go
+++ b/validators/performance/trainer_lifecycle_test.go
@@ -17,6 +17,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestRewriteJobSetStagingImage(t *testing.T) {
@@ -74,5 +76,143 @@ func TestRewriteJobSetStagingImage_PreservesTag(t *testing.T) {
 	want := "image: " + jobSetPromotedImageRepo + ":v0.11.0"
 	if got := string(rewriteJobSetStagingImage([]byte(in))); got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// deploymentFixture returns a minimal unstructured Deployment, optionally with an
+// existing tolerations list, for exercising applyControllerTolerations.
+func deploymentFixture(name string, existingTolerations []any) *unstructured.Unstructured {
+	podSpec := map[string]any{
+		"containers": []any{
+			map[string]any{"name": "manager", "image": "example/manager:latest"},
+		},
+	}
+	if existingTolerations != nil {
+		podSpec["tolerations"] = existingTolerations
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": podSpec,
+			},
+		},
+	}}
+}
+
+// TestApplyControllerTolerations covers both controller names, the two
+// mutation-failure paths, and that an unrelated Deployment is left untouched.
+func TestApplyControllerTolerations(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     *unstructured.Unstructured
+		wantErr bool
+		// wantTolerations is checked only when wantErr is false. nil means "the
+		// tolerations field must not be present at all" (untouched, not merely
+		// empty).
+		wantTolerations []any
+	}{
+		{
+			name: "Trainer controller Deployment with no tolerations gets tolerate-all",
+			obj:  deploymentFixture(trainerControllerDeployment, nil),
+			wantTolerations: []any{
+				map[string]any{"operator": "Exists"},
+			},
+		},
+		{
+			name: "JobSet controller Deployment with no tolerations gets tolerate-all",
+			obj:  deploymentFixture(jobSetControllerDeployment, nil),
+			wantTolerations: []any{
+				map[string]any{"operator": "Exists"},
+			},
+		},
+		{
+			name: "Deployment with existing tolerations is left untouched",
+			obj: deploymentFixture(trainerControllerDeployment, []any{
+				map[string]any{"key": "dedicated", "operator": "Equal", "value": "trainer", "effect": "NoSchedule"},
+			}),
+			wantTolerations: []any{
+				map[string]any{"key": "dedicated", "operator": "Equal", "value": "trainer", "effect": "NoSchedule"},
+			},
+		},
+		{
+			name:            "non-controller Deployment is left untouched",
+			obj:             deploymentFixture("some-other-deployment", nil),
+			wantTolerations: nil,
+		},
+		{
+			name: "non-Deployment resource is left untouched",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata":   map[string]any{"name": trainerControllerDeployment},
+				"spec":       map[string]any{},
+			}},
+			wantTolerations: nil,
+		},
+		{
+			name: "missing pod spec fails closed",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]any{"name": trainerControllerDeployment},
+				"spec":       map[string]any{},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "malformed tolerations field fails closed",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]any{"name": trainerControllerDeployment},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							// A string, not a slice: NestedSlice's type assertion fails.
+							"tolerations": "not-a-slice",
+						},
+					},
+				},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := applyControllerTolerations(tt.obj)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			got, found, _ := unstructured.NestedSlice(tt.obj.Object, "spec", "template", "spec", "tolerations")
+			if tt.wantTolerations == nil {
+				if found {
+					t.Errorf("expected no tolerations field, got %v", got)
+				}
+				return
+			}
+			if !found {
+				t.Fatalf("expected tolerations %v, found none", tt.wantTolerations)
+			}
+			if len(got) != len(tt.wantTolerations) {
+				t.Fatalf("got %d toleration(s) %v, want %d %v", len(got), got, len(tt.wantTolerations), tt.wantTolerations)
+			}
+			for i := range got {
+				gotTol, _ := got[i].(map[string]any)
+				wantTol, _ := tt.wantTolerations[i].(map[string]any)
+				for k, v := range wantTol {
+					if gotTol[k] != v {
+						t.Errorf("toleration[%d][%q] = %v, want %v", i, k, gotTol[k], v)
+					}
+				}
+			}
+		})
 	}
 }

--- a/validators/performance/trainer_lifecycle_test.go
+++ b/validators/performance/trainer_lifecycle_test.go
@@ -104,6 +104,35 @@ func deploymentFixture(name string, existingTolerations []any) *unstructured.Uns
 
 // TestApplyControllerTolerations covers both controller names, the two
 // mutation-failure paths, and that an unrelated Deployment is left untouched.
+// TestApplyControllerTolerations_Isolation pins that the two controllers do
+// not share a live toleration slice: mutating one Deployment's stamped
+// tolerations in place must not affect the other, or the shared
+// controllerTolerateAll package-level global.
+func TestApplyControllerTolerations_Isolation(t *testing.T) {
+	trainerObj := deploymentFixture(trainerControllerDeployment, nil)
+	jobSetObj := deploymentFixture(jobSetControllerDeployment, nil)
+
+	if err := applyControllerTolerations(trainerObj); err != nil {
+		t.Fatalf("applyControllerTolerations(trainer) error = %v", err)
+	}
+	if err := applyControllerTolerations(jobSetObj); err != nil {
+		t.Fatalf("applyControllerTolerations(jobset) error = %v", err)
+	}
+
+	trainerTols, _, _ := unstructured.NestedSlice(trainerObj.Object, "spec", "template", "spec", "tolerations")
+	trainerTol, _ := trainerTols[0].(map[string]any)
+	trainerTol["key"] = "mutated-for-trainer-only"
+
+	jobSetTols, _, _ := unstructured.NestedSlice(jobSetObj.Object, "spec", "template", "spec", "tolerations")
+	jobSetTol, _ := jobSetTols[0].(map[string]any)
+	if _, mutated := jobSetTol["key"]; mutated {
+		t.Errorf("mutating the Trainer Deployment's toleration leaked into the JobSet Deployment: %v", jobSetTol)
+	}
+	if _, mutated := controllerTolerateAll[0].(map[string]any)["key"]; mutated {
+		t.Errorf("mutating a stamped toleration leaked into the shared controllerTolerateAll global: %v", controllerTolerateAll[0])
+	}
+}
+
 func TestApplyControllerTolerations(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/validators/performance/trainer_lifecycle_test.go
+++ b/validators/performance/trainer_lifecycle_test.go
@@ -15,10 +15,13 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/api/hasher"
+	"sigs.k8s.io/kustomize/api/resource"
 )
 
 func TestRewriteJobSetStagingImage(t *testing.T) {
@@ -264,5 +267,95 @@ func TestApplyControllerTolerations(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDecodeTrainerObjects exercises decodeTrainerObjects end to end: the
+// toleration lands only on a controller Deployment resource, not on an
+// unrelated resource in the same manifest set, and the Kind=="" skip ordering
+// above the applyControllerTolerations call does not interfere.
+func TestDecodeTrainerObjects(t *testing.T) {
+	rf := resource.NewFactory(&hasher.Hasher{})
+
+	manifest := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: example/trainer:latest
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: some-config
+data:
+  foo: bar
+`, trainerControllerDeployment)
+
+	resources, err := rf.SliceFromBytes([]byte(manifest))
+	if err != nil {
+		t.Fatalf("SliceFromBytes() error = %v", err)
+	}
+
+	objs, err := decodeTrainerObjects(resources)
+	if err != nil {
+		t.Fatalf("decodeTrainerObjects() error = %v", err)
+	}
+	if len(objs) != 2 {
+		t.Fatalf("got %d decoded object(s), want 2", len(objs))
+	}
+
+	var trainerObj, unrelatedObj *unstructured.Unstructured
+	for _, o := range objs {
+		switch o.GetName() {
+		case trainerControllerDeployment:
+			trainerObj = o
+		case "some-config":
+			unrelatedObj = o
+		}
+	}
+	if trainerObj == nil {
+		t.Fatal("Trainer controller Deployment missing from decoded objects")
+	}
+	tols, found, _ := unstructured.NestedSlice(trainerObj.Object, "spec", "template", "spec", "tolerations")
+	if !found || len(tols) != 1 {
+		t.Errorf("Trainer Deployment tolerations = %v, want a single blanket tolerate-all entry", tols)
+	}
+
+	if unrelatedObj == nil {
+		t.Fatal("unrelated ConfigMap missing from decoded objects")
+	}
+	if _, found, _ := unstructured.NestedSlice(unrelatedObj.Object, "spec", "template", "spec", "tolerations"); found {
+		t.Error("unrelated ConfigMap must not receive a toleration")
+	}
+}
+
+// TestDecodeTrainerObjects_PropagatesTolerationError verifies a malformed
+// resource that fails applyControllerTolerations aborts decoding rather than
+// leaving a partial object list.
+func TestDecodeTrainerObjects_PropagatesTolerationError(t *testing.T) {
+	rf := resource.NewFactory(&hasher.Hasher{})
+
+	manifest := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s
+spec:
+  template:
+    spec:
+      tolerations: not-a-slice
+`, trainerControllerDeployment)
+
+	resources, err := rf.SliceFromBytes([]byte(manifest))
+	if err != nil {
+		t.Fatalf("SliceFromBytes() error = %v", err)
+	}
+
+	if _, err := decodeTrainerObjects(resources); err == nil {
+		t.Fatal("decodeTrainerObjects() expected error for a malformed tolerations field, got nil")
 	}
 }

--- a/validators/performance/trainer_lifecycle_test.go
+++ b/validators/performance/trainer_lifecycle_test.go
@@ -182,6 +182,16 @@ func TestApplyControllerTolerations(t *testing.T) {
 			wantTolerations: nil,
 		},
 		{
+			name: "Deployment-kind resource in a non-apps group is left untouched",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "example.com/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]any{"name": trainerControllerDeployment},
+				"spec":       map[string]any{},
+			}},
+			wantTolerations: nil,
+		},
+		{
 			name: "missing pod spec fails closed",
 			obj: &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": "apps/v1",

--- a/validators/performance/trainer_lifecycle_test.go
+++ b/validators/performance/trainer_lifecycle_test.go
@@ -172,6 +172,17 @@ func TestApplyControllerTolerations(t *testing.T) {
 			wantTolerations: nil,
 		},
 		{
+			// found && len(existing) > 0 is the guard: an explicit empty slice is
+			// "present but empty," which must fall through to being stamped, not
+			// be treated the same as "already tolerated." Pins this boundary
+			// against a future refactor that flips the guard to `found` alone.
+			name: "Deployment with present-but-empty tolerations gets tolerate-all",
+			obj:  deploymentFixture(trainerControllerDeployment, []any{}),
+			wantTolerations: []any{
+				map[string]any{"operator": "Exists"},
+			},
+		},
+		{
 			name: "non-Deployment resource is left untouched",
 			obj: &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": "v1",


### PR DESCRIPTION
## Summary

Make the Kubeflow Trainer/JobSet controller-manager Deployments schedulable on all-tainted node pools, and widen the Trainer controller readiness timeout to accommodate its cert-controller sidecar's normal cold-start retry latency.

## Motivation / Context

The Kubeflow Trainer/JobSet controller-manager Deployments ship with no tolerations. On a cluster where every node pool carries a taint (e.g. an arch-tainted GPU pool plus a system pool GKE reserves for its own managed components once no untainted pool remains), the controllers have nowhere to schedule and `installTrainer` times out waiting for a Deployment that can never become Ready.

Separately, on cold start the Trainer controller-manager's cert-controller sidecar provisions its webhook cert via a get-or-create against the API server; racing that against a not-yet-synced informer cache produces a `resourceVersion` conflict that the sidecar's own reconcile loop retries and self-heals from unassisted — but each retry adds latency, and on a slow cold start the cumulative delay could push first-ready past the old 2-minute budget, failing the validator's readiness wait for a controller that was already recovering on its own.

Fixes: N/A
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [x] Validator (`pkg/validator`) <!-- validators/performance, pkg/defaults -->
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

`applyControllerTolerations` stamps a blanket tolerate-all onto the Trainer and JobSet controller-manager Deployments specifically (by name) when either has no existing tolerations; a Deployment that already declares tolerations, or any other Deployment in the manifest set, is left untouched. Scoping by name rather than by Kind alone matters here: this runs for every Deployment decoded from the installer's manifest set, and a future addition to that set must not silently inherit a blanket `{operator: Exists}` it never asked for. Built through `component.TolerationsToPodSpec`, the same converter used for Helm-values toleration overrides, so there's one canonical place that knows the toleration-to-map shape.

Also extracted the repeated `"operator"` toleration-key literal into a `keyOperator` const (used in `inference_perf_constraint.go` and `nccl_all_reduce_bw_constraint.go` too) to satisfy golangci-lint's `goconst` threshold across the package — no behavior change there.

`TrainerControllerReadyTimeout` widened from 2 to 3 minutes in `pkg/defaults/timeouts.go` — a single-constant change, independent of the toleration fix.

## Testing

```bash
make qualify
```

`make qualify` passed clean:
- `make test-coverage`: all packages pass with `-race`; `validators/performance` at 62.0% (repo-wide 84.1%, threshold 80%)
- `make lint` (golangci-lint + yamllint): clean
- `make tuning-check`: clean
- `make e2e` (chainsaw, `--no-cluster`): 24/24 passed, 0 failed, 0 skipped
- `make scan` (grype): no new vulnerabilities introduced by this change
- `make license-check`: clean
- `make api-diff`: no incompatible SDK facade / transparent-alias changes since v0.20.0

Added `trainer_lifecycle_test.go` coverage for `applyControllerTolerations` (existing tolerations preserved, blanket toleration applied when absent, unrelated Deployments/Kinds untouched).

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** N/A — internal validator behavior only. No recipe/API/CLI surface change; the Trainer/JobSet controller Deployments now tolerate all taints and get one extra minute to become ready, nothing else changes.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed <!-- no user-facing behavior changed -->
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)