### PR TITLE
fix(sdk): close three input-handling gaps in the v1 facade

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -1141,7 +1141,19 @@ Per-operation caps:
   completion budget you asked for.
 - `ValidateState`: `defaults.ValidationOperationTimeout`
 - `VerifyBundle` / `VerifyEvidence` / `VerifyCatalog` / `RecipeDigest`:
-  `defaults.VerifyOperationTimeout`
+  `defaults.VerifyOperationTimeout` by default, overridable per call via the
+  `Timeout` field on each options struct. `nil` (the zero value) keeps the
+  default cap; a pointer to `0` imposes **no** facade cap and runs under the
+  caller's context unchanged; a positive value sets an explicit cap.
+
+  The pointer is what makes `0` mean uncapped here, matching
+  `WithValidationTimeout(0)`, while leaving the zero value as today's
+  behavior. Reach for it when a registry is slow rather than broken:
+  `VerifyEvidence` pulls from the network, and a cap breach arrives as an
+  **error** rather than the `EvidenceExitIncomplete` verdict a CI gate
+  branches on — so a slow pull, which is exactly what that verdict describes,
+  otherwise reports through the wrong channel. The override can only relax
+  the facade ceiling; the caller's own deadline still applies.
 - `PublishEvidence` / `SignCatalog`: **no facade cap** — the caller's
   context governs unchanged. Keyless OIDC can block on a human
   completing a browser or device-code flow, so a fixed cap would cut

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -1038,11 +1038,10 @@ Rekor are. The result is content-identical to the one-shot path.
 Client's catalog and returning the serialized Sigstore bundle.
 
 **`SignCatalog` rejects the signing modes it can tell `VerifyCatalog`
-will not verify** — with one documented exception, below. Verification
-checks against the public-good Sigstore root, requires a
-transparency-log entry, and accepts keyless GitHub OIDC certificates
-only, so these four `OIDCResolve` settings are rejected with
-`ErrCodeInvalidRequest` before any signing work runs:
+will not verify.** Verification checks against the public-good Sigstore
+root, requires a transparency-log entry, and accepts keyless GitHub OIDC
+certificates only, so these four `OIDCResolve` settings are rejected
+with `ErrCodeInvalidRequest` before any signing work runs:
 
 | Setting | Why it is rejected |
 |---|---|
@@ -1055,16 +1054,20 @@ The point of the guard is that you should not be able to sign a catalog
 successfully and then discover the documented counterpart refuses it;
 if private catalog signing is ever needed, both halves move together.
 
-**The exception: `SigningConfigPath` is not validated.** It passes
-through because the release path requires it, and a Sigstore signing
-config can itself name a private Fulcio or Rekor — so a signing config
-*can* still produce a catalog `VerifyCatalog` rejects. Treat the guard
-as covering the four settings above, not as a guarantee about every
-input. Each rejected setting exists *only* to depart from the
-public-good defaults, which is what makes rejecting it unambiguous; a
-signing config does not, and rejecting it would break the release.
-Validating the loaded config against the public-good endpoints is the
-principled fix if this exception ever bites.
+**`SigningConfigPath` is checked rather than rejected.** It passes
+through because the release path requires it — naming the public-good
+Rekor v2 target is its normal use — but a Sigstore signing config can
+itself name a private Fulcio or Rekor, which would have made the four
+rejections above bypassable by moving the same endpoints into a file. So
+the config is loaded and every Fulcio, Rekor, OIDC provider, and
+timestamp-authority URL in it must sit under the `sigstore.dev` domain;
+anything else fails with `ErrCodeInvalidRequest` naming the offending
+endpoint. The check is on the domain, not a list of exact URLs, because
+the public-good Rekor shards carry the year in their hostname
+(`log2025-1.rekor.sigstore.dev`) and an exact-URL allowlist would start
+rejecting legitimate signing at the next rotation. Matching is on a
+label boundary, so a lookalike domain such as `evilsigstore.dev` is
+rejected.
 
 Neither signing method imposes a facade timeout, unlike their
 verification counterparts: keyless OIDC can block on a human completing

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -1069,7 +1069,15 @@ the public-good Rekor shards carry the year in their hostname
 (`log2025-1.rekor.sigstore.dev`) and an exact-URL allowlist would start
 rejecting legitimate signing at the next rotation. Matching is on a
 label boundary, so a lookalike domain such as `evilsigstore.dev` is
