### PR TITLE
fix(cli): correct migration guidance and close two surface-gate gaps

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,6 +52,24 @@ window rather than a flat one, because an alpha version never promised
 stability in the first place. Its rules are below and take precedence for that
 surface.
 
+**Closing a fail-open gate is not a deprecation.** When two enforcement paths
+disagree about the same document and one of them already rejected it, aligning
+the permissive path to the strict one owes no notice window. The permissive
+behavior was a defect, not a contract: it accepted input the project had
+already decided was invalid, and continuing to honor it for two releases would
+mean knowingly shipping the fail-open seam the stricter path exists to close.
+Such a change must still be recorded in
+[`docs/user/deprecations.md`](docs/user/deprecations.md) with its real release,
+and its rationale written down in the governing ADR.
+
+Exercised exactly once so far, in v0.21: a `RecipeMetadata` overlay with an
+empty `apiVersion` was rejected by the catalog scanner but silently hydrated on
+the direct-input path. ADR-022 §3 records the decision and
+[#2421](https://github.com/NVIDIA/aicr/issues/2421) the analysis; no committed
+artifact in the tree was affected. This clause is deliberately narrow — it does
+not cover tightening validation that both paths previously accepted, which is an
+ordinary breaking change and owes the full window.
+
 ### How a deprecation is announced
 
 Every deprecation appears in all three places. One is not a substitute for

--- a/docs/design/022-artifact-maturity-and-deprecation.md
+++ b/docs/design/022-artifact-maturity-and-deprecation.md
@@ -198,7 +198,7 @@ unchallenged — the fail-open shape §8 exists to close.
 **A catalog kind is governed by §8 on every path it can arrive by.** The
 tolerance above is scoped by wire kind, not by entry point. A `RecipeMetadata`
 reaching AICR as a direct recipe input (`aicr bundle -r overlay.yaml`,
-`aicr bundle -r overlay.yaml`) is the same catalog document it would be inside a
+`aicr validate -r overlay.yaml`) is the same catalog document it would be inside a
 `--data` tree, so it is held to the same fail-closed authoring gate the catalog
 scanner applies, including the rejection of an empty value. §3 step 1's
 "existing empty-value tolerances remain where they already exist" does not

--- a/docs/design/022-artifact-maturity-and-deprecation.md
+++ b/docs/design/022-artifact-maturity-and-deprecation.md
@@ -197,7 +197,7 @@ unchallenged — the fail-open shape §8 exists to close.
 
 **A catalog kind is governed by §8 on every path it can arrive by.** The
 tolerance above is scoped by wire kind, not by entry point. A `RecipeMetadata`
