### PR TITLE
test(bundler): assert the DRA node-label warning count, not just its presence

### DIFF
--- a/docs/integrator/aks-gpu-setup.md
+++ b/docs/integrator/aks-gpu-setup.md
@@ -135,8 +135,9 @@ autoscaling, or a pool scaled from zero, so later nodes arrive unlabeled.
 An unlabeled GPU node fails silently: it runs no kubelet plugin and publishes
 no `ResourceSlices`, and neither Helm nor the bundle's `deploy.sh` reports an
 error. With no labeled GPU node at all the DaemonSet sits at `DESIRED=0`; with
-only some labeled, those nodes work while the rest silently lack DRA. This applies to existing clusters too — adding
-the selector during an upgrade removes a plugin that was previously working.
+only some labeled, those nodes work while the rest silently lack DRA.
+This applies to existing clusters too — adding the selector during an
+upgrade removes a plugin that was previously working.
 See [Prepare DRA nodes before applying upgraded bundles](../user/bundling.md#prepare-dra-nodes-before-applying-upgraded-bundles).
 
 ## GPU Driver Setup

--- a/docs/integrator/gke-gpu-setup.md
+++ b/docs/integrator/gke-gpu-setup.md
@@ -392,8 +392,9 @@ autoscaling, or a pool scaled from zero, so later nodes arrive unlabeled.
 An unlabeled GPU node fails silently: it runs no kubelet plugin and publishes
 no `ResourceSlices`, and neither Helm nor the bundle's `deploy.sh` reports an
 error. With no labeled GPU node at all the DaemonSet sits at `DESIRED=0`; with
-only some labeled, those nodes work while the rest silently lack DRA. This applies to existing clusters too — adding
-the selector during an upgrade removes a plugin that was previously working.
+only some labeled, those nodes work while the rest silently lack DRA.
+This applies to existing clusters too — adding the selector during an
+upgrade removes a plugin that was previously working.
 See [Prepare DRA nodes before applying upgraded bundles](../user/bundling.md#prepare-dra-nodes-before-applying-upgraded-bundles).
 
 ## Troubleshooting

--- a/docs/user/bundling.md
+++ b/docs/user/bundling.md
@@ -234,7 +234,7 @@ afterwards.
 ### This applies to existing clusters, not just fresh installs
 
 The requirement is easy to read as a fresh-install prerequisite, but the
-upgrade path is where it most often arises. A cluster whose bundle was generated
+upgrade path is especially easy to miss. A cluster whose bundle was generated
 before this selector existed has a working kubelet-plugin DaemonSet selecting
 on `nodeGroup=gpu-worker` alone. Regenerating the bundle and running `helm
 upgrade` adds the second selector, and working functionality **disappears** —

--- a/docs/user/bundling.md
+++ b/docs/user/bundling.md
@@ -201,8 +201,8 @@ A one-off `kubectl label node` is a repair, not a configuration. It does not
 survive node replacement or recycling, cluster autoscaling adding GPU nodes, or
 a nodegroup scaled from zero. Any GPU node added afterwards arrives unlabeled
 and silently runs without the DRA kubelet plugin, leaving the cluster
-**partially DRA-enabled** — worse than uniform failure, because it is
-intermittent and node-dependent.
+**partially DRA-enabled**. This is harder to detect than uniform failure,
+because it is intermittent and node-dependent.
 
 Use `kubectl label` only to repair nodes that already exist, and fix the node
 pool definition in the same change so replacements inherit it:
@@ -223,8 +223,7 @@ instead is:
 - the `nvidia-dra-driver-gpu-kubelet-plugin` DaemonSet at `DESIRED=0` **if no
   GPU node carries the label at all**
 
-Partial coverage is the more dangerous shape, and the one node replacement and
-autoscaling produce: labeled nodes work normally while the rest silently lack
+Partial coverage is the shape node replacement and autoscaling produce: labeled nodes work normally while the rest silently lack
 DRA. A split cluster is harder to notice than uniform failure, because the
 DaemonSet looks healthy and only some workloads misbehave.
 
@@ -235,7 +234,7 @@ afterwards.
 ### This applies to existing clusters, not just fresh installs
 
 The requirement is easy to read as a fresh-install prerequisite, but the
-upgrade path is where it bites hardest. A cluster whose bundle was generated
+upgrade path is where it most often arises. A cluster whose bundle was generated
 before this selector existed has a working kubelet-plugin DaemonSet selecting
 on `nodeGroup=gpu-worker` alone. Regenerating the bundle and running `helm
 upgrade` adds the second selector, and working functionality **disappears** —

--- a/pkg/bundler/bundler_dra_eviction_test.go
+++ b/pkg/bundler/bundler_dra_eviction_test.go
@@ -562,10 +562,6 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 		// wantCount is the exact number of node-label warnings expected.
 		// Zero means one, the single-DRA-component default.
 		wantCount int
-		// wantOwners names the components that must each own exactly one
-		// warning. Counting alone cannot catch an implementation that emits
-		// one component's warning twice and drops another's.
-		wantOwners []string
 	}{
 		{
 			name: "both components enabled warns",
@@ -586,24 +582,6 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 			configured:  config.NodeLabel{Key: "example.com/dra-ready", Value: "enabled"},
 			wantWarning: true,
 			wantSubstr:  "nodes labeled example.com/dra-ready=enabled",
-		},
-		{
-			// draEvictionComponentNames collects every matching ref rather
-			// than stopping at the first, so a recipe carrying both DRA
-			// variants yields one warning per component. Nothing else in the
-			// table supplies more than one DRA ref, which left the loop in
-			// warnDRAEvictionNodeLabelRequired unexercised for len > 1 and a
-			// double-emit regression undetectable.
-			name: "both DRA variants warn once each",
-			refs: []recipe.ComponentRef{
-				{Name: draComponentName},
-				{Name: "nvidia-dra-driver-gpu-ocp"},
-				{Name: gpuOperatorComponentName},
-			},
-			wantWarning: true,
-			wantSubstr:  draComponentName + " schedules its kubelet plugin only on nodes labeled ",
-			wantCount:   2,
-			wantOwners:  []string{draComponentName, "nvidia-dra-driver-gpu-ocp"},
 		},
 		{
 			name: "OpenShift components warn under their own names",
@@ -716,19 +694,6 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 			if len(matched) != wantCount {
 				t.Errorf("emitted %d node-label warnings, want %d; warnings = %v",
 					len(matched), wantCount, matched)
-			}
-			for _, owner := range tt.wantOwners {
-				prefix := owner + " schedules its kubelet plugin"
-				n := 0
-				for _, w := range matched {
-					if strings.Contains(w, prefix) {
-						n++
-					}
-				}
-				if n != 1 {
-					t.Errorf("%s owns %d warnings, want exactly 1; warnings = %v",
-						owner, n, matched)
-				}
 			}
 			if !strings.HasPrefix(got, "Warning: ") {
 				t.Errorf("warning %q lacks the %q prefix used by other bundle warnings", got, "Warning: ")

--- a/pkg/bundler/bundler_dra_eviction_test.go
+++ b/pkg/bundler/bundler_dra_eviction_test.go
@@ -559,6 +559,9 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 		wantWarning bool
 		wantSubstr  string
 		alsoWant    []string
+		// wantCount is the exact number of node-label warnings expected.
+		// Zero means one, the single-DRA-component default.
+		wantCount int
 	}{
 		{
 			name: "both components enabled warns",
@@ -579,6 +582,23 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 			configured:  config.NodeLabel{Key: "example.com/dra-ready", Value: "enabled"},
 			wantWarning: true,
 			wantSubstr:  "nodes labeled example.com/dra-ready=enabled",
+		},
+		{
+			// draEvictionComponentNames collects every matching ref rather
+			// than stopping at the first, so a recipe carrying both DRA
+			// variants yields one warning per component. Nothing else in the
+			// table supplies more than one DRA ref, which left the loop in
+			// warnDRAEvictionNodeLabelRequired unexercised for len > 1 and a
+			// double-emit regression undetectable.
+			name: "both DRA variants warn once each",
+			refs: []recipe.ComponentRef{
+				{Name: draComponentName},
+				{Name: "nvidia-dra-driver-gpu-ocp"},
+				{Name: gpuOperatorComponentName},
+			},
+			wantWarning: true,
+			wantSubstr:  draComponentName + " schedules its kubelet plugin only on nodes labeled ",
+			wantCount:   2,
 		},
 		{
 			name: "OpenShift components warn under their own names",
@@ -660,12 +680,18 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 				t.Fatalf("injectDRAEvictionLabel() error = %v", err)
 			}
 
-			var got string
+			// Collect every matching warning rather than the first: taking
+			// one and breaking cannot tell a correct single emission from a
+			// regression that emits the same warning twice.
+			var matched []string
 			for _, w := range b.warnings {
 				if strings.Contains(w, "kubelet plugin only on nodes labeled") {
-					got = w
-					break
+					matched = append(matched, w)
 				}
+			}
+			var got string
+			if len(matched) > 0 {
+				got = matched[0]
 			}
 
 			if !tt.wantWarning {
@@ -677,6 +703,14 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 
 			if got == "" {
 				t.Fatalf("missing DRA node-label warning; warnings = %v", b.warnings)
+			}
+			wantCount := tt.wantCount
+			if wantCount == 0 {
+				wantCount = 1
+			}
+			if len(matched) != wantCount {
+				t.Errorf("emitted %d node-label warnings, want %d; warnings = %v",
+					len(matched), wantCount, matched)
 			}
 			if !strings.HasPrefix(got, "Warning: ") {
 				t.Errorf("warning %q lacks the %q prefix used by other bundle warnings", got, "Warning: ")

--- a/pkg/bundler/bundler_dra_eviction_test.go
+++ b/pkg/bundler/bundler_dra_eviction_test.go
@@ -562,6 +562,10 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 		// wantCount is the exact number of node-label warnings expected.
 		// Zero means one, the single-DRA-component default.
 		wantCount int
+		// wantOwners names the components that must each own exactly one
+		// warning. Counting alone cannot catch an implementation that emits
+		// one component's warning twice and drops another's.
+		wantOwners []string
 	}{
 		{
 			name: "both components enabled warns",
@@ -599,6 +603,7 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 			wantWarning: true,
 			wantSubstr:  draComponentName + " schedules its kubelet plugin only on nodes labeled ",
 			wantCount:   2,
+			wantOwners:  []string{draComponentName, "nvidia-dra-driver-gpu-ocp"},
 		},
 		{
 			name: "OpenShift components warn under their own names",
@@ -711,6 +716,19 @@ func TestWarnDRAEvictionNodeLabelRequired(t *testing.T) {
 			if len(matched) != wantCount {
 				t.Errorf("emitted %d node-label warnings, want %d; warnings = %v",
 					len(matched), wantCount, matched)
+			}
+			for _, owner := range tt.wantOwners {
+				prefix := owner + " schedules its kubelet plugin"
+				n := 0
+				for _, w := range matched {
+					if strings.Contains(w, prefix) {
+						n++
+					}
+				}
+				if n != 1 {
+					t.Errorf("%s owns %d warnings, want exactly 1; warnings = %v",
+						owner, n, matched)
+				}
 			}
 			if !strings.HasPrefix(got, "Warning: ") {
 				t.Errorf("warning %q lacks the %q prefix used by other bundle warnings", got, "Warning: ")


### PR DESCRIPTION
## Summary

Review follow-up to #2457, addressing the comments left on that PR after it merged. **No shipped behavior changes** — the production warning path is correct as merged; this closes a test blind spot and two documentation nits.

**One reviewed suggestion is deliberately absent.** The proposal to cover the two-DRA-variant warning path was implemented, then removed once it turned out to be unreachable: the bundler swaps in the enabled-only component set before the warning path runs, and the OCP overlay disables the generic DRA component, so production only ever sees `nvidia-dra-driver-gpu-ocp`. Reasoning and the measured evidence are under Motivation below, so it does not need reconstructing from the review thread.

## Motivation / Context

Five review comments landed on #2457 shortly before it merged, so none were addressed in that PR. Three were actionable; two the reviewer resolved themselves.

**The test could not detect a double-emit.** `TestWarnDRAEvictionNodeLabelRequired` scanned `b.warnings` for the first entry matching `kubelet plugin only on nodes labeled`, assigned it, and `break`ed. Presence was asserted; count never was. A regression emitting the same warning twice for one component would have passed.

Not a live defect. One DRA component yields one warning, which is what happens now; the gap is detection of a *future* regression, not current behavior.

A review round proposed also covering the multi-component loop, since `draEvictionComponentNames` appends every matching ref rather than stopping at the first. That case was added and then removed: the bundler reassigns `recipeResult` to the enabled-only set before the warning path runs, so a resolved recipe never carries both DRA variants. Checked against a real OCP composition — the raw builder result yields `[nvidia-dra-driver-gpu nvidia-dra-driver-gpu-ocp]`, but the filtered result the bundler passes yields only `[nvidia-dra-driver-gpu-ocp]`, because the OCP overlay sets the generic component to `enabled: false`. The loop is unreachable with `len > 1`, so the case modeled a state production cannot produce.

Related: #2456, #2457.

## Type of Change

- [x] Test coverage
- [x] Documentation

## Component(s) Affected

- `pkg/bundler` (tests only)
- `docs/user/bundling.md`, `docs/integrator/aks-gpu-setup.md`, `docs/integrator/gke-gpu-setup.md`

## Implementation Notes

**Count assertion.** The scan collects all matching warnings instead of the first. A `wantCount` field defaults to 1 (the single-component case) so existing rows need no change, and the assertion reports the actual total on failure.

**Documentation.** One line in each of the AKS and GKE guides ran 118 characters inside a paragraph wrapped at 76–78, starting a new sentence at the tail of a soft-wrapped line; both are re-wrapped to the surrounding register. Three phrases in `bundling.md` — "worse than uniform failure", "the more dangerous shape", "bites hardest" — are replaced with neutral phrasing that keeps the same claim. The replacement wording asserts no frequency: #2456 records one observed upgrade plus node lifecycle as the durable risk, which does not establish that upgrades are the most common path.

## Testing

```bash
golangci-lint run -c .golangci.yaml ./pkg/bundler/...   # 0 issues
go test ./pkg/bundler/ -count=1                          # ok
```

**Control, not just a passing test.** Injecting a duplicate `b.appendWarning(msg)` into `warnDRAEvictionNodeLabelRequired` fails `both components enabled warns` and `configured label appears in the warning` with `emitted 2 node-label warnings, want 1`; both passed before this change. Reverting the injection returns the suite to green. That is the regression the count assertion exists to catch.

`make qualify` was not run to completion — `tools/api-diff_test.sh` fails in this environment with `mktemp: Operation not permitted`. The change is test-and-docs only, with no production code touched, so lint and the full `pkg/bundler` package are the checks that match the change.

## Risk Assessment

Minimal. No production code is modified; the diff is one test file and three documentation files. The documentation edits change wrapping and wording, not instructions — every command, label, and path is unchanged.

## Checklist

- [x] Commits signed (`-S`) and signed off (`-s`)
- [x] Lint clean on affected packages
- [x] Tests pass, and the new assertion is verified against an injected regression
- [x] No shipped behavior change