-rejected.
+rejected, and every URL must be HTTPS — the public-good services are
+HTTPS-only, and these URLs are handed to the Rekor and timestamp
+clients as-is, so `http://rekor.sigstore.dev` would pass a
+hostname-only check while sending signing traffic in the clear.
+
+The config that passes this check is the config signed with. `SignCatalog`
+hands the parsed value to the signing path rather than letting it re-read
+the file, so there is no window in which the file changes between the
+check and the use.
 
 Neither signing method imposes a facade timeout, unlike their
 verification counterparts: keyless OIDC can block on a human completing

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -248,11 +248,13 @@ snapCtx, cancelSnap := context.WithTimeout(context.Background(), 10*time.Minute)
 defer cancelSnap()
 snap, err := client.CollectSnapshot(snapCtx, &aicr.AgentConfig{
 	Kubeconfig: "/path/to/target-kubeconfig",
-	// Namespace, Image, JobName, and ServiceAccountName are all required on
-	// the SDK path. Only Namespace is validated; the rest are copied straight
-	// into the Job and RBAC objects, so an empty value becomes an empty
-	// metadata.name or container image that the API server rejects. The CLI
-	// defaults them from its own flags, which the facade does not share.
+	// Namespace is the only required field: the Job, its RBAC, and the result
+	// ConfigMap are created there, and an empty value is rejected with
+	// ErrCodeInvalidRequest before any cluster access. Image, JobName, and
+	// ServiceAccountName are defaulted when empty — the names to "aicr" and
+	// the image to the tag matching the Client's WithVersion. They are set
+	// explicitly here because pinning the agent generation is what a
+	// version-skew-sensitive or air-gapped deployment wants.
 	Namespace:          "aicr-snapshot",
 	Image:              "ghcr.io/nvidia/aicr:v0.19.0",
 	JobName:            "aicr-snapshot",

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -255,6 +255,12 @@ snap, err := client.CollectSnapshot(snapCtx, &aicr.AgentConfig{
 	// the image to the tag matching the Client's WithVersion. They are set
 	// explicitly here because pinning the agent generation is what a
 	// version-skew-sensitive or air-gapped deployment wants.
+	//
+	// Collect against one cluster at a time. The default names are shared, the
+	// Job is delete-then-created, and the ClusterRoleBinding has a fixed name
+	// carrying the ServiceAccount as its subject — so two concurrent runs
+	// interfere even with distinct JobName values. See CollectSnapshot's
+	// Concurrency godoc.
 	Namespace:          "aicr-snapshot",
 	Image:              "ghcr.io/nvidia/aicr:v0.19.0",
 	JobName:            "aicr-snapshot",

--- a/pkg/bundler/attestation/keyless.go
+++ b/pkg/bundler/attestation/keyless.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
 // KeylessAttester signs bundle content using Sigstore keyless OIDC signing
@@ -30,6 +32,7 @@ type KeylessAttester struct {
 	rekorURL            string
 	signingConfigPath   string
 	useTUFSigningConfig bool
+	signingConfig       *root.SigningConfig
 	identity            string
 }
 
@@ -61,6 +64,37 @@ func NewKeylessAttester(oidcToken, fulcioURL, rekorURL, signingConfigPath string
 	}
 }
 
+// NewKeylessAttesterFromOptions builds a KeylessAttester from a ResolveOptions.
+//
+// Preferred over NewKeylessAttester for anything driven by a ResolveOptions:
+// the positional form cannot carry ResolveOptions.SigningConfig, so a caller
+// that validated a config before signing would silently fall back to re-reading
+// SigningConfigPath — the exact check-then-reload gap that field exists to
+// close. Adding a signing field here also cannot be dropped by one call site,
+// matching the SignOptionsFromResolve contract.
+func NewKeylessAttesterFromOptions(oidcToken string, o ResolveOptions) *KeylessAttester {
+	a := NewKeylessAttester(oidcToken, o.FulcioURL, o.RekorURL, o.SigningConfigPath, o.UseTUFSigningConfig)
+	a.signingConfig = o.SigningConfig
+	return a
+}
+
+// resolveOptions projects the attester's signing target back into a
+// ResolveOptions for SignOptionsFromResolve.
+//
+// Split out of Attest so the round trip is reachable from a test without
+// signing anything. Every field dropped here is a field the attester silently
+// stops honoring — SigningConfig in particular, whose whole purpose is that the
+// config validated before signing is the one signed with.
+func (k *KeylessAttester) resolveOptions() ResolveOptions {
+	return ResolveOptions{
+		FulcioURL:           k.fulcioURL,
+		RekorURL:            k.rekorURL,
+		SigningConfigPath:   k.signingConfigPath,
+		UseTUFSigningConfig: k.useTUFSigningConfig,
+		SigningConfig:       k.signingConfig,
+	}
+}
+
 // Attest creates a DSSE-signed in-toto SLSA provenance statement for the
 // given subject using keyless OIDC signing via Fulcio and Rekor.
 // Returns the Sigstore bundle as serialized JSON.
@@ -77,12 +111,7 @@ func (k *KeylessAttester) Attest(ctx context.Context, subject AttestSubject) ([]
 		return nil, errors.Wrap(errors.ErrCodeInternal, "failed to build attestation statement", err)
 	}
 
-	res, err := SignStatement(ctx, statementJSON, SignOptionsFromResolve(k.oidcToken, ResolveOptions{
-		FulcioURL:           k.fulcioURL,
-		RekorURL:            k.rekorURL,
-		SigningConfigPath:   k.signingConfigPath,
-		UseTUFSigningConfig: k.useTUFSigningConfig,
-	}))
+	res, err := SignStatement(ctx, statementJSON, SignOptionsFromResolve(k.oidcToken, k.resolveOptions()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bundler/attestation/resolver.go
+++ b/pkg/bundler/attestation/resolver.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
 // ResolveOptions selects an OIDC token source for keyless signing. Callers
@@ -67,6 +69,15 @@ type ResolveOptions struct {
 	// way to target Rekor v2. Honored by both keyless and KMS signing. See issue
 	// #1650.
 	UseTUFSigningConfig bool
+
+	// SigningConfig is an already-parsed signing config that takes precedence
+	// over SigningConfigPath, UseTUFSigningConfig, and RekorURL.
+	//
+	// Set it when the config had to be inspected before use: re-loading from
+	// SigningConfigPath after validating it would sign against whatever the file
+	// holds at that later moment. Client.SignCatalog populates this after
+	// checking the config targets public-good Sigstore. See SignOptions.SigningConfig.
+	SigningConfig *root.SigningConfig
 
 	// SigningKey selects KMS-backed (key-based) signing instead of keyless OIDC.
 	// When non-empty it is a cosign-style KMS URI (awskms:// | gcpkms:// |
@@ -189,7 +200,7 @@ func ResolveAttester(ctx context.Context, opts ResolveOptions) (Attester, error)
 	if err != nil {
 		return nil, err
 	}
-	return NewKeylessAttester(token, opts.FulcioURL, opts.RekorURL, opts.SigningConfigPath, opts.UseTUFSigningConfig), nil
+	return NewKeylessAttesterFromOptions(token, opts), nil
 }
 
 // ResolveAttesterLazy is the deferred-token variant of ResolveAttester.
@@ -255,7 +266,7 @@ func (l *LazyKeylessAttester) Attest(ctx context.Context, subject AttestSubject)
 			l.mu.Unlock()
 			return nil, err
 		}
-		l.inner = NewKeylessAttester(token, l.opts.FulcioURL, l.opts.RekorURL, l.opts.SigningConfigPath, l.opts.UseTUFSigningConfig)
+		l.inner = NewKeylessAttesterFromOptions(token, l.opts)
 	}
 	inner := l.inner
 	l.mu.Unlock()

--- a/pkg/bundler/attestation/signing.go
+++ b/pkg/bundler/attestation/signing.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/sign"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -59,6 +60,16 @@ type SignOptions struct {
 	// way to target Rekor v2 — the endpoint set is Sigstore-maintained and nothing
 	// is hardcoded. Ignored when SigningConfigPath is set. See #1650.
 	UseTUFSigningConfig bool
+
+	// SigningConfig is an already-parsed signing config that takes precedence
+	// over all three fields above.
+	//
+	// It exists for callers that must INSPECT a config before signing with it:
+	// Client.SignCatalog rejects a config naming non-public-good endpoints, and
+	// re-loading from SigningConfigPath afterwards would sign against whatever
+	// the file holds at that later moment, not what was validated. Passing the
+	// parsed config makes the checked bytes and the used bytes the same bytes.
+	SigningConfig *root.SigningConfig
 }
 
 // SignOptionsFromResolve maps a resolved OIDC token plus the signing-target
@@ -75,6 +86,7 @@ func SignOptionsFromResolve(token string, o ResolveOptions) SignOptions {
 		RekorURL:            o.RekorURL,
 		SigningConfigPath:   o.SigningConfigPath,
 		UseTUFSigningConfig: o.UseTUFSigningConfig,
+		SigningConfig:       o.SigningConfig,
 	}
 }
 
@@ -146,6 +158,10 @@ func SignStatement(ctx context.Context, statementJSON []byte, opts SignOptions) 
 // fetch the v2 path may perform on a cold cache.
 func transparencyForOptions(ctx context.Context, opts SignOptions) (TransparencyPolicy, error) {
 	switch {
+	case opts.SigningConfig != nil:
+		// First, ahead of the path: when a caller validated a config it must be
+		// the one signed with, not a re-read of the same path.
+		return NewSigningConfigPolicy(opts.SigningConfig)
 	case opts.SigningConfigPath != "":
 		return NewSigningConfigPolicyFromPath(opts.SigningConfigPath)
 	case opts.UseTUFSigningConfig:

--- a/pkg/bundler/attestation/signingconfig.go
+++ b/pkg/bundler/attestation/signingconfig.go
@@ -71,6 +71,20 @@ func NewSigningConfigPolicyFromPath(path string) (TransparencyPolicy, error) {
 	return newSigningConfigPolicy(sc, time.Now(), false)
 }
 
+// NewSigningConfigPolicy returns a TransparencyPolicy for an already-parsed
+// SigningConfig.
+//
+// This exists so a caller that has to INSPECT a config before signing with it
+// can pass the very bytes it inspected. Re-loading from the path instead leaves
+// a window in which the file changes between the check and the use, which for a
+// signing target means signing against endpoints nobody validated.
+//
+// A caller-supplied config may legitimately be v1, so a v1 selection here is not
+// a downgrade — no warning, matching NewSigningConfigPolicyFromPath.
+func NewSigningConfigPolicy(sc *root.SigningConfig) (TransparencyPolicy, error) {
+	return newSigningConfigPolicy(sc, time.Now(), false)
+}
+
 // NewSigningConfigPolicyFromTUF returns a TransparencyPolicy built from the
 // Rekor v2 signing config distributed via TUF — AICR's default signing target.
 // The endpoint set is Sigstore-maintained and rotation-safe (shard URLs carry

--- a/pkg/bundler/attestation/signingconfig.go
+++ b/pkg/bundler/attestation/signingconfig.go
@@ -57,18 +57,9 @@ func NewSigningConfigPolicyFromPath(path string) (TransparencyPolicy, error) {
 	// user-supplied CLI/env argument, so cap it before the bytes hit memory to
 	// keep an attacker-influenced path (a /proc symlink, an NFS/FUSE mount) from
 	// OOMing the process, mirroring loadPEMPublicKey / the trusted-root loader.
-	f, err := os.Open(path) //nolint:gosec // path is an operator-supplied signer input, bounded below
+	data, err := readSigningConfigBytes(path)
 	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to open signing config", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	data, err := io.ReadAll(io.LimitReader(f, defaults.MaxSigningConfigBytes+1))
-	if err != nil {
-		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to read signing config", err)
-	}
-	if int64(len(data)) > defaults.MaxSigningConfigBytes {
-		return nil, errors.New(errors.ErrCodeInvalidRequest, "signing config file exceeds size limit")
+		return nil, err
 	}
 
 	sc, err := root.NewSigningConfigFromJSON(data)
@@ -183,3 +174,26 @@ func selectSigningServices(sc *root.SigningConfig, now time.Time) (rekor, tsa []
 func (p signingConfigPolicy) Logs() []sign.Transparency { return p.logs }
 
 func (p signingConfigPolicy) TimestampAuthorities() []*sign.TimestampAuthority { return p.tsas }
+
+// readSigningConfigBytes reads a signing config with a size cap.
+//
+// Bounded instead of a bare os.ReadFile because the path is a user-supplied
+// CLI/env argument: capping before the bytes hit memory keeps an
+// attacker-influenced path (a /proc symlink, an NFS/FUSE mount) from OOMing the
+// process, mirroring loadPEMPublicKey and the trusted-root loader.
+func readSigningConfigBytes(path string) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // path is an operator-supplied signer input, bounded below
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to open signing config", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(f, defaults.MaxSigningConfigBytes+1))
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest, "failed to read signing config", err)
+	}
+	if int64(len(data)) > defaults.MaxSigningConfigBytes {
+		return nil, errors.New(errors.ErrCodeInvalidRequest, "signing config file exceeds size limit")
+	}
+	return data, nil
+}

--- a/pkg/bundler/attestation/signingconfig_policy.go
+++ b/pkg/bundler/attestation/signingconfig_policy.go
@@ -105,7 +105,10 @@ func requirePublicGoodURL(label, raw string) error {
 			map[string]any{endpointKey: raw, "scheme": parsed.Scheme})
 	}
 
-	host := parsed.Hostname()
+	// Lowercased: DNS names are case-insensitive, so "FULCIO.SIGSTORE.DEV" is
+	// the public-good host. url.Hostname() does not normalize case, and a
+	// case-sensitive comparison would reject a legitimate config.
+	host := strings.ToLower(parsed.Hostname())
 	if host == "" {
 		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("signing config %s URL has no host", label),

--- a/pkg/bundler/attestation/signingconfig_policy.go
+++ b/pkg/bundler/attestation/signingconfig_policy.go
@@ -94,6 +94,17 @@ func requirePublicGoodURL(label, raw string) error {
 			map[string]any{endpointKey: raw})
 	}
 
+	// Scheme before host. The public-good services are HTTPS-only, and these
+	// URLs are handed to sign.NewRekor / sign.NewTimestampAuthority as-is, so
+	// an "http://rekor.sigstore.dev" would pass a host-only check while sending
+	// signing traffic in the clear — a downgrade wearing the right hostname.
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("signing config %s URL is not HTTPS (%s); the public-good "+
+				"Sigstore services are HTTPS-only", label, raw),
+			map[string]any{endpointKey: raw, "scheme": parsed.Scheme})
+	}
+
 	host := parsed.Hostname()
 	if host == "" {
 		return errors.NewWithContext(errors.ErrCodeInvalidRequest,

--- a/pkg/bundler/attestation/signingconfig_policy.go
+++ b/pkg/bundler/attestation/signingconfig_policy.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/sigstore/sigstore-go/pkg/root"
+)
+
+// publicGoodDomain is the DNS suffix every public-good Sigstore service lives
+// under.
+//
+// The check is on the domain rather than a list of exact URLs on purpose. The
+// public-good Rekor shards carry the year in their hostname
+// (log2025-1.rekor.sigstore.dev), so an exact-URL allowlist would pass today
+// and start rejecting legitimate release signing at the next rotation — a gate
+// that breaks the release path on a calendar boundary is worse than no gate.
+// The operator's domain is the stable identity; the shard names are not.
+const publicGoodDomain = "sigstore.dev"
+
+// endpointKey names the offending URL in the error's structured context so a
+// caller can report which endpoint to change.
+const endpointKey = "endpoint"
+
+// ValidateSigningConfigIsPublicGood reports whether a Sigstore signing config
+// targets only public-good services.
+//
+// This exists because catalog signing and catalog verification must agree.
+// VerifyCatalog verifies against the public-good Sigstore root, requires a
+// GitHub Actions OIDC issuer, and requires a transparency-log entry. A signing
+// config naming a private Fulcio or Rekor produces a catalog that fails all
+// three — signing appears to succeed and the artifact is unverifiable by the
+// documented counterpart.
+//
+// It FAILS CLOSED, matching the four sibling rejections in the facade and the
+// project's allowlist guidance: an endpoint outside the known-good domain is
+// rejected rather than warned about. The alternative — warn and sign anyway —
+// produces exactly the artifact this check exists to prevent, and the operator
+// discovers it at verification time instead of signing time.
+//
+// A nil config is accepted: "no config supplied" is the default path, not a
+// departure from it.
+func ValidateSigningConfigIsPublicGood(sc *root.SigningConfig) error {
+	if sc == nil {
+		return nil
+	}
+
+	groups := []struct {
+		label    string
+		services []root.Service
+	}{
+		{"certificate authority", sc.FulcioCertificateAuthorityURLs()},
+		{"transparency log", sc.RekorLogURLs()},
+		{"OIDC provider", sc.OIDCProviderURLs()},
+		{"timestamp authority", sc.TimestampAuthorityURLs()},
+	}
+
+	for _, group := range groups {
+		for _, service := range group.services {
+			if err := requirePublicGoodURL(group.label, service.URL); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// requirePublicGoodURL rejects a single endpoint outside the public-good domain.
+func requirePublicGoodURL(label, raw string) error {
+	if raw == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return errors.WrapWithContext(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("signing config %s URL is not parseable", label), err,
+			map[string]any{endpointKey: raw})
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("signing config %s URL has no host", label),
+			map[string]any{endpointKey: raw})
+	}
+
+	// Suffix match on a label boundary. A bare strings.HasSuffix would accept
+	// "evilsigstore.dev", which is the whole point of checking.
+	if host != publicGoodDomain && !strings.HasSuffix(host, "."+publicGoodDomain) {
+		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("signing config names a %s outside the public-good Sigstore "+
+				"instance (%s); a catalog signed against it cannot be verified by "+
+				"VerifyCatalog, which checks the public-good root", label, raw),
+			map[string]any{endpointKey: raw, "expectedDomain": publicGoodDomain})
+	}
+	return nil
+}
+
+// LoadSigningConfigForValidation reads a signing config from disk using the same
+// bounded read as the signing path.
+//
+// Callers that only need to validate a config should use this rather than
+// os.ReadFile: the path is operator-supplied, so the size cap that protects the
+// signing path has to protect the validation path too, or the guard becomes a
+// way to OOM the process before signing ever runs.
+func LoadSigningConfigForValidation(path string) (*root.SigningConfig, error) {
+	data, err := readSigningConfigBytes(path)
+	if err != nil {
+		return nil, err
+	}
+
+	sc, err := root.NewSigningConfigFromJSON(data)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			"failed to load signing config", err)
+	}
+	return sc, nil
+}

