### PR TITLE
chore(make): add update-goldens target for golden fixture regeneration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,11 @@ test-coverage: check-coverage-threshold test ## Runs tests and enforces coverage
 	fi; \
 	echo "Coverage check passed"
 
+.PHONY: update-goldens
+update-goldens: ## Regenerates golden test fixtures (catalog/coverage/render parity); review with git diff before committing
+	@GOFLAGS="-mod=readonly" AICR_UPDATE_GOLDEN=1 go test -count=1 -run 'TestCatalogParityGolden|TestCoverageGoldenMatrix' ./pkg/recipe/
+	@GOFLAGS="-mod=readonly" AICR_UPDATE_GOLDEN=1 go test -count=1 -run 'TestStockRenderParityGolden' ./pkg/bundler/
+
 .PHONY: bench
 bench: ## Runs benchmarks
 	@echo "Running benchmarks..."

--- a/pkg/bundler/stock_render_parity_golden_test.go
+++ b/pkg/bundler/stock_render_parity_golden_test.go
@@ -112,6 +112,9 @@ func TestStockRenderParityGolden(t *testing.T) {
 	}
 
 	if os.Getenv("AICR_UPDATE_GOLDEN") == "1" {
+		if t.Failed() {
+			t.Fatal("not writing golden: one or more leaves failed to resolve or render (see errors above)")
+		}
 		writeStockRenderGolden(t, got)
 		t.Logf("golden updated: %d leaves", len(got))
 		return

--- a/pkg/recipe/catalog_parity_golden_test.go
+++ b/pkg/recipe/catalog_parity_golden_test.go
@@ -99,6 +99,9 @@ func TestCatalogParityGolden(t *testing.T) {
 	}
 
 	if os.Getenv("AICR_UPDATE_GOLDEN") == "1" {
+		if t.Failed() {
+			t.Fatal("not writing golden: one or more leaves failed to resolve (see errors above)")
+		}
 		writeCatalogParityGolden(t, got)
 		t.Logf("golden updated: %d leaves", len(got))
 		return

--- a/pkg/recipe/coverage_matrix_test.go
+++ b/pkg/recipe/coverage_matrix_test.go
@@ -93,6 +93,9 @@ func TestCoverageGoldenMatrix(t *testing.T) {
 	}
 
 	if os.Getenv("AICR_UPDATE_GOLDEN") == "1" {
+		if t.Failed() {
+			t.Fatal("not writing golden: one or more projections failed to classify (see errors above)")
+		}
 		writeGolden(t, got)
 		t.Logf("golden updated: %d projections", len(got))
 		return


### PR DESCRIPTION
Wraps the three AICR_UPDATE_GOLDEN=1 go test invocations (catalog parity, coverage matrix, stock render parity) so contributors don't need to recall the env var or exact -run patterns; each test file's own goldenPath constant remains the only source of truth for file location.

Also guard both golden writers against a partially-failed run: AICR_UPDATE_GOLDEN=1 now refuses to persist a golden file if any leaf failed to resolve or render, since writing it anyway would silently rebase the comparison baseline onto output that only reflects whichever leaves happened to succeed, masking the very regressions these tests exist to catch.

## Summary

Adds a `make update-goldens` target that wraps the three `AICR_UPDATE_GOLDEN=1` golden-regeneration test invocations, and guards both golden writers against persisting output from a partially-failed run.

## Motivation / Context

Regenerating golden fixtures (catalog parity, coverage matrix, stock render parity) required contributors to recall the `AICR_UPDATE_GOLDEN=1` env var and the exact `-run` patterns for each test file. Wrapping these in a single Makefile target removes that friction; each test file's own `goldenPath` constant remains the only source of truth for file location.

Separately, `AICR_UPDATE_GOLDEN=1` previously wrote the golden file unconditionally, even if one or more leaves failed to resolve or render. That would silently rebase the comparison baseline onto incomplete output, masking the very regressions these tests exist to catch.

Fixes: N/A
Related: N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `Makefile` (new `update-goldens` target)

## Implementation Notes

`update-goldens` runs `AICR_UPDATE_GOLDEN=1 go test -count=1 -run '...'` against `TestCatalogParityGolden`/`TestCoverageGoldenMatrix` (`pkg/recipe`) and `TestStockRenderParityGolden` (`pkg/bundler`) with `GOFLAGS="-mod=readonly"`.

Both golden-writer tests now check `t.Failed()` before writing: if any leaf failed to resolve/render earlier in the same test run, the writer calls `t.Fatal` instead of persisting a golden built from only the leaves that happened to succeed. This is a fail-closed guard, not a functional behavior change for a fully-passing run.

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/recipe/... ./pkg/bundler/...
go test -race -v ./pkg/recipe/... -run 'TestCatalogParityGolden|TestCoverageGoldenMatrix'
go test -race -v ./pkg/bundler/ -run 'TestStockRenderParityGolden'
make update-goldens
```

Full `make qualify` isn't warranted for this change (Makefile target + a fail-safe guard in two existing tests, no new production code path). Ran the mandatory Go lint gate on both touched packages (0 issues), the affected golden tests directly (both PASS), and exercised the new `update-goldens` target itself end-to-end — it regenerated all three goldens with zero diff against the committed baseline, confirming the target works and the new guard doesn't false-trip on a healthy run.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — dev-tooling only; no production code path changes. The only behavior change is that an already-broken `AICR_UPDATE_GOLDEN=1` run (one with a failing leaf) now fails loudly instead of silently writing a bad baseline.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality
- [ ] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)