### PR TITLE
feat(api): gate the REST contract against a committed baseline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,7 +38,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
 unset GITLAB_TOKEN
 
 # Development workflow
-make qualify      # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff (run before PR)
+make qualify      # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff + openapi-diff (run before PR)
 make test         # Unit tests with -race
 make lint         # golangci-lint + yamllint
 make scan         # Grype vulnerability scan
@@ -558,7 +558,7 @@ Process and unique findings below; the rule sections above (Error Wrapping, Cont
 
 ## Pull Request Requirements
 
-**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers coverage-gated tests, linting (golangci-lint + yamllint + license headers, agents sync, docs filename/MDX gates, chart-version pins), tuning-check, e2e, vulnerability scan, license allowlist check, and API compatibility (api-diff). Do not substitute a subset of commands — `make qualify` is the closest local equivalent of the CI gate. A few checks run only in CI (e.g. the lychee docs link check on `docs/**` PRs, CodeQL, and the GPU test lanes), so a green local `qualify` does not guarantee every CI job passes.
+**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers coverage-gated tests, linting (golangci-lint + yamllint + license headers, agents sync, docs filename/MDX gates, chart-version pins), tuning-check, e2e, vulnerability scan, license allowlist check, API compatibility (api-diff), and REST contract compatibility (openapi-diff). Do not substitute a subset of commands — `make qualify` is the closest local equivalent of the CI gate. A few checks run only in CI (e.g. the lychee docs link check on `docs/**` PRs, CodeQL, and the GPU test lanes), so a green local `qualify` does not guarantee every CI job passes.
 
 **Mandatory lint gate for Go changes:** If your PR changes any `.go` files, you MUST run `golangci-lint run -c .golangci.yaml` on each affected package path (e.g., `./pkg/recipe/...`, `./cmd/aicr/...`, `./tests/chainsaw/...`) and confirm zero issues before creating or pushing the PR. For a full module scan, use `./...`. Do not rely on CI to catch lint failures — fix them locally first. This applies even to PRs labeled as "documentation only" if they include Go code changes.
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -24,6 +24,7 @@ executable bits or `./script.sh` invocation.
 - `helm_version` (required): Helm version from `load-versions`
 - `setup_envtest_version` (required): setup-envtest version from `load-versions`
 - `apidiff_version` (optional): apidiff version from `load-versions`; when set, installs apidiff and runs `make api-diff` (default: empty, which skips both steps)
+- `oasdiff_version` (**required**): oasdiff version from `load-versions`; installs oasdiff before `make test` and runs `make openapi-diff` after. Not optional, because `make test` runs `tools/openapi-diff_test.sh`, which fails in CI when oasdiff is absent rather than skipping — the REST contract gate cannot be silently unverified
 
 Callers that set `apidiff_version` must check out full history with
 `fetch-depth: 0` so `make api-diff` can resolve a reachable stable release tag.
@@ -385,6 +386,7 @@ jobs:
           helm_version: ${{ steps.versions.outputs.helm }}
           setup_envtest_version: ${{ steps.versions.outputs.setup_envtest }}
           apidiff_version: ${{ steps.versions.outputs.apidiff }}
+          oasdiff_version: ${{ steps.versions.outputs.oasdiff }}
           coverage_report: 'true'
       - uses: ./.github/actions/go-lint
         with:
@@ -409,6 +411,7 @@ jobs:
           go_version: ${{ steps.versions.outputs.go }}
           helm_version: ${{ steps.versions.outputs.helm }}
           apidiff_version: ${{ steps.versions.outputs.apidiff }}
+          oasdiff_version: ${{ steps.versions.outputs.oasdiff }}
       - uses: ./.github/actions/go-build-release
         id: release
         with:

--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -34,6 +34,12 @@ inputs:
     description: 'Optional apidiff version pinned in .settings.yaml (linting.apidiff, via load-versions); leave empty to skip the SDK API compatibility check'
     required: false
     default: ''
+  oasdiff_version:
+    # Required rather than optional: make test runs tools/openapi-diff_test.sh,
+    # which fails in CI when oasdiff is absent rather than skipping, so the REST
+    # contract gate cannot be left silently unverified.
+    description: 'oasdiff version pinned in .settings.yaml (linting.oasdiff, via load-versions)'
+    required: true
   setup_envtest_version:
     description: 'setup-envtest version pinned in .settings.yaml (testing_tools.setup_envtest, via load-versions)'
     required: true
@@ -104,6 +110,19 @@ runs:
         set -euo pipefail
         GOFLAGS= go install "golang.org/x/exp/cmd/apidiff@${APIDIFF_VERSION}"
 
+    # Installed before `make test`, not after: test-shell runs
+    # tools/openapi-diff_test.sh, which exercises the real oasdiff rather than a
+    # stub and fails in CI when it is missing.
+    - name: Install OpenAPI-diff tool
+      shell: bash
+      env:
+        OASDIFF_VERSION: ${{ inputs.oasdiff_version }}
+      run: |
+        set -euo pipefail
+        [ -n "${OASDIFF_VERSION}" ] \
+          || { echo "oasdiff_version input is required" >&2; exit 1; }
+        GOFLAGS= go install "github.com/oasdiff/oasdiff@${OASDIFF_VERSION}"
+
     - name: Run Tests with Coverage
       shell: bash
       run: make test
@@ -119,3 +138,7 @@ runs:
       if: inputs.apidiff_version != ''
       shell: bash
       run: make api-diff
+
+    - name: Check REST contract compatibility
+      shell: bash
+      run: make openapi-diff

--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -34,6 +34,9 @@ outputs:
   apidiff:
     description: 'API-diff version pinned in .settings.yaml'
     value: ${{ steps.versions.outputs.apidiff }}
+  oasdiff:
+    description: 'oasdiff version from .settings.yaml (linting.oasdiff)'
+    value: ${{ steps.versions.outputs.oasdiff }}
   addlicense:
     description: 'addlicense version'
     value: ${{ steps.versions.outputs.addlicense }}
@@ -178,6 +181,7 @@ runs:
         # Linting
         echo "golangci_lint=$(yq eval '.linting.golangci_lint' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "apidiff=$(yq eval '.linting.apidiff' .settings.yaml)" >> $GITHUB_OUTPUT
+        echo "oasdiff=$(yq eval '.linting.oasdiff' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "yamllint=$(yq eval '.linting.yamllint' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "addlicense=$(yq eval '.linting.addlicense' .settings.yaml)" >> $GITHUB_OUTPUT
         echo "go_licenses=$(yq eval '.linting.go_licenses' .settings.yaml)" >> $GITHUB_OUTPUT
@@ -239,6 +243,7 @@ runs:
         echo "  crane: ${{ steps.versions.outputs.crane }}"
         echo "  golangci_lint: ${{ steps.versions.outputs.golangci_lint }}"
         echo "  apidiff: ${{ steps.versions.outputs.apidiff }}"
+        echo "  oasdiff: ${{ steps.versions.outputs.oasdiff }}"
         echo "  yamllint: ${{ steps.versions.outputs.yamllint }}"
         echo "  addlicense: ${{ steps.versions.outputs.addlicense }}"
         echo "  go_licenses: ${{ steps.versions.outputs.go_licenses }}"

--- a/.github/workflows/qualification.yaml
+++ b/.github/workflows/qualification.yaml
@@ -67,6 +67,7 @@ jobs:
           setup_envtest_version: ${{ steps.versions.outputs.setup_envtest }}
           helm_version: ${{ steps.versions.outputs.helm }}
           apidiff_version: ${{ steps.versions.outputs.apidiff }}
+          oasdiff_version: ${{ steps.versions.outputs.oasdiff }}
 
   lint:
     name: Lint

--- a/.settings.yaml
+++ b/.settings.yaml
@@ -31,6 +31,8 @@ build_tools:
 linting:
   # renovate: datasource=go depName=golang.org/x/exp depType=linting
   apidiff: 'v0.0.0-20260824195058-e88cd73687aa'
+  # renovate: datasource=github-releases depName=oasdiff/oasdiff depType=linting
+  oasdiff: 'v1.29.1'
   # renovate: datasource=github-releases depName=golangci/golangci-lint depType=linting
   golangci_lint: 'v2.13.1'
   # renovate: datasource=pypi depName=yamllint depType=linting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ NVIDIA AI Cluster Runtime (AICR) generates validated GPU-accelerated Kubernetes 
 unset GITLAB_TOKEN
 
 # Development workflow
-make qualify      # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff (run before PR)
+make qualify      # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff + openapi-diff (run before PR)
 make test         # Unit tests with -race
 make lint         # golangci-lint + yamllint
 make scan         # Grype vulnerability scan
@@ -558,7 +558,7 @@ Process and unique findings below; the rule sections above (Error Wrapping, Cont
 
 ## Pull Request Requirements
 
-**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers coverage-gated tests, linting (golangci-lint + yamllint + license headers, agents sync, docs filename/MDX gates, chart-version pins), tuning-check, e2e, vulnerability scan, license allowlist check, and API compatibility (api-diff). Do not substitute a subset of commands — `make qualify` is the closest local equivalent of the CI gate. A few checks run only in CI (e.g. the lychee docs link check on `docs/**` PRs, CodeQL, and the GPU test lanes), so a green local `qualify` does not guarantee every CI job passes.
+**Pre-push checklist:** Always run `make qualify` before pushing. This is the CI-equivalent gate that covers coverage-gated tests, linting (golangci-lint + yamllint + license headers, agents sync, docs filename/MDX gates, chart-version pins), tuning-check, e2e, vulnerability scan, license allowlist check, API compatibility (api-diff), and REST contract compatibility (openapi-diff). Do not substitute a subset of commands — `make qualify` is the closest local equivalent of the CI gate. A few checks run only in CI (e.g. the lychee docs link check on `docs/**` PRs, CodeQL, and the GPU test lanes), so a green local `qualify` does not guarantee every CI job passes.
 
 **Mandatory lint gate for Go changes:** If your PR changes any `.go` files, you MUST run `golangci-lint run -c .golangci.yaml` on each affected package path (e.g., `./pkg/recipe/...`, `./cmd/aicr/...`, `./tests/chainsaw/...`) and confirm zero issues before creating or pushing the PR. For a full module scan, use `./...`. Do not rely on CI to catch lint failures — fix them locally first. This applies even to PRs labeled as "documentation only" if they include Go code changes.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,6 +44,7 @@ make qualify        # Full check: test-coverage + lint + tuning-check + e2e + sc
 | Tool | Purpose |
 |------|---------|
 | golangci-lint | Go linting |
+| oasdiff | REST contract breaking-change detection (`make openapi-diff`) |
 | yamllint | YAML linting (requires Python/pip) |
 | addlicense | License header management |
 | grype | Vulnerability scanning |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ make lint           # Run linters
 make build          # Build binaries
 
 # 3. Before submitting PR
-make qualify        # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff
+make qualify        # Full check: test-coverage + lint + tuning-check + e2e + scan + license-check + api-diff + openapi-diff
 ```
 
 ## Prerequisites
@@ -262,7 +262,7 @@ Before submitting a PR, run everything:
 make qualify
 ```
 
-This runs: `test-coverage` → `lint` → `tuning-check` → `e2e` → `scan` → `license-check` → `api-diff`
+This runs: `test-coverage` → `lint` → `tuning-check` → `e2e` → `scan` → `license-check` → `api-diff` → `openapi-diff`
 
 ## Local Kubernetes Development
 
@@ -465,7 +465,7 @@ See [kwok/README.md](kwok/README.md) for adding recipes, profiles, and troublesh
 
 | Target | Description |
 |--------|-------------|
-| `make qualify` | Full qualification (test-coverage, lint, tuning-check, e2e, scan, license-check, api-diff) |
+| `make qualify` | Full qualification (test-coverage, lint, tuning-check, e2e, scan, license-check, api-diff, openapi-diff) |
 | `make test` | Unit tests with race detector and coverage |
 | `make test-coverage` | Tests with coverage threshold (from `.settings.yaml` `quality.coverage_threshold`) |
 | `make lint` | Lint Go and YAML; verify license headers, agents sync, docs filename/MDX gates, and chart-version pins |

--- a/Makefile
+++ b/Makefile
@@ -382,6 +382,15 @@ openapi-baseline: ## Accepts the current REST spec as the frozen contract (regen
 		|| { rm -f api/aicr/v1/server.baseline.yaml.tmp; \
 		     echo "ERROR: no 'openapi:' key in api/aicr/v1/server.yaml; refusing to write a header-only baseline" >&2; \
 		     exit 1; }
+# The openapi: guard above proves a marker exists, not that the result is a
+# document oasdiff can read. Validate with the actual consumer -- a self-diff
+# loads and parses the file -- so a spec that is malformed below that line
+# cannot replace the committed baseline.
+	@oasdiff breaking api/aicr/v1/server.baseline.yaml.tmp \
+		api/aicr/v1/server.baseline.yaml.tmp >/dev/null 2>&1 \
+		|| { rm -f api/aicr/v1/server.baseline.yaml.tmp; \
+		     echo "ERROR: generated baseline is not a document oasdiff can load; refusing to replace the committed baseline" >&2; \
+		     exit 1; }
 	@mv api/aicr/v1/server.baseline.yaml.tmp api/aicr/v1/server.baseline.yaml
 	@echo "Baseline updated."
 

--- a/Makefile
+++ b/Makefile
@@ -377,13 +377,16 @@ openapi-baseline: ## Accepts the current REST spec as the frozen contract (regen
 # spec's own license header is dropped because the baseline carries its own.
 	@awk '/^[^#]/ && NF {exit} {print}' api/aicr/v1/server.baseline.yaml \
 		> api/aicr/v1/server.baseline.yaml.tmp
-	@awk 'p {print} /^openapi:/ {if (!p) {p=1; print}}' api/aicr/v1/server.yaml \
-		>> api/aicr/v1/server.baseline.yaml.tmp
+	@awk 'p {print} /^openapi:/ && !p {p=1; print} END {exit !p}' api/aicr/v1/server.yaml \
+		>> api/aicr/v1/server.baseline.yaml.tmp \
+		|| { rm -f api/aicr/v1/server.baseline.yaml.tmp; \
+		     echo "ERROR: no 'openapi:' key in api/aicr/v1/server.yaml; refusing to write a header-only baseline" >&2; \
+		     exit 1; }
 	@mv api/aicr/v1/server.baseline.yaml.tmp api/aicr/v1/server.baseline.yaml
 	@echo "Baseline updated."
 
 .PHONY: qualify
-qualify: test-coverage lint tuning-check coverage-check e2e scan license-check api-diff openapi-diff ## Qualifies the codebase (test-coverage, lint, tuning-check, coverage-check, e2e, scan, API compatibility)
+qualify: test-coverage lint tuning-check coverage-check e2e scan license-check api-diff openapi-diff ## Qualifies the codebase (test-coverage, lint, tuning-check, coverage-check, e2e, scan, SDK and REST API compatibility)
 	@echo "Codebase qualification completed"
 
 .PHONY: bom

--- a/Makefile
+++ b/Makefile
@@ -363,8 +363,27 @@ scan: ## Scans for vulnerabilities with grype
 api-diff: ## Checks pkg/client/v1 and transparent-alias target compatibility against the latest stable release
 	@bash tools/api-diff
 
+.PHONY: openapi-diff
+openapi-diff: ## Checks the REST contract in api/aicr/v1/server.yaml against its committed baseline
+	@bash tools/openapi-diff
+
+.PHONY: openapi-baseline
+openapi-baseline: ## Accepts the current REST spec as the frozen contract (regenerates the baseline)
+	@printf '%s\n' "Regenerating api/aicr/v1/server.baseline.yaml from api/aicr/v1/server.yaml." \
+		"This accepts every current difference into the frozen contract, so the" \
+		"resulting diff is the change under review -- read it before committing."
+# The header is taken from the existing baseline rather than a hardcoded line
+# count, so editing the explanatory comment cannot make regeneration lossy. The
+# spec's own license header is dropped because the baseline carries its own.
+	@awk '/^[^#]/ && NF {exit} {print}' api/aicr/v1/server.baseline.yaml \
+		> api/aicr/v1/server.baseline.yaml.tmp
+	@awk 'p {print} /^openapi:/ {if (!p) {p=1; print}}' api/aicr/v1/server.yaml \
+		>> api/aicr/v1/server.baseline.yaml.tmp
+	@mv api/aicr/v1/server.baseline.yaml.tmp api/aicr/v1/server.baseline.yaml
+	@echo "Baseline updated."
+
 .PHONY: qualify
-qualify: test-coverage lint tuning-check coverage-check e2e scan license-check api-diff ## Qualifies the codebase (test-coverage, lint, tuning-check, coverage-check, e2e, scan, API compatibility)
+qualify: test-coverage lint tuning-check coverage-check e2e scan license-check api-diff openapi-diff ## Qualifies the codebase (test-coverage, lint, tuning-check, coverage-check, e2e, scan, API compatibility)
 	@echo "Codebase qualification completed"
 
 .PHONY: bom

--- a/api/aicr/v1/openapi-diff-exceptions.yaml
+++ b/api/aicr/v1/openapi-diff-exceptions.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Intentional breaking changes to the frozen REST contract, checked by
+# `make openapi-diff` against api/aicr/v1/server.baseline.yaml.
+#
+# Each entry needs:
+#   id      oasdiff rule id, e.g. api-path-removed-without-deprecation
+#   path    optional operation path to narrow the entry to one endpoint.
+#           Omit only when the break genuinely applies to every path -- an
+#           unnarrowed entry pre-approves the same class of break anywhere.
+#   reason  why this break is acceptable, and when it goes away.
+#
+# An entry that matches no reported breaking change FAILS the gate. That is
+# deliberate: a stale acknowledgement silently pre-approves the break coming
+# back, which is the failure this file exists to prevent. Same contract as
+# pkg/client/v1/api-diff-exceptions.yaml.
+#
+# The scheduled ADR-022 apiVersion removals in v0.22 (#2416) and v0.23 (#2417)
+# are the expected future occupants: they are planned narrowings of an enum,
+# and recording them here is what the acceptance criteria mean by representing
+# a transition explicitly rather than disabling the gate.
+acknowledgements: []

--- a/api/aicr/v1/server.baseline.yaml
+++ b/api/aicr/v1/server.baseline.yaml
@@ -496,13 +496,14 @@ paths:
       summary: Generate a bundle from a legacy or profiled recipe
       operationId: createBundle
       description: >
-        Uses the same query parameters and ZIP response as POST /v1/bundle.
-        The body is an already-selected RecipeResult, so this route has no
-        profile-selection field. Default recipes stamped aicr.run/v1alpha2,
-        aicr.run/v1, or omitting apiVersion are accepted; profile recipes
-        stamped aicr.run/v1alpha3 or aicr.run/v1beta2 are decoded strictly.
-        Content-Type must be application/json or application/x-yaml.
-        Query parameter details are documented on POST /v1/bundle.
+        Renders a deployment bundle and returns it as a ZIP archive. The body is
+        an already-selected RecipeResult, so this route has no profile-selection
+        field; select the profile when resolving the recipe. Default recipes
+        stamped aicr.run/v1alpha2, aicr.run/v1, or omitting apiVersion are
+        accepted; profile recipes stamped aicr.run/v1alpha3 or aicr.run/v1beta2
+        are decoded strictly. Content-Type must be application/json or
+        application/x-yaml. The query parameters below control deployer, value
+        overrides, node scheduling, workload gating and attestation.
       parameters:
         - $ref: "#/components/parameters/RequestId"
         - $ref: "#/components/parameters/BundleComponents"
@@ -1061,10 +1062,12 @@ components:
           description: Human-readable error message
           example: "Invalid recipe query"
         details:
-          type: object
+          # OpenAPI 3.1 has no `nullable` keyword; it is JSON Schema, where null
+          # is expressed in the type. With `type: object` alone a null details
+          # field would not validate against the document the server emits.
+          type: [object, "null"]
           additionalProperties: true
           description: Additional context-specific error details
-          nullable: true
         requestId:
           type: string
           format: uuid

--- a/api/aicr/v1/server.baseline.yaml
+++ b/api/aicr/v1/server.baseline.yaml
@@ -1,0 +1,1861 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# GENERATED SNAPSHOT -- DO NOT EDIT BY HAND.
+#
+# The frozen REST contract that `make openapi-diff` compares against (issue
+# #2112, ROADMAP section 1). Regenerate with `make openapi-baseline` only when
+# accepting the current spec as the new contract, and expect the resulting diff
+# to be read in review: moving this file is how a change becomes part of the
+# frozen surface.
+#
+# Additive changes do not require a refresh -- the gate passes and the baseline
+# may lag until the next release. A breaking change fails the gate and needs
+# either an entry in openapi-diff-exceptions.yaml (for a scheduled ADR-022
+# transition) or a deliberate refresh here.
+openapi: 3.1.0
+info:
+  title: AICR API Server - AICR Recipe API
+  version: 1.0.0
+  description: >
+    Returns optimized system configuration recipes (component references and deployment constraints)
+    for a given combination of platform parameters (service, accelerator, OS, intent, nodes).
+
+    The recipe system uses a criteria-based overlay architecture where base configurations are layered
+    with environment-specific overlays based on criteria matching.
+
+    The API server exposes recipe generation and bundle creation. The following CLI-only
+    capabilities are intentionally excluded because they require direct cluster access,
+    long-running Kubernetes Jobs, interactive authentication, or local filesystem operations:
+
+    - **Snapshot capture** (`aicr snapshot`) — deploys an agent Job to collect cluster state.
+
+    - **Validation** (`aicr validate`) — deploys per-check Jobs and evaluates constraints
+      against a live cluster.
+
+    - **Bundle verification** (`aicr verify`) — verifies attestation signatures and checksums
+      from a local bundle directory.
+
+    - **Trust management** (`aicr trust update`) — updates the local Sigstore TUF root cache.
+
+    - **Interactive Sigstore attestation** (`aicr bundle --attest` with browser-based OIDC):
+      the interactive, user-authenticated signing flow is CLI-only. The API server instead
+      offers non-interactive server-side attestation: `POST /v1/bundle?attest=true`
+      returns a signed bundle, with the server signing as itself using its operator-configured
+      KMS key or private-Sigstore keyless identity. No signing identity is ever taken from the
+      request. See the `attest` query parameter on POST /v1/bundle.
+
+    - **OCI registry push** (`aicr bundle --output oci://...`) — pushes bundle artifacts to
+      a container registry.
+
+    - **Snapshot-based recipe generation** (`aicr recipe --snapshot`) — evaluates constraints
+      against snapshot data to produce a cluster-aware recipe.
+
+    - **External data overlays** (`aicr recipe --data`, `aicr bundle --data`) — overlays
+      custom components and overlays from a local directory onto embedded recipe data.
+
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+tags:
+  - name: Recipes
+    description: Configuration recipe operations
+  - name: Bundles
+    description: Deployment bundle generation
+  - name: Health
+    description: Service health and readiness checks
+
+paths:
+  /:
+    get:
+      tags: [Health]
+      summary: Get service information and available routes
+      operationId: getRoot
+      description: Returns service name, version, and list of available API routes
+      responses:
+        "200":
+          description: Service information
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [service, version, routes]
+                properties:
+                  service:
+                    type: string
+                    example: aicrd
+                  version:
+                    type: string
+                    example: v1.0.0
+                  routes:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - /v1/recipe
+                      - /v1/query
+                      - /v1/bundle
+
+  /v1/recipe:
+    get:
+      tags: [Recipes]
+      summary: Resolve a configured recipe
+      operationId: getRecipe
+      description: >
+        Resolves criteria with optional profile and Slurm accounting selections.
+        An omitted profile applies the declaration's required default; an
+        omitted Slurm accounting mode defaults to disabled. Unknown query
+        parameters and conflicting repeated values are rejected.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/Service"
+        - $ref: "#/components/parameters/Accelerator"
+        - $ref: "#/components/parameters/GPUAlias"
+        - $ref: "#/components/parameters/Intent"
+        - $ref: "#/components/parameters/OS"
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Nodes"
+        - $ref: "#/components/parameters/ProfileSelection"
+        - $ref: "#/components/parameters/SlurmAccountingMode"
+      responses:
+        "200":
+          description: Resolved legacy, profile-bearing, or accounting-configured recipe
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecipeResponse"
+        "400":
+          description: Invalid criteria, profile selection, or query parameter
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags: [Recipes]
+      summary: Resolve a configured recipe from a strict envelope
+      operationId: createRecipe
+      description: >
+        Accepts a strict criteria/profile envelope and an optional profile
+        query parameter. Matching query and envelope selections are accepted;
+        conflicting selections, unknown fields, unknown query parameters, and
+        trailing JSON or YAML documents are rejected. Content-Type must be
+        application/json or application/x-yaml.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/ProfileSelection"
+        - $ref: "#/components/parameters/SlurmAccountingMode"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecipeRequest"
+          application/x-yaml:
+            schema:
+              $ref: "#/components/schemas/RecipeRequest"
+      responses:
+        "200":
+          description: Resolved legacy or profile-bearing recipe
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecipeResponse"
+        "400":
+          description: Invalid request envelope, criteria, or profile selection
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body exceeds the maximum allowed size
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/query:
+    get:
+      tags: [Recipes]
+      summary: Query a configured hydrated recipe
+      operationId: getQuery
+      description: >
+        Resolves criteria and an optional profile, hydrates the recipe, and
+        returns the value at selector. Unknown query parameters are rejected.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/Service"
+        - $ref: "#/components/parameters/Accelerator"
+        - $ref: "#/components/parameters/GPUAlias"
+        - $ref: "#/components/parameters/Intent"
+        - $ref: "#/components/parameters/OS"
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Nodes"
+        - $ref: "#/components/parameters/ProfileSelection"
+        - $ref: "#/components/parameters/SlurmAccountingMode"
+        - $ref: "#/components/parameters/Selector"
+      responses:
+        "200":
+          description: Selected scalar, object, or array
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                description: The value at the selector path
+        "400":
+          description: Invalid criteria, profile selection, or query parameter
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Selector path not found
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags: [Recipes]
+      summary: Query a configured recipe from a strict envelope
+      operationId: createQuery
+      description: >
+        Accepts a strict criteria/profile/selector envelope and an optional
+        profile query parameter. Matching query and envelope selections are
+        accepted; conflicting selections, unknown fields, unknown query
+        parameters, and trailing JSON or YAML documents are rejected.
+        Content-Type must be application/json or application/x-yaml.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/ProfileSelection"
+        - $ref: "#/components/parameters/SlurmAccountingMode"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueryRequest"
+          application/x-yaml:
+            schema:
+              $ref: "#/components/schemas/QueryRequest"
+      responses:
+        "200":
+          description: Selected scalar, object, or array
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Cache-Control:
+              $ref: "#/components/headers/CacheControl"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                description: The value at the selector path
+        "400":
+          description: Invalid request envelope, criteria, or profile selection
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body exceeds the maximum allowed size
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Selector path not found
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitReset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Recipe resolution or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/bundle:
+    post:
+      tags: [Bundles]
+      summary: Generate a bundle from a legacy or profiled recipe
+      operationId: createBundle
+      description: >
+        Uses the same query parameters and ZIP response as POST /v1/bundle.
+        The body is an already-selected RecipeResult, so this route has no
+        profile-selection field. Default recipes stamped aicr.run/v1alpha2,
+        aicr.run/v1, or omitting apiVersion are accepted; profile recipes
+        stamped aicr.run/v1alpha3 or aicr.run/v1beta2 are decoded strictly.
+        Content-Type must be application/json or application/x-yaml.
+        Query parameter details are documented on POST /v1/bundle.
+      parameters:
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/BundleComponents"
+        - $ref: "#/components/parameters/BundleSet"
+        - $ref: "#/components/parameters/BundleDynamic"
+        - $ref: "#/components/parameters/SystemNodeSelector"
+        - $ref: "#/components/parameters/SystemNodeToleration"
+        - $ref: "#/components/parameters/AcceleratedNodeSelector"
+        - $ref: "#/components/parameters/AcceleratedNodeToleration"
+        - $ref: "#/components/parameters/DRAEvictionNodeLabel"
+        - $ref: "#/components/parameters/BundleDeployer"
+        - $ref: "#/components/parameters/BundleRepo"
+        - $ref: "#/components/parameters/WorkloadGate"
+        - $ref: "#/components/parameters/WorkloadSelector"
+        - $ref: "#/components/parameters/BundleNodes"
+        - $ref: "#/components/parameters/VendorCharts"
+        - $ref: "#/components/parameters/Serial"
+        - $ref: "#/components/parameters/AppName"
+        - $ref: "#/components/parameters/Attest"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BundleRecipeRequest"
+          application/x-yaml:
+            schema:
+              $ref: "#/components/schemas/BundleRecipeRequest"
+      responses:
+        "200":
+          description: ZIP archive containing generated bundle artifacts
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+            Content-Disposition:
+              schema:
+                type: string
+                example: 'attachment; filename="bundles.zip"'
+              description: Indicates the response should be downloaded as a file
+            X-Bundle-Files:
+              schema:
+                type: integer
+              description: Total number of files in the bundle
+              example: 12
+            X-Bundle-Size:
+              schema:
+                type: integer
+              description: Total size of all files in bytes (uncompressed)
+              example: 45678
+            X-Bundle-Duration:
+              schema:
+                type: string
+              description: Time taken to generate bundles
+              example: "1.234s"
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: Invalid Content-Type, recipe, profile lock violation, or bundle option
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication failed while pulling a vendored chart
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: A requested vendored chart was not found
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body exceeds the maximum allowed size
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until retry allowed
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: A required bundling dependency or upstream service is unavailable
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Bundle generation or an upstream operation timed out
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestIdResponse"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /health:
+    get:
+      tags: [Health]
+      summary: Health check endpoint
+      operationId: healthCheck
+      description: Returns the health status of the service
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, timestamp]
+                properties:
+                  status:
+                    type: string
+                    enum: [healthy]
+                    example: healthy
+                  timestamp:
+                    type: string
+                    format: date-time
+                    description: ISO 8601 timestamp of the health check
+                  reason:
+                    type: string
+                    description: Optional reason for status
+
+  /ready:
+    get:
+      tags: [Health]
+      summary: Readiness check endpoint
+      operationId: readinessCheck
+      description: Returns whether the service is ready to serve traffic
+      responses:
+        "200":
+          description: Service is ready to serve traffic
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, timestamp]
+                properties:
+                  status:
+                    type: string
+                    enum: [ready]
+                    example: ready
+                  timestamp:
+                    type: string
+                    format: date-time
+                    description: ISO 8601 timestamp of the readiness check
+                  reason:
+                    type: string
+                    description: Optional reason for status
+        "503":
+          description: Service is not ready
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, timestamp]
+                properties:
+                  status:
+                    type: string
+                    enum: [not_ready]
+                    example: not_ready
+                  timestamp:
+                    type: string
+                    format: date-time
+                    description: ISO 8601 timestamp of the readiness check
+                  reason:
+                    type: string
+                    example: "service is initializing"
+  /metrics:
+    head:
+      tags: [Health]
+      summary: Prometheus metrics endpoint (headers only)
+      operationId: headMetrics
+      description: >-
+        Same as GET but returns headers only. Declared because RFC 9110
+        section 9.1 makes GET and HEAD mandatory for a general-purpose
+        server, and some monitoring probes reach /metrics with HEAD.
+      responses:
+        "200":
+          description: Headers for the Prometheus metrics response
+    get:
+      tags: [Health]
+      summary: Prometheus metrics endpoint
+      operationId: getMetrics
+      description: Returns Prometheus-formatted metrics including HTTP request counts, durations, and rate limiting statistics
+      responses:
+        "200":
+          description: Prometheus metrics in text format
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: |
+                  # HELP aicr_http_requests_total Total number of HTTP requests
+                  # TYPE aicr_http_requests_total counter
+                  aicr_http_requests_total{method="GET",path="/v1/recipe",status="200"} 42
+components:
+  headers:
+    RequestIdResponse:
+      schema:
+        type: string
+        format: uuid
+      description: Server-assigned or echoed request ID for tracing
+    CacheControl:
+      schema:
+        type: string
+      description: Cache directives for CDN/client caching
+      example: "public, max-age=600"
+    RateLimitLimit:
+      schema:
+        type: integer
+      description: Request quota in current window
+      example: 100
+    RateLimitRemaining:
+      schema:
+        type: integer
+      description: Remaining requests in current window
+      example: 95
+    RateLimitReset:
+      schema:
+        type: integer
+      description: Unix timestamp when quota resets
+      example: 1705318200
+
+  parameters:
+    RequestId:
+      name: X-Request-Id
+      in: header
+      required: false
+      description: Client-provided request ID for tracing.
+      schema:
+        type: string
+        format: uuid
+    Service:
+      name: service
+      in: query
+      required: false
+      description: Kubernetes service/environment type.
+      schema:
+        type: string
+        enum: [eks, gke, aks, oke, ocp, kind, lke, bcm, metal3, any]
+        default: any
+    Accelerator:
+      name: accelerator
+      in: query
+      required: false
+      description: GPU/accelerator type.
+      schema:
+        type: string
+        enum: [h100, h200, gb200, gb300, b200, a100, l40, l40s, rtx-pro-6000, any]
+        default: any
+    GPUAlias:
+      name: gpu
+      in: query
+      required: false
+      description: Backward-compatible alias for accelerator.
+      schema:
+        type: string
+        enum: [h100, h200, gb200, gb300, b200, a100, l40, l40s, rtx-pro-6000, any]
+        default: any
+    Intent:
+      name: intent
+      in: query
+      required: false
+      description: Workload intent.
+      schema:
+        type: string
+        enum: [training, inference, any]
+        default: any
+    OS:
+      name: os
+      in: query
+      required: false
+      description: GPU node operating system.
+      schema:
+        type: string
+        enum: [ubuntu, rhel, cos, amazonlinux, ol, talos, any]
+        default: any
+    Platform:
+      name: platform
+      in: query
+      required: false
+      description: Platform/framework type.
+      schema:
+        type: string
+        enum: [dynamo, kubeflow, nim, runai, slurm, any]
+        default: any
+    Nodes:
+      name: nodes
+      in: query
+      required: false
+      description: Number of GPU nodes (0 means unspecified).
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    ProfileSelection:
+      name: profile
+      in: query
+      required: false
+      description: >
+        Configuration profile selection in exact name=value form. Omission
+        applies the declaration's required default.
+      schema:
+        type: string
+        pattern: "^$|^[A-Za-z0-9._-]+=[A-Za-z0-9._-]+$"
+    SlurmAccountingMode:
+      name: slurmAccountingMode
+      in: query
+      required: false
+      description: Slurm accounting database ownership mode. Valid only when platform=slurm.
+      schema:
+        type: string
+        enum: [disabled, customer-managed, aicr-provided]
+        default: disabled
+    Selector:
+      name: selector
+      in: query
+      required: true
+      description: Dot-delimited path; empty returns the hydrated recipe.
+      schema:
+        type: string
+    BundleComponents:
+      name: bundlers
+      in: query
+      required: false
+      description: Comma-delimited enabled component names to include.
+      schema:
+        type: string
+    BundleSet:
+      name: set
+      in: query
+      required: false
+      description: >-
+        Repeatable component:path=value override. Rejected with HTTP 400
+        when the component is absent from the generated bundle (scalar
+        enabled=false exempt on a declared component).
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    BundleDynamic:
+      name: dynamic
+      in: query
+      required: false
+      description: >-
+        Repeatable install-time component:path declaration. Rejected with
+        HTTP 400 when the component is absent from the generated bundle;
+        no path is exempt. Certain gate- or contract-owned paths on present
+        components are also rejected (driver-ownership paths, GPU
+        allocation-policy keys, the DRA eviction paths
+        kubeletPlugin.nodeSelector and driver.manager.env when both contract
+        components are enabled, and — where the corresponding NVSentinel gate
+        applies on the recipe's platform and configuration — the NVSentinel
+        remedy/consumer/runtime-class paths).
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    SystemNodeSelector:
+      name: system-node-selector
+      in: query
+      required: false
+      description: Repeatable key=value selector for system components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    SystemNodeToleration:
+      name: system-node-toleration
+      in: query
+      required: false
+      description: Repeatable key=value:effect toleration for system components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    AcceleratedNodeSelector:
+      name: accelerated-node-selector
+      in: query
+      required: false
+      description: Repeatable key=value selector for accelerated components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    AcceleratedNodeToleration:
+      name: accelerated-node-toleration
+      in: query
+      required: false
+      description: Repeatable key=value:effect toleration for accelerated components.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    DRAEvictionNodeLabel:
+      name: dra-eviction-node-label
+      in: query
+      required: false
+      description: >
+        Single key=value node label coordinating NVIDIA DRA kubelet-plugin
+        eviction with GPU Operator driver upgrades. Applied only when both
+        components are enabled.
+      schema:
+        type: string
+        default: nvidia.com/dra-kubelet-plugin=true
+      example: "example.com/dra-ready=enabled"
+    BundleDeployer:
+      name: deployer
+      in: query
+      required: false
+      description: Bundle deployment method.
+      schema:
+        type: string
+        enum: [helm, argocd, argocd-helm, flux, helmfile]
+        default: helm
+    BundleRepo:
+      name: repo
+      in: query
+      required: false
+      description: Git repository URL for supported GitOps deployers.
+      schema:
+        type: string
+        format: uri
+    WorkloadGate:
+      name: workload-gate
+      in: query
+      required: false
+      description: >
+        Taint for nodewright-operator workload gating (format:
+        key=value:effect or key:effect).
+      schema:
+        type: string
+      example: "skyhook.nvidia.com/runtime=required:NoSchedule"
+    WorkloadSelector:
+      name: workload-selector
+      in: query
+      required: false
+      description: Repeatable key=value selector for workload-gate classification.
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true
+    BundleNodes:
+      name: nodes
+      in: query
+      required: false
+      description: Estimated GPU node count for bundle-time injections.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    VendorCharts:
+      name: vendor-charts
+      in: query
+      required: false
+      description: Include upstream chart bytes in the generated bundle.
+      schema:
+        type: boolean
+        default: false
+    Serial:
+      name: serial
+      in: query
+      required: false
+      description: Sequence components strictly in deployment order.
+      schema:
+        type: boolean
+        default: false
+    AppName:
+      name: app-name
+      in: query
+      required: false
+      description: Parent Argo CD Application name.
+      schema:
+        type: string
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+        maxLength: 253
+    Attest:
+      name: attest
+      in: query
+      required: false
+      description: Return a server-signed bundle.
+      schema:
+        type: boolean
+        default: false
+
+  schemas:
+    Error:
+      type: object
+      required: [code, message, requestId, timestamp, retryable]
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+          examples:
+            - INVALID_REQUEST
+            - METHOD_NOT_ALLOWED
+            - INTERNAL_ERROR
+            - RATE_LIMIT_EXCEEDED
+        message:
+          type: string
+          description: Human-readable error message
+          example: "Invalid recipe query"
+        details:
+          type: object
+          additionalProperties: true
+          description: Additional context-specific error details
+          nullable: true
+        requestId:
+          type: string
+          format: uuid
+          description: Unique request identifier for tracing
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when error occurred
+        retryable:
+          type: boolean
+          description: Whether client should retry this request
+          example: false
+
+    Criteria:
+      type: object
+      description: Strict recipe criteria specification for v2 request bodies
+      additionalProperties: false
+      properties:
+        service:
+          type: string
+          description: Kubernetes service type
+          enum: [eks, gke, aks, oke, ocp, kind, lke, bcm, metal3, any]
+          example: eks
+        accelerator:
+          type: string
+          description: GPU/accelerator type
+          enum: [h100, h200, gb200, gb300, b200, a100, l40, l40s, rtx-pro-6000, any]
+          example: h100
+        intent:
+          type: string
+          description: Workload intent
+          enum: [training, inference, any]
+          example: training
+        os:
+          type: string
+          description: Operating system family
+          enum: [ubuntu, rhel, cos, amazonlinux, ol, talos, any]
+          example: ubuntu
+        platform:
+          type: string
+          description: Platform/framework type
+          enum: [dynamo, kubeflow, nim, runai, slurm, any]
+          example: kubeflow
+        nodes:
+          type: integer
+          description: Number of GPU nodes (0 = any)
+          minimum: 0
+          default: 0
+
+    RecipeRequest:
+      type: object
+      description: >
+        Strict profile-aware recipe-resolution envelope. Unknown fields are
+        rejected both at this envelope level and inside criteria.
+      required: [criteria]
+      additionalProperties: false
+      properties:
+        criteria:
+          $ref: "#/components/schemas/Criteria"
+        profile:
+          type: string
+          description: Optional configuration profile selection in name=value form
+          pattern: "^$|^[A-Za-z0-9._-]+=[A-Za-z0-9._-]+$"
+
+    QueryRequest:
+      type: object
+      description: >
+        Strict profile-aware query envelope. Unknown fields are rejected both
+        at this envelope level and inside criteria.
+      required: [criteria, selector]
+      additionalProperties: false
+      properties:
+        criteria:
+          $ref: "#/components/schemas/Criteria"
+        profile:
+          type: string
+          description: Optional configuration profile selection in name=value form
+          pattern: "^$|^[A-Za-z0-9._-]+=[A-Za-z0-9._-]+$"
+        selector:
+          type: string
+          description: Dot-delimited path; empty returns the hydrated recipe
+
+    RecipeResponseBase:
+      type: object
+      description: >
+        Reusable RecipeResult shape. Response and bundle-request wrappers apply
+        their respective apiVersion requirements.
+      properties:
+        apiVersion:
+          type: string
+          description: >
+            API version of the recipe format. Response and bundle-request
+            wrappers constrain the supported value.
+        kind:
+          type: string
+          description: >
+            Resource type. Response and bundle-request wrappers constrain the
+            supported value.
+        metadata:
+          type: object
+          description: Recipe metadata
+          properties:
+            version:
+              type: string
+              description: Recipe version
+              example: v1.0.0
+            appliedOverlays:
+              type: array
+              items:
+                type: string
+              description: List of overlay criteria that were applied
+            excludedOverlays:
+              type: array
+              description: Optional list of matching overlays excluded from the final recipe
+              items:
+                oneOf:
+                  - type: string
+                    description: Legacy excluded-overlay name
+                  - type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                        description: Name of the excluded overlay
+                      reason:
+                        type: string
+                        description: >
+                          Machine-readable reason for exclusion. API-generated responses
+                          populate this field; legacy stored recipes accepted for backward
+                          compatibility may omit it when deserialized.
+                        enum: [constraint-failed, mixin-constraint-failed]
+            constraintWarnings:
+              type: array
+              description: Optional details about failed constraint evaluations for excluded overlays
+              items:
+                type: object
+                required: [overlay, constraint, expected, reason]
+                properties:
+                  overlay:
+                    type: string
+                    description: Overlay that was excluded
+                  constraint:
+                    type: string
+                    description: Constraint name that failed evaluation
+                  expected:
+                    type: string
+                    description: Expected constraint value
+                  actual:
+                    type: string
+                    description: Actual evaluated value when available
+                  reason:
+                    type: string
+                    description: Human-readable explanation of the failure
+            gpuDriverState:
+              type: string
+              description: >
+                Snapshot-observed NVIDIA kernel driver state on the sampled GPU
+                node, recorded only by snapshot-driven resolution. Omitted when
+                the snapshot carried no usable driver-loaded reading (or no
+                snapshot was provided). Consumed by the bundle-time
+                CheckDriverOwnershipCoherence validation.
+              enum: [preinstalled, absent]
+            selectedProfile:
+              type: object
+              description: >
+                Selected profile identity and declaration-wide lock surface.
+                Present only when apiVersion is aicr.run/v1alpha3.
+              required: [name, value, ownedPaths]
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+                  pattern: "^[A-Za-z0-9._-]+$"
+                value:
+                  type: string
+                  pattern: "^[A-Za-z0-9._-]+$"
+                advertiser:
+                  type: string
+                  enum: [external]
+                  description: >
+                    Declares that a platform-managed component outside the
+                    recipe advertises nvidia.com/gpu (ADR-015 GKE
+                    allocation-policy amendment; e.g. GKE's managed device
+                    plugin on the gke-default gpuStack value). Absent when
+                    no external advertiser is declared — the recipe's own
+                    components then determine advertisement (the GPU
+                    operator's device plugin, or DRA resources.gpus.enabled);
+                    external is the only accepted non-empty value.
+                ownedPaths:
+                  type: object
+                  description: >
+                    Canonical component names mapped to sorted owned dotted
+                    paths. Every listed component includes synthetic "enabled".
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+            mariaDBOperatorState:
+              type: string
+              description: >
+                Official MariaDB Operator API/CR conflict evidence recorded
+                during snapshot-driven resolution of AICR-provided Slurm
+                accounting. Existing CRs and inconclusive discovery block
+                bundling; API-only detection or omitted evidence produces a
+                non-blocking warning.
+              enum: [absent, api-detected, crs-detected, unknown]
+        criteria:
+          $ref: "#/components/schemas/Criteria"
+          description: Original criteria parameters
+        configuration:
+          type: object
+          description: Typed desired state that affects rendering without participating in criteria matching
+          properties:
+            slurm:
+              type: object
+              properties:
+                accounting:
+                  type: object
+                  required: [mode]
+                  properties:
+                    mode:
+                      type: string
+                      enum: [disabled, customer-managed, aicr-provided]
+            runtimeInventory:
+              type: object
+              required: [mode]
+              properties:
+                mode:
+                  type: string
+                  enum: [enabled, disabled]
+        componentRefs:
+          type: array
+          items:
+            type: object
+            required: [name]
+            properties:
+              name:
+                type: string
+                description: >-
+                  Component name. Must be unique within componentRefs (across
+                  both enabled and disabled refs) when non-empty; a duplicate
+                  non-empty name is rejected with 400. Refs with an empty
+                  name are exempt from the uniqueness check.
+              namespace:
+                type: string
+                description: Kubernetes namespace for the component
+              type:
+                type: string
+                enum: [Helm, Kustomize]
+                description: >-
+                  Deployment type; send the canonical value `Helm` or
+                  `Kustomize` (the normative contract). A Helm ref must not carry
+                  `tag`/`path`; a Kustomize ref requires `path` (and, when it
+                  sets `tag`, a `source`). An enabled Helm ref must reference a
+                  deployable primary: either an external chart (a `source`
+                  repository plus an effective `version`; the chart name falls
+                  back to the component name when `chart` is unset, but a
+                  `chart` without a `source` is rejected) or local primary
+                  `manifestFiles` (a manifest-only component; `preManifestFiles`
+                  alone do not qualify). Helm `chart` and `source` values must
+                  not carry surrounding whitespace. Incoherent combinations are
+                  rejected with 400. For back-compatibility the server back-fills a
+                  missing type on an enabled ref from the registry when the
+                  component is known (a missing type on an unknown component is
+                  rejected with 400), and accepts other casings (e.g. `helm`)
+                  and normalizes them — but clients should send the canonical
+                  values above.
+              version:
+                type: string
+                description: >-
+                  Chart version (Helm). Required for an enabled Helm ref that
+                  references an external chart: an empty, whitespace-only, or
+                  bare `v` value is rejected with 400, as is a value carrying
+                  surrounding whitespace (deployers consume the version
+                  verbatim). Flux and Argo CD strip
+                  a leading `v` for non-OCI outputs (Helm resolves the empty
+                  remainder as "latest"), non-vendored Helm/Helmfile and OCI
+                  outputs preserve it, and vendored wrappers substitute a
+                  fabricated default — a bare `v` is rejected uniformly to
+                  avoid output-dependent chart identities. Not required for
+                  manifest-only Helm components, but when set there the same
+                  whitespace and bare-`v` rules apply (the value lands in the
+                  rendered chart's `helm.sh/chart` label).
+              tag:
+                type: string
+                description: Git tag/ref (Kustomize); only meaningful with a source
+              source:
+                type: string
+                description: >-
+                  Chart repository URL (Helm) or OCI/Git source reference
+                  (Kustomize). For Helm refs, values with surrounding
+                  whitespace are rejected with 400 — deployers consume the
+                  field verbatim. (Kustomize sources are not whitespace-
+                  validated today.)
+              chart:
+                type: string
+                description: >-
+                  Helm chart name; falls back to the component name when unset
+                  on a source-backed ref. Values with surrounding whitespace
+                  are rejected with 400. A chart without a source is rejected
+                  (nothing to pull from).
+              valuesFile:
+                type: string
+                description: Path to component values relative to the data directory
+              overrides:
+                type: object
+                description: Inline component values, merged after valuesFile
+                additionalProperties: true
+              path:
+                type: string
+                description: Path within the source to the kustomization (Kustomize)
+              manifestFiles:
+                type: array
+                items:
+                  type: string
+                description: >-
+                  Manifest files bundled with a Helm component (paths relative
+                  to the data directory). Without a chart/source they form the
+                  manifest-only primary and exempt the ref from the `version`
+                  requirement; with an external chart they apply AFTER the
+                  primary release. Rejected with 400 on Kustomize refs (a
+                  Kustomize ref wraps a single primary source).
+              preManifestFiles:
+                type: array
+                items:
+                  type: string
+                description: >-
+                  Manifest files applied BEFORE the component's primary release
+                  (paths relative to the data directory). Auxiliary only:
+                  pre-manifests alone do not make a ref deployable or exempt it
+                  from the `version` requirement.
+              patches:
+                type: array
+                items:
+                  type: string
+                description: >-
+                  Unsupported / not applied. No deployer applies patch files, so
+                  an enabled ref that sets `patches` is rejected with 400 rather
+                  than silently producing an unpatched bundle. Do not set. See
+                  issue #1588.
+              dependencyRefs:
+                type: array
+                items:
+                  type: string
+                description: Component names that must be deployed first
+              cleanup:
+                type: boolean
+                description: Whether validation infrastructure is removed after use
+              expectedResources:
+                type: array
+                description: Kubernetes resources expected after deployment
+                items:
+                  type: object
+                  required: [kind, name]
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+              healthCheckAsserts:
+                type: string
+                description: Hydrated Chainsaw-style health-check assertions
+              healthCheckSkip:
+                type: boolean
+                description: Whether registry health-check assertion hydration is skipped
+          description: >-
+            List of component references. Deployment order is not per-ref; it is
+            the top-level `deploymentOrder` array.
+        deploymentOrder:
+          type: array
+          items:
+            type: string
+          description: >-
+            Topologically sorted component names giving the order to deploy in.
+            Preserve this on a GET→POST round trip (POST /v1/bundle accepts this
+            same shape) — dropping it changes deployment sequencing.
+        constraints:
+          type: array
+          description: Deployment constraints and assumptions
+          items:
+            type: object
+            required: [name, value]
+            properties:
+              name:
+                type: string
+              value:
+                type: string
+              severity:
+                type: string
+              remediation:
+                type: string
+              unit:
+                type: string
+
+    RecipeResponse:
+      description: >
+        Complete legacy, profile-aware, or Slurm-accounting-aware recipe
+        response with metadata and component references. Recipes without typed
+        configuration emitted by this release use aicr.run/v1alpha2;
+        profile-bearing recipes and recipes carrying
+        configuration.slurm.accounting use aicr.run/v1alpha3. The schema also
+        admits both ADR-022 targets, aicr.run/v1 for the default track and
+        aicr.run/v1beta2 for the profile track, so a client generated from this
+        spec tolerates them a release before the emitter switch. This release
+        emits neither.
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponseBase"
+        - type: object
+          required: [apiVersion, kind]
+          properties:
+            apiVersion:
+              type: string
+              enum: [aicr.run/v1alpha2, aicr.run/v1alpha3, aicr.run/v1, aicr.run/v1beta2]
+              example: aicr.run/v1alpha2
+            kind:
+              type: string
+              enum: [RecipeResult]
+              example: RecipeResult
+
+    ConfiguredRecipeConfiguration:
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponseBase/properties/configuration"
+        - type: object
+          # At least one section, but not any particular one: a recipe may
+          # record a runtime-inventory selection without Slurm accounting, or
+          # the reverse. Requiring `slurm` rejected the former outright.
+          minProperties: 1
+          additionalProperties: false
+          properties:
+            slurm:
+              type: object
+              required: [accounting]
+              additionalProperties: false
+              properties:
+                accounting:
+                  type: object
+                  required: [mode]
+                  additionalProperties: false
+                  properties:
+                    mode:
+                      type: string
+                      enum: [disabled, customer-managed, aicr-provided]
+            runtimeInventory:
+              type: object
+              required: [mode]
+              additionalProperties: false
+              properties:
+                mode:
+                  type: string
+                  enum: [enabled, disabled]
+
+    ProfileRecipeResponse:
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponse"
+        - type: object
+          description: >
+            Closed profile-bearing RecipeResult shape. aicr.run/v1alpha3 is
+            emitted; aicr.run/v1beta2 is accepted during ADR-022 Release N.
+            Unknown fields are rejected at its typed object boundaries.
+          required: [metadata, componentRefs]
+          additionalProperties: false
+          properties:
+            apiVersion:
+              type: string
+              enum: [aicr.run/v1alpha3, aicr.run/v1beta2]
+            kind:
+              type: string
+              enum: [RecipeResult]
+            metadata:
+              type: object
+              required: [selectedProfile]
+              propertyNames:
+                enum:
+                  - version
+                  - appliedOverlays
+                  - excludedOverlays
+                  - constraintWarnings
+                  - gpuDriverState
+                  - mariaDBOperatorState
+                  - selectedProfile
+              properties:
+                mariaDBOperatorState:
+                  type: string
+                  enum: [absent, api-detected, crs-detected, unknown]
+                excludedOverlays:
+                  type: array
+                  items:
+                    type: object
+                    required: [name]
+                    propertyNames:
+                      enum: [name, reason]
+                constraintWarnings:
+                  type: array
+                  items:
+                    type: object
+                    required: [overlay, constraint, expected, reason]
+                    propertyNames:
+                      enum: [overlay, constraint, expected, actual, reason]
+                selectedProfile:
+                  type: object
+            criteria:
+              $ref: "#/components/schemas/Criteria"
+            configuration:
+              $ref: "#/components/schemas/ConfiguredRecipeConfiguration"
+            constraints:
+              type: array
+              items:
+                type: object
+                required: [name, value]
+                propertyNames:
+                  enum: [name, value, severity, remediation, unit]
+            componentRefs:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                required: [name]
+                propertyNames:
+                  enum:
+                    - name
+                    - namespace
+                    - chart
+                    - type
+                    - source
+                    - version
+                    - tag
+                    - valuesFile
+                    - overrides
+                    - patches
+                    - dependencyRefs
+                    - manifestFiles
+                    - preManifestFiles
+                    - path
+                    - cleanup
+                    - expectedResources
+                    - healthCheckAsserts
+                    - healthCheckSkip
+                properties:
+                  expectedResources:
+                    type: array
+                    items:
+                      type: object
+                      required: [kind, name]
+                      additionalProperties: false
+                      properties:
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+            deploymentOrder:
+              type: array
+              items:
+                type: string
+            validation:
+              type: object
+              propertyNames:
+                enum: [readiness, deployment, performance, conformance]
+              additionalProperties:
+                type: object
+                propertyNames:
+                  enum: [timeout, constraints, checks, nodeSelection, infrastructure]
+                properties:
+                  timeout:
+                    type: string
+                  constraints:
+                    type: array
+                    items:
+                      type: object
+                      required: [name, value]
+                      propertyNames:
+                        enum: [name, value, severity, remediation, unit]
+                  checks:
+                    type: array
+                    items:
+                      type: string
+                  nodeSelection:
+                    type: object
+                    propertyNames:
+                      enum: [selector, maxNodes, excludeNodes]
+                    properties:
+                      selector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      maxNodes:
+                        type: integer
+                      excludeNodes:
+                        type: array
+                        items:
+                          type: string
+                  infrastructure:
+                    type: string
+
+    ConfiguredRecipeResponse:
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponse"
+        - type: object
+          description: >
+            Closed accounting-configured RecipeResult shape without a selected
+            profile. aicr.run/v1alpha3 is emitted; aicr.run/v1beta2 is
+            accepted during ADR-022 Release N.
+          required: [metadata, configuration, componentRefs]
+          additionalProperties: false
+          properties:
+            apiVersion:
+              type: string
+              enum: [aicr.run/v1alpha3, aicr.run/v1beta2]
+            kind:
+              type: string
+              enum: [RecipeResult]
+            metadata:
+              allOf:
+                - $ref: "#/components/schemas/RecipeResponseBase/properties/metadata"
+                - type: object
+                  propertyNames:
+                    enum:
+                      - version
+                      - appliedOverlays
+                      - excludedOverlays
+                      - constraintWarnings
+                      - gpuDriverState
+                      - mariaDBOperatorState
+                      - selectedProfile
+                  not:
+                    required: [selectedProfile]
+                  properties:
+                    mariaDBOperatorState:
+                      type: string
+                      enum: [absent, api-detected, crs-detected, unknown]
+                    excludedOverlays:
+                      type: array
+                      items:
+                        type: object
+                        required: [name]
+                        propertyNames:
+                          enum: [name, reason]
+                    constraintWarnings:
+                      type: array
+                      items:
+                        type: object
+                        required: [overlay, constraint, expected, reason]
+                        propertyNames:
+                          enum: [overlay, constraint, expected, actual, reason]
+                    selectedProfile:
+                      type: object
+            criteria:
+              $ref: "#/components/schemas/Criteria"
+            configuration:
+              allOf:
+                - $ref: "#/components/schemas/ConfiguredRecipeConfiguration"
+                - type: object
+                  required: [slurm]
+            componentRefs:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                required: [name]
+                propertyNames:
+                  enum:
+                    - name
+                    - namespace
+                    - chart
+                    - type
+                    - source
+                    - version
+                    - tag
+                    - valuesFile
+                    - overrides
+                    - patches
+                    - dependencyRefs
+                    - manifestFiles
+                    - preManifestFiles
+                    - path
+                    - cleanup
+                    - expectedResources
+                    - healthCheckAsserts
+                    - healthCheckSkip
+                properties:
+                  expectedResources:
+                    type: array
+                    items:
+                      type: object
+                      required: [kind, name]
+                      additionalProperties: false
+                      properties:
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+            deploymentOrder:
+              $ref: "#/components/schemas/RecipeResponseBase/properties/deploymentOrder"
+            constraints:
+              type: array
+              items:
+                type: object
+                required: [name, value]
+                propertyNames:
+                  enum: [name, value, severity, remediation, unit]
+            validation:
+              type: object
+              propertyNames:
+                enum: [readiness, deployment, performance, conformance]
+              additionalProperties:
+                type: object
+                propertyNames:
+                  enum: [timeout, constraints, checks, nodeSelection, infrastructure]
+                properties:
+                  timeout:
+                    type: string
+                  constraints:
+                    type: array
+                    items:
+                      type: object
+                      required: [name, value]
+                      propertyNames:
+                        enum: [name, value, severity, remediation, unit]
+                  checks:
+                    type: array
+                    items:
+                      type: string
+                  nodeSelection:
+                    type: object
+                    propertyNames:
+                      enum: [selector, maxNodes, excludeNodes]
+                    properties:
+                      selector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      maxNodes:
+                        type: integer
+                      excludeNodes:
+                        type: array
+                        items:
+                          type: string
+                  infrastructure:
+                    type: string
+
+    LegacyBundleRecipeRequest:
+      description: >
+        Additive legacy RecipeResult accepted by POST /v1/bundle: any
+        combination of apiVersion absent, empty, aicr.run/v1alpha2, or
+        aicr.run/v1 with kind absent, empty, or RecipeResult. One branch
+        covers the whole legacy square because DecodeRecipeResult accepts
+        every cell of it — kind is enforced only when non-empty, and only the
+        profile track requires it.
+        The legacy kind Recipe, published through v0.18.0, is no longer
+        accepted on any path.
+        metadata.selectedProfile remains reserved for v1alpha3/v1beta2.
+        configuration is likewise reserved for v1alpha3/v1beta2; default request
+        headers cannot carry typed Slurm accounting configuration.
+      allOf:
+        - $ref: "#/components/schemas/RecipeResponseBase"
+        - type: object
+          not:
+            required: [configuration]
+          properties:
+            apiVersion:
+              type: string
+              description: >
+                aicr.run/v1alpha2, aicr.run/v1, absent, or empty after a legacy struct
+                round trip
+              enum: ["", aicr.run/v1alpha2, aicr.run/v1]
+            kind:
+              type: string
+              description: >
+                RecipeResult, absent, or empty for a round-tripped artifact
+              enum: ["", RecipeResult]
+              example: RecipeResult
+            metadata:
+              type: object
+              not:
+                required: [selectedProfile]
+    BundleRecipeRequest:
+      description: >
+        Version-partitioned RecipeResult accepted by POST /v1/bundle.
+        Default input with apiVersion aicr.run/v1alpha2, aicr.run/v1, or no
+        apiVersion remains additive; v1alpha3/v1beta2 input is closed and requires either
+        metadata.selectedProfile or configuration.slurm.accounting. The
+        branches are disjoint on apiVersion:
+        the default branch admits only absent/empty/v1alpha2/v1 and prohibits
+        selectedProfile, while both configured branches require the profile track.
+      oneOf:
+        - $ref: "#/components/schemas/LegacyBundleRecipeRequest"
+        - $ref: "#/components/schemas/ProfileRecipeResponse"
+        - $ref: "#/components/schemas/ConfiguredRecipeResponse"

--- a/api/aicr/v1/server.yaml
+++ b/api/aicr/v1/server.yaml
@@ -483,13 +483,14 @@ paths:
       summary: Generate a bundle from a legacy or profiled recipe
       operationId: createBundle
       description: >
-        Uses the same query parameters and ZIP response as POST /v1/bundle.
-        The body is an already-selected RecipeResult, so this route has no
-        profile-selection field. Default recipes stamped aicr.run/v1alpha2,
-        aicr.run/v1, or omitting apiVersion are accepted; profile recipes
-        stamped aicr.run/v1alpha3 or aicr.run/v1beta2 are decoded strictly.
-        Content-Type must be application/json or application/x-yaml.
-        Query parameter details are documented on POST /v1/bundle.
+        Renders a deployment bundle and returns it as a ZIP archive. The body is
+        an already-selected RecipeResult, so this route has no profile-selection
+        field; select the profile when resolving the recipe. Default recipes
+        stamped aicr.run/v1alpha2, aicr.run/v1, or omitting apiVersion are
+        accepted; profile recipes stamped aicr.run/v1alpha3 or aicr.run/v1beta2
+        are decoded strictly. Content-Type must be application/json or
+        application/x-yaml. The query parameters below control deployer, value
+        overrides, node scheduling, workload gating and attestation.
       parameters:
         - $ref: "#/components/parameters/RequestId"
         - $ref: "#/components/parameters/BundleComponents"
@@ -1048,10 +1049,12 @@ components:
           description: Human-readable error message
           example: "Invalid recipe query"
         details:
-          type: object
+          # OpenAPI 3.1 has no `nullable` keyword; it is JSON Schema, where null
+          # is expressed in the type. With `type: object` alone a null details
+          # field would not validate against the document the server emits.
+          type: [object, "null"]
           additionalProperties: true
           description: Additional context-specific error details
-          nullable: true
         requestId:
           type: string
           format: uuid

--- a/docs/contributor/api-server.md
+++ b/docs/contributor/api-server.md
@@ -284,19 +284,21 @@ contains two contract gates:
   `api/aicr/v1/server.yaml` matches the corresponding
   `pkg/recipe.GetCriteria*Types()` function. It scans both query-parameter enums
   and `components.schemas.Criteria` properties.
-- `TestOpenAPIV1BundleRecipeContract` asserts that `/v1/bundle` and its
-  deprecated wrapper share the request schema, that both `/v1/recipe` success
-  responses still point at the strict `RecipeResponse`, and that the header
-  enums on both sides stay synchronized with the Go constants. It matches the
-  `allOf` branches by content rather than position, since `allOf` is
-  semantically unordered.
+- `TestOpenAPIBundleContract` asserts that `POST /v1/bundle` points at
+  `BundleRecipeRequest`, that the union's branches stay wired to the legacy and
+  configured schemas, and that the header enums stay synchronized with the Go
+  constants. It matches the `allOf` branches by content rather than position,
+  since `allOf` is semantically unordered.
 
   Runtime acceptance of the legacy header shapes is pinned separately by
   `TestBundleHandler_LegacyRecipeHeaders`, which posts absent, empty, and
-  `kind: Recipe` bodies to the handler, asserts 200, and round-trips the
+  target-`apiVersion` bodies to the handler, asserts 200, and round-trips the
   emitted `recipe.yaml` back through the file loader to prove the ingest
   normalization holds. The spec gate alone would only be checking the spec
-  against itself.
+  against itself. The one legacy shape that is *not* accepted, `kind: Recipe`
+  (published through v0.18.0 and removed by the v1 collapse), is pinned by
+  `TestBundleHandler_RejectsLegacyRecipeKind` so the rejection stays a decision
+  rather than becoming an accident of a later refactor.
 
 Drift is a contract bug: clients conforming to the spec will reject
 inputs the server actually accepts, or generate types that reject
@@ -305,6 +307,49 @@ the spec — or the reverse — fails CI here.
 
 The wildcard `"any"` is allowed in the spec but not the Go list; the
 test strips it before comparison.
+
+## REST Contract Gate
+
+REST is one of the four surfaces [ROADMAP](https://github.com/NVIDIA/aicr/blob/main/ROADMAP.md)
+section 1 freezes at v1. Two gates guard it, and they fail for different
+reasons.
+
+**`make openapi-diff`** ([`tools/openapi-diff`](https://github.com/NVIDIA/aicr/blob/main/tools/openapi-diff))
+compares `api/aicr/v1/server.yaml` against the committed snapshot
+`api/aicr/v1/server.baseline.yaml` using the pinned `oasdiff`, and fails on
+breaking changes: a removed endpoint, a removed or narrowed field, a new
+required request field, a removed enum value. Additive change passes. It runs
+in `make qualify`, next to `api-diff`, which guards the Go SDK the same way.
+
+Three ways to resolve a failure, in order of preference:
+
+1. Make the change additive instead.
+2. Record it in `api/aicr/v1/openapi-diff-exceptions.yaml` with the oasdiff
+   rule id, the operation path, and a reason. **Scheduled ADR-022 apiVersion
+   removals belong here** — that is what the issue means by representing a
+   transition explicitly rather than disabling the gate.
+3. Accept it into the contract with `make openapi-baseline`, which rewrites the
+   baseline. That diff is the change under review; read it.
+
+An acknowledgement that stops matching a real breaking change **fails the
+gate**. A stale entry silently pre-approves the break returning later, which is
+the failure the file exists to prevent — the same contract as
+`pkg/client/v1/api-diff-exceptions.yaml`. `tools/openapi-diff_test.sh` pins each
+branch of that verdict to an exact exit code.
+
+**`pkg/server/openapi_validity_test.go`** answers a different question: not
+"did this change break the contract" but "is the contract coherent". A dangling
+`$ref`, an orphaned component, or a duplicate `operationId` is present in both
+baseline and spec, so the diff sees no change and passes while every generated
+client is wrong. It also guards the baseline against silent truncation, which
+would make the diff gate report no breaking changes for anything the truncated
+file omits.
+
+The baseline is a committed snapshot rather than the previous release, unlike
+`api-diff`. The v1 collapse (#2464) is unreleased, so comparing against v0.20.0
+reports 28 breaking changes that are all one already-merged decision — the gate
+would ship pre-loaded with noise that clears itself at v0.21 and teaches
+everyone to skim it in the meantime.
 
 ## Adding an Endpoint
 

--- a/docs/contributor/tests.md
+++ b/docs/contributor/tests.md
@@ -484,6 +484,9 @@ half of the pipeline and skips deploy-side assertions.
 - `e2e` — the end-to-end pipeline runner.
 - `scan` — Grype vulnerability scan.
 - `license-check` — license header / dependency-license sweep.
+- `openapi-diff` — the REST contract in `api/aicr/v1/server.yaml` against its
+  committed baseline, failing on unacknowledged breaking changes and on stale
+  acknowledgements. See [API server](api-server.md#rest-contract-gate).
 - `api-diff` — exported `pkg/client/v1` compatibility, including the scoped
   repository-local type closure reachable through transparent aliases, against
   the latest stable release.

--- a/pkg/server/openapi_validity_test.go
+++ b/pkg/server/openapi_validity_test.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Structural validity for the frozen REST contract (issue #2112, scope item 2).
+//
+// tools/openapi-diff answers "did this change break the contract"; it does not
+// answer "is the contract coherent". Those fail differently: a dangling $ref or
+// a duplicate operationId is present in both baseline and spec, so a diff sees
+// no change and passes while every generated client is wrong.
+//
+// This is not a substitute for a full OpenAPI linter. It covers the internal
+// consistency the collapse in #2464 actually put at risk — that change deleted
+// eleven schemas, and verifying nothing pointed at them was a manual step at
+// the time.
+
+const baselineRelPath = "../../api/aicr/v1/server.baseline.yaml"
+
+// TestOpenAPIRefsResolve asserts every internal $ref points at something that
+// exists.
+//
+// A dangling $ref is invisible to the diff gate — both sides carry it — and
+// invisible to the route tests, which read paths rather than schemas. It
+// surfaces only when a client generator or validator chokes on it.
+func TestOpenAPIRefsResolve(t *testing.T) {
+	for _, spec := range []string{specRelPath, baselineRelPath} {
+		t.Run(filepath.Base(spec), func(t *testing.T) {
+			doc := loadOpenAPIDocument(t, spec)
+
+			refs := collectRefs(doc)
+			if len(refs) == 0 {
+				t.Fatal("no $refs found; the walk is broken and every assertion " +
+					"below would pass vacuously")
+			}
+
+			var dangling []string
+			for ref := range refs {
+				if !strings.HasPrefix(ref, "#/") {
+					// External refs are a different risk (SSRF, availability)
+					// and are not used here; flag rather than silently skip.
+					dangling = append(dangling, ref+" (external ref)")
+					continue
+				}
+				if !refExists(doc, ref) {
+					dangling = append(dangling, ref)
+				}
+			}
+			sort.Strings(dangling)
+			for _, ref := range dangling {
+				t.Errorf("%s: $ref %q does not resolve; a generated client cannot "+
+					"be built from this document", spec, ref)
+			}
+		})
+	}
+}
+
+// TestOpenAPIHasNoOrphanedComponents asserts every declared component is
+// referenced.
+//
+// An orphan is not a correctness bug on its own, but it is how a deleted
+// surface leaves residue: #2464 removed the /v2 family and eleven schemas
+// became unreachable, which was caught by reading the file. An orphan that
+// survives is a schema reviewers assume is live, and the breaking-change gate
+// will faithfully protect it forever.
+func TestOpenAPIHasNoOrphanedComponents(t *testing.T) {
+	doc := loadOpenAPIDocument(t, specRelPath)
+
+	refs := collectRefs(doc)
+	components, ok := doc["components"].(map[string]any)
+	if !ok {
+		t.Fatal("spec declares no components object")
+	}
+
+	var checked int
+	for _, kind := range []string{"schemas", "parameters", "responses"} {
+		group, groupOK := components[kind].(map[string]any)
+		if !groupOK {
+			continue
+		}
+		for name := range group {
+			checked++
+			ref := fmt.Sprintf("#/components/%s/%s", kind, name)
+			if !refs[ref] {
+				t.Errorf("component %s is declared but never referenced; delete it "+
+					"or wire it up", ref)
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no components inspected; the parse shape is wrong and this " +
+			"assertion would pass vacuously")
+	}
+}
+
+// TestOpenAPIOperationIDsAreUniqueAndPresent asserts each operation carries a
+// distinct operationId.
+//
+// Generators derive method names from operationId. A duplicate silently
+// collapses two operations into one method, or produces a client that cannot
+// compile, and neither the diff gate nor the route tests look at the field.
+func TestOpenAPIOperationIDsAreUniqueAndPresent(t *testing.T) {
+	doc := loadOpenAPIDocument(t, specRelPath)
+
+	paths, ok := doc["paths"].(map[string]any)
+	if !ok || len(paths) == 0 {
+		t.Fatal("spec declares no paths; this assertion would pass vacuously")
+	}
+
+	seen := map[string]string{}
+	var operations int
+
+	for path, item := range paths {
+		pathItem, itemOK := item.(map[string]any)
+		if !itemOK {
+			continue
+		}
+		for method, raw := range pathItem {
+			if !httpMethods[strings.ToLower(method)] {
+				continue
+			}
+			operation, opOK := raw.(map[string]any)
+			if !opOK {
+				continue
+			}
+			operations++
+
+			id, _ := operation["operationId"].(string)
+			location := strings.ToUpper(method) + " " + path
+			if id == "" {
+				t.Errorf("%s has no operationId; client generators name methods "+
+					"from it", location)
+				continue
+			}
+			if prior, dup := seen[id]; dup {
+				t.Errorf("operationId %q is used by both %s and %s; a generated "+
+					"client cannot have two methods with one name",
+					id, prior, location)
+				continue
+			}
+			seen[id] = location
+
+			if responses, hasResponses := operation["responses"].(map[string]any); !hasResponses ||
+				len(responses) == 0 {
+
+				t.Errorf("%s declares no responses", location)
+			}
+		}
+	}
+
+	if operations == 0 {
+		t.Fatal("no operations inspected; the parse shape is wrong")
+	}
+}
+
+// TestOpenAPIBaselineIsAWholeDocument guards the baseline against silent
+// truncation.
+//
+// make openapi-baseline rebuilds the file by splicing a header onto the spec.
+// If that ever emits a partial document, tools/openapi-diff would compare
+// against a stub and report no breaking changes for anything the stub omits —
+// the gate would pass precisely when it should fail loudest. An early version
+// of the target did truncate, which is why this exists.
+func TestOpenAPIBaselineIsAWholeDocument(t *testing.T) {
+	spec := loadOpenAPIDocument(t, specRelPath)
+	baseline := loadOpenAPIDocument(t, baselineRelPath)
+
+	for _, key := range []string{"openapi", "info", "paths", "components"} {
+		if _, ok := baseline[key]; !ok {
+			t.Errorf("baseline is missing the top-level %q key; it is not a whole "+
+				"OpenAPI document and the diff gate would compare against a stub", key)
+		}
+	}
+
+	specPaths, _ := spec["paths"].(map[string]any)
+	basePaths, _ := baseline["paths"].(map[string]any)
+	if len(basePaths) == 0 {
+		t.Fatal("baseline declares no paths; the diff gate would report no " +
+			"breaking changes no matter what the spec did")
+	}
+
+	// The baseline may legitimately lag the spec on additive change, so this is
+	// a floor rather than an equality check: it catches truncation without
+	// forcing a refresh on every additive edit.
+	if len(basePaths) < len(specPaths)/2 {
+		t.Errorf("baseline declares %d paths against the spec's %d; that gap "+
+			"suggests truncation rather than additive drift",
+			len(basePaths), len(specPaths))
+	}
+}
+
+// loadOpenAPIDocument parses an OpenAPI document into a generic tree.
+func loadOpenAPIDocument(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read %q: %v", path, err)
+	}
+
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %q: %v", path, err)
+	}
+	if len(doc) == 0 {
+		t.Fatalf("%q parsed to an empty document", path)
+	}
+	return doc
+}
+
+// collectRefs walks the document and returns every $ref value it finds.
+func collectRefs(node any) map[string]bool {
+	refs := map[string]bool{}
+	walkRefs(node, refs)
+	return refs
+}
+
+func walkRefs(node any, refs map[string]bool) {
+	switch typed := node.(type) {
+	case map[string]any:
+		for key, value := range typed {
+			if key == "$ref" {
+				if ref, ok := value.(string); ok {
+					refs[ref] = true
+				}
+				continue
+			}
+			walkRefs(value, refs)
+		}
+	case []any:
+		for _, item := range typed {
+			walkRefs(item, refs)
+		}
+	}
+}
+
+// refExists resolves a local JSON pointer of the form #/a/b/c.
+func refExists(doc map[string]any, ref string) bool {
+	current := any(doc)
+	for _, segment := range strings.Split(strings.TrimPrefix(ref, "#/"), "/") {
+		// JSON pointer escaping; rare here but wrong to ignore.
+		segment = strings.ReplaceAll(segment, "~1", "/")
+		segment = strings.ReplaceAll(segment, "~0", "~")
+
+		container, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = container[segment]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/server/openapi_validity_test.go
+++ b/pkg/server/openapi_validity_test.go
@@ -94,16 +94,19 @@ func TestOpenAPIHasNoOrphanedComponents(t *testing.T) {
 		t.Fatal("spec declares no components object")
 	}
 
+	// Every group the document declares, not a hand-picked subset: an orphaned
+	// header is the same residue class as an orphaned schema, and omitting
+	// headers meant the check could not see one.
 	var checked int
-	for _, kind := range []string{"schemas", "parameters", "responses"} {
-		group, groupOK := components[kind].(map[string]any)
+	for kind, raw := range components {
+		group, groupOK := raw.(map[string]any)
 		if !groupOK {
 			continue
 		}
 		for name := range group {
 			checked++
 			ref := fmt.Sprintf("#/components/%s/%s", kind, name)
-			if !refs[ref] {
+			if !isReferenced(refs, ref) {
 				t.Errorf("component %s is declared but never referenced; delete it "+
 					"or wire it up", ref)
 			}
@@ -210,6 +213,25 @@ func TestOpenAPIBaselineIsAWholeDocument(t *testing.T) {
 			"suggests truncation rather than additive drift",
 			len(basePaths), len(specPaths))
 	}
+}
+
+// isReferenced reports whether a component is reached by any $ref.
+//
+// Exact string equality is not enough: the spec points into subschemas, e.g.
+// #/components/schemas/RecipeResponseBase/properties/configuration. A component
+// reached only through such a pointer is live, and comparing whole strings
+// would report it as an orphan. Matching on the pointer prefix at a path
+// boundary avoids that without letting a similarly-named component match.
+func isReferenced(refs map[string]bool, ref string) bool {
+	if refs[ref] {
+		return true
+	}
+	for candidate := range refs {
+		if strings.HasPrefix(candidate, ref+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // loadOpenAPIDocument parses an OpenAPI document into a generic tree.

--- a/pkg/server/openapi_validity_test.go
+++ b/pkg/server/openapi_validity_test.go
@@ -101,6 +101,11 @@ func TestOpenAPIHasNoOrphanedComponents(t *testing.T) {
 	for kind, raw := range components {
 		group, groupOK := raw.(map[string]any)
 		if !groupOK {
+			// Skipping silently would let a document with one valid group and
+			// one malformed group pass this check while half of it was never
+			// inspected.
+			t.Errorf("components.%s is %T, want an object; its entries cannot be "+
+				"checked for orphans", kind, raw)
 			continue
 		}
 		for name := range group {

--- a/tools/check-tools
+++ b/tools/check-tools
@@ -88,6 +88,12 @@ get_tool_metadata() {
         apidiff)
             echo "apidiff:::go_binary_module_version \"\$(command -v apidiff)\" golang.org/x/exp:::strict_exact"
             ;;
+        oasdiff)
+            # `oasdiff --version` reports "main" when installed with go install,
+            # so the module version recorded in the binary is the only reliable
+            # source.
+            echo "oasdiff:::go_binary_module_version \"\$(command -v oasdiff)\" github.com/oasdiff/oasdiff:::strict_exact"
+            ;;
         yamllint)
             echo "yamllint:::yamllint --version 2>/dev/null | awk '{print \$2}':::major"
             ;;

--- a/tools/openapi-diff
+++ b/tools/openapi-diff
@@ -55,6 +55,7 @@ readonly EXIT_BREAKING=1
 readonly EXIT_MISSING_INPUT=10
 readonly EXIT_EXCEPTIONS_MALFORMED=11
 readonly EXIT_STALE_ACKNOWLEDGEMENT=12
+readonly EXIT_UNREADABLE_REPORT=13
 
 for required in "${SPEC}" "${BASELINE}" "${EXCEPTIONS}"; do
     [[ -f "${required}" ]] || {
@@ -86,8 +87,10 @@ fi
 [[ -n "${report}" ]] || report='[]'
 
 if ! echo "${report}" | yq -p json '.' >/dev/null 2>&1; then
+    # Distinct from EXIT_EXCEPTIONS_MALFORMED: sharing that code would point a
+    # reader at the exceptions file for a fault in the tool's output.
     log_error "oasdiff produced output that is not valid JSON; refusing to guess."
-    exit "${EXIT_EXCEPTIONS_MALFORMED}"
+    exit "${EXIT_UNREADABLE_REPORT}"
 fi
 
 # `yq '.acknowledgements'` returns null without error on a scalar document, so
@@ -99,11 +102,17 @@ if [[ "${ack_kind}" != "!!seq" ]]; then
     exit "${EXIT_EXCEPTIONS_MALFORMED}"
 fi
 
-breaking_count="$(echo "${report}" | yq -p json '[.[] | select(.level == 3)] | length')"
+breaking_count="$(echo "${report}" | yq -p json '[.[] | select(.level >= 2)] | length')"
 ack_count="$(yq '.acknowledgements | length' "${EXCEPTIONS}")"
 
 log_info "oasdiff reported ${breaking_count} breaking change(s); ${ack_count} acknowledged exception(s) on file"
 
+# `oasdiff breaking` reports only breaking changes, but grades them: ERR is
+# level 3 and WARN is level 2. Filtering to level 3 alone silently dropped
+# whole rule classes -- request-parameter-removed and request-property-removed
+# are level 2, so removing a query parameter from an endpoint passed the gate
+# reporting zero breaking changes. Both levels are breaking here.
+#
 # Each acknowledgement is matched by rule id, optionally narrowed by operation
 # path. Matching by id alone would let an acknowledgement for one endpoint
 # silently cover the same class of break on another.
@@ -128,7 +137,7 @@ if [[ "${breaking_count}" != "0" ]]; then
         fi
     done < <(
         echo "${report}" |
-            yq -p json -r '.[] | select(.level == 3) | [.id, (.path // ""), .text] | @tsv'
+            yq -p json -r '.[] | select(.level >= 2) | [.id, (.path // ""), .text] | @tsv'
     )
 fi
 
@@ -141,7 +150,7 @@ if [[ "${ack_count}" != "0" ]]; then
         hits="$(
             echo "${report}" |
                 RULE_ID="${rule_id}" ACK_PATH="${ack_path}" yq -p json \
-                    '[.[] | select(.level == 3) | select(.id == strenv(RULE_ID)) | select(strenv(ACK_PATH) == "" or (.path // "") == strenv(ACK_PATH))] | length'
+                    '[.[] | select(.level >= 2) | select(.id == strenv(RULE_ID)) | select(strenv(ACK_PATH) == "" or (.path // "") == strenv(ACK_PATH))] | length'
         )"
         if [[ "${hits}" == "0" ]]; then
             log_error "Stale acknowledgement [${rule_id}] ${ack_path:-(any path)}: ${reason}"

--- a/tools/openapi-diff
+++ b/tools/openapi-diff
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# openapi-diff compares api/aicr/v1/server.yaml against the committed baseline
+# and fails on breaking changes that are not explicitly acknowledged.
+#
+# REST is one of the four surfaces ROADMAP section 1 freezes at v1 (issue
+# #2112). This is the REST counterpart of tools/api-diff, which guards the Go
+# SDK, and it follows that script's contract deliberately: an exceptions file
+# records intentional breaks, and a stale acknowledgement fails rather than
+# lingering. A list of permanent exceptions that nothing ever revisits is how a
+# gate stops meaning anything.
+#
+# The baseline is a committed snapshot rather than the previous release, unlike
+# api-diff. The v1 collapse (#2464) is unreleased, so comparing against v0.20.0
+# reports 28 breaking changes that are all one already-merged decision; the gate
+# would ship pre-loaded with noise that clears itself at v0.21 and teaches
+# everyone to skim it in the meantime.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/common
+. "${DIR}/common"
+
+if command -v go >/dev/null 2>&1; then
+    if ! go_path="$(go env GOPATH)" || [[ -z "${go_path}" ]]; then
+        err "Could not determine GOPATH with 'go env GOPATH'."
+    fi
+    export PATH="${go_path}/bin:${PATH}"
+fi
+
+has_tools oasdiff yq
+
+cd "${REPO_ROOT}"
+
+# Overridable so tools/openapi-diff_test.sh can drive the verdict logic against
+# fixtures instead of mutating the real contract.
+readonly SPEC="${OPENAPI_DIFF_SPEC_FILE:-api/aicr/v1/server.yaml}"
+readonly BASELINE="${OPENAPI_DIFF_BASELINE_FILE:-api/aicr/v1/server.baseline.yaml}"
+readonly EXCEPTIONS="${OPENAPI_DIFF_EXCEPTIONS_FILE:-api/aicr/v1/openapi-diff-exceptions.yaml}"
+readonly EXIT_BREAKING=1
+readonly EXIT_MISSING_INPUT=10
+readonly EXIT_EXCEPTIONS_MALFORMED=11
+readonly EXIT_STALE_ACKNOWLEDGEMENT=12
+
+for required in "${SPEC}" "${BASELINE}" "${EXCEPTIONS}"; do
+    [[ -f "${required}" ]] || {
+        log_error "Required file not found: ${required}"
+        exit "${EXIT_MISSING_INPUT}"
+    }
+done
+
+log_info "Comparing ${SPEC} against ${BASELINE}"
+
+# --fail-on is deliberately omitted: this script decides the verdict after
+# applying acknowledgements, so oasdiff must report rather than exit non-zero.
+# `|| true` would mask a crash, so the status is captured and inspected.
+stderr_file="$(mktemp "${TMPDIR:-/tmp}/openapi-diff-err.XXXXXX")"
+trap 'rm -f "${stderr_file}"' EXIT
+
+set +e
+report="$(oasdiff breaking "${BASELINE}" "${SPEC}" --format json 2>"${stderr_file}")"
+oasdiff_status=$?
+set -e
+
+if [[ ${oasdiff_status} -gt 1 ]]; then
+    log_error "oasdiff failed (exit ${oasdiff_status}):"
+    cat "${stderr_file}" >&2 || true
+    exit "${oasdiff_status}"
+fi
+
+# An empty report is emitted as `[]` or as nothing at all depending on version.
+[[ -n "${report}" ]] || report='[]'
+
+if ! echo "${report}" | yq -p json '.' >/dev/null 2>&1; then
+    log_error "oasdiff produced output that is not valid JSON; refusing to guess."
+    exit "${EXIT_EXCEPTIONS_MALFORMED}"
+fi
+
+# `yq '.acknowledgements'` returns null without error on a scalar document, so
+# a malformed file would be read as "no exceptions" and silently change the
+# verdict. The type must be asserted, not just the lookup.
+ack_kind="$(yq 'select(document_index == 0) | .acknowledgements | tag' "${EXCEPTIONS}" 2>/dev/null || echo '!!missing')"
+if [[ "${ack_kind}" != "!!seq" ]]; then
+    log_error "${EXCEPTIONS} is malformed: 'acknowledgements' must be a list (found ${ack_kind})."
+    exit "${EXIT_EXCEPTIONS_MALFORMED}"
+fi
+
+breaking_count="$(echo "${report}" | yq -p json '[.[] | select(.level == 3)] | length')"
+ack_count="$(yq '.acknowledgements | length' "${EXCEPTIONS}")"
+
+log_info "oasdiff reported ${breaking_count} breaking change(s); ${ack_count} acknowledged exception(s) on file"
+
+# Each acknowledgement is matched by rule id, optionally narrowed by operation
+# path. Matching by id alone would let an acknowledgement for one endpoint
+# silently cover the same class of break on another.
+unmatched_errors=0
+stale_acks=0
+
+if [[ "${breaking_count}" != "0" ]]; then
+    while IFS=$'\t' read -r rule_id op_path text; do
+        [[ -n "${rule_id}" ]] || continue
+        covered="$(
+            RULE_ID="${rule_id}" OP_PATH="${op_path}" \
+                yq -o=json '.acknowledgements // []' "${EXCEPTIONS}" |
+                RULE_ID="${rule_id}" OP_PATH="${op_path}" yq -p json \
+                    '[.[] | select(.id == strenv(RULE_ID)) | select((.path // "") == "" or .path == strenv(OP_PATH))] | length'
+        )"
+        if [[ "${covered}" == "0" ]]; then
+            log_error "Unacknowledged breaking change [${rule_id}] ${op_path}"
+            echo "    ${text}" >&2
+            unmatched_errors=$((unmatched_errors + 1))
+        else
+            log_warning "Acknowledged breaking change [${rule_id}] ${op_path}"
+        fi
+    done < <(
+        echo "${report}" |
+            yq -p json -r '.[] | select(.level == 3) | [.id, (.path // ""), .text] | @tsv'
+    )
+fi
+
+# Staleness: an acknowledgement that matches nothing is describing a break that
+# no longer happens. Left in place it would silently pre-approve that break
+# returning later, which is exactly the failure this check exists to prevent.
+if [[ "${ack_count}" != "0" ]]; then
+    while IFS=$'\t' read -r rule_id ack_path reason; do
+        [[ -n "${rule_id}" ]] || continue
+        hits="$(
+            echo "${report}" |
+                RULE_ID="${rule_id}" ACK_PATH="${ack_path}" yq -p json \
+                    '[.[] | select(.level == 3) | select(.id == strenv(RULE_ID)) | select(strenv(ACK_PATH) == "" or (.path // "") == strenv(ACK_PATH))] | length'
+        )"
+        if [[ "${hits}" == "0" ]]; then
+            log_error "Stale acknowledgement [${rule_id}] ${ack_path:-(any path)}: ${reason}"
+            echo "    No such breaking change is reported. Remove this entry." >&2
+            stale_acks=$((stale_acks + 1))
+        fi
+    done < <(
+        yq -o=json '.acknowledgements // []' "${EXCEPTIONS}" |
+            yq -p json -r '.[] | [.id, (.path // ""), (.reason // "")] | @tsv'
+    )
+fi
+
+# Both conditions are reported before exiting. Returning on staleness first hid
+# the unacknowledged break behind it, which is the more urgent of the two and
+# the one that actually blocks the merge -- an acknowledgement narrowed to the
+# wrong path produces exactly that pair.
+if [[ ${stale_acks} -gt 0 ]]; then
+    log_error "${stale_acks} stale acknowledgement(s) in ${EXCEPTIONS}"
+    if [[ ${unmatched_errors} -eq 0 ]]; then
+        exit "${EXIT_STALE_ACKNOWLEDGEMENT}"
+    fi
+fi
+
+if [[ ${unmatched_errors} -gt 0 ]]; then
+    log_error "${unmatched_errors} unacknowledged breaking change(s) to the frozen REST contract"
+    cat >&2 <<EOF
+
+To resolve, choose one:
+  * Make the change non-breaking (add rather than remove or narrow).
+  * Record it in ${EXCEPTIONS} with an id, an optional path, and a reason.
+    Scheduled ADR-022 transitions belong here.
+  * Accept it into the contract with 'make openapi-baseline', which moves
+    ${BASELINE}. Expect that diff to be read in review.
+EOF
+    exit "${EXIT_BREAKING}"
+fi
+
+log_success "No unacknowledged breaking changes to the REST contract"

--- a/tools/openapi-diff_test.sh
+++ b/tools/openapi-diff_test.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verdict tests for tools/openapi-diff, driven against fixture specs through the
+# OPENAPI_DIFF_*_FILE overrides so the real REST contract is never mutated.
+#
+# The whole point of the gate is the verdict, and every branch of it can pass for
+# the wrong reason: a clean run proves nothing about detection, an acknowledged
+# run can be silently ignoring everything, and a staleness check that never fires
+# lets dead entries pre-approve a break returning. Each case below therefore
+# pins an exact exit code rather than "non-zero".
+#
+# oasdiff and yq are not stubbed: these exercise the real pinned toolchain,
+# because a stub of oasdiff would be a stub of the thing under test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPENAPI_DIFF="${SCRIPT_DIR}/openapi-diff"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if command -v go >/dev/null 2>&1; then
+    test_go_bin="$(go env GOBIN 2>/dev/null || true)"
+    if [[ -z "${test_go_bin}" ]]; then
+        test_go_path="$(go env GOPATH 2>/dev/null || true)"
+        test_go_path="${test_go_path%%:*}"
+        [[ -n "${test_go_path}" ]] && test_go_bin="${test_go_path}/bin"
+    fi
+    [[ -n "${test_go_bin}" ]] && export PATH="${test_go_bin}:${PATH}"
+fi
+
+# Mirrors api-diff_test.sh: a missing tool otherwise reads as many unrelated
+# failures instead of one cause. Skip locally, fail in CI where the gate must
+# actually run.
+missing=""
+if ! command -v oasdiff >/dev/null 2>&1; then
+    missing="oasdiff is not installed"
+elif ! command -v yq >/dev/null 2>&1; then
+    missing="yq is not installed"
+elif ! yq --version 2>/dev/null | grep -q "mikefarah/yq"; then
+    missing="yq at $(command -v yq) is not mikefarah/yq (Go-based)"
+fi
+if [[ -n "${missing}" ]]; then
+    if [[ -n "${CI:-}" ]]; then
+        echo "FAIL: ${missing}; the OpenAPI-diff gate cannot be verified in CI" >&2
+        exit 1
+    fi
+    echo "SKIP: ${missing}; run 'make tools-setup' to install the pinned version"
+    exit 0
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/openapi-diff-test.XXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+fails=0
+pass() { echo "PASS: $1"; }
+fail() {
+    echo "FAIL: $1 — $2"
+    fails=$((fails + 1))
+}
+
+check_rc() {
+    local name="$1" want="$2" got="$3"
+    if [[ "${got}" == "${want}" ]]; then
+        pass "${name}"
+    else
+        fail "${name}" "exit ${got}, want ${want}"
+    fi
+}
+
+# The fixture is the real committed contract, so these tests stay meaningful as
+# the spec evolves rather than drifting against a hand-written toy spec.
+BASE_SPEC="${REPO_ROOT}/api/aicr/v1/server.baseline.yaml"
+
+write_exceptions() {
+    printf '%s\n' "acknowledgements:$1" > "${WORK}/exceptions.yaml"
+}
+
+run_gate() {
+    (
+        cd "${REPO_ROOT}" || exit 99
+        OPENAPI_DIFF_SPEC_FILE="${WORK}/spec.yaml" \
+            OPENAPI_DIFF_BASELINE_FILE="${WORK}/baseline.yaml" \
+            OPENAPI_DIFF_EXCEPTIONS_FILE="${WORK}/exceptions.yaml" \
+            bash "${OPENAPI_DIFF}" >"${WORK}/out.txt" 2>&1
+    )
+}
+
+cp "${BASE_SPEC}" "${WORK}/baseline.yaml"
+
+# 1. Identical spec and baseline: the gate must pass. A failure here would mean
+#    the gate reports drift on an unchanged contract, which trains people to
+#    ignore it.
+cp "${BASE_SPEC}" "${WORK}/spec.yaml"
+write_exceptions " []"
+run_gate
+check_rc "identical-spec-passes" 0 "$?"
+
+# 2. Removing an endpoint is the canonical break. Without this the gate could be
+#    passing case 1 by never running oasdiff at all.
+python3 - "${WORK}/spec.yaml" <<'PY'
+import sys
+path = sys.argv[1]
+text = open(path).read()
+start = text.index("  /v1/query:")
+end = text.index("  /v1/bundle:")
+open(path, "w").write(text[:start] + text[end:])
+PY
+run_gate
+check_rc "unacknowledged-break-fails" 1 "$?"
+if grep -q "api-path-removed-without-deprecation" "${WORK}/out.txt"; then
+    pass "unacknowledged-break-names-the-rule"
+else
+    fail "unacknowledged-break-names-the-rule" "rule id absent from output"
+fi
+
+# 3. An acknowledgement matching that break must clear it.
+write_exceptions "
+  - id: api-path-removed-without-deprecation
+    path: /v1/query
+    reason: fixture"
+run_gate
+check_rc "acknowledged-break-passes" 0 "$?"
+
+# 4. An acknowledgement narrowed to a different path must NOT clear it.
+#    Matching on rule id alone would let one endpoint's exception cover the same
+#    class of break anywhere.
+write_exceptions "
+  - id: api-path-removed-without-deprecation
+    path: /v1/bundle
+    reason: fixture for a different endpoint"
+run_gate
+check_rc "acknowledgement-does-not-leak-across-paths" 1 "$?"
+
+# 5. Restoring the spec leaves the acknowledgement matching nothing. A stale
+#    entry silently pre-approves the break returning, so it must fail.
+cp "${BASE_SPEC}" "${WORK}/spec.yaml"
+write_exceptions "
+  - id: api-path-removed-without-deprecation
+    path: /v1/query
+    reason: fixture"
+run_gate
+check_rc "stale-acknowledgement-fails" 12 "$?"
+
+# 6. A malformed exceptions file must fail loudly rather than being read as
+#    "no exceptions", which would silently change the verdict.
+printf 'not-a-mapping\n' > "${WORK}/exceptions.yaml"
+run_gate
+check_rc "malformed-exceptions-fails" 11 "$?"
+
+# 7. A missing input must not be mistaken for an empty contract.
+write_exceptions " []"
+rm -f "${WORK}/spec.yaml"
+run_gate
+check_rc "missing-spec-fails" 10 "$?"
+
+# 8. Additive change: a new optional parameter must not fail. A gate that
+#    rejects additions would push authors to bypass it.
+cp "${BASE_SPEC}" "${WORK}/spec.yaml"
+python3 - "${WORK}/spec.yaml" <<'PY'
+import sys
+path = sys.argv[1]
+text = open(path).read()
+anchor = "    Accelerator:\n      name: accelerator"
+addition = (
+    "    FixtureOptional:\n"
+    "      name: fixtureOptional\n"
+    "      in: query\n"
+    "      required: false\n"
+    "      description: Additive optional parameter.\n"
+    "      schema:\n"
+    "        type: string\n"
+)
+assert text.count(anchor) == 1
+open(path, "w").write(text.replace(anchor, addition + anchor))
+PY
+run_gate
+check_rc "additive-change-passes" 0 "$?"
+
+if (( fails > 0 )); then
+    echo "${fails} test(s) failed"
+    exit 1
+fi
+echo "All OpenAPI-diff tests passed"

--- a/tools/openapi-diff_test.sh
+++ b/tools/openapi-diff_test.sh
@@ -70,6 +70,22 @@ fail() {
     fails=$((fails + 1))
 }
 
+# require_fixture_edit fails loudly when a fixture edit did not change the spec.
+# Without it a moved anchor turns a case into a no-op that reports PASS.
+require_fixture_edit() {
+    # Must be the first statement: any command here, including `local name=`,
+    # overwrites $? and would make the script-failure branch below unreachable.
+    local status=$?
+    local name="$1"
+    if [[ ${status} -ne 0 ]]; then
+        fail "${name}" "fixture edit script failed"
+        return
+    fi
+    if cmp -s "${WORK}/spec.yaml" "${WORK}/baseline.yaml"; then
+        fail "${name}" "fixture edit produced no change; the case would pass vacuously"
+    fi
+}
+
 check_rc() {
     local name="$1" want="$2" got="$3"
     if [[ "${got}" == "${want}" ]]; then
@@ -109,6 +125,9 @@ check_rc "identical-spec-passes" 0 "$?"
 
 # 2. Removing an endpoint is the canonical break. Without this the gate could be
 #    passing case 1 by never running oasdiff at all.
+# A failed fixture edit leaves spec.yaml identical to the baseline, so the gate
+# would pass and the case would report success without testing anything. set -e
+# is intentionally off in this file, so the status is checked explicitly.
 python3 - "${WORK}/spec.yaml" <<'PY'
 import sys
 path = sys.argv[1]
@@ -117,6 +136,7 @@ start = text.index("  /v1/query:")
 end = text.index("  /v1/bundle:")
 open(path, "w").write(text[:start] + text[end:])
 PY
+require_fixture_edit "remove-endpoint"
 run_gate
 check_rc "unacknowledged-break-fails" 1 "$?"
 if grep -q "api-path-removed-without-deprecation" "${WORK}/out.txt"; then
@@ -185,8 +205,35 @@ addition = (
 assert text.count(anchor) == 1
 open(path, "w").write(text.replace(anchor, addition + anchor))
 PY
+require_fixture_edit "add-optional-parameter"
 run_gate
 check_rc "additive-change-passes" 0 "$?"
+
+# 9. A removed request parameter is reported at WARN (level 2), not ERR. An
+#    ERR-only filter reported zero breaking changes here and passed, dropping a
+#    whole rule class the gate exists to cover.
+cp "${BASE_SPEC}" "${WORK}/spec.yaml"
+write_exceptions " []"
+python3 - "${WORK}/spec.yaml" <<'PY'
+import sys
+path = sys.argv[1]
+lines = open(path).read().split("\n")
+for i, line in enumerate(lines):
+    if "parameters/Nodes" in line:
+        del lines[i]
+        break
+else:
+    raise SystemExit("no Nodes parameter reference to remove")
+open(path, "w").write("\n".join(lines))
+PY
+require_fixture_edit "remove-request-parameter"
+run_gate
+check_rc "warn-level-break-fails" 1 "$?"
+if grep -q "request-parameter-removed" "${WORK}/out.txt"; then
+    pass "warn-level-break-names-the-rule"
+else
+    fail "warn-level-break-names-the-rule" "rule id absent from output"
+fi
 
 if (( fails > 0 )); then
     echo "${fails} test(s) failed"

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -1026,10 +1026,20 @@ if [[ "${SKIP_TOOLS}" == "false" ]] && command_exists go; then
         fi
     fi
 
-    # oasdiff
-    if command_exists oasdiff && [[ "${UPGRADE}" != "true" ]]; then
-        log_success "oasdiff already installed"
+    # oasdiff. Existence is not enough: tools/check-tools requires an exact
+    # module-version match, so an older binary already on PATH would leave
+    # setup reporting success while the gate runs on a different version.
+    oasdiff_current=""
+    if command_exists oasdiff; then
+        oasdiff_current="$(go version -m "$(command -v oasdiff)" 2>/dev/null |
+            awk '$1 == "mod" && $2 == "github.com/oasdiff/oasdiff" {print $3; exit}')"
+    fi
+    if [[ "${oasdiff_current}" == "${OASDIFF_VERSION}" && "${UPGRADE}" != "true" ]]; then
+        log_success "oasdiff ${OASDIFF_VERSION} already installed"
     else
+        if [[ -n "${oasdiff_current}" && "${oasdiff_current}" != "${OASDIFF_VERSION}" ]]; then
+            log_warning "oasdiff ${oasdiff_current} found; replacing with the pinned ${OASDIFF_VERSION}"
+        fi
         log_info "Installing oasdiff ${OASDIFF_VERSION}..."
         if prompt_continue; then
             GOFLAGS= go install github.com/oasdiff/oasdiff@"${OASDIFF_VERSION}"

--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -274,6 +274,7 @@ cd "${REPO_ROOT}"
 GO_VERSION=$(yq '.languages.go' .settings.yaml)
 GOLANGCI_LINT_VERSION=$(yq '.linting.golangci_lint' .settings.yaml)
 APIDIFF_VERSION=$(yq '.linting.apidiff' .settings.yaml)
+OASDIFF_VERSION=$(yq '.linting.oasdiff' .settings.yaml)
 YAMLLINT_VERSION=$(yq '.linting.yamllint' .settings.yaml)
 ADDLICENSE_VERSION=$(yq '.linting.addlicense' .settings.yaml)
 GO_LICENSES_VERSION=$(yq '.linting.go_licenses' .settings.yaml)
@@ -303,6 +304,7 @@ log_info "Target Versions:"
 echo "  Go:              ${GO_VERSION}"
 echo "  golangci-lint:   ${GOLANGCI_LINT_VERSION}"
 echo "  apidiff:         ${APIDIFF_VERSION}"
+echo "  oasdiff:         ${OASDIFF_VERSION}"
 echo "  grype:           ${GRYPE_VERSION}"
 echo "  cosign:          ${COSIGN_VERSION}"
 echo "  syft:            ${SYFT_VERSION}"
@@ -1021,6 +1023,17 @@ if [[ "${SKIP_TOOLS}" == "false" ]] && command_exists go; then
         if prompt_continue; then
             GOFLAGS= go install golang.org/x/exp/cmd/apidiff@"${APIDIFF_VERSION}"
             log_success "apidiff ${APIDIFF_VERSION} installed"
+        fi
+    fi
+
+    # oasdiff
+    if command_exists oasdiff && [[ "${UPGRADE}" != "true" ]]; then
+        log_success "oasdiff already installed"
+    else
+        log_info "Installing oasdiff ${OASDIFF_VERSION}..."
+        if prompt_continue; then
+            GOFLAGS= go install github.com/oasdiff/oasdiff@"${OASDIFF_VERSION}"
+            log_success "oasdiff ${OASDIFF_VERSION} installed"
         fi
     fi
 


### PR DESCRIPTION
## Summary

Gates the REST contract against a committed baseline with the pinned `oasdiff`. **Closes scope items 2, 3, 4 and 6 of #2112 — with #2466's item 7 and #2464's item 1, the issue is complete.**

## Motivation / Context

REST is one of the four surfaces ROADMAP §1 freezes at v1. Until now nothing failed CI when the contract changed: #2464 removed five endpoints and eleven schemas and every gate stayed green.

`make openapi-diff` fails on removed endpoints, removed or narrowed fields, newly required request fields, and removed enum values. Additive change passes. It runs in `make qualify` beside `api-diff`, which guards the Go SDK the same way.

Fixes: N/A
Related: #2112, #2370, #2113

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Component(s) Affected

- [x] API server (`cmd/aicrd`, `pkg/server`)
- [x] CI/CD (`.github/`)
- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

### oasdiff is pinned as a binary, not imported

As a **library** it pulls in `cloud.google.com/go`, viper, pflag, goldmark and kin-openapi. Go does not separate test-only dependencies from the module graph, so all of that would land in the **SBOM and the vulnerability surface of the shipped binary** — for a gate that never runs in production. `tools/api-diff` already established the binary-tool shape for exactly this job, so this follows it: pinned in `.settings.yaml`, installed by `tools/setup-tools`, verified by `tools/check-tools`.

### The baseline is a committed snapshot, not the previous release

This is the one place it departs from `api-diff`, and the reason is concrete: the v1 collapse is unreleased, so comparing against v0.20.0 reports **28 breaking changes that are all one already-merged decision**. The gate would ship pre-loaded with noise that clears itself at v0.21, having first taught everyone to skim it.

### Exceptions, including the half that makes them safe

An acknowledgement that matches **no** reported change **fails the gate** — a stale entry silently pre-approves the break returning, which is the failure the file exists to prevent. Same contract as `pkg/client/v1/api-diff-exceptions.yaml`. Entries match on rule id **and** operation path; id alone would let one endpoint's exception cover the same class of break anywhere.

The scheduled ADR-022 removals in v0.22 (#2416) and v0.23 (#2417) are the expected occupants — that is what "represented explicitly rather than disabling the gate" means in the acceptance criteria.

### Writing the tests found two defects in the script

Both would have made the gate quietly wrong:

- A **malformed exceptions file was read as "no exceptions"** — `yq '.acknowledgements'` returns null rather than erroring on a scalar document, so a typo'd file silently changed the verdict. Now the type is asserted.
- A **stale acknowledgement exited before reporting an unacknowledged break** that was also present, hiding the more urgent of the two. An acknowledgement narrowed to the wrong path produces exactly that pair. Both are now reported, with the merge-blocking one setting the exit code.

### A second gate, for what the diff cannot see

`openapi_validity_test.go` answers "is the contract coherent", not "did it change". A dangling `$ref`, an orphaned component, or a duplicate `operationId` exists in **both** baseline and spec — the diff sees no change and passes while every generated client is wrong. It also guards the baseline against truncation, which would make the diff report no breaking changes for whatever the truncated file omits. An early version of `make openapi-baseline` did truncate, which is why the test exists.

## Testing

```bash
go test -race ./pkg/... ./cmd/...          # 0 failures
golangci-lint run -c .golangci.yaml ./...  # 0 issues
bash tools/openapi-diff_test.sh            # 9/9 pass (runs in make test-shell)
make openapi-diff lint-yaml check-docs-mdx # OK
```

**Every gate was verified by breaking what it protects**, then restoring:

| Mutation | Expected | Result |
|---|---|---|
| Remove an endpoint | fail | exit 1 |
| Remove an enum value | fail | exit 1 |
| Optional param → required | fail | exit 1 |
| **Add an optional param** | **pass** | exit 0 |
| Acknowledgement for a different path | fail | exit 1 |
| Acknowledgement matching nothing | fail | exit 12 |
| Malformed exceptions | fail | exit 11 |
| Dangling `$ref` | fail | test fails |
| Orphaned component | fail | test fails |
| Duplicate `operationId` | fail | test fails |
| Truncated baseline | fail | test fails |

`make openapi-baseline` is idempotent: regenerating from an unchanged spec is byte-identical.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested

Adds a gate and a pinned tool. No production code changes. Contributors need `make tools-setup` for `oasdiff`; the shell test skips locally with a clear message when it is missing and **fails in CI**, where the gate must actually run.

## Note

Also corrects `docs/contributor/api-server.md`, which still described `TestOpenAPIV1BundleRecipeContract` under its pre-collapse name and claimed `kind: Recipe` posts return 200 — #2464 made that a rejection. A doc bug I shipped there.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