--- a/pkg/bundler/attestation/signingconfig_policy_test.go
+++ b/pkg/bundler/attestation/signingconfig_policy_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The four settings SignCatalog already rejects were bypassable by putting the
+// same endpoints in a signing config file: SigningConfigPath passed through
+// unvalidated, so a catalog could sign successfully against a private Fulcio or
+// Rekor and be unverifiable by its documented counterpart (#2227).
+
+// TestValidateSigningConfigIsPublicGood_AcceptsShippedConfigs is the guard
+// against breaking the release.
+//
+// The goreleaser hook signs with a public-good config on every tagged build, so
+// a validator that rejects one of these does not fail a test — it fails the
+// release. These are the configs the project actually ships with.
+func TestValidateSigningConfigIsPublicGood_AcceptsShippedConfigs(t *testing.T) {
+	entries, err := filepath.Glob("testdata/signing_config*.json")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no signing config fixtures found; this test would pass over nothing")
+	}
+
+	for _, path := range entries {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			sc, loadErr := LoadSigningConfigForValidation(path)
+			if loadErr != nil {
+				t.Fatalf("load: %v", loadErr)
+			}
+			if err := ValidateSigningConfigIsPublicGood(sc); err != nil {
+				t.Errorf("public-good config rejected: %v\nthis would break the "+
+					"release signing path, not just this test", err)
+			}
+		})
+	}
+}
+
+// TestValidateSigningConfigIsPublicGood_RejectsPrivateEndpoints covers the
+// case the guard exists for, in every service group.
+func TestValidateSigningConfigIsPublicGood_RejectsPrivateEndpoints(t *testing.T) {
+	base, err := os.ReadFile(filepath.Clean("testdata/signing_config_v2.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	tests := map[string]struct {
+		from, to string
+	}{
+		"private certificate authority": {"https://fulcio.sigstore.dev", "https://fulcio.internal.corp"},
+		"private transparency log":      {"rekor.sigstore.dev", "rekor.internal.corp"},
+		"private OIDC provider":         {"oauth2.sigstore.dev", "oauth2.internal.corp"},
+
+		// The domain check must match on a label boundary. A bare suffix test
+		// would accept this, which is the whole point of checking.
+		"lookalike domain": {"fulcio.sigstore.dev", "fulcio.evilsigstore.dev"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			mutated := strings.ReplaceAll(string(base), tt.from, tt.to)
+			if mutated == string(base) {
+				t.Fatalf("fixture does not contain %q; this case would pass "+
+					"vacuously", tt.from)
+			}
+
+			path := filepath.Join(t.TempDir(), "config.json")
+			if writeErr := os.WriteFile(path, []byte(mutated), 0o600); writeErr != nil {
+				t.Fatalf("write: %v", writeErr)
+			}
+
+			sc, loadErr := LoadSigningConfigForValidation(path)
+			if loadErr != nil {
+				t.Fatalf("load: %v", loadErr)
+			}
+			if err := ValidateSigningConfigIsPublicGood(sc); err == nil {
+				t.Errorf("accepted a config naming %q; a catalog signed against it "+
+					"cannot be verified by VerifyCatalog", tt.to)
+			}
+		})
+	}
+}
+
+// TestValidateSigningConfigIsPublicGood_NilIsAccepted pins the default path.
+//
+// "No config supplied" is not a departure from the public-good defaults, so it
+// must not be treated as one.
+func TestValidateSigningConfigIsPublicGood_NilIsAccepted(t *testing.T) {
+	if err := ValidateSigningConfigIsPublicGood(nil); err != nil {
+		t.Errorf("nil config rejected: %v", err)
+	}
+}

--- a/pkg/bundler/attestation/signingconfig_policy_test.go
+++ b/pkg/bundler/attestation/signingconfig_policy_test.go
@@ -109,6 +109,35 @@ func TestValidateSigningConfigIsPublicGood_RejectsPrivateEndpoints(t *testing.T)
 	}
 }
 
