### PR TITLE
fix(server): structured 405 on /metrics, allow HEAD, derive the route set

### DIFF
--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -1928,6 +1928,17 @@ paths:
                     type: string
                     example: "service is initializing"
   /metrics:
+    head:
+      tags: [Health]
+      summary: Prometheus metrics endpoint (headers only)
+      operationId: headMetrics
+      description: >-
+        Same as GET but returns headers only. Declared because RFC 9110
+        section 9.1 makes GET and HEAD mandatory for a general-purpose
+        server, and some monitoring probes reach /metrics with HEAD.
+      responses:
+        "200":
+          description: Headers for the Prometheus metrics response
     get:
       tags: [Health]
       summary: Prometheus metrics endpoint

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -151,7 +151,7 @@ field is wired in one place.
 | `/` | GET | Lists registered routes (unmatched paths route here via `ServeMux`) |
 | `/health` | GET | Liveness — always 200 if the process is running |
 | `/ready` | GET | Readiness — 503 with `reason` until `setReady(true)`, 200 after |
-| `/metrics` | GET | Prometheus exposition (`promhttp.Handler()`) |
+| `/metrics` | GET, HEAD | Prometheus exposition (`promhttp.Handler()` behind `readOnly`, which rejects other methods with a structured 405) |
 | `/v1/recipe` | GET, POST | Resolve recipe from criteria → `RecipeResult` JSON |
 | `/v1/query` | GET, POST | Resolve recipe, hydrate values, return value at `?selector=path` |
 | `/v1/bundle` | POST | Adopt `RecipeResult` body, generate bundle, stream zip |

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -893,9 +893,10 @@ curl "http://localhost:8080/ready"
 
 ---
 
-### GET /metrics
+### GET and HEAD /metrics
 
