### PR TITLE
test(cli): cover the urfave-injected CLI surface behaviorally

### DIFF
--- a/docs/contributor/cli.md
+++ b/docs/contributor/cli.md
@@ -398,6 +398,16 @@ with a warning first, remove it only after the window, and add an entry to
 [`docs/user/deprecations.md`](../user/deprecations.md). Regenerate the golden
 only once the removal is actually due.
 
+**Framework-injected surface is covered separately.** `renderSurface` walks
+`RootCommand()`, which is the tree *before* urfave performs setup, so the
+`completion` command, its four shell subcommands, `--help`, and root
+`--version` never reach the golden. Rendering post-setup is not an option:
+urfave's setup functions are unexported, so reaching them means calling `Run`,
+which mutates parsed state on the instance (see the comment at
+`pkg/cli/root.go:64`) and would bake that state into a committed baseline.
+`pkg/cli/injected_surface_test.go` asserts that surface behaviorally instead —
+that the commands actually run, not that a golden line exists.
+
 Usage strings are deliberately not pinned. They are prose, they change for good
 reasons, and including them would make the gate fail on every wording fix — the
 fastest way to train everyone to run `-update` without reading the diff.

--- a/pkg/cli/injected_surface_test.go
+++ b/pkg/cli/injected_surface_test.go
@@ -200,16 +200,31 @@ func TestCompletionCommandIsPublic(t *testing.T) {
 		t.Error("completion has no category; root.go assigns one so it groups in help")
 	}
 
-	// The four shell subcommands are the surface users actually invoke.
+	// The four shell subcommands are the surface users actually invoke. The
+	// comparison runs both ways: a missing one breaks a documented command, and
+	// an unexpected one is public surface nothing covers, since the golden
+	// cannot see this tree either. A urfave upgrade adding a fifth shell should
+	// be a conscious decision, not a silent one.
 	want := map[string]bool{"bash": true, "zsh": true, "fish": true, "pwsh": true}
 	got := make(map[string]bool, len(completion.Commands))
 	for _, sub := range completion.Commands {
 		got[sub.Name] = true
 	}
+
 	for shell := range want {
 		if !got[shell] {
 			t.Errorf("completion has no %q subcommand; `aicr completion %s` is "+
 				"documented surface", shell, shell)
 		}
+	}
+	for shell := range got {
+		if !want[shell] {
+			t.Errorf("completion has an unexpected %q subcommand. It is public "+
+				"surface that neither this test nor cli-surface.golden covers. "+
+				"Add it here and to docs/user/cli-reference.md, or remove it.", shell)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("completion has %d subcommands, want %d", len(got), len(want))
 	}
 }