-reaching AICR as a direct recipe input (`aicr recipe -r overlay.yaml`,
+reaching AICR as a direct recipe input (`aicr bundle -r overlay.yaml`,
 `aicr bundle -r overlay.yaml`) is the same catalog document it would be inside a
 `--data` tree, so it is held to the same fail-closed authoring gate the catalog
 scanner applies, including the rejection of an empty value. §3 step 1's

--- a/docs/integrator/data-extension.md
+++ b/docs/integrator/data-extension.md
@@ -138,7 +138,7 @@ existing skip behavior, and `ValidatorCatalog` sits on a separate API domain
 outside this contract.
 
 This gate follows the document, not the entry point. Passing a single overlay
-directly — `aicr recipe -r overlay.yaml`, `aicr bundle -r overlay.yaml` —
+directly — `aicr bundle -r overlay.yaml`, `aicr validate -r overlay.yaml` —
 applies the same check as a `--data` catalog scan, so a `RecipeMetadata`
 with a missing or empty `apiVersion` is rejected on both paths. Through v0.20
 the direct path accepted it and hydrated silently

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -603,7 +603,7 @@ path. An absent or empty `apiVersion` is still admitted as the legacy shape on
 `RecipeResult` inputs through v0.22, and v0.23 stops admitting it along with the
 alpha values. The tolerance is scoped to `RecipeResult`, which predates the
 field: a `RecipeMetadata` overlay is a catalog document however it arrives, so
-`aicr recipe -r` and `aicr bundle -r` reject a headerless one exactly as a
+`aicr bundle -r` and `aicr validate -r` reject a headerless one exactly as a
 `--data` catalog scan does. The reader and emitter clocks are separate: v0.21
 and v0.22 both read the alpha values, the target values, and the empty header,
 while generated recipes keep their alpha headers until v0.22 switches the

--- a/docs/user/deprecations.md
+++ b/docs/user/deprecations.md
@@ -73,8 +73,8 @@ empty. That tolerance retires alongside the alpha values — except for
 see below.
 
 One narrowing landed earlier than the rest: as of v0.21, a `RecipeMetadata`
-overlay passed directly (`aicr recipe -r overlay.yaml`,
-`aicr bundle -r overlay.yaml`) must carry an `apiVersion`, because the catalog
+overlay passed directly (`aicr bundle -r overlay.yaml`,
+`aicr validate -r overlay.yaml`) must carry an `apiVersion`, because the catalog
 scanner already required one and the two paths disagreed on the same bytes
 ([#2421](https://github.com/NVIDIA/aicr/issues/2421)). Hydrated `RecipeResult`
 inputs keep the tolerance until v0.23.

--- a/pkg/cli/surface_test.go
+++ b/pkg/cli/surface_test.go
@@ -186,7 +186,8 @@ func TestCLISurface(t *testing.T) {
 		return
 	}
 
-	added, removed := diffLines(stripComments(string(wantBytes)), stripComments(got))
+	want := stripComments(string(wantBytes))
+	added, removed := diffLines(want, stripComments(got))
 
 	var b strings.Builder
 	b.WriteString("the aicr CLI surface no longer matches its committed baseline.\n\n")
@@ -203,9 +204,36 @@ func TestCLISurface(t *testing.T) {
 			"intentional and the window has passed, regenerate the golden.\n\n")
 	}
 
-	if len(added) > 0 {
+	// Not every addition is compatible. A newly required flag on a command that
+	// already existed invalidates invocations that were valid before, which
+	// RELEASING.md classifies as breaking — only a new flag whose default
+	// preserves behavior is additive. On a brand-new command there is no prior
+	// invocation to break, so requiredness there is additive; the split is by
+	// whether the command was already in the baseline.
+	existing := commandPaths(want)
+	var newlyRequired, compatible []string
+	for _, line := range added {
+		if isRequiredFlagLine(line) && existing[flagCommandPath(line)] {
+			newlyRequired = append(newlyRequired, line)
+			continue
+		}
+		compatible = append(compatible, line)
+	}
+
+	if len(newlyRequired) > 0 {
+		b.WriteString("BREAKING — these flags are newly required on commands that already existed:\n")
+		for _, line := range newlyRequired {
+			fmt.Fprintf(&b, "  ! %s\n", line)
+		}
+		b.WriteString("\nAdding a required flag to an existing command makes previously valid\n" +
+			"invocations fail, which RELEASING.md § Deprecation Policy classifies as\n" +
+			"breaking. Give the flag a default that preserves current behavior, or\n" +
+			"ship it through the deprecation window.\n\n")
+	}
+
+	if len(compatible) > 0 {
 		b.WriteString("Additive — these entries are new:\n")
-		for _, line := range added {
+		for _, line := range compatible {
 			fmt.Fprintf(&b, "  + %s\n", line)
 		}
 		b.WriteString("\nAdditions are compatible. Regenerate the golden and commit it in\n" +
@@ -416,6 +444,98 @@ func TestFlagFactsRendersDashPrefixByNameLength(t *testing.T) {
 			}
 			if names != tt.want {
 				t.Errorf("rendered names = %q, want %q", names, tt.want)
+			}
+		})
+	}
+}
+
+// commandPaths returns the command paths present in a baseline line set.
+func commandPaths(lines []string) map[string]bool {
+	paths := make(map[string]bool)
+	for _, line := range lines {
+		rest, ok := strings.CutPrefix(line, "command ")
+		if !ok {
+			continue
+		}
+		if path, _, found := strings.Cut(rest, "  aliases="); found {
+			paths[path] = true
+		}
+	}
+	return paths
+}
+
+// isRequiredFlagLine reports whether a rendered flag line marks the flag
+// required.
+func isRequiredFlagLine(line string) bool {
+	return strings.HasPrefix(line, "flag ") && strings.Contains(line, " required=true ")
+}
+
+// flagCommandPath extracts the command path from a rendered flag line, whose
+// shape is "flag    <path>  <names>  type=...".
+func flagCommandPath(line string) string {
+	rest, ok := strings.CutPrefix(line, "flag    ")
+	if !ok {
+		return ""
+	}
+	path, _, found := strings.Cut(rest, "  ")
+	if !found {
+		return ""
+	}
+	return path
+}
+
+// TestNewlyRequiredFlagOnExistingCommandIsBreaking pins the classification that
+// decides whether a surface change blocks or merely needs a regenerated golden.
+//
+// Every added line used to be reported as "Additions are compatible." That is
+// wrong for a flag that arrives already required on a command that already
+// shipped: invocations that were valid before now fail, which RELEASING.md
+// classifies as breaking. On a brand-new command there is no prior invocation to
+// break, so requiredness there really is additive — the distinction is the whole
+// point, and it is why this is asserted directly rather than through the golden.
+func TestNewlyRequiredFlagOnExistingCommandIsBreaking(t *testing.T) {
+	t.Parallel()
+
+	baseline := []string{
+		"command aicr  aliases= hidden=false",
+		"command aicr bundle  aliases= hidden=false",
+		`flag    aicr bundle  --recipe,-r  type=string default= required=false hidden=false env=`,
+	}
+	existing := commandPaths(baseline)
+
+	tests := []struct {
+		name       string
+		line       string
+		wantBroken bool
+	}{
+		{
+			name:       "required flag on an existing command is breaking",
+			line:       `flag    aicr bundle  --must-set  type=string default= required=true hidden=false env=`,
+			wantBroken: true,
+		},
+		{
+			name:       "optional flag on an existing command is additive",
+			line:       `flag    aicr bundle  --nice-to-have  type=string default= required=false hidden=false env=`,
+			wantBroken: false,
+		},
+		{
+			name:       "required flag on a brand-new command is additive",
+			line:       `flag    aicr brandnew  --must-set  type=string default= required=true hidden=false env=`,
+			wantBroken: false,
+		},
+		{
+			name:       "a new command line itself is additive",
+			line:       "command aicr brandnew  aliases= hidden=false",
+			wantBroken: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isRequiredFlagLine(tt.line) && existing[flagCommandPath(tt.line)]
+			if got != tt.wantBroken {
+				t.Errorf("classified breaking=%v, want %v for %q", got, tt.wantBroken, tt.line)
 			}
 		})
 	}

--- a/pkg/cli/surface_test.go
+++ b/pkg/cli/surface_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -204,21 +205,7 @@ func TestCLISurface(t *testing.T) {
 			"intentional and the window has passed, regenerate the golden.\n\n")
 	}
 
-	// Not every addition is compatible. A newly required flag on a command that
-	// already existed invalidates invocations that were valid before, which
-	// RELEASING.md classifies as breaking — only a new flag whose default
-	// preserves behavior is additive. On a brand-new command there is no prior
-	// invocation to break, so requiredness there is additive; the split is by
-	// whether the command was already in the baseline.
-	existing := commandPaths(want)
-	var newlyRequired, compatible []string
-	for _, line := range added {
-		if isRequiredFlagLine(line) && existing[flagCommandPath(line)] {
-			newlyRequired = append(newlyRequired, line)
-			continue
-		}
-		compatible = append(compatible, line)
-	}
+	newlyRequired, compatible := classifyAdded(want, added)
 
 	if len(newlyRequired) > 0 {
 		b.WriteString("BREAKING — these flags are newly required on commands that already existed:\n")
@@ -449,6 +436,32 @@ func TestFlagFactsRendersDashPrefixByNameLength(t *testing.T) {
 	}
 }
 
+// classifyAdded splits new baseline lines into the ones that break the CLI
+// contract and the ones that do not.
+//
+// Not every addition is compatible. A flag arriving already required on a
+// command that already existed invalidates invocations that were valid before,
+// which RELEASING.md classifies as breaking — only a new flag whose default
+// preserves behavior is additive. On a brand-new command there is no prior
+// invocation to break, so requiredness there is additive; the split is by
+// whether the command was already in the baseline.
+//
+// This is a named function rather than a loop inside TestCLISurface because the
+// reporting block around it runs only on the failure path, which a green CI run
+// never reaches. Asserting on this directly is what keeps the classification
+// itself covered.
+func classifyAdded(want, added []string) (newlyRequired, compatible []string) {
+	existing := commandPaths(want)
+	for _, line := range added {
+		if isRequiredFlagLine(line) && existing[flagCommandPath(line)] {
+			newlyRequired = append(newlyRequired, line)
+			continue
+		}
+		compatible = append(compatible, line)
+	}
+	return newlyRequired, compatible
+}
+
 // commandPaths returns the command paths present in a baseline line set.
 func commandPaths(lines []string) map[string]bool {
 	paths := make(map[string]bool)
@@ -484,59 +497,44 @@ func flagCommandPath(line string) string {
 	return path
 }
 
-// TestNewlyRequiredFlagOnExistingCommandIsBreaking pins the classification that
-// decides whether a surface change blocks or merely needs a regenerated golden.
+// TestClassifyAddedSplitsBreakingFromAdditive drives the real classification
+// used by TestCLISurface's failure report.
 //
-// Every added line used to be reported as "Additions are compatible." That is
-// wrong for a flag that arrives already required on a command that already
-// shipped: invocations that were valid before now fail, which RELEASING.md
-// classifies as breaking. On a brand-new command there is no prior invocation to
-// break, so requiredness there really is additive — the distinction is the whole
-// point, and it is why this is asserted directly rather than through the golden.
-func TestNewlyRequiredFlagOnExistingCommandIsBreaking(t *testing.T) {
+// Two things make this worth asserting directly. The classify-and-report block
+// runs only when the live tree diverges from the golden, so a normal green run
+// never executes it — a swapped bucket would mislabel a newly required flag as
+// "Additive — Regenerate the golden", which is precisely the reflexive -update
+// this file exists to prevent. And the lines are produced by real flagFacts
+// calls rather than hand-written literals, so if its render format ever drifts,
+// flagCommandPath stops matching and this test fails instead of silently
+// fail-opening a breaking flag into the compatible bucket.
+func TestClassifyAddedSplitsBreakingFromAdditive(t *testing.T) {
 	t.Parallel()
 
 	baseline := []string{
 		"command aicr  aliases= hidden=false",
 		"command aicr bundle  aliases= hidden=false",
-		`flag    aicr bundle  --recipe,-r  type=string default= required=false hidden=false env=`,
-	}
-	existing := commandPaths(baseline)
-
-	tests := []struct {
-		name       string
-		line       string
-		wantBroken bool
-	}{
-		{
-			name:       "required flag on an existing command is breaking",
-			line:       `flag    aicr bundle  --must-set  type=string default= required=true hidden=false env=`,
-			wantBroken: true,
-		},
-		{
-			name:       "optional flag on an existing command is additive",
-			line:       `flag    aicr bundle  --nice-to-have  type=string default= required=false hidden=false env=`,
-			wantBroken: false,
-		},
-		{
-			name:       "required flag on a brand-new command is additive",
-			line:       `flag    aicr brandnew  --must-set  type=string default= required=true hidden=false env=`,
-			wantBroken: false,
-		},
-		{
-			name:       "a new command line itself is additive",
-			line:       "command aicr brandnew  aliases= hidden=false",
-			wantBroken: false,
-		},
+		flagFacts("aicr bundle", &cli.StringFlag{Name: "recipe", Aliases: []string{"r"}}),
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := isRequiredFlagLine(tt.line) && existing[flagCommandPath(tt.line)]
-			if got != tt.wantBroken {
-				t.Errorf("classified breaking=%v, want %v for %q", got, tt.wantBroken, tt.line)
-			}
-		})
+	requiredOnExisting := flagFacts("aicr bundle",
+		&cli.StringFlag{Name: "must-set", Required: true})
+	optionalOnExisting := flagFacts("aicr bundle",
+		&cli.StringFlag{Name: "nice-to-have"})
+	requiredOnNew := flagFacts("aicr brandnew",
+		&cli.StringFlag{Name: "must-set", Required: true})
+	newCommand := "command aicr brandnew  aliases= hidden=false"
+
+	newlyRequired, compatible := classifyAdded(baseline, []string{
+		requiredOnExisting, optionalOnExisting, requiredOnNew, newCommand,
+	})
+
+	if len(newlyRequired) != 1 || newlyRequired[0] != requiredOnExisting {
+		t.Errorf("newlyRequired = %q, want exactly [%q]", newlyRequired, requiredOnExisting)
+	}
+
+	wantCompatible := []string{optionalOnExisting, requiredOnNew, newCommand}
+	if !slices.Equal(compatible, wantCompatible) {
+		t.Errorf("compatible = %q, want %q", compatible, wantCompatible)
 	}
 }

--- a/pkg/deprecation/deprecation_test.go
+++ b/pkg/deprecation/deprecation_test.go
@@ -130,13 +130,20 @@ func TestRecorderIgnoresEmptySubject(t *testing.T) {
 
 	var r Recorder
 	r.Warn(Notice{RemovedIn: "v0.25"})
+
+	// Assert on the empty-subject call in isolation, before anything else has
+	// logged. An earlier version of this test made both calls first and then
+	// looked for the malformed line "and no --real-flag line" — but the second
+	// call always logs --real-flag, so that condition was never true and the
+	// assertion could not fail. It also anchored on a newline immediately after
+	// the message, which slog's text handler never emits because the structured
+	// attributes follow on the same line.
+	if got := buf.String(); got != "" {
+		t.Errorf("empty-subject notice was logged, want it dropped; got: %s", got)
+	}
+
 	r.Warn(Notice{Subject: "--real-flag", RemovedIn: "v0.25"})
 
-	if strings.Contains(buf.String(), "is deprecated and will be removed in v0.25\n") &&
-		!strings.Contains(buf.String(), "--real-flag") {
-
-		t.Error("empty-subject notice was logged")
-	}
 	if !strings.Contains(buf.String(), "--real-flag is deprecated") {
 		t.Error("a real notice was suppressed by the empty-subject call")
 	}

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -446,7 +446,7 @@ componentRefs: []
 // TestRecipeMetadataHeaderGatesAgree pins the #2421 invariant: the same
 // RecipeMetadata header is accepted or rejected identically whether the
 // document reaches AICR through the catalog scanner (`--data`) or through the
-// direct recipe input path (`aicr recipe -r`, `aicr bundle -r`).
+// direct recipe input path (`aicr bundle -r`, `aicr validate -r`).
 //
 // The two gates live in different files and were written at different times.
 // They diverged on the empty string for the whole life of the direct loader:


### PR DESCRIPTION
## Summary

Addresses four of the five post-merge review findings on #2436. Nothing here reached a released artifact — v0.21 has not been cut.

## Motivation / Context

Post-merge review of #2436 raised five findings. Four are addressed here; the fifth is filed separately because it is a design problem rather than a mechanical one (see below).

Fixes: N/A
Related: #2436, #2421, #2112

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `RELEASING.md`, `pkg/deprecation`

## Implementation Notes

### 1. The migration guidance named a command that does not exist

Five places told users to pass an overlay with `aicr recipe -r`. That command has `--snapshot,-s` and **no** `--recipe` flag:

```
$ aicr recipe -r /tmp/x.yaml
Incorrect Usage: flag provided but not defined: -r
```

This was the remediation path for exactly the users the #2421 change breaks, so it was the worst possible place to be wrong. The CLI surface baseline committed in the same PR is what proves the flag was never there.

The direct-input loader (`client.LoadRecipe`) is reached from `pkg/cli/bundle.go`, `pkg/cli/validate.go`, and `pkg/cli/mirror.go` — so the correct commands are `aicr bundle -r`, `aicr validate -r`, and `aicr mirror list -r`. Corrected in four published docs plus one test comment.

### 2. The surface gate reported a newly required flag as compatible

`diffLines` routed every new baseline line into the additive bucket under "Additions are compatible. Regenerate the golden." A flag arriving **already required** on a command that already shipped invalidates invocations that were valid before, which `RELEASING.md` classifies as breaking — only a new flag whose default preserves behavior is additive.

The classification is now scoped by whether the command was already in the baseline, because requiredness on a brand-new command breaks nothing. `TestNewlyRequiredFlagOnExistingCommandIsBreaking` pins all four quadrants directly rather than through the golden, since the golden cannot express a hypothetical future flag.

### 3. `TestRecorderIgnoresEmptySubject` could not fail

The assertion required both that the malformed line be present **and** that `--real-flag` be absent — but the preceding call always logs `--real-flag`, so the condition was never true and `t.Error` was unreachable. It also anchored on a newline immediately after the message, which slog's text handler never emits because structured attributes follow on the same line:

```
level=WARN msg=" is deprecated and will be removed in v0.25" subject="" removedIn=v0.25
```

The empty-subject call is now asserted in isolation, before anything else has logged. Removing the production guard now fails it — verified.

### 4. Reconciling the early closure with the central policy

`RELEASING.md` now states when closing a fail-open gate owes no notice window, so the v0.21 `RecipeMetadata` narrowing is reconciled with the policy the same release introduced, rather than left as an implicit contradiction that three separate reviewers each had to re-derive.

The clause is deliberately narrow: it covers only the case where two enforcement paths disagree and one already rejected the document. Tightening validation that **both** paths previously accepted remains an ordinary breaking change owing the full window.

### Filed separately, not fixed here

The fifth finding — the baseline omits urfave-injected surface (`completion` and its four shell subcommands, `--help`, root `--version`) — is **not mechanical**. `setupDefaults` is unexported, so rendering post-setup means triggering `Run()`, which collides with the parsed-state mutation hazard `pkg/cli/root.go` explicitly warns about. It needs a design decision, so it is filed as its own issue.

## Testing

```bash
go test -race ./pkg/cli/... ./pkg/deprecation/... ./pkg/recipe/...   # pass
golangci-lint run -c .golangci.yaml ./pkg/cli/... ./pkg/deprecation/...  # 0 issues
make check-docs-mdx check-docs-mdx-parse   # OK
```

Live probe confirmed `aicr recipe -r` fails; `grep` confirms no occurrence remains. The repaired empty-subject test was mutation-tested by deleting the production guard.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Docs and test-code only; no production behavior changes. All four corrections land before v0.21 is cut, so none of the incorrect guidance reaches a release.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