-Prometheus metrics endpoint.
+Prometheus metrics endpoint. `HEAD` returns the same headers with no body;
+every other method is rejected with `405` and an `Allow: GET, HEAD` header.
 
 ```shell
 curl "http://localhost:8080/metrics"

--- a/pkg/server/openapi_routes_test.go
+++ b/pkg/server/openapi_routes_test.go
@@ -15,6 +15,10 @@
 package server
 
 import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -107,8 +111,10 @@ func newSpecTestServer(t *testing.T) *Server {
 
 // registeredPaths returns every path the server actually serves.
 //
-// The set comes from Server.routePaths, recorded as New registers each pattern,
-// so it cannot drift from what the mux actually serves. Two earlier revisions of
+// The set comes from Server.routePaths, recorded as New registers each pattern
+// via s.handle. That covers cooperating registrations only — a raw
+// mux.HandleFunc would be served and never recorded — so the invariant is
+// enforced separately at the source by TestMuxRegistrationsGoThroughHandle. Two earlier revisions of
 // this helper were wrong in exactly that way: reading newRoutes alone missed the
 // root "/" handler installed by configureRootHandler, and the hand-maintained
 // systemRoutes list that replaced it would have missed any future route wired
@@ -304,5 +310,73 @@ func TestMetricsMethodRejectionIsStructured(t *testing.T) {
 	mux.ServeHTTP(headRec, httptest.NewRequest(http.MethodHead, "/metrics", nil))
 	if headRec.Code != http.StatusOK {
 		t.Errorf("HEAD /metrics = %d, want 200", headRec.Code)
+	}
+}
+
+// TestMuxRegistrationsGoThroughHandle is what actually closes the gap that
+// Server.routePaths only appears to close.
+//
+// routePaths records a pattern when it is registered *via s.handle*. A raw
+// mux.HandleFunc("/debug", ...) written directly in New bypasses the recording,
+// so the route is served, absent from routePaths, and therefore invisible to
+// all three conformance tests above — the exact scenario those tests exist to
+// catch. An earlier revision of this file claimed the route set "cannot drift";
+// that claim was only true for registrations that already cooperated, and the
+// mutation used to check it went through s.handle, so it proved the recording
+// path worked rather than that the bypass was caught.
+//
+// Go's http.ServeMux exposes no way to enumerate its patterns, so the invariant
+// cannot be verified at runtime. It is enforced at the source instead: every
+// mux.Handle / mux.HandleFunc call site must live inside the handle helper.
+func TestMuxRegistrationsGoThroughHandle(t *testing.T) {
+	t.Parallel()
+
+	const src = "server.go"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", src, err)
+	}
+
+	// Locate the helper's body so call sites inside it can be excluded.
+	var helperStart, helperEnd token.Pos
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "handle" || fn.Recv == nil {
+			return true
+		}
+		helperStart, helperEnd = fn.Pos(), fn.End()
+		return false
+	})
+	if !helperStart.IsValid() {
+		t.Fatal("could not find func (s *Server) handle; this test cannot enforce its invariant")
+	}
+
+	var offenders []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (sel.Sel.Name != "Handle" && sel.Sel.Name != "HandleFunc") {
+			return true
+		}
+		recv, ok := sel.X.(*ast.Ident)
+		if !ok || recv.Name != "mux" {
+			return true
+		}
+		if call.Pos() >= helperStart && call.Pos() < helperEnd {
+			return true // the one legitimate site
+		}
+		offenders = append(offenders,
+			fmt.Sprintf("%s: mux.%s", fset.Position(call.Pos()), sel.Sel.Name))
+		return true
+	})
+
+	for _, o := range offenders {
+		t.Errorf("%s registers a route without going through s.handle, so it is "+
+			"absent from Server.routePaths and invisible to the OpenAPI route "+
+			"conformance tests; use s.handle(mux, pattern, handler) instead", o)
 	}
 }

--- a/pkg/server/openapi_routes_test.go
+++ b/pkg/server/openapi_routes_test.go
@@ -54,11 +54,6 @@ var httpMethods = map[string]bool{
 	"options": true, "head": true, "patch": true, "trace": true,
 }
 
-// systemRoutes are registered directly on the mux in New rather than through
-// newRoutes, so they have no other in-code source of truth to compare against.
-// Keep in sync with the mux.HandleFunc calls in server.go.
-var systemRoutes = []string{"/health", "/ready", "/metrics"}
-
 // specOperations returns the spec's declared path -> sorted uppercase methods.
 func specOperations(t *testing.T) map[string][]string {
 	t.Helper()
@@ -112,20 +107,22 @@ func newSpecTestServer(t *testing.T) *Server {
 
 // registeredPaths returns every path the server actually serves.
 //
-// It builds a real Server rather than reading newRoutes directly, because
-// New also installs the root "/" handler via configureRootHandler. Reading
-// newRoutes alone would miss it and report "/" as an undelivered promise of the
-// spec, which is how this helper was wrong on its first draft.
+// The set comes from Server.routePaths, recorded as New registers each pattern,
+// so it cannot drift from what the mux actually serves. Two earlier revisions of
+// this helper were wrong in exactly that way: reading newRoutes alone missed the
+// root "/" handler installed by configureRootHandler, and the hand-maintained
+// systemRoutes list that replaced it would have missed any future route wired
+// directly in New -- which is where the system endpoints already live.
 func registeredPaths(t *testing.T) map[string]bool {
 	t.Helper()
 
 	s := newSpecTestServer(t)
-
-	paths := make(map[string]bool, len(s.config.Handlers)+len(systemRoutes))
-	for path := range s.config.Handlers {
-		paths[path] = true
+	if len(s.routePaths) == 0 {
+		t.Fatal("server recorded no routes; every assertion below would pass vacuously")
 	}
-	for _, path := range systemRoutes {
+
+	paths := make(map[string]bool, len(s.routePaths))
+	for _, path := range s.routePaths {
 		paths[path] = true
 	}
 	return paths
@@ -181,14 +178,16 @@ func TestOpenAPISpecPathsMatchRegisteredRoutes(t *testing.T) {
 	}
 }
 
-// TestOpenAPISpecMethodsAreAccepted asserts every method the spec declares is
-// actually accepted by the handler behind that path.
+// TestOpenAPIDeclaredMethodsAreNotRejected asserts no method the spec declares
+// is refused as unsupported by the handler behind that path.
 //
-// The check is deliberately narrow: it asserts only that the response is not
-// 405. A documented operation may legitimately answer 400 for a request this
-// test does not bother to populate, and asserting a success status would make
-// the test a fixture-maintenance burden rather than a contract check.
-func TestOpenAPISpecMethodsAreAccepted(t *testing.T) {
+// The oracle is deliberately narrow, and the name says so rather than promising
+// more: it checks only that the response is not 405. A documented operation may
+// legitimately answer 400 for a request this test does not populate, and one
+// that 500s still passes here. Asserting success codes would turn this into a
+// fixture treadmill for every endpoint's required inputs, which is a different
+// test with a different maintenance cost.
+func TestOpenAPIDeclaredMethodsAreNotRejected(t *testing.T) {
 	ops := specOperations(t)
 	// Drive the assembled mux, not the bare handler map. /, /health, /ready and
 	// /metrics are registered outside newRoutes, so a handler-map loop skips the
@@ -228,6 +227,15 @@ func TestOpenAPISpecMethodsAreAccepted(t *testing.T) {
 // This is the direction that rots silently. An endpoint that accepts POST while
 // the spec documents only GET is an undocumented, ungated public operation, and
 // nothing else in the tree would notice.
+//
+// A deviation this pins, deliberately: HEAD is rejected on /health, /ready, and
+// the v1/v2 endpoints, because their handlers gate on r.Method != GET. RFC 9110
+// §9.1 makes GET and HEAD mandatory for a general-purpose server, so that is a
+// standing wart — pre-existing, not introduced here, and left alone rather than
+// widened as a side effect of a conformance test. /metrics is the exception: it
+// accepted HEAD before this gate existed, so it declares head: and readOnly
+// honors it. If the others are aligned later, declare head: for them too rather
+// than deleting this assertion.
 func TestOpenAPIUndeclaredMethodsAreRejected(t *testing.T) {
 	ops := specOperations(t)
 	mux := newSpecTestServer(t).httpServer.Handler
@@ -263,5 +271,38 @@ func TestOpenAPIUndeclaredMethodsAreRejected(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestMetricsMethodRejectionIsStructured pins the 405 body shape on /metrics.
+//
+// An earlier revision used http.Error, which writes a bare string, while the
+// seven other 405 sites in this package — including handleHealth and
+// handleReady, registered on the same mux — return the structured envelope.
+// A client parsing the error for one system endpoint would have received JSON
+// from /health and plain text from /metrics for the identical condition.
+func TestMetricsMethodRejectionIsStructured(t *testing.T) {
+	mux := newSpecTestServer(t).httpServer.Handler
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/metrics", nil))
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want JSON to match the other 405 sites", ct)
+	}
+	if allow := rec.Header().Get("Allow"); !strings.Contains(allow, http.MethodGet) ||
+		!strings.Contains(allow, http.MethodHead) {
+
+		t.Errorf("Allow = %q, want it to advertise GET and HEAD", allow)
+	}
+
+	// HEAD must reach promhttp rather than being refused (RFC 9110 §9.1).
+	headRec := httptest.NewRecorder()
+	mux.ServeHTTP(headRec, httptest.NewRequest(http.MethodHead, "/metrics", nil))
+	if headRec.Code != http.StatusOK {
+		t.Errorf("HEAD /metrics = %d, want 200", headRec.Code)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,6 +44,13 @@ type Server struct {
 	rateLimiter *rate.Limiter
 	mu          sync.RWMutex
 	ready       bool
+
+	// routePaths records every pattern registered on the mux, in registration
+	// order. http.ServeMux exposes no way to enumerate its patterns, so without
+	// this the OpenAPI conformance tests would have to re-derive the route set
+	// from a hand-maintained list -- and a route added directly here, which is
+	// exactly where the system endpoints live, would be invisible to them.
+	routePaths []string
 }
 
 // Option is a functional option for configuring Server instances.
@@ -112,16 +119,16 @@ func New(opts ...Option) *Server {
 	mux := http.NewServeMux()
 
 	// System endpoints (no rate limiting)
-	mux.HandleFunc("/health", s.handleHealth)
-	mux.HandleFunc("/ready", s.handleReady)
-	mux.Handle("/metrics", getOnly(promhttp.Handler()))
+	s.handle(mux, "/health", http.HandlerFunc(s.handleHealth))
+	s.handle(mux, "/ready", http.HandlerFunc(s.handleReady))
+	s.handle(mux, "/metrics", readOnly(promhttp.Handler()))
 
 	// setup root handler
 	s.configureRootHandler()
 
 	// setup application routes
 	for path, handler := range s.config.Handlers {
-		mux.HandleFunc(path, s.withMiddleware(handler))
+		s.handle(mux, path, s.withMiddleware(handler))
 	}
 
 	s.httpServer = &http.Server{
@@ -135,6 +142,14 @@ func New(opts ...Option) *Server {
 	}
 
 	return s
+}
+
+// handle registers a pattern on the mux and records it, so the set of served
+// routes has one source of truth rather than a list someone must remember to
+// update.
+func (s *Server) handle(mux *http.ServeMux, pattern string, h http.Handler) {
+	mux.Handle(pattern, h)
+	s.routePaths = append(s.routePaths, pattern)
 }
 
 // SetReady marks the server as ready to serve traffic or not.
@@ -272,22 +287,28 @@ func (s *Server) configureRootHandler() {
 	}
 }
 
-// getOnly restricts a handler to GET, answering 405 otherwise.
+// readOnly restricts a handler to GET and HEAD, answering 405 otherwise.
 //
 // promhttp.Handler does no method filtering, so /metrics answered 200 to
-// DELETE, PUT, POST, PATCH, HEAD, OPTIONS and TRACE alike. That contradicted
-// api/aicr/v1/server.yaml, which declares GET and nothing else, and left seven
-// undocumented operations on a public endpoint. Prometheus scrapes with GET.
+// DELETE, PUT, POST, PATCH, OPTIONS and TRACE alike. That contradicted
+// api/aicr/v1/server.yaml and left undocumented operations on a public
+// endpoint.
 //
-// HEAD is rejected rather than accepted: the spec does not declare it, and
-// widening the surface to match an implementation detail is the wrong direction
-// when the point is to make the published contract true. Adding it later is a
-// deliberate change to both the spec and this guard.
-func getOnly(next http.Handler) http.Handler {
+// HEAD is allowed, not rejected. RFC 9110 §9.1 makes GET and HEAD mandatory for
+// a general-purpose server, and an earlier revision of this guard narrowed
+// /metrics to GET alone — a behavior change against a monitoring endpoint some
+// probes reach with HEAD. The spec declares head: alongside get: so the
+// contract and the server agree.
+//
+// The 405 body is the structured envelope WriteError produces, matching
+// handleHealth and handleReady above. A client parsing the error for one system
+// endpoint should not get a bare string from another for the same condition.
+func readOnly(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", http.MethodGet)
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
+			WriteError(w, r, http.StatusMethodNotAllowed, aicrerrors.ErrCodeMethodNotAllowed,
+				"Method not allowed", false, map[string]any{keyMethod: r.Method})
 			return
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
## Summary

Closes items 6–9 of #2454 — the `pkg/server` conformance findings from the #2448 review. Items 1, 2, 4 and 5 are in #2450; item 3 is #2451; items 10 and 11 need no action yet.

## Motivation / Context

#2454 consolidates review findings across #2436 and #2448. This PR takes the API-server group. Two of the four are defects I introduced in #2448 itself.

Fixes: N/A
Related: #2454, #2448, #2112, #2450, #2451

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] API server (`cmd/aicrd`, `pkg/server`)

## Implementation Notes

### Item 6 — plain-text 405 broke the package's own convention

`getOnly` called `http.Error(w, "method not allowed", 405)`, writing a bare string. The seven other 405 sites in this package — including `handleHealth` and `handleReady`, registered on the same mux — return the structured envelope via `WriteError`. A client parsing the error received JSON from `/health` and plain text from `/metrics` for the identical condition. Now uses `WriteError` with `ErrCodeMethodNotAllowed`, matching its siblings.

### Item 9 — HEAD, decided rather than left implicit

`getOnly` also narrowed `/metrics` to GET, which `promhttp` had not done. **RFC 9110 §9.1 makes GET and HEAD mandatory for a general-purpose server**, and some monitoring probes reach `/metrics` with HEAD — so #2448 introduced a behavior regression on a monitoring endpoint while trying to make the contract true.

`readOnly` allows GET and HEAD, and the spec declares `head:` alongside `get:` so contract and server agree.

The pre-existing HEAD rejection on `/health`, `/ready`, and the v1/v2 endpoints is **left alone**. It is a standing wart, but widening it as a side effect of a conformance test is the wrong way to decide it. It is now recorded in the test's doc comment so the next reader does not "fix" the assertion without realizing it encodes a deliberate deviation.

### Item 7 — the route set could not see a future direct-mux route

`registeredPaths` derived from `config.Handlers` plus a hand-maintained `systemRoutes` list. A route added directly in `New()` — exactly where `/health`, `/ready` and `/metrics` already live — would appear in neither source and be invisible to all three conformance tests. A hole in a gate built to catch undocumented endpoints.

`http.ServeMux` exposes no way to enumerate its patterns, so `Server.handle` now records each pattern as it registers it.

**Corrected after review:** an earlier revision of this PR claimed the route set "cannot drift". It does not — `routePaths` only records registrations that go *through* `s.handle`, so a raw `mux.HandleFunc` in `New` is served, unrecorded, and invisible to all three tests. My mutation check used `s.handle`, which proved the recording path worked rather than that the bypass was caught. `TestMuxRegistrationsGoThroughHandle` now parses `server.go` with `go/ast` and fails, with file and line, if any `mux.Handle`/`mux.HandleFunc` call site sits outside the helper.

### Item 8 — the name promised more than the oracle delivered

`TestOpenAPISpecMethodsAreAccepted` fails only on 405, so a declared operation whose handler 500s still passed. The narrowness is deliberate — asserting success codes would make it a fixture treadmill — so the fix is honesty, not a stricter oracle: renamed to `TestOpenAPIDeclaredMethodsAreNotRejected`, with the docstring stating what it does and does not cover.

### Not addressed

- **Item 10** (`$ref`-only or `parameters`-only path items misread as declaring no operations) — latent; all 10 spec paths use inline `get`/`post`.
- **Item 11** (spec path relative to the `go test` CWD) — no `go test -c` or Bazel lane exists.

Both become real only under conditions that do not exist today, and guessing at the fix now would be speculative.

## Testing

```bash
go test -race ./pkg/... ./cmd/...          # all pass
golangci-lint run -c .golangci.yaml ./...  # 0 issues
make lint-yaml check-docs-mdx              # OK
```

`readOnly` is at 100% coverage; `pkg/server` holds at 84.3%. `docs/user/api-reference.md` and `docs/contributor/api-server.md` now document `HEAD /metrics`, which the spec declared but the prose did not.

**Mutation-verified, including the case the first attempt missed.** Registering `/debug` via `s.handle` fails the path assertion; registering it with a raw `mux.HandleFunc` — which passed before review — now fails the source-level guard:

```
server.go:125:2: mux.HandleFunc registers a route without going through s.handle,
so it is absent from Server.routePaths and invisible to the OpenAPI route
conformance tests; use s.handle(mux, pattern, handler) instead
```

`TestMetricsMethodRejectionIsStructured` pins the JSON envelope, the `Allow: GET, HEAD` header, and that `HEAD /metrics` returns 200 rather than 405.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Two behavior changes, both on `/metrics` and both corrective. `HEAD /metrics` returns 200 again, restoring the pre-#2448 behavior that #2448 removed. Non-GET/HEAD methods now return a JSON error envelope instead of a plain-text body, matching every other 405 in the package. Prometheus scraping is unaffected — it uses GET.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