--- a/pkg/cli/injected_surface_test.go
+++ b/pkg/cli/injected_surface_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+// Part of the CLI surface is injected by urfave/cli during setup rather than
+// declared in the command tree: the `completion` command with its four shell
+// subcommands, `--help` throughout, and root `--version`.
+//
+// cli-surface.golden cannot cover them. renderSurface walks RootCommand(),
+// which is the tree *before* setup runs, so none of that surface appears in the
+// baseline and removing any of it passes TestCLISurface silently (#2451).
+//
+// The obvious fix — render from a post-setup tree — is not available. urfave's
+// setupDefaults and setupCommandGraph are unexported, so reaching them means
+// calling Run, and root.go:64 warns that urfave mutates parsed state on the
+// Flag value, which is why the codebase builds a fresh command per invocation.
+// Baking parsed state into a committed golden would trade a known gap for an
+// unpredictable one.
+//
+// So this surface is asserted behaviorally instead, which is also the stronger
+// claim: not that the golden contains a line, but that a user can actually run
+// the command. Every case uses a fresh newRootCmd() for exactly the reason
+// root.go gives.
+//
+// This is not incidental surface. root.go sets EnableShellCompletion and then
+// uses ConfigureShellCompletionCommand to un-hide the completion command and
+// give it a category — a deliberate decision to make it public. Users script
+// against `aicr completion bash`.
+
+// runFresh invokes args against a brand-new command tree and returns its
+// output. A fresh instance per call is required: urfave performs setup and
+// records parsed state on the instance, so reuse leaks state between cases.
+func runFresh(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	cmd := newRootCmd()
+	cmd.Writer = &buf
+	cmd.ErrWriter = &buf
+	err := cmd.Run(t.Context(), args)
+	return buf.String(), err
+}
+
+// completionCommand returns the injected completion command from a throwaway
+// post-setup tree, or nil.
+//
+// Callers must check this before invoking `aicr completion <shell>`. When the
+// command is absent, urfave routes the invocation to its help handler, which
+// calls os.Exit and takes the whole test binary with it — the run then reports
+// only "No help topic for 'completion'" with no failing test named. Checking
+// first turns that into an actionable message.
+func completionCommand(t *testing.T) *cli.Command {
+	t.Helper()
+
+	var buf bytes.Buffer
+	cmd := newRootCmd()
+	cmd.Writer = &buf
+	if err := cmd.Run(t.Context(), []string{"aicr", "--help"}); err != nil {
+		t.Fatalf("run --help to trigger setup: %v", err)
+	}
+	for _, sub := range cmd.Commands {
+		if sub.Name == "completion" {
+			return sub
+		}
+	}
+	return nil
+}
+
+// requireCompletion fails with a useful message rather than letting a missing
+// command kill the process.
+func requireCompletion(t *testing.T) *cli.Command {
+	t.Helper()
+
+	c := completionCommand(t)
+	if c == nil {
+		t.Fatal("no completion command after setup. urfave injects it when " +
+			"EnableShellCompletion is set OR ConfigureShellCompletionCommand is " +
+			"non-nil (command_setup.go:124, an OR); root.go sets both, so both " +
+			"must be removed to lose it. `aicr completion bash` is public surface " +
+			"users script against.")
+	}
+	return c
+}
+
+// TestShellCompletionIsInvokable asserts each shell script the CLI advertises
+// can actually be produced.
+func TestShellCompletionIsInvokable(t *testing.T) {
+	requireCompletion(t)
+
+	// urfave injects exactly these four. A fifth appearing, or one of these
+	// disappearing, is a surface change worth noticing.
+	for _, shell := range []string{"bash", "zsh", "fish", "pwsh"} {
+		t.Run(shell, func(t *testing.T) {
+			out, err := runFresh(t, "aicr", "completion", shell)
+			if err != nil {
+				t.Fatalf("aicr completion %s: %v\noutput: %s", shell, err, out)
+			}
+			if strings.TrimSpace(out) == "" {
+				t.Errorf("aicr completion %s produced no script", shell)
+			}
+		})
+	}
+}
+
+// TestShellCompletionScriptsAreDistinct is what keeps the case above from
+// being vacuous.
+//
+// Asserting only "no error, non-empty output" would pass even if every shell
+// resolved to the same handler, or to the root help text. Four distinct scripts
+// prove four distinct subcommands actually resolved.
+//
+// The negative form — invoking an unknown shell and expecting an error — is not
+// usable here: urfave routes it to the help handler, which calls os.Exit and
+// takes the test binary with it.
+func TestShellCompletionScriptsAreDistinct(t *testing.T) {
+	requireCompletion(t)
+
+	shells := []string{"bash", "zsh", "fish", "pwsh"}
+	scripts := make(map[string]string, len(shells))
+
+	for _, shell := range shells {
+		out, err := runFresh(t, "aicr", "completion", shell)
+		if err != nil {
+			t.Fatalf("aicr completion %s: %v", shell, err)
+		}
+		scripts[shell] = out
+	}
+
+	for i, a := range shells {
+		for _, b := range shells[i+1:] {
+			if scripts[a] == scripts[b] {
+				t.Errorf("aicr completion %s and %s produced identical output; "+
+					"the shell subcommands are not resolving separately, so the "+
+					"invokability assertions prove nothing", a, b)
+			}
+		}
+	}
+}
+
+// TestRootVersionAndHelpAreInvokable covers the other injected surface.
+func TestRootVersionAndHelpAreInvokable(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"root version", []string{"aicr", "--version"}, "aicr version"},
+		{"root help", []string{"aicr", "--help"}, "COMMANDS"},
+		{"subcommand help", []string{"aicr", "bundle", "--help"}, "OPTIONS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runFresh(t, tt.args...)
+			if err != nil {
+				t.Fatalf("%v: %v\noutput: %s", tt.args, err, out)
+			}
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("%v output does not contain %q\ngot: %s", tt.args, tt.want, out)
+			}
+		})
+	}
+}
+
+// TestCompletionCommandIsPublic pins the two choices root.go makes about the
+// injected completion command.
+//
+// ConfigureShellCompletionCommand un-hides it and gives it a category. Both are
+// deliberate — the default is hidden — and both are invisible to the golden,
+// so silently reverting either would change documented public surface with no
+// test failing.
+func TestCompletionCommandIsPublic(t *testing.T) {
+	completion := requireCompletion(t)
+
+	if completion.Hidden {
+		t.Error("completion is hidden; root.go's ConfigureShellCompletionCommand " +
+			"un-hides it deliberately, so it is public surface")
+	}
+	if completion.Category == "" {
+		t.Error("completion has no category; root.go assigns one so it groups in help")
+	}
+
+	// The four shell subcommands are the surface users actually invoke.
+	want := map[string]bool{"bash": true, "zsh": true, "fish": true, "pwsh": true}
+	got := make(map[string]bool, len(completion.Commands))
+	for _, sub := range completion.Commands {
+		got[sub.Name] = true
+	}
+	for shell := range want {
+		if !got[shell] {
+			t.Errorf("completion has no %q subcommand; `aicr completion %s` is "+
+				"documented surface", shell, shell)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Covers the CLI surface urfave injects during setup, which `cli-surface.golden` structurally cannot reach. Closes #2451 using option 2 from that issue.

## Motivation / Context

`renderSurface` walks `RootCommand()` — the tree *before* urfave performs setup — so none of this appears in the baseline:

- the `completion` command and its `bash`, `zsh`, `fish`, `pwsh` subcommands
- `--help` across the tree
- root `--version`

Removing any of it passes `TestCLISurface` silently. That matters because `root.go` deliberately makes completion **public**: it sets `EnableShellCompletion` and uses `ConfigureShellCompletionCommand` to un-hide the command and give it a category. Users script against `aicr completion bash`.

Fixes: #2451
Related: #2111, #2454

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**Why not render from a post-setup tree**, which #2451 lists as option 1: urfave's `setupDefaults` and `setupCommandGraph` are unexported, so reaching them means calling `Run`. `pkg/cli/root.go:64` warns that urfave mutates parsed state on the `Flag` value — the reason this codebase builds a fresh command per invocation. Baking that state into a committed golden trades a known gap for an unpredictable one.

So the surface is asserted **behaviorally**, which is the stronger claim: not that a golden line exists, but that the command actually runs.

Two things this had to get right beyond the happy path:

**Distinctness.** Asserting only "no error, non-empty output" would pass if every shell resolved to the same handler, or to root help text. The four scripts must *differ* — that is what proves four subcommands resolved.

**Clean failure.** When completion is absent, invoking it routes to urfave's help handler, which calls `os.Exit` and kills the test binary; the run then reports only `No help topic for 'completion'` with no test named. Existence is checked first, so the failure names the cause and the fix instead.

## Testing

```bash
go test -race ./pkg/... ./cmd/...          # all pass
golangci-lint run -c .golangci.yaml ./pkg/cli/...  # 0 issues
make check-docs-mdx check-docs-mdx-parse   # OK
```

Every guard falsified — each mutation removes surface the test claims to protect:

| Mutation | Result |
|---|---|
| Remove completion entirely (both triggers) | 3 tests fail |
| Re-hide the completion command | 1 fails |
| Drop the completion category | 1 fails |
| Remove root `--version` | 1 fails |

**One finding worth recording.** Disabling `EnableShellCompletion` alone does **not** remove the command. `command_setup.go:124` injects it when that flag is set **OR** when `ConfigureShellCompletionCommand` is non-nil, and `root.go` sets both. My first mutation flipped only the flag, saw the tests pass, and looked like evidence of a vacuous guard — it was a vacuous *mutation*. Both triggers must be removed. I checked urfave's source rather than concluding either way from the passing run.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** Test-only plus one doc paragraph. No production code. Runs under `make test`, already inside the merge gate; no new workflow or tool dependency. `docs/contributor/cli.md` now states what the golden does and does not cover, so the split between the two mechanisms is discoverable.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