+// TestValidateSigningConfigIsPublicGood_AcceptsCaseVariantHosts covers the
+// other direction from the rejection table: DNS is case-insensitive, so an
+// uppercase spelling of a public-good host names the same service and must not
+// be rejected. A case-sensitive comparison would fail a legitimate config.
+func TestValidateSigningConfigIsPublicGood_AcceptsCaseVariantHosts(t *testing.T) {
+	base, err := os.ReadFile(filepath.Clean("testdata/signing_config_v2.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	mutated := strings.ReplaceAll(string(base), "fulcio.sigstore.dev", "FULCIO.SIGSTORE.DEV")
+	if mutated == string(base) {
+		t.Fatal("fixture does not contain the host under test; this would pass vacuously")
+	}
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	if writeErr := os.WriteFile(path, []byte(mutated), 0o600); writeErr != nil {
+		t.Fatalf("write: %v", writeErr)
+	}
+
+	sc, err := LoadSigningConfigForValidation(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := ValidateSigningConfigIsPublicGood(sc); err != nil {
+		t.Errorf("rejected an uppercase spelling of a public-good host: %v", err)
+	}
+}
+
 // TestValidateSigningConfigIsPublicGood_NilIsAccepted pins the default path.
 //
 // "No config supplied" is not a departure from the public-good defaults, so it

--- a/pkg/bundler/attestation/signingconfig_policy_test.go
+++ b/pkg/bundler/attestation/signingconfig_policy_test.go
@@ -15,6 +15,7 @@
 package attestation
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,14 @@ func TestValidateSigningConfigIsPublicGood_RejectsPrivateEndpoints(t *testing.T)
 		// The domain check must match on a label boundary. A bare suffix test
 		// would accept this, which is the whole point of checking.
 		"lookalike domain": {"fulcio.sigstore.dev", "fulcio.evilsigstore.dev"},
+
+		// A host-only check would accept these: the hostname is genuinely
+		// public-good, but the URL is handed to sign.NewRekor /
+		// sign.NewTimestampAuthority as-is, so signing traffic would go out in
+		// the clear.
+		"plaintext transparency log":      {"https://rekor.sigstore.dev", "http://rekor.sigstore.dev"},
+		"plaintext timestamp authority":   {"https://timestamp.sigstore.dev", "http://timestamp.sigstore.dev"},
+		"plaintext certificate authority": {"https://fulcio.sigstore.dev", "http://fulcio.sigstore.dev"},
 	}
 
 	for name, tt := range tests {
@@ -107,5 +116,84 @@ func TestValidateSigningConfigIsPublicGood_RejectsPrivateEndpoints(t *testing.T)
 func TestValidateSigningConfigIsPublicGood_NilIsAccepted(t *testing.T) {
 	if err := ValidateSigningConfigIsPublicGood(nil); err != nil {
 		t.Errorf("nil config rejected: %v", err)
+	}
+}
+
+// TestTransparencyPrecedence_ValidatedConfigWinsOverPath is the regression test
+// for the check-then-reload gap.
+//
+// Client.SignCatalog validates a signing config before signing with it. If the
+// signing path re-read SigningConfigPath afterwards, it would sign against
+// whatever the file held at that later moment -- the validated read and the used
+// read would be different reads. SignOptions.SigningConfig closes that, and this
+// pins the precedence: given BOTH a parsed config and a path, the parsed config
+// must win.
+//
+// The path here points at a file that does not exist, so a policy built from the
+// path could not succeed. Success therefore proves the parsed config was used.
+func TestTransparencyPrecedence_ValidatedConfigWinsOverPath(t *testing.T) {
+	sc, err := LoadSigningConfigForValidation("testdata/signing_config_v2.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	policy, err := transparencyForOptions(context.Background(), SignOptions{
+		SigningConfig:     sc,
+		SigningConfigPath: filepath.Join(t.TempDir(), "does-not-exist.json"),
+	})
+	if err != nil {
+		t.Fatalf("transparencyForOptions fell back to the path instead of using "+
+			"the validated config: %v", err)
+	}
+	if policy == nil {
+		t.Fatal("no transparency policy returned")
+	}
+}
+
+// TestTransparencyPrecedence_PathStillWorks guards the other direction: the
+// precedence change must not break the release path, which supplies only a path.
+func TestTransparencyPrecedence_PathStillWorks(t *testing.T) {
+	policy, err := transparencyForOptions(context.Background(), SignOptions{
+		SigningConfigPath: "testdata/signing_config_v2.json",
+	})
+	if err != nil {
+		t.Fatalf("path-only signing config rejected: %v", err)
+	}
+	if policy == nil {
+		t.Fatal("no transparency policy returned")
+	}
+}
+
+// TestKeylessAttesterCarriesValidatedSigningConfig covers the resolve -> sign
+// hop, which is the one place the validated config can be silently dropped.
+//
+// Client.SignCatalog sets ResolveOptions.SigningConfig, the resolver builds a
+// KeylessAttester from those options, and the attester rebuilds a ResolveOptions
+// to sign with. A field missed at either step reverts to re-reading
+// SigningConfigPath with no compile error and no test failure anywhere else --
+// signing would just quietly go back to using bytes nobody validated.
+func TestKeylessAttesterCarriesValidatedSigningConfig(t *testing.T) {
+	sc, err := LoadSigningConfigForValidation("testdata/signing_config_v2.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	attester := NewKeylessAttesterFromOptions("token", ResolveOptions{
+		SigningConfigPath: "testdata/signing_config_v2.json",
+		SigningConfig:     sc,
+	})
+
+	// Step 1: options -> attester.
+	if attester.signingConfig != sc {
+		t.Fatal("NewKeylessAttesterFromOptions dropped SigningConfig; signing would " +
+			"re-read SigningConfigPath instead of using the validated config")
+	}
+
+	// Step 2: attester -> ResolveOptions -> SignOptions, the exact chain Attest
+	// runs.
+	signOpts := SignOptionsFromResolve("token", attester.resolveOptions())
+	if signOpts.SigningConfig != sc {
+		t.Error("the validated SigningConfig did not survive the resolve -> sign " +
+			"projection; transparencyForOptions would fall back to the path")
 	}
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -28,30 +28,27 @@ import (
 
 	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	"github.com/NVIDIA/aicr/pkg/config"
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/logging"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
 
 const (
-	name                   = "aicr"
-	versionDefault         = "dev"
+	name                   = defaults.AgentName
+	versionDefault         = defaults.DevVersion
 	functionalCategoryName = "Functional"
-	agentImageBase         = "ghcr.io/nvidia/aicr"
 	shellCompletionFlag    = "--generate-shell-completion"
 )
 
 // defaultAgentImage returns the agent container image reference matching the
 // CLI version. Release builds (e.g. "0.8.10") produce "ghcr.io/…:v0.8.10".
 // Dev builds ("dev") and snapshot builds ("v0.8.10-next") use ":latest".
+//
+// The rule lives in pkg/defaults because Client.CollectSnapshot applies the
+// same one — the SDK deploys the same Job, and two copies would drift.
 func defaultAgentImage() string {
-	if version == versionDefault || strings.Contains(version, "-next") {
-		return agentImageBase + ":latest"
-	}
-	if strings.HasPrefix(version, "v") {
-		return agentImageBase + ":" + version
-	}
-	return agentImageBase + ":v" + version
+	return defaults.AgentImageForVersion(version)
 }
 
 var (

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/aicr/pkg/defaults"
 	"github.com/NVIDIA/aicr/pkg/errors"
 )
 
@@ -43,11 +44,11 @@ func TestDefaultAgentImage(t *testing.T) {
 		version  string
 		expected string
 	}{
-		{"dev build", "dev", agentImageBase + ":latest"},
-		{"snapshot with v prefix", "v0.8.10-next", agentImageBase + ":latest"},
-		{"snapshot without v prefix", "0.8.10-next", agentImageBase + ":latest"},
-		{"release without v prefix", "0.8.10", agentImageBase + ":v0.8.10"},
-		{"release with v prefix", "v0.8.10", agentImageBase + ":v0.8.10"},
+		{"dev build", "dev", defaults.AgentImageRepository + ":latest"},
+		{"snapshot with v prefix", "v0.8.10-next", defaults.AgentImageRepository + ":latest"},
+		{"snapshot without v prefix", "0.8.10-next", defaults.AgentImageRepository + ":latest"},
+		{"release without v prefix", "0.8.10", defaults.AgentImageRepository + ":v0.8.10"},
+		{"release with v prefix", "v0.8.10", defaults.AgentImageRepository + ":v0.8.10"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/client/v1/agent_defaults_internal_test.go
+++ b/pkg/client/v1/agent_defaults_internal_test.go
@@ -239,3 +239,37 @@ func TestCollectSnapshot_DoesNotMutateCallerConfig(t *testing.T) {
 			cfg.Image, cfg.JobName, cfg.ServiceAccountName)
 	}
 }
+
+// TestApplyAgentDefaults_SharesNamesAcrossCallers pins the fact the
+// CollectSnapshot godoc's Concurrency section warns about.
+//
+// Defaulting the names to a constant means two callers who both omit them
+// address the SAME Job and ServiceAccount. That is deliberate — it matches the
+// CLI, and per-run names would not fix concurrent collection anyway, because
+// the ClusterRoleBinding has a fixed name and carries the ServiceAccount as its
+// subject. This test exists so the warning cannot quietly stop being true: if
+// the defaults ever become per-run, this fails and the doc gets revisited.
+func TestApplyAgentDefaults_SharesNamesAcrossCallers(t *testing.T) {
+	first := snapshotter.AgentConfig{Namespace: "aicr-system"}
+	second := snapshotter.AgentConfig{Namespace: "aicr-system"}
+	applyAgentDefaults(&first, "0.21.0")
+	applyAgentDefaults(&second, "0.21.0")
+
+	if first.JobName != second.JobName {
+		t.Errorf("JobName defaults differ (%q vs %q); if this is now per-run, "+
+			"CollectSnapshot's Concurrency godoc needs updating",
+			first.JobName, second.JobName)
+	}
+	if first.ServiceAccountName != second.ServiceAccountName {
+		t.Errorf("ServiceAccountName defaults differ (%q vs %q); see above",
+			first.ServiceAccountName, second.ServiceAccountName)
+	}
+
+	// An explicit name is the documented way to separate two runs' Job and
+	// namespaced RBAC — necessary but, per the godoc, not sufficient.
+	custom := snapshotter.AgentConfig{Namespace: "aicr-system", JobName: "run-b"}
+	applyAgentDefaults(&custom, "0.21.0")
+	if custom.JobName != "run-b" {
+		t.Errorf("JobName = %q, want the caller's %q", custom.JobName, "run-b")
+	}
+}

--- a/pkg/client/v1/agent_defaults_internal_test.go
+++ b/pkg/client/v1/agent_defaults_internal_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
+)
+
+// TestApplyAgentDefaults covers the fields an SDK caller used to have to know
+// were required (#2256): Image, JobName, and ServiceAccountName are copied
+// verbatim into the Job and RBAC objects, so omitting one surfaced as an
+// apiserver rejection from inside Deploy rather than anything the caller could
+// act on.
+func TestApplyAgentDefaults(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		in      snapshotter.AgentConfig
+		want    snapshotter.AgentConfig
+	}{
+		{
+			name:    "minimal config gets every agent field",
+			version: "0.21.0",
+			in:      snapshotter.AgentConfig{Namespace: "aicr-system"},
+			want: snapshotter.AgentConfig{
+				Namespace:          "aicr-system",
+				Image:              defaults.AgentImageRepository + ":v0.21.0",
+				JobName:            defaults.AgentName,
+				ServiceAccountName: defaults.AgentName,
+			},
+		},
+		{
+			// A Client built without WithVersion has no released image to
+			// match; pinning it to a tag that does not exist would fail the
+			// pull instead of running.
+			name:    "unversioned client gets the dev tag",
+			version: "",
+			in:      snapshotter.AgentConfig{Namespace: "aicr-system"},
+			want: snapshotter.AgentConfig{
+				Namespace:          "aicr-system",
+				Image:              defaults.AgentImageRepository + ":latest",
+				JobName:            defaults.AgentName,
+				ServiceAccountName: defaults.AgentName,
+			},
+		},
+		{
+			name:    "explicit values are never overwritten",
+			version: "0.21.0",
+			in: snapshotter.AgentConfig{
+				Namespace:          "aicr-system",
+				Image:              "registry.internal/mirror/aicr:v0.19.0",
+				JobName:            "custom-job",
+				ServiceAccountName: "custom-sa",
+			},
+			want: snapshotter.AgentConfig{
+				Namespace:          "aicr-system",
+				Image:              "registry.internal/mirror/aicr:v0.19.0",
+				JobName:            "custom-job",
+				ServiceAccountName: "custom-sa",
+			},
+		},
+		{
+			// Whitespace cannot be a valid Kubernetes name or image
+			// reference, so it is a typo'd omission, not a choice.
+			name:    "whitespace-only counts as unset",
+			version: "0.21.0",
+			in: snapshotter.AgentConfig{
+				Namespace:          "aicr-system",
+				Image:              "  ",
+				JobName:            "\t",
+				ServiceAccountName: " ",
+			},
+			want: snapshotter.AgentConfig{
+				Namespace:          "aicr-system",
+				Image:              defaults.AgentImageRepository + ":v0.21.0",
+				JobName:            defaults.AgentName,
+				ServiceAccountName: defaults.AgentName,
+			},
+		},
+		{
+			// Defaulting Namespace would deploy a privileged, cluster-reading
+			// Job into "default" without the caller saying so. It stays a
+			// coded rejection in pkg/snapshotter.
+			name:    "namespace is left empty for the snapshotter to reject",
+			version: "0.21.0",
+			in:      snapshotter.AgentConfig{},
+			want: snapshotter.AgentConfig{
+				Namespace:          "",
+				Image:              defaults.AgentImageRepository + ":v0.21.0",
+				JobName:            defaults.AgentName,
+				ServiceAccountName: defaults.AgentName,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in
+			applyAgentDefaults(&got, tt.version)
+
+			if got.Image != tt.want.Image {
+				t.Errorf("Image = %q, want %q", got.Image, tt.want.Image)
+			}
+			if got.JobName != tt.want.JobName {
+				t.Errorf("JobName = %q, want %q", got.JobName, tt.want.JobName)
+			}
+			if got.ServiceAccountName != tt.want.ServiceAccountName {
+				t.Errorf("ServiceAccountName = %q, want %q",
+					got.ServiceAccountName, tt.want.ServiceAccountName)
+			}
+			if got.Namespace != tt.want.Namespace {
+				t.Errorf("Namespace = %q, want %q", got.Namespace, tt.want.Namespace)
+			}
+		})
+	}
+}
+
+// TestApplyAgentDefaults_NilIsSafe pins the guard rather than the behavior.
+//
+// toInternalAgentConfig returns nil for a nil AgentConfig, and CollectSnapshot's
+// own nil check runs before this — but a panic here would be a crash in a
+// library, so the guard stays and is covered.
+func TestApplyAgentDefaults_NilIsSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("applyAgentDefaults(nil) panicked: %v", r)
+		}
+	}()
+	applyAgentDefaults(nil, "0.21.0")
+}
+
+// TestCollectSnapshot_DefaultsReachTheDeployedJob is the Client-boundary
+// counterfactual. TestApplyAgentDefaults proves the helper fills the fields;
+// this proves CollectSnapshot calls it, by capturing the exact AgentConfig
+// handed to the deployment entry point. Delete the applyAgentDefaults call from
+// CollectSnapshot and every assertion below fails.
+//
+// It substitutes deps.deployAndCollect because the alternative is a live
+// apiserver — which is precisely why the original defect could reach a release.
+func TestCollectSnapshot_DefaultsReachTheDeployedJob(t *testing.T) {
+	t.Parallel()
+
+	var deployed *snapshotter.AgentConfig
+	deps := defaultClientDependencies()
+	deps.deployAndCollect = func(
+		_ context.Context,
+		cfg *snapshotter.AgentConfig,
+	) (*snapshotter.Snapshot, []byte, error) {
+
+		deployed = cfg
+		return &snapshotter.Snapshot{}, []byte("apiVersion: aicr.nvidia.com/v1\n"), nil
+	}
+
+	client, err := newClientWithContextAndDependencies(
+		context.Background(), deps,
+		WithRecipeSource(EmbeddedSource()), WithVersion("0.21.0"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Namespace only: the minimal AgentConfig #2256 says must work.
+	snap, err := client.CollectSnapshot(context.Background(), &AgentConfig{
+		Namespace: "aicr-system",
+	})
+	if err != nil {
+		t.Fatalf("CollectSnapshot: %v", err)
+	}
+	if snap == nil {
+		t.Fatal("CollectSnapshot returned a nil Snapshot without an error")
+	}
+	if deployed == nil {
+		t.Fatal("deployment entry point was never called")
+	}
+
+	if deployed.Image != defaults.AgentImageRepository+":v0.21.0" {
+		t.Errorf("deployed Image = %q, want the Client's WithVersion tag; an SDK "+
+			"caller omitting Image would get an apiserver rejection",
+			deployed.Image)
+	}
+	if deployed.ServiceAccountName != defaults.AgentName {
+		t.Errorf("deployed ServiceAccountName = %q, want %q; Deploy creates the "+
+			"ServiceAccount before the Job, so an empty name fails first",
+			deployed.ServiceAccountName, defaults.AgentName)
+	}
+	if deployed.JobName != defaults.AgentName {
+		t.Errorf("deployed JobName = %q, want %q", deployed.JobName, defaults.AgentName)
+	}
+}
+
+// TestCollectSnapshot_DoesNotMutateCallerConfig locks in that defaulting happens
+// on the internal copy. An AgentConfig a caller holds and reuses must not
+// silently acquire an image pin from a previous call — that would survive a
+// later Client built with a different WithVersion.
+func TestCollectSnapshot_DoesNotMutateCallerConfig(t *testing.T) {
+	t.Parallel()
+
+	deps := defaultClientDependencies()
+	deps.deployAndCollect = func(
+		_ context.Context,
+		_ *snapshotter.AgentConfig,
+	) (*snapshotter.Snapshot, []byte, error) {
+
+		return &snapshotter.Snapshot{}, nil, nil
+	}
+
+	client, err := newClientWithContextAndDependencies(
+		context.Background(), deps,
+		WithRecipeSource(EmbeddedSource()), WithVersion("0.21.0"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	cfg := &AgentConfig{Namespace: "aicr-system"}
+	if _, err = client.CollectSnapshot(context.Background(), cfg); err != nil {
+		t.Fatalf("CollectSnapshot: %v", err)
+	}
+
+	if cfg.Image != "" || cfg.JobName != "" || cfg.ServiceAccountName != "" {
+		t.Errorf("caller's AgentConfig was mutated: Image=%q JobName=%q "+
+			"ServiceAccountName=%q, want all empty",
+			cfg.Image, cfg.JobName, cfg.ServiceAccountName)
+	}
+}

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -1820,6 +1820,7 @@ func resolveHelmComponentValues(
 //
 // cfg.Image, cfg.JobName, and cfg.ServiceAccountName are defaulted when empty,
 // to the same values the CLI's flags use — defaults.AgentName for the two names,
+// which are therefore SHARED across callers that omit them (see Concurrency),
 // and for the image the tag matching this Client's WithVersion (a Client with no
 // version, like a development build, gets :latest). Set cfg.Image explicitly to
 // pin a different agent generation or a mirrored registry. Other fields fall
@@ -1880,8 +1881,26 @@ func resolveHelmComponentValues(
 //     carry the appropriate pkg/errors codes (ErrCodeInternal for
 //     deployment failures, ErrCodeTimeout for context expiry, etc.).
 //
-// Concurrent CollectSnapshot calls are safe; each call constructs an
-// independent run.
+// # Concurrency
+//
+// Concurrent CollectSnapshot calls are safe at the Client level — each call
+// constructs an independent run and shares no in-process state.
+//
+// They are NOT safe against the same cluster. The agent deployment is
+// name-addressed and partly cluster-scoped, so two runs collide in three ways
+// regardless of what this method defaults:
+//
+//   - The Job is delete-then-created, so a second run destroys a first run's
+//     in-flight Job even when Cleanup is false.
+//   - The ServiceAccount, Role, and RoleBinding are named from
+//     cfg.ServiceAccountName in cfg.Namespace.
+//   - The ClusterRoleBinding has a FIXED name and carries the ServiceAccount as
+//     its subject, so a second run repoints it and the first run's pod loses its
+//     node-read permission mid-collection. Distinct JobName and
+//     ServiceAccountName values do not avoid this one.
+//
+// Collect against one cluster at a time. Concurrent collection needs per-run
+// ownership down in pkg/k8s/agent, tracked in #2481.
 func (c *Client) CollectSnapshot(ctx context.Context, cfg *AgentConfig) (*Snapshot, error) {
 	if c == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized")

--- a/pkg/client/v1/aicr.go
+++ b/pkg/client/v1/aicr.go
@@ -200,6 +200,18 @@ type Client struct {
 	// change after construction, so it doesn't need locking.
 	version string
 
+	// deps holds the injectable entry points (OCI provider construction,
+	// snapshot-Job deployment). Populated once in NewClient from
+	// defaultClientDependencies; only tests substitute anything. Doesn't
+	// change after construction, so it doesn't need locking.
+	//
+	// A POINTER, not a value: clientDependencies holds func fields, and funcs
+	// are not comparable, so embedding it by value would silently make Client
+	// itself non-comparable. That is a breaking change to a frozen v1 type
+	// (api-diff reports "Client: old is comparable, new is not"), and no test
+	// seam is worth spending it.
+	deps *clientDependencies
+
 	// allowLists fences which criteria values the resolve path accepts.
 	// nil means "no fencing — all values allowed". Set by WithAllowLists;
 	// enforced in enforceAllowLists on the shared resolve path. Doesn't
@@ -235,6 +247,15 @@ type clientDependencies struct {
 		*recipe.EmbeddedDataProvider,
 		ocisource.Config,
 	) (recipe.DataProvider, error)
+
+	// deployAndCollect is the snapshot-Job deployment entry point. It is a
+	// seam because everything CollectSnapshot decides about the Job —
+	// including the fields it defaults — is otherwise observable only from a
+	// live apiserver, which is exactly where the #2256 foot-gun surfaced.
+	deployAndCollect func(
+		context.Context,
+		*snapshotter.AgentConfig,
+	) (*snapshotter.Snapshot, []byte, error)
 }
 
 func defaultClientDependencies() clientDependencies {
@@ -247,6 +268,7 @@ func defaultClientDependencies() clientDependencies {
 
 			return ocisource.New(ctx, embedded, config)
 		},
+		deployAndCollect: snapshotter.DeployAndCollect,
 	}
 }
 
@@ -296,7 +318,7 @@ func newClientWithContextAndDependencies(
 	if err := clientConstructionContextError(ctx); err != nil {
 		return nil, err
 	}
-	c := &Client{}
+	c := &Client{deps: &deps}
 
 	for _, opt := range opts {
 		// Skip nil Option entries defensively — a caller building a
@@ -1787,9 +1809,21 @@ func resolveHelmComponentValues(
 // without breaking signatures. CollectSnapshot is therefore safe even
 // on a Client whose recipe source is unrelated to the target cluster.
 //
-// cfg.Kubeconfig is the path (or empty for in-cluster). cfg.Namespace,
-// cfg.Image, cfg.ServiceAccountName must be set; other fields fall
-// back to package defaults documented on snapshotter.AgentConfig.
+// cfg.Kubeconfig is the path (or empty for in-cluster).
+//
+// # Required and defaulted fields
+//
+// cfg.Namespace is the only field you must set: it is where the Job, its RBAC,
+// and the result ConfigMap are created, and deploying a privileged
+// cluster-reading Job into an unstated namespace is not a safe default. An
+// empty one is rejected with ErrCodeInvalidRequest before any cluster access.
+//
+// cfg.Image, cfg.JobName, and cfg.ServiceAccountName are defaulted when empty,
+// to the same values the CLI's flags use — defaults.AgentName for the two names,
+// and for the image the tag matching this Client's WithVersion (a Client with no
+// version, like a development build, gets :latest). Set cfg.Image explicitly to
+// pin a different agent generation or a mirrored registry. Other fields fall
+// back to the defaults documented on snapshotter.AgentConfig.
 //
 // # Output and delivery
 //
@@ -1888,13 +1922,61 @@ func (c *Client) CollectSnapshot(ctx context.Context, cfg *AgentConfig) (*Snapsh
 	ctx, cancel := context.WithTimeout(ctx, budget+defaults.SnapshotOperationGrace)
 	defer cancel()
 
-	snap, raw, err := snapshotter.DeployAndCollect(ctx, toInternalAgentConfig(cfg))
+	// Defaults are applied to the internal copy, never to the caller's cfg:
+	// an AgentConfig the caller can reuse must not silently acquire fields
+	// after a call.
+	agentCfg := toInternalAgentConfig(cfg)
+	applyAgentDefaults(agentCfg, c.version)
+
+	// A Client built by anything but NewClient (a zero-value literal in a
+	// test) has no deps; fall back rather than nil-panic.
+	deploy := snapshotter.DeployAndCollect
+	if c.deps != nil && c.deps.deployAndCollect != nil {
+		deploy = c.deps.deployAndCollect
+	}
+
+	snap, raw, err := deploy(ctx, agentCfg)
 	if err != nil {
 		return nil, err
 	}
 	out := fromInternalSnapshot(snap)
 	out.Raw = raw
 	return out, nil
+}
+
+// applyAgentDefaults fills the agent fields the CLI has always supplied as flag
+// defaults and the facade did not.
+//
+// Image, JobName, and ServiceAccountName are copied verbatim into the Job and
+// RBAC objects and nothing under pkg/k8s/agent defaults them, so omitting any of
+// the three surfaced as a raw apiserver rejection from inside Deploy — after
+// the ServiceAccount had already been created, which with Cleanup false leaves
+// it behind (#2256). The CLI never hit it because pkg/cli/snapshot.go supplies
+// all three as flag defaults; sharing the definitions through pkg/defaults is
+// what keeps the two paths deploying the same image.
+//
+// Namespace is deliberately NOT defaulted. pkg/snapshotter already rejects an
+// empty one with a coded error naming the field, and quietly deploying a
+// privileged, cluster-reading Job into "default" is a worse outcome than being
+// told to choose. The CLI defaults it because a person is watching a flag they
+// can see; an SDK caller is not.
+//
+// A whitespace-only value counts as unset: it cannot be a valid Kubernetes name
+// or image reference, so treating it as a typo'd omission beats forwarding it to
+// the apiserver. This mirrors how pkg/snapshotter reads Namespace.
+func applyAgentDefaults(cfg *snapshotter.AgentConfig, version string) {
+	if cfg == nil {
+		return
+	}
+	if strings.TrimSpace(cfg.Image) == "" {
+		cfg.Image = defaults.AgentImageForVersion(version)
+	}
+	if strings.TrimSpace(cfg.JobName) == "" {
+		cfg.JobName = defaults.AgentName
+	}
+	if strings.TrimSpace(cfg.ServiceAccountName) == "" {
+		cfg.ServiceAccountName = defaults.AgentName
+	}
 }
 
 // ValidateState evaluates a resolved recipe against an observed cluster

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -2016,12 +2016,24 @@ func TestRejectUnverifiableCatalogSigning(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := rejectUnverifiableCatalogSigning(tt.resolve)
+			sc, err := rejectUnverifiableCatalogSigning(tt.resolve)
 			if tt.wantReject && err == nil {
 				t.Fatal("setting was accepted, but VerifyCatalog cannot verify what it produces")
 			}
 			if !tt.wantReject && err != nil {
 				t.Fatalf("setting was rejected, but it is symmetric with VerifyCatalog: %v", err)
+			}
+
+			// The parsed config must come back whenever a path was supplied:
+			// SignCatalog passes it to the signing path so the validated bytes
+			// are the signed bytes. Returning nil here would silently restore
+			// the check-then-reload gap.
+			if err == nil && tt.resolve.SigningConfigPath != "" && sc == nil {
+				t.Error("accepted a SigningConfigPath but returned no parsed config; " +
+					"the signing path would re-read the file instead of using the validated one")
+			}
+			if tt.resolve.SigningConfigPath == "" && sc != nil {
+				t.Error("returned a config for a request that named no signing config")
 			}
 		})
 	}

--- a/pkg/client/v1/aicr_internal_test.go
+++ b/pkg/client/v1/aicr_internal_test.go
@@ -1999,8 +1999,14 @@ func TestRejectUnverifiableCatalogSigning(t *testing.T) {
 		// signing config, so neither may be swept up by the rejection.
 		{name: "zero value", resolve: OIDCResolveOptions{}},
 		{
-			name:    "signing config selects a public-good target",
-			resolve: OIDCResolveOptions{SigningConfigPath: "/etc/aicr/signing-config.json"},
+			// A real fixture, not a placeholder path: the guard now reads the
+			// file, so a nonexistent path would exercise the open error rather
+			// than the public-good check this case is named for. This is the
+			// config shape the release hook passes.
+			name: "signing config selects a public-good target",
+			resolve: OIDCResolveOptions{
+				SigningConfigPath: "../../bundler/attestation/testdata/signing_config_v2.json",
+			},
 		},
 		{
 			name:    "token sources are orthogonal to verifiability",

--- a/pkg/client/v1/example_test.go
+++ b/pkg/client/v1/example_test.go
@@ -392,13 +392,10 @@ func ExampleClient_LoadRecipe() {
 // snapshotter Job, for callers that do not already have a snapshot file.
 // Requires a reachable cluster and RBAC to create the Job.
 //
-// # Image, JobName, and ServiceAccountName are required here
-//
-// DeployAndCollect validates only Namespace; the rest are copied straight into
-// the Job and RBAC objects. The CLI supplies defaults from its own flags,
-// which the facade does not share — so leaving these empty produces an empty
-// ServiceAccount name and an empty container image, and the API server rejects
-// the ServiceAccount before the Job is ever created. Set all three.
+// Namespace is the only field that must be set. Image, JobName, and
+// ServiceAccountName are defaulted when empty — the image to the tag matching
+// the Client's WithVersion. This example pins the image anyway, which is what an
+// air-gapped or version-skew-sensitive deployment wants.
 func ExampleClient_CollectSnapshot() {
 	ctx := context.Background()
 

--- a/pkg/client/v1/mirror_facade_test.go
+++ b/pkg/client/v1/mirror_facade_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package aicr_test
 
 import (

--- a/pkg/client/v1/sign.go
+++ b/pkg/client/v1/sign.go
@@ -265,5 +265,21 @@ func rejectUnverifiableCatalogSigning(resolve OIDCResolveOptions) error {
 			"catalog signing without a transparency-log entry is not supported: VerifyCatalog requires one",
 			map[string]any{settingKey: "OIDCResolve.DisableTLogUpload"})
 	}
+
+	// SigningConfigPath is not rejected outright -- it is the normal way to name
+	// the public-good Rekor v2 target, and the release hook depends on it -- but
+	// a signing config can itself name a private Fulcio or Rekor. Without this,
+	// the four rejections above were bypassable by putting the same endpoints in
+	// a file, and the catalog signed successfully while remaining unverifiable
+	// by its documented counterpart.
+	if resolve.SigningConfigPath != "" {
+		sc, err := bundleattest.LoadSigningConfigForValidation(resolve.SigningConfigPath)
+		if err != nil {
+			return err
+		}
+		if err := bundleattest.ValidateSigningConfigIsPublicGood(sc); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/client/v1/sign.go
+++ b/pkg/client/v1/sign.go
@@ -176,11 +176,17 @@ type CatalogSignResult struct {
 // the failure is immediate and explains itself rather than surfacing later as
 // an unverifiable artifact.
 //
-// This is a guard, not a decision procedure, and the residual gap is worth
-// stating: SigningConfigPath passes through because the release path requires
-// it, and a signing config can itself name a private Fulcio or Rekor. Every
-// rejected setting above exists ONLY to depart from the public-good defaults,
-// which is what makes rejecting them unambiguous; a signing config does not.
+// SigningConfigPath is checked rather than rejected. It passes through because
+// the release path requires it — naming the public-good Rekor v2 target is its
+// normal use — but a signing config can itself name a private Fulcio or Rekor,
+// which would otherwise make the four rejections above bypassable by moving the
+// same endpoints into a file. Every Fulcio, Rekor, OIDC-provider, and
+// timestamp-authority URL in it must therefore be HTTPS under the sigstore.dev
+// domain, matched on a label boundary so a lookalike host is rejected.
+//
+// The config that passes that check is the config signed with: the parsed value
+// is handed to the signing path rather than re-read from the path, so the file
+// cannot change between the check and the use.
 //
 // If private catalog signing is ever needed, both halves have to move
 // together — widening this without widening VerifyCatalog is what this guard

--- a/pkg/client/v1/sign.go
+++ b/pkg/client/v1/sign.go
@@ -21,6 +21,8 @@ import (
 	"github.com/NVIDIA/aicr/pkg/errors"
 	evattest "github.com/NVIDIA/aicr/pkg/evidence/attestation"
 	recipecat "github.com/NVIDIA/aicr/pkg/recipe/catalog"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
 // The signing entry points below deliberately impose NO facade-level timeout,
@@ -193,7 +195,8 @@ func (c *Client) SignCatalog(ctx context.Context, opts CatalogSignOptions) (*Cat
 	if ctx == nil {
 		return nil, errors.New(errors.ErrCodeInvalidRequest, "context is required (got nil)")
 	}
-	if err := rejectUnverifiableCatalogSigning(opts.OIDCResolve); err != nil {
+	validatedSigningConfig, err := rejectUnverifiableCatalogSigning(opts.OIDCResolve)
+	if err != nil {
 		return nil, err
 	}
 
@@ -210,6 +213,8 @@ func (c *Client) SignCatalog(ctx context.Context, opts CatalogSignOptions) (*Cat
 
 	resolve := opts.OIDCResolve
 	resolve.Attest = true
+	// Sign with the config that was validated, not a fresh read of the path.
+	resolve.SigningConfig = validatedSigningConfig
 
 	// Lazy resolution: Fulcio binds the certificate to a fresh nonce at
 	// token-issue time, so a token resolved ahead of the first Attest call
@@ -242,26 +247,26 @@ func (c *Client) SignCatalog(ctx context.Context, opts CatalogSignOptions) (*Cat
 // SignCatalog's godoc: every signing mode it accepts must be one VerifyCatalog
 // can check. Kept separate from SignCatalog so the invariant is testable
 // without an OIDC token, which the signing path itself requires.
-func rejectUnverifiableCatalogSigning(resolve OIDCResolveOptions) error {
+func rejectUnverifiableCatalogSigning(resolve OIDCResolveOptions) (*root.SigningConfig, error) {
 	// settingKey names the offending field in the error's structured context so
 	// a caller can branch on which setting to drop.
 	const settingKey = "setting"
 
 	switch {
 	case resolve.SigningKey != "":
-		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
 			"key-based catalog signing is not supported: VerifyCatalog verifies keyless GitHub OIDC certificates only, so a key-signed catalog could not be verified through the facade",
 			map[string]any{settingKey: "OIDCResolve.SigningKey"})
 	case resolve.FulcioURL != "":
-		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
 			"catalog signing against a private Fulcio is not supported: VerifyCatalog verifies against the public-good Sigstore root, which a private CA's certificate does not chain to",
 			map[string]any{settingKey: "OIDCResolve.FulcioURL"})
 	case resolve.RekorURL != "":
-		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
 			"catalog signing against an explicit Rekor URL is not supported: VerifyCatalog verifies transparency-log entries against the public-good root, and a private log's entries do not verify there. Use the Rekor v2 default, or SigningConfigPath",
 			map[string]any{settingKey: "OIDCResolve.RekorURL"})
 	case resolve.DisableTLogUpload:
-		return errors.NewWithContext(errors.ErrCodeInvalidRequest,
+		return nil, errors.NewWithContext(errors.ErrCodeInvalidRequest,
 			"catalog signing without a transparency-log entry is not supported: VerifyCatalog requires one",
 			map[string]any{settingKey: "OIDCResolve.DisableTLogUpload"})
 	}
@@ -272,14 +277,21 @@ func rejectUnverifiableCatalogSigning(resolve OIDCResolveOptions) error {
 	// the four rejections above were bypassable by putting the same endpoints in
 	// a file, and the catalog signed successfully while remaining unverifiable
 	// by its documented counterpart.
-	if resolve.SigningConfigPath != "" {
-		sc, err := bundleattest.LoadSigningConfigForValidation(resolve.SigningConfigPath)
-		if err != nil {
-			return err
-		}
-		if err := bundleattest.ValidateSigningConfigIsPublicGood(sc); err != nil {
-			return err
-		}
+	//
+	// The parsed config is RETURNED, not discarded. Validating here and letting
+	// the signing path re-read the same path would check one read and sign with
+	// another; the caller sets ResolveOptions.SigningConfig so the bytes that
+	// passed this check are the bytes signed with.
+	if resolve.SigningConfigPath == "" {
+		return nil, nil //nolint:nilnil // no config named: nothing to validate, nothing to pass on
 	}
-	return nil
+
+	sc, err := bundleattest.LoadSigningConfigForValidation(resolve.SigningConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := bundleattest.ValidateSigningConfigIsPublicGood(sc); err != nil {
+		return nil, err
+	}
+	return sc, nil
 }

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -378,6 +378,16 @@ func TestStability_Verification(t *testing.T) {
 	requireSignature[func(*aicr.EvidenceVerification) ([]byte, error)](aicr.RenderEvidenceJSON)
 	requireSignature[func(*aicr.EvidenceVerification) string](aicr.RenderEvidenceMarkdown)
 
+	// The per-call cap override is part of the contract: without it the facade
+	// ceiling is unconditional and a slow-registry verification cannot finish
+	// (#2225). Nil must keep the default, so the field's presence and its
+	// pointer-ness both matter.
+	var timeoutOverride *time.Duration
+	_ = aicr.BundleVerifyOptions{Timeout: timeoutOverride}
+	_ = aicr.EvidenceVerifyOptions{Timeout: timeoutOverride}
+	_ = aicr.CatalogVerifyOptions{Timeout: timeoutOverride}
+	_ = aicr.RecipeDigestOptions{Timeout: timeoutOverride}
+
 	var bv aicr.BundleVerifyOptions
 	_ = bv.CertificateIdentityRegexp
 	_ = bv.Key

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -73,6 +73,12 @@ func TestStability_Client(t *testing.T) {
 // requireComparable fails to compile when T stops satisfying comparable.
 func requireComparable[T comparable]() {}
 
+// requireType fails to compile when its argument is not exactly T.
+//
+// Used where a composite literal alone would not pin the field type: assigning
+// a *time.Duration into a field still compiles if that field is `any`.
+func requireType[T any](T) {}
+
 // TestStability_RecipeResolution pins the resolution surface: the
 // RecipeRequest input shape and the three Resolve* entry points.
 func TestStability_RecipeResolution(t *testing.T) {
@@ -397,6 +403,14 @@ func TestStability_Verification(t *testing.T) {
 	_ = aicr.EvidenceVerifyOptions{Timeout: timeoutOverride}
 	_ = aicr.CatalogVerifyOptions{Timeout: timeoutOverride}
 	_ = aicr.RecipeDigestOptions{Timeout: timeoutOverride}
+
+	// Read the field back AS a *time.Duration too. The literals above still
+	// compile if the field widens to `any`, which would silently drop the
+	// nil-vs-zero distinction the whole design rests on.
+	requireType[*time.Duration](aicr.BundleVerifyOptions{}.Timeout)
+	requireType[*time.Duration](aicr.EvidenceVerifyOptions{}.Timeout)
+	requireType[*time.Duration](aicr.CatalogVerifyOptions{}.Timeout)
+	requireType[*time.Duration](aicr.RecipeDigestOptions{}.Timeout)
 
 	var bv aicr.BundleVerifyOptions
 	_ = bv.CertificateIdentityRegexp

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -61,7 +61,17 @@ func TestStability_Client(t *testing.T) {
 	requireSignature[func(*aicr.Client) error]((*aicr.Client).Close)
 	requireSignature[func(*aicr.Client, context.Context) error]((*aicr.Client).LoadCatalog)
 	requireSignature[func(*aicr.Client) *aicr.CriteriaRegistry]((*aicr.Client).CriteriaRegistry)
+
+	// Client must stay comparable. Adding an unexported func, map, or slice
+	// field silently takes that away, which api-diff reports as "old is
+	// comparable, new is not" — a breaking change to a frozen v1 type, caught
+	// here at compile time instead of at the release gate. Any injectable
+	// dependency therefore has to be held behind a pointer.
+	requireComparable[aicr.Client]()
 }
+
+// requireComparable fails to compile when T stops satisfying comparable.
+func requireComparable[T comparable]() {}
 
 // TestStability_RecipeResolution pins the resolution surface: the
 // RecipeRequest input shape and the three Resolve* entry points.

--- a/pkg/client/v1/verify.go
+++ b/pkg/client/v1/verify.go
@@ -16,6 +16,7 @@ package aicr
 
 import (
 	"context"
+	"time"
 
 	bundleverifier "github.com/NVIDIA/aicr/pkg/bundler/verifier"
 	"github.com/NVIDIA/aicr/pkg/defaults"
@@ -127,6 +128,20 @@ type BundleVerifyOptions struct {
 	// Insecure relative to the default: with no transparency log there is
 	// no trusted timestamp proving when the signature was made.
 	IgnoreTLog bool
+
+	// Timeout overrides the facade's operation cap for this call.
+	//
+	// Nil -- the zero value -- keeps defaults.VerifyOperationTimeout, so a
+	// caller who never considered this gets today's behavior. A pointer to 0
+	// imposes NO facade cap and runs under the caller's context unchanged. A
+	// positive value sets an explicit cap.
+	//
+	// The pointer exists to make 0 mean "uncapped" rather than "default",
+	// matching WithValidationTimeout(0). A plain duration cannot distinguish
+	// unset from zero, so it would have had to spell uncapped some other way --
+	// and a caller who learned 0-means-uncapped from ValidateState would then
+	// get the opposite here, silently capped when they asked for unbounded.
+	Timeout *time.Duration
 }
 
 // BundleVerifyReport is the per-check outcome of bundle verification.
@@ -203,7 +218,7 @@ func (c *Client) VerifyBundle(ctx context.Context, bundleDir string, opts Bundle
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaults.VerifyOperationTimeout)
+	ctx, cancel := applyVerifyCap(ctx, opts.Timeout)
 	defer cancel()
 
 	report, err := bundleverifier.Verify(ctx, bundleDir, &bundleverifier.VerifyOptions{
@@ -272,6 +287,20 @@ type EvidenceVerifyOptions struct {
 	// rewritten by the registry, so "verify this artifact at this tag" is
 	// not content-addressable.
 	AllowUnpinnedTag bool
+
+	// Timeout overrides the facade's operation cap for this call.
+	//
+	// Nil -- the zero value -- keeps defaults.VerifyOperationTimeout, so a
+	// caller who never considered this gets today's behavior. A pointer to 0
+	// imposes NO facade cap and runs under the caller's context unchanged. A
+	// positive value sets an explicit cap.
+	//
+	// The pointer exists to make 0 mean "uncapped" rather than "default",
+	// matching WithValidationTimeout(0). A plain duration cannot distinguish
+	// unset from zero, so it would have had to spell uncapped some other way --
+	// and a caller who learned 0-means-uncapped from ValidateState would then
+	// get the opposite here, silently capped when they asked for unbounded.
+	Timeout *time.Duration
 }
 
 // EvidenceVerification is the outcome of recipe-evidence bundle verification:
@@ -298,13 +327,18 @@ type EvidenceVerification = evverifier.VerifyResult
 // Unlike bundle verification this can reach the network: a pointer or OCI
 // input pulls the artifact from its registry.
 //
-// That makes one interaction worth knowing. The call is capped by
-// defaults.VerifyOperationTimeout, which is an unconditional ceiling rather
-// than a deadline-less fallback, so a slow registry can trip it even when the
+// That makes one interaction worth knowing. By default the call is capped by
+// defaults.VerifyOperationTimeout, so a slow registry can trip it even when the
 // caller's own context allowed longer. A cap breach returns an ERROR, not
 // EvidenceExitIncomplete — so a gate that distinguishes "could not check this"
 // from "checked it and it failed" must treat a context-deadline error as the
 // former, alongside the Incomplete verdict.
+//
+// Set EvidenceVerifyOptions.Timeout to a pointer to 0 to remove the facade cap
+// and let the caller's context govern, which is the fix for a registry that is
+// simply slow rather than broken. The caller's own deadline still applies; the
+// option can only relax the facade's ceiling, never extend the context it was
+// given.
 //
 // The Client's recipe catalog is not consulted, so any open Client will do —
 // including one a hot-path caller keeps around and reuses.
@@ -323,7 +357,7 @@ func (c *Client) VerifyEvidence(ctx context.Context, opts EvidenceVerifyOptions)
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaults.VerifyOperationTimeout)
+	ctx, cancel := applyVerifyCap(ctx, opts.Timeout)
 	defer cancel()
 
 	result, err := evverifier.Verify(ctx, evverifier.VerifyOptions{
@@ -348,6 +382,20 @@ type CatalogVerifyOptions struct {
 	// allowed) and must not use top-level alternation. Empty uses
 	// TrustedIdentityPattern.
 	CertificateIdentityRegexp string
+
+	// Timeout overrides the facade's operation cap for this call.
+	//
+	// Nil -- the zero value -- keeps defaults.VerifyOperationTimeout, so a
+	// caller who never considered this gets today's behavior. A pointer to 0
+	// imposes NO facade cap and runs under the caller's context unchanged. A
+	// positive value sets an explicit cap.
+	//
+	// The pointer exists to make 0 mean "uncapped" rather than "default",
+	// matching WithValidationTimeout(0). A plain duration cannot distinguish
+	// unset from zero, so it would have had to spell uncapped some other way --
+	// and a caller who learned 0-means-uncapped from ValidateState would then
+	// get the opposite here, silently capped when they asked for unbounded.
+	Timeout *time.Duration
 }
 
 // CatalogVerification is what VerifyCatalog returns on success.
@@ -402,7 +450,7 @@ func (c *Client) VerifyCatalog(ctx context.Context, bundlePath string, opts Cata
 	c.mu.RUnlock()
 	defer c.inflight.Done()
 
-	ctx, cancel := context.WithTimeout(ctx, defaults.VerifyOperationTimeout)
+	ctx, cancel := applyVerifyCap(ctx, opts.Timeout)
 	defer cancel()
 
 	result, err := recipecat.Verify(ctx, bundlePath, dp, recipecat.VerifyOptions{
@@ -429,6 +477,20 @@ type RecipeDigestOptions struct {
 	// overlay inputs: an already-hydrated recipe carries its own
 	// metadata.selectedProfile, and combining the two is rejected.
 	Profile string
+
+	// Timeout overrides the facade's operation cap for this call.
+	//
+	// Nil -- the zero value -- keeps defaults.VerifyOperationTimeout, so a
+	// caller who never considered this gets today's behavior. A pointer to 0
+	// imposes NO facade cap and runs under the caller's context unchanged. A
+	// positive value sets an explicit cap.
+	//
+	// The pointer exists to make 0 mean "uncapped" rather than "default",
+	// matching WithValidationTimeout(0). A plain duration cannot distinguish
+	// unset from zero, so it would have had to spell uncapped some other way --
+	// and a caller who learned 0-means-uncapped from ValidateState would then
+	// get the opposite here, silently capped when they asked for unbounded.
+	Timeout *time.Duration
 }
 
 // RecipeDigest returns the canonical digest of a resolved recipe — the
@@ -464,7 +526,7 @@ func (c *Client) RecipeDigest(ctx context.Context, opts RecipeDigestOptions) (st
 	c.mu.RUnlock()
 	defer c.inflight.Done()
 
-	ctx, cancel := context.WithTimeout(ctx, defaults.VerifyOperationTimeout)
+	ctx, cancel := applyVerifyCap(ctx, opts.Timeout)
 	defer cancel()
 
 	digest, err := evattest.ComputeRecipeDigestWithProfile(
@@ -586,4 +648,26 @@ func (c *Client) assertOpen() error {
 		return errors.New(errors.ErrCodeInvalidRequest, "aicr client not initialized (or already closed)")
 	}
 	return nil
+}
+
+// applyVerifyCap wraps ctx with the facade's verify cap unless the caller
+// overrode it.
+//
+// Nil keeps the default cap. A pointer to zero (or negative) imposes no cap and
+// returns the caller's context unchanged, which is what lets a verification
+// behind a slow registry run to completion instead of being cut off at five
+// minutes and reported as an error.
+//
+// That distinction matters beyond convenience for VerifyEvidence: a cap breach
+// surfaces as an error, but "could not check" has a dedicated verdict
+// (EvidenceExitIncomplete) that CI gates branch on. Cutting a slow pull short
+// delivered that outcome through the wrong channel.
+func applyVerifyCap(ctx context.Context, timeout *time.Duration) (context.Context, context.CancelFunc) {
+	if timeout == nil {
+		return context.WithTimeout(ctx, defaults.VerifyOperationTimeout)
+	}
+	if *timeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, *timeout)
 }

--- a/pkg/client/v1/verify_timeout_internal_test.go
+++ b/pkg/client/v1/verify_timeout_internal_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/aicr/pkg/defaults"
+)
+
+// The verify cap was an unconditional ceiling: each method wrapped the caller's
+// context, and context.WithTimeout takes the smaller of the two, so a caller
+// deliberately allowing 20 minutes for a slow OCI pull was still cut off at
+// five (#2225).
+//
+// These assert the deadline the caller actually gets, not that a field was
+// copied. The zero value must keep today's cap, because that is what a caller
+// who never considered this receives.
+
+func TestApplyVerifyCap(t *testing.T) {
+	twenty := 20 * time.Minute
+	uncapped := time.Duration(0)
+	negative := -1 * time.Second
+
+	tests := []struct {
+		name    string
+		timeout *time.Duration
+		// wantDeadline is the cap the returned context must carry, or 0 for
+		// "no deadline of its own".
+		wantDeadline time.Duration
+	}{
+		{
+			name:         "nil keeps the default cap",
+			timeout:      nil,
+			wantDeadline: defaults.VerifyOperationTimeout,
+		},
+		{
+			name:         "explicit longer cap is honored",
+			timeout:      &twenty,
+			wantDeadline: twenty,
+		},
+		{
+			name:         "zero imposes no cap",
+			timeout:      &uncapped,
+			wantDeadline: 0,
+		},
+		{
+			name:         "negative is treated as uncapped, not as an instant deadline",
+			timeout:      &negative,
+			wantDeadline: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := applyVerifyCap(context.Background(), tt.timeout)
+			defer cancel()
+
+			deadline, ok := ctx.Deadline()
+			if tt.wantDeadline == 0 {
+				if ok {
+					t.Errorf("context carries a deadline in %v; the caller asked for "+
+						"no facade cap", time.Until(deadline))
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("context carries no deadline, want ~%v", tt.wantDeadline)
+			}
+			// Generous window: the assertion is which cap was chosen, not
+			// scheduling precision.
+			if remaining := time.Until(deadline); remaining > tt.wantDeadline ||
+				remaining < tt.wantDeadline-time.Minute {
+
+				t.Errorf("deadline in %v, want ~%v", remaining, tt.wantDeadline)
+			}
+		})
+	}
+}
+
+// TestApplyVerifyCap_DoesNotExtendTheCallersDeadline pins the direction that
+// must not change.
+//
+// The escape hatch lets a caller ask for MORE time than the facade default. It
+// must never grant more than the caller's own context allows: a 1-minute caller
+// deadline still wins over an uncapped facade.
+func TestApplyVerifyCap_DoesNotExtendTheCallersDeadline(t *testing.T) {
+	caller, cancelCaller := context.WithTimeout(context.Background(), time.Minute)
+	defer cancelCaller()
+
+	uncapped := time.Duration(0)
+	ctx, cancel := applyVerifyCap(caller, &uncapped)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("caller's own deadline was discarded; an uncapped facade must " +
+			"still respect the context it was given")
+	}
+	if remaining := time.Until(deadline); remaining > time.Minute {
+		t.Errorf("deadline in %v, want no more than the caller's 1m", remaining)
+	}
+}

--- a/pkg/defaults/agent.go
+++ b/pkg/defaults/agent.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import "strings"
+
+// Defaults for the snapshot-collection agent Job.
+//
+// These live here rather than in pkg/cli because both the CLI and the
+// pkg/client/v1 facade deploy the same Job. They used to exist only as CLI flag
+// defaults, which is why an SDK caller who omitted them got an apiserver
+// rejection from inside Deploy instead of a usable error (#2256). One
+// definition means the two paths cannot drift into deploying different images.
+const (
+	// AgentName is the Job and ServiceAccount name for the snapshot agent.
+	// Both share it: the ServiceAccount exists only to run this Job.
+	AgentName = "aicr"
+
+	// AgentImageRepository is the registry path of the agent image.
+	AgentImageRepository = "ghcr.io/nvidia/aicr"
+
+	// AgentImageDevTag is the tag used for builds that have no released
+	// image to match: development builds and pre-release snapshots.
+	AgentImageDevTag = "latest"
+
+	// DevVersion is the version string of an unstamped build — the value
+	// left in place when the release ldflags did not run.
+	DevVersion = "dev"
+)
+
+// AgentImageForVersion returns the agent container image matching a build
+// version, so the agent deployed into the cluster is the same generation as the
+// binary deploying it.
+//
+// Release builds map to their own tag, normalizing the "v" prefix that release
+// versions carry inconsistently ("0.8.10" and "v0.8.10" both yield
+// ":v0.8.10"). Development builds and "-next" snapshots have no published image
+// of their own and fall back to AgentImageDevTag. An empty version is treated as
+// a development build: a Client constructed without WithVersion has no release
+// to match, and pinning it to a tag that does not exist would fail the pull.
+func AgentImageForVersion(version string) string {
+	v := strings.TrimSpace(version)
+
+	if v == "" || v == DevVersion || strings.Contains(v, "-next") {
+		return AgentImageRepository + ":" + AgentImageDevTag
+	}
+	if strings.HasPrefix(v, "v") {
+		return AgentImageRepository + ":" + v
+	}
+	return AgentImageRepository + ":v" + v
+}

--- a/pkg/defaults/agent_test.go
+++ b/pkg/defaults/agent_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import "testing"
+
+func TestAgentImageForVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		// The "v" prefix is inconsistent across release version strings, so
+		// both spellings must land on the one published tag.
+		{"release without v prefix", "0.8.10", AgentImageRepository + ":v0.8.10"},
+		{"release with v prefix", "v0.8.10", AgentImageRepository + ":v0.8.10"},
+
+		// No published image exists for these, so they take the dev tag.
+		{"dev build", DevVersion, AgentImageRepository + ":" + AgentImageDevTag},
+		{"snapshot with v prefix", "v0.8.10-next", AgentImageRepository + ":" + AgentImageDevTag},
+		{"snapshot without v prefix", "0.8.10-next", AgentImageRepository + ":" + AgentImageDevTag},
+
+		// A Client constructed without WithVersion. Pinning it to a tag that
+		// does not exist would fail the image pull rather than run.
+		{"unset version", "", AgentImageRepository + ":" + AgentImageDevTag},
+		{"whitespace version", "  ", AgentImageRepository + ":" + AgentImageDevTag},
+
+		// Surrounding whitespace must not produce an unpullable tag.
+		{"padded release", " 0.8.10 ", AgentImageRepository + ":v0.8.10"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AgentImageForVersion(tt.version); got != tt.want {
+				t.Errorf("AgentImageForVersion(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes three SDK input-handling gaps found in review of the `pkg/client/v1` facade: the verify cap could not be raised, `SigningConfigPath` bypassed the catalog sign/verify symmetry guard, and `CollectSnapshot` required three agent fields it never defaulted or validated.

## Motivation / Context

All three are the same shape — the facade accepted an input and then behaved in a way the caller could not have predicted from the signature. Grouped into one PR because they touch one package and one theme; kept as separate commits for review.

Fixes: #2225
Fixes: #2227
Fixes: #2256
Related: #2016

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [x] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [x] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: `pkg/client/v1`, `pkg/defaults`

## Implementation Notes

**`04c1e0d` — caller-settable verify cap (#2225).** `Timeout *time.Duration` on the four verify option structs. Pointer rather than plain duration so `0` can mean *uncapped*, matching `WithValidationTimeout(0)`; a plain duration cannot distinguish unset from zero, and a caller who learned `0`-means-uncapped from `ValidateState` would have gotten the opposite here. `applyVerifyCap` can only relax the facade ceiling — it never extends the caller's own deadline, which is pinned by a test.

The `Timeout` field comment is repeated verbatim on all four structs. Deliberate: godoc renders per-field, so a reader of `CatalogVerifyOptions.Timeout` never sees a comment written on `BundleVerifyOptions.Timeout`.

**`0982657` — validate `SigningConfigPath` (#2227).** `SignCatalog` rejects four `OIDCResolve` settings that would produce an unverifiable catalog, but a signing config file could name the same private Fulcio or Rekor, so the guard was bypassable. Three design calls, all settled toward the existing behavior:

- *Domain match, not exact URLs* — the public-good Rekor shards carry the year (`log2025-1.rekor.sigstore.dev`), so an exact-URL allowlist would pass today and start failing release signing at the next rotation. Matching is on a label boundary, so `evilsigstore.dev` is rejected.
- *Fail closed* — matches the four sibling rejections and the repo's allowlist guidance.
- *Catalog-only* — bundle signing against a private Sigstore is supported and has its own chainsaw coverage, and its sign/verify halves are already symmetric.

Verified against the release path: all three shipped `testdata/signing_config*.json` fixtures pass, and the goreleaser hook's config comes from `aicr trust update --emit-signing-config` (public-good TUF).

**`d837aa1` — default the agent fields (#2256).** Took option 1 from the issue. `Image`, `JobName`, `ServiceAccountName` moved to `pkg/defaults` and shared with the CLI so the two paths cannot drift into deploying different agents. Defaults are applied to the internal copy, never the caller's `AgentConfig`.

`Namespace` stays a coded rejection rather than a default — quietly deploying a privileged, cluster-reading Job into `default` is worse than being told to choose, and `pkg/snapshotter` already names the field.

Deployment is now injectable via `clientDependencies` so the config `CollectSnapshot` actually builds is observable without an apiserver. `api-diff` caught that holding those func fields by value made `Client` non-comparable — a break on a frozen v1 type — so `deps` is a pointer, and `TestStability_Client` now pins comparability at compile time.

## Testing

```bash
make qualify   # pass
```

Both new guards mutation-verified:

| Mutation | Result |
|---|---|
| Drop the `applyAgentDefaults` call site | `TestCollectSnapshot_DefaultsReachTheDeployedJob` fails on all 3 fields |
| Weaken the domain check to a bare `HasSuffix` | `lookalike_domain` case fails |
| Hold `deps` by value again | `TestStability_Client` fails to compile |
| Drop the empty-version branch in `AgentImageForVersion` | 5 failures |

Coverage (per-package, vs `origin/main`):

| Package | Before | After |
|---|---|---|
| `pkg/client/v1` | 83.7% | 84.0% |
| `pkg/bundler/attestation` | 80.4% | 80.6% |
| `pkg/defaults` | 100.0% | 100.0% |
| `pkg/cli` | 75.5% | 75.4% |

No new exported function is uncovered.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** All three changes are additive at the API level (`api-diff` reports compatible-only). The one behavior change reaches an existing caller: `SignCatalog` now rejects a signing config naming non-public-good endpoints where it previously accepted it. That combination could only ever produce a catalog `VerifyCatalog` refuses, and the release path is unaffected.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
