### PR TITLE
fix(ci): preload KWOK registry and Gitea images into the Kind node

### DIFF
--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -97,6 +97,7 @@ jobs:
           command -v yq >/dev/null || { echo "::error::yq is required for kwok/scripts/lib tests"; exit 1; }
           bash kwok/scripts/lib/sync-budget_test.sh
           bash kwok/scripts/lib/profile-select_test.sh
+          bash kwok/scripts/lib/preload-image_test.sh
           bash kwok/scripts/run-all-recipes_test.sh
 
       - name: Classify recipes into tiers

--- a/kwok/scripts/install-infra.sh
+++ b/kwok/scripts/install-infra.sh
@@ -100,6 +100,15 @@
 #                                         reachable. Same caveat as
 #                                         KWOK_REGISTRY_HOST_PORT: must match
 #                                         the Kind extraPortMappings hostPort.
+#   KWOK_CLUSTER             (optional, default "aicr-kwok-test") - Kind cluster
+#                                         name used only to side-load the
+#                                         registry and Gitea images before
+#                                         their Deployments are applied. Ignored
+#                                         when KUBECTL_CONTEXT is set, since the
+#                                         cluster is then read from the context
+#                                         ("kind-<cluster>"). Preloading is best
+#                                         effort: a wrong or missing value falls
+#                                         back to the kubelet pulling the image.
 #   KWOK_GITEA_USER          (optional, default "aicr") - Gitea admin user the
 #                                         flux-git / argocd-git lanes push as.
 #   KWOK_GITEA_PASSWORD      (optional, default "aicr-kwok-ci") - Password for
@@ -140,6 +149,12 @@ log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 log_debug() { echo -e "${BLUE}[DEBUG]${NC} $*"; }
+
+# preload_image() — side-loads the registry / Gitea images into the Kind node
+# before their Deployments are applied. Sourced after the log_* helpers it
+# calls. Resolved SCRIPT_DIR-relative so a deployed copy is never picked up.
+# shellcheck source=lib/preload-image.sh
+source "${SCRIPT_DIR}/lib/preload-image.sh"
 
 # Configuration
 REGISTRY_NAMESPACE="aicr-registry"
@@ -260,6 +275,10 @@ install_registry() {
     local image="$1"
 
     log_info "Installing in-cluster OCI registry (${image}) in namespace ${REGISTRY_NAMESPACE}..."
+
+    # Before the Deployment exists, so the 120s rollout budget below is spent
+    # waiting on the container starting rather than on an upstream pull.
+    preload_image "${image}"
 
     # Namespace — apply, not create, so re-runs upsert cleanly.
     kc apply -f - <<EOF
@@ -578,6 +597,10 @@ install_gitea() {
     local image="$1"
 
     log_info "Installing in-cluster Gitea (${image}) in namespace ${REGISTRY_NAMESPACE}..."
+
+    # Same exposure as the registry: a public pull inside a fixed rollout
+    # budget. See preload_image.
+    preload_image "${image}"
 
     # Namespace may not exist yet if install order ever changes; apply is
     # idempotent either way.

--- a/kwok/scripts/lib/preload-image.sh
+++ b/kwok/scripts/lib/preload-image.sh
@@ -62,6 +62,22 @@ preload_remaining() {
     echo "${left}"
 }
 
+# preload_have_image reports whether the image is already in the host's Docker
+# cache, bounded by the remaining budget.
+#
+# Bounded because `docker image inspect` is a request to the Docker Engine, not
+# a local file read: a wedged daemon stalls it like any other call. Inside the
+# retry loop it would stall once per attempt before the kubelet fallback could
+# run — the same unbounded-wait failure this function exists to remove.
+#
+# A spent budget reports "not cached", which is the safe reading: the caller
+# then either bails on its own budget check or reports the pull as unsuccessful.
+preload_have_image() {
+    local image="$1" deadline="$2" remaining
+    remaining=$(preload_remaining "${deadline}") || return 1
+    timeout "${remaining}" docker image inspect "${image}" &>/dev/null
+}
+
 preload_image() {
     local image="$1"
 
@@ -106,7 +122,7 @@ preload_image() {
     # clears; a longer schedule would just delay the kubelet fallback.
     local attempt remaining
     for attempt in 1 2 3; do
-        if docker image inspect "${image}" &>/dev/null; then
+        if preload_have_image "${image}" "${deadline}"; then
             break
         fi
         if ! remaining=$(preload_remaining "${deadline}"); then
@@ -122,8 +138,8 @@ preload_image() {
         fi
     done
 
-    if ! docker image inspect "${image}" &>/dev/null; then
-        log_warn "Could not pull ${image} on the host; the kubelet will retry in-cluster"
+    if ! preload_have_image "${image}" "${deadline}"; then
+        log_warn "${image} is not cached after pulling (failed, or the budget ran out); the kubelet will retry in-cluster"
         return 0
     fi
 

--- a/kwok/scripts/lib/preload-image.sh
+++ b/kwok/scripts/lib/preload-image.sh
@@ -17,6 +17,19 @@
 # Callers must provide log_info / log_warn / log_debug; install-infra.sh
 # defines them before sourcing this file.
 
+# Total wall-clock budget for preloading ONE image, across every retry and the
+# side-load. Overridable for tests.
+#
+# A per-operation timeout would not be enough: three stalled pulls plus a stalled
+# load still multiply out. The budget is checked before each operation and passed
+# to `timeout`, so the function cannot outlive it no matter how many steps run.
+# 180s is generous for two small images and leaves the 20-minute KWOK job budget
+# essentially intact even if both preloads time out completely.
+#
+# Read at CALL time, not source time, so a caller (or a test) can change it
+# between invocations.
+KWOK_PRELOAD_BUDGET_DEFAULT=180
+
 # Side-load an image into the Kind node so the kubelet never pulls it.
 #
 # The registry and Gitea Deployments are the only two workloads in the KWOK
@@ -37,13 +50,34 @@
 # become a new way for the lane to fail: it removes a failure mode or it does
 # nothing. That is why it never propagates an error, even when docker or kind
 # is missing entirely (a non-Kind cluster, or a dev box driving a remote one).
+# preload_remaining prints the seconds left before the deadline, and returns 1
+# when the budget is spent so callers can bail instead of starting an operation
+# they cannot finish.
+preload_remaining() {
+    local deadline="$1" left
+    left=$(( deadline - $(date +%s) ))
+    if (( left <= 0 )); then
+        return 1
+    fi
+    echo "${left}"
+}
+
 preload_image() {
     local image="$1"
 
-    if ! command -v docker &>/dev/null || ! command -v kind &>/dev/null; then
-        log_debug "docker or kind unavailable — leaving ${image} to the kubelet"
+    # `timeout` is required, not optional. Without it every docker/kind call is
+    # unbounded, and a stalled pull would hold the lane for the whole job — the
+    # precise failure this function exists to prevent, in a new place. If it is
+    # missing, skip preloading rather than risk that.
+    if ! command -v docker &>/dev/null || ! command -v kind &>/dev/null ||
+        ! command -v timeout &>/dev/null; then
+        log_debug "docker, kind, or timeout unavailable — leaving ${image} to the kubelet"
         return 0
     fi
+
+    # One deadline for the whole function; every operation below draws from it.
+    local budget="${KWOK_PRELOAD_BUDGET_SECONDS:-${KWOK_PRELOAD_BUDGET_DEFAULT}}"
+    local deadline=$(( $(date +%s) + budget ))
 
     # Kind names the context "kind-<cluster>", so the cluster name is the
     # context with that prefix stripped. Fall back to the same default
@@ -57,7 +91,12 @@ preload_image() {
         cluster="${KUBECTL_CONTEXT#kind-}"
     fi
 
-    if ! kind get clusters 2>/dev/null | grep -qx "${cluster}"; then
+    if ! preload_remaining "${deadline}" >/dev/null; then
+        log_warn "Preload budget exhausted before resolving the cluster; the kubelet will pull ${image}"
+        return 0
+    fi
+
+    if ! timeout "$(preload_remaining "${deadline}")" kind get clusters 2>/dev/null | grep -qx "${cluster}"; then
         log_debug "Kind cluster ${cluster} not found — leaving ${image} to the kubelet"
         return 0
     fi
@@ -65,13 +104,17 @@ preload_image() {
     # Three attempts with linear backoff. The upstream failures seen in CI are
     # transient resets and timeouts, which a second attempt seconds later
     # clears; a longer schedule would just delay the kubelet fallback.
-    local attempt
+    local attempt remaining
     for attempt in 1 2 3; do
         if docker image inspect "${image}" &>/dev/null; then
             break
         fi
-        log_info "Pulling ${image} on the host (attempt ${attempt}/3)..."
-        if docker pull --quiet "${image}" >/dev/null 2>&1; then
+        if ! remaining=$(preload_remaining "${deadline}"); then
+            log_warn "Preload budget exhausted pulling ${image}; the kubelet will retry in-cluster"
+            return 0
+        fi
+        log_info "Pulling ${image} on the host (attempt ${attempt}/3, ${remaining}s left)..."
+        if timeout "${remaining}" docker pull --quiet "${image}" >/dev/null 2>&1; then
             break
         fi
         if (( attempt < 3 )); then
@@ -84,7 +127,12 @@ preload_image() {
         return 0
     fi
 
-    if kind load docker-image "${image}" --name "${cluster}" >/dev/null 2>&1; then
+    if ! remaining=$(preload_remaining "${deadline}"); then
+        log_warn "Preload budget exhausted before side-loading ${image}; the kubelet will pull it"
+        return 0
+    fi
+
+    if timeout "${remaining}" kind load docker-image "${image}" --name "${cluster}" >/dev/null 2>&1; then
         log_info "Preloaded ${image} into Kind cluster ${cluster}"
     else
         log_warn "Could not side-load ${image} into ${cluster}; the kubelet will pull it"

--- a/kwok/scripts/lib/preload-image.sh
+++ b/kwok/scripts/lib/preload-image.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# preload-image.sh - side-load a public image into the Kind node so the
+# kubelet never has to pull it mid-rollout.
+#
+# Sourced by install-infra.sh. Kept as its own lib (like sync-budget.sh and
+# profile-select.sh) so the retry and cluster-resolution logic can be unit
+# tested with stubbed docker/kind instead of only in a live CI lane.
+#
+# Callers must provide log_info / log_warn / log_debug; install-infra.sh
+# defines them before sourcing this file.
+
+# Side-load an image into the Kind node so the kubelet never pulls it.
+#
+# The registry and Gitea Deployments are the only two workloads in the KWOK
+# lanes whose images come from a public registry, and both used to be pulled by
+# the kubelet inside a 120s rollout budget with no retry. That made every lane
+# depend on a single upstream reach at exactly the wrong moment: an ECR blip
+# surfaced as "Registry Deployment did not become Ready within 120s", exit 20,
+# and a red matrix cell with nothing wrong in the repo. It was the single
+# largest source of KWOK-lane failures.
+#
+# Pulling on the host instead has three advantages: `docker pull` can be
+# retried without holding a rollout budget open, the runner's Docker cache
+# survives across lanes in a job, and both Deployments already set
+# imagePullPolicy: IfNotPresent, so a preloaded image is used as-is.
+#
+# BEST EFFORT BY DESIGN. Every failure path here logs and returns 0, leaving
+# the kubelet pull as the fallback exactly as before. This function must not
+# become a new way for the lane to fail: it removes a failure mode or it does
+# nothing. That is why it never propagates an error, even when docker or kind
+# is missing entirely (a non-Kind cluster, or a dev box driving a remote one).
+preload_image() {
+    local image="$1"
+
+    if ! command -v docker &>/dev/null || ! command -v kind &>/dev/null; then
+        log_debug "docker or kind unavailable — leaving ${image} to the kubelet"
+        return 0
+    fi
+
+    # Kind names the context "kind-<cluster>", so the cluster name is the
+    # context with that prefix stripped. Fall back to the same default
+    # run-all-recipes.sh uses when no context is pinned.
+    local cluster="${KWOK_CLUSTER:-aicr-kwok-test}"
+    if [[ -n "${KUBECTL_CONTEXT:-}" ]]; then
+        if [[ "${KUBECTL_CONTEXT}" != kind-* ]]; then
+            log_debug "context ${KUBECTL_CONTEXT} is not a Kind cluster — leaving ${image} to the kubelet"
+            return 0
+        fi
+        cluster="${KUBECTL_CONTEXT#kind-}"
+    fi
+
+    if ! kind get clusters 2>/dev/null | grep -qx "${cluster}"; then
+        log_debug "Kind cluster ${cluster} not found — leaving ${image} to the kubelet"
+        return 0
+    fi
+
+    # Three attempts with linear backoff. The upstream failures seen in CI are
+    # transient resets and timeouts, which a second attempt seconds later
+    # clears; a longer schedule would just delay the kubelet fallback.
+    local attempt
+    for attempt in 1 2 3; do
+        if docker image inspect "${image}" &>/dev/null; then
+            break
+        fi
+        log_info "Pulling ${image} on the host (attempt ${attempt}/3)..."
+        if docker pull --quiet "${image}" >/dev/null 2>&1; then
+            break
+        fi
+        if (( attempt < 3 )); then
+            sleep $(( attempt * 5 ))
+        fi
+    done
+
+    if ! docker image inspect "${image}" &>/dev/null; then
+        log_warn "Could not pull ${image} on the host; the kubelet will retry in-cluster"
+        return 0
+    fi
+
+    if kind load docker-image "${image}" --name "${cluster}" >/dev/null 2>&1; then
+        log_info "Preloaded ${image} into Kind cluster ${cluster}"
+    else
+        log_warn "Could not side-load ${image} into ${cluster}; the kubelet will pull it"
+    fi
+    return 0
+}
+

--- a/kwok/scripts/lib/preload-image.sh
+++ b/kwok/scripts/lib/preload-image.sh
@@ -22,7 +22,8 @@
 #
 # A per-operation timeout would not be enough: three stalled pulls plus a stalled
 # load still multiply out. The budget is checked before each operation and passed
-# to `timeout`, so the function cannot outlive it no matter how many steps run.
+# to `timeout`, and the retry backoff is clamped to it as well, so the function
+# cannot outlive it by more than scheduling noise no matter how many steps run.
 # 180s is generous for two small images and leaves the 20-minute KWOK job budget
 # essentially intact even if both preloads time out completely.
 #
@@ -134,7 +135,17 @@ preload_image() {
             break
         fi
         if (( attempt < 3 )); then
-            sleep $(( attempt * 5 ))
+            # Clamp the backoff to the budget. Sleeping past the deadline is
+            # pure dead time: it cannot buy another attempt, and it delays the
+            # kubelet fallback by exactly as long as it oversleeps. Without this
+            # the function's real ceiling is the budget PLUS the whole backoff
+            # schedule, not the budget.
+            local backoff=$(( attempt * 5 ))
+            remaining=$(preload_remaining "${deadline}") || break
+            if (( backoff > remaining )); then
+                backoff="${remaining}"
+            fi
+            sleep "${backoff}"
         fi
     done
 

--- a/kwok/scripts/lib/preload-image_test.sh
+++ b/kwok/scripts/lib/preload-image_test.sh
@@ -50,6 +50,24 @@ check() { # <name> <want_rc> <got_rc> [<must_contain> ...]
     (( ok == 1 )) && echo "PASS: ${name}" || fails=$((fails + 1))
 }
 
+# check_bounded asserts the call finished within its CONFIGURED budget rather
+# than some loose ceiling. A generous threshold would let a retry-backoff or
+# extra-operation regression push the real ceiling well past the budget and
+# still pass, which is the thing being tested.
+#
+# The margin covers process spawn and scheduling only.
+BOUND_MARGIN_SECONDS=3
+check_bounded() { # <name> <budget> <elapsed>
+    local name="$1" budget="$2" elapsed="$3"
+    local ceiling=$(( budget + BOUND_MARGIN_SECONDS ))
+    if (( elapsed <= ceiling )); then
+        echo "PASS: ${name} (${elapsed}s, budget ${budget}s)"
+    else
+        echo "FAIL: ${name} (took ${elapsed}s, budget ${budget}s + ${BOUND_MARGIN_SECONDS}s margin)"
+        fails=$((fails + 1))
+    fi
+}
+
 check_absent() { # <name> <must_not_contain>
     local name="$1" needle="$2"
     if grep -q -- "${needle}" "${TRACE}"; then
@@ -251,14 +269,10 @@ started=$(date +%s)
 preload_image "${IMG}" >/dev/null; rc=$?
 elapsed=$(( $(date +%s) - started ))
 check "hanging-pull-does-not-fail-the-lane" 0 "${rc}"
-# Generous ceiling: the budget plus the retry backoff, well under any job
-# budget. A missing bound would sit here for an hour.
-if (( elapsed <= 30 )); then
-    echo "PASS: hanging-pull-is-bounded (${elapsed}s)"
-else
-    echo "FAIL: hanging-pull-is-bounded (took ${elapsed}s; the pull is unbounded)"
-    fails=$((fails + 1))
-fi
+# Against the configured budget, not a loose ceiling. This also pins the
+# backoff clamp: without it the first attempt's timeout would be followed by a
+# full 5s sleep, overshooting the budget.
+check_bounded "hanging-pull-is-bounded" "${KWOK_PRELOAD_BUDGET_SECONDS}" "${elapsed}"
 check_absent "hanging-pull-skips-load" "kind load"
 unset STUB_PULL_HANGS KWOK_PRELOAD_BUDGET_SECONDS
 
@@ -273,12 +287,7 @@ started=$(date +%s)
 preload_image "${IMG}" >/dev/null; rc=$?
 elapsed=$(( $(date +%s) - started ))
 check "hanging-inspect-does-not-fail-the-lane" 0 "${rc}"
-if (( elapsed <= 30 )); then
-    echo "PASS: hanging-inspect-is-bounded (${elapsed}s)"
-else
-    echo "FAIL: hanging-inspect-is-bounded (took ${elapsed}s; the inspect is unbounded)"
-    fails=$((fails + 1))
-fi
+check_bounded "hanging-inspect-is-bounded" "${KWOK_PRELOAD_BUDGET_SECONDS}" "${elapsed}"
 check_absent "hanging-inspect-skips-load" "kind load"
 unset STUB_INSPECT_HANGS KWOK_PRELOAD_BUDGET_SECONDS
 

--- a/kwok/scripts/lib/preload-image_test.sh
+++ b/kwok/scripts/lib/preload-image_test.sh
@@ -73,6 +73,7 @@ PATH="${STUB_DIR}:${PATH}"
 #   STUB_INSPECT_RC   docker image inspect exit code (1 = not cached locally)
 #   STUB_PULL_FAILS   number of leading `docker pull` attempts that fail
 #   STUB_PULL_HANGS   non-empty makes every `docker pull` hang forever
+#   STUB_INSPECT_HANGS non-empty makes every `docker image inspect` hang forever
 #   STUB_KIND_LOAD_RC `kind load` exit code
 #   STUB_CLUSTERS     newline-separated `kind get clusters` output
 write_stubs() {
@@ -81,6 +82,8 @@ write_stubs() {
 echo "docker $*" >> "${TRACE}"
 case "$1 $2" in
     "image inspect")
+        # A wedged Docker Engine: the request is accepted and never answered.
+        if [[ -n "${STUB_INSPECT_HANGS:-}" ]]; then sleep 3600; fi
         # Once a pull has succeeded the image is cached, so later inspects
         # must succeed too — otherwise the retry loop could not terminate.
         if [[ -f "${STUB_DIR}/pulled" ]]; then exit 0; fi
@@ -119,6 +122,7 @@ reset() {
     : > "${TRACE}"
     rm -f "${STUB_DIR}/pulls" "${STUB_DIR}/pulled"
     unset STUB_INSPECT_RC STUB_PULL_FAILS STUB_KIND_LOAD_RC STUB_CLUSTERS STUB_PULL_HANGS
+    unset STUB_INSPECT_HANGS
     unset KWOK_PRELOAD_BUDGET_SECONDS
     unset KUBECTL_CONTEXT KWOK_CLUSTER
     export STUB_DIR TRACE
@@ -257,6 +261,26 @@ else
 fi
 check_absent "hanging-pull-skips-load" "kind load"
 unset STUB_PULL_HANGS KWOK_PRELOAD_BUDGET_SECONDS
+
+# 12. A wedged Docker Engine: `docker image inspect` never returns. It is the
+#     first call in the retry loop, so an unbounded inspect stalls once per
+#     attempt before the kubelet fallback can run — the same failure class as a
+#     hanging pull, in the call that is easiest to assume is local and cheap.
+reset
+export STUB_INSPECT_HANGS=1
+export KWOK_PRELOAD_BUDGET_SECONDS=3
+started=$(date +%s)
+preload_image "${IMG}" >/dev/null; rc=$?
+elapsed=$(( $(date +%s) - started ))
+check "hanging-inspect-does-not-fail-the-lane" 0 "${rc}"
+if (( elapsed <= 30 )); then
+    echo "PASS: hanging-inspect-is-bounded (${elapsed}s)"
+else
+    echo "FAIL: hanging-inspect-is-bounded (took ${elapsed}s; the inspect is unbounded)"
+    fails=$((fails + 1))
+fi
+check_absent "hanging-inspect-skips-load" "kind load"
+unset STUB_INSPECT_HANGS KWOK_PRELOAD_BUDGET_SECONDS
 
 if (( fails > 0 )); then
     echo "FAILED: ${fails} case(s)"

--- a/kwok/scripts/lib/preload-image_test.sh
+++ b/kwok/scripts/lib/preload-image_test.sh
@@ -72,6 +72,7 @@ PATH="${STUB_DIR}:${PATH}"
 # over the wrong scenario.
 #   STUB_INSPECT_RC   docker image inspect exit code (1 = not cached locally)
 #   STUB_PULL_FAILS   number of leading `docker pull` attempts that fail
+#   STUB_PULL_HANGS   non-empty makes every `docker pull` hang forever
 #   STUB_KIND_LOAD_RC `kind load` exit code
 #   STUB_CLUSTERS     newline-separated `kind get clusters` output
 write_stubs() {
@@ -89,6 +90,9 @@ esac
 if [[ "$1" == "pull" ]]; then
     n=$(( $(cat "${STUB_DIR}/pulls" 2>/dev/null || echo 0) + 1 ))
     echo "${n}" > "${STUB_DIR}/pulls"
+    # A pull that never returns — the registry accepts the connection and then
+    # goes quiet. Only `timeout` ends this.
+    if [[ -n "${STUB_PULL_HANGS:-}" ]]; then sleep 3600; fi
     if (( n <= ${STUB_PULL_FAILS:-0} )); then exit 1; fi
     touch "${STUB_DIR}/pulled"
     exit 0
@@ -114,7 +118,8 @@ EOF
 reset() {
     : > "${TRACE}"
     rm -f "${STUB_DIR}/pulls" "${STUB_DIR}/pulled"
-    unset STUB_INSPECT_RC STUB_PULL_FAILS STUB_KIND_LOAD_RC STUB_CLUSTERS
+    unset STUB_INSPECT_RC STUB_PULL_FAILS STUB_KIND_LOAD_RC STUB_CLUSTERS STUB_PULL_HANGS
+    unset KWOK_PRELOAD_BUDGET_SECONDS
     unset KUBECTL_CONTEXT KWOK_CLUSTER
     export STUB_DIR TRACE
     write_stubs
@@ -204,11 +209,54 @@ check "kwok-cluster-env-selects-the-cluster" 0 "${rc}" "--name custom-kwok"
 
 # 10. Neither docker nor kind on PATH (a dev box driving a remote cluster).
 #     Must be a silent no-op rather than an error.
+#
+#     Removing the stubs is NOT enough: the host running this harness usually
+#     HAS docker and kind, so command lookup falls through to the real binaries
+#     and the case passes having exercised a live pull instead of the branch it
+#     names. Point PATH at an empty directory so the lookup genuinely fails, and
+#     assert the log line so the branch is proven to have run rather than
+#     inferred from rc=0.
 reset
-rm -f "${STUB_DIR}/docker" "${STUB_DIR}/kind"
-preload_image "${IMG}" >/dev/null; rc=$?
+mkdir -p "${STUB_DIR}/no-tools"
+saved_path="${PATH}"
+# shellcheck disable=SC2123  # Replacing PATH is the point: it is what makes
+# `command -v docker` fail. Restored two lines down.
+PATH="${STUB_DIR}/no-tools"
+out=$(preload_image "${IMG}" 2>&1); rc=$?
+PATH="${saved_path}"
 check "missing-tooling-is-a-noop" 0 "${rc}"
-write_stubs
+if [[ "${out}" == *"unavailable"* ]]; then
+    echo "PASS: missing-tooling-takes-the-unavailable-branch"
+else
+    echo "FAIL: missing-tooling-takes-the-unavailable-branch (got: ${out})"
+    fails=$((fails + 1))
+fi
+check_absent "missing-tooling-runs-nothing" "docker"
+
+# 11. A pull that never returns. This is the failure mode the whole change
+#     exists to prevent, reintroduced in a new place: without a bound, three
+#     stalled pulls plus a stalled side-load hold the lane for the entire
+#     20-minute KWOK job, and the kubelet fallback never gets to run.
+#
+#     The budget is squeezed to 3s so the assertion is about the bound existing,
+#     not about its production value.
+reset
+export STUB_PULL_HANGS=1
+export KWOK_PRELOAD_BUDGET_SECONDS=3
+started=$(date +%s)
+preload_image "${IMG}" >/dev/null; rc=$?
+elapsed=$(( $(date +%s) - started ))
+check "hanging-pull-does-not-fail-the-lane" 0 "${rc}"
+# Generous ceiling: the budget plus the retry backoff, well under any job
+# budget. A missing bound would sit here for an hour.
+if (( elapsed <= 30 )); then
+    echo "PASS: hanging-pull-is-bounded (${elapsed}s)"
+else
+    echo "FAIL: hanging-pull-is-bounded (took ${elapsed}s; the pull is unbounded)"
+    fails=$((fails + 1))
+fi
+check_absent "hanging-pull-skips-load" "kind load"
+unset STUB_PULL_HANGS KWOK_PRELOAD_BUDGET_SECONDS
 
 if (( fails > 0 )); then
     echo "FAILED: ${fails} case(s)"

--- a/kwok/scripts/lib/preload-image_test.sh
+++ b/kwok/scripts/lib/preload-image_test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unit harness for lib/preload-image.sh (Kind image side-loading).
+#
+# The property under test is mostly about what preload_image must NOT do. It
+# exists to remove a failure mode -- the kubelet pulling a public image inside a
+# fixed 120s rollout budget -- so a bug that makes it fail the lane is strictly
+# worse than not having it. Every case below therefore asserts rc=0, and the
+# interesting assertions are on which stub commands ran.
+#
+# Run directly: bash kwok/scripts/lib/preload-image_test.sh
+# Wired into CI by the kwok-recipes discover job.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# install-infra.sh defines these before sourcing the subject; the harness
+# supplies its own so log output does not pollute the assertions.
+log_info()  { echo "INFO: $*"; }
+log_warn()  { echo "WARN: $*"; }
+log_debug() { echo "DEBUG: $*"; }
+
+# Resolve the subject SCRIPT_DIR-relative — never a deployed copy.
+# shellcheck source=preload-image.sh
+source "${SCRIPT_DIR}/preload-image.sh"
+
+fails=0
+check() { # <name> <want_rc> <got_rc> [<must_contain> ...]
+    local name="$1" want_rc="$2" got_rc="$3"; shift 3
+    local ok=1 needle
+    if [[ "${got_rc}" != "${want_rc}" ]]; then
+        echo "FAIL: ${name} (want rc=${want_rc}, got rc=${got_rc})"
+        fails=$((fails + 1))
+        return
+    fi
+    for needle in "$@"; do
+        if ! grep -q -- "${needle}" "${TRACE}"; then
+            echo "FAIL: ${name} (trace missing '${needle}')"
+            echo "      trace was: $(tr '\n' '|' < "${TRACE}")"
+            ok=0
+        fi
+    done
+    (( ok == 1 )) && echo "PASS: ${name}" || fails=$((fails + 1))
+}
+
+check_absent() { # <name> <must_not_contain>
+    local name="$1" needle="$2"
+    if grep -q -- "${needle}" "${TRACE}"; then
+        echo "FAIL: ${name} (trace unexpectedly contains '${needle}')"
+        echo "      trace was: $(tr '\n' '|' < "${TRACE}")"
+        fails=$((fails + 1))
+    else
+        echo "PASS: ${name}"
+    fi
+}
+
+STUB_DIR="$(mktemp -d)"
+TRACE="${STUB_DIR}/trace"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+PATH="${STUB_DIR}:${PATH}"
+
+# Stub behavior is driven by these, reset before each case:
+# Each must be EXPORTED: the stubs are separate processes, so a plain
+# assignment would leave them at their defaults and quietly make a case pass
+# over the wrong scenario.
+#   STUB_INSPECT_RC   docker image inspect exit code (1 = not cached locally)
+#   STUB_PULL_FAILS   number of leading `docker pull` attempts that fail
+#   STUB_KIND_LOAD_RC `kind load` exit code
+#   STUB_CLUSTERS     newline-separated `kind get clusters` output
+write_stubs() {
+    cat > "${STUB_DIR}/docker" <<'EOF'
+#!/usr/bin/env bash
+echo "docker $*" >> "${TRACE}"
+case "$1 $2" in
+    "image inspect")
+        # Once a pull has succeeded the image is cached, so later inspects
+        # must succeed too — otherwise the retry loop could not terminate.
+        if [[ -f "${STUB_DIR}/pulled" ]]; then exit 0; fi
+        exit "${STUB_INSPECT_RC:-1}"
+        ;;
+esac
+if [[ "$1" == "pull" ]]; then
+    n=$(( $(cat "${STUB_DIR}/pulls" 2>/dev/null || echo 0) + 1 ))
+    echo "${n}" > "${STUB_DIR}/pulls"
+    if (( n <= ${STUB_PULL_FAILS:-0} )); then exit 1; fi
+    touch "${STUB_DIR}/pulled"
+    exit 0
+fi
+exit 0
+EOF
+
+    cat > "${STUB_DIR}/kind" <<'EOF'
+#!/usr/bin/env bash
+echo "kind $*" >> "${TRACE}"
+if [[ "$1 $2" == "get clusters" ]]; then
+    printf '%s\n' ${STUB_CLUSTERS:-aicr-kwok-test}
+    exit 0
+fi
+if [[ "$1 $2" == "load docker-image" ]]; then
+    exit "${STUB_KIND_LOAD_RC:-0}"
+fi
+exit 0
+EOF
+    chmod +x "${STUB_DIR}/docker" "${STUB_DIR}/kind"
+}
+
+reset() {
+    : > "${TRACE}"
+    rm -f "${STUB_DIR}/pulls" "${STUB_DIR}/pulled"
+    unset STUB_INSPECT_RC STUB_PULL_FAILS STUB_KIND_LOAD_RC STUB_CLUSTERS
+    unset KUBECTL_CONTEXT KWOK_CLUSTER
+    export STUB_DIR TRACE
+    write_stubs
+}
+
+IMG="public.ecr.aws/docker/library/registry:3.1.1"
+
+# 1. The happy path: image is not cached, one pull, one side-load.
+reset
+preload_image "${IMG}" >/dev/null; rc=$?
+check "pulls-then-loads" 0 "${rc}" "docker pull" "kind load docker-image ${IMG}"
+
+# 2. Already cached on the runner -> no pull, still side-loaded. Lanes share a
+#    runner, so the second lane must not re-pull.
+reset
+export STUB_INSPECT_RC=0
+preload_image "${IMG}" >/dev/null; rc=$?
+check "cached-image-still-loads" 0 "${rc}" "kind load docker-image ${IMG}"
+check_absent "cached-image-skips-pull" "docker pull"
+
+# 3. The case this whole change exists for: the first two pulls fail (the
+#    transient upstream reset seen in CI) and the third succeeds.
+reset
+export STUB_PULL_FAILS=2
+preload_image "${IMG}" >/dev/null; rc=$?
+check "retries-transient-pull-failure" 0 "${rc}" "kind load docker-image ${IMG}"
+if [[ "$(cat "${STUB_DIR}/pulls" 2>/dev/null || echo 0)" != "3" ]]; then
+    echo "FAIL: retries-transient-pull-failure (want 3 pull attempts, got $(cat "${STUB_DIR}/pulls" 2>/dev/null || echo 0))"
+    fails=$((fails + 1))
+else
+    echo "PASS: retries-exactly-three-times"
+fi
+
+# 4. Every pull fails -> rc still 0 and NO side-load attempted. The kubelet
+#    fallback must remain, and a missing image must not be "loaded".
+reset
+export STUB_PULL_FAILS=99
+preload_image "${IMG}" >/dev/null; rc=$?
+check "pull-exhausted-does-not-fail-the-lane" 0 "${rc}"
+check_absent "pull-exhausted-skips-load" "kind load"
+
+# 5. Side-load itself fails -> rc still 0. Same reason.
+reset
+export STUB_KIND_LOAD_RC=1
+preload_image "${IMG}" >/dev/null; rc=$?
+check "load-failure-does-not-fail-the-lane" 0 "${rc}" "kind load docker-image"
+
+# 6. Cluster named by the context, not the default.
+reset
+export STUB_CLUSTERS="other-cluster"
+export KUBECTL_CONTEXT="kind-other-cluster"
+preload_image "${IMG}" >/dev/null; rc=$?
+check "context-selects-the-cluster" 0 "${rc}" "kind load docker-image ${IMG} --name other-cluster"
+
+# 7. A non-Kind context (a real cluster) -> no docker or kind work at all.
+#    Preloading into a Kind node would be meaningless there.
+reset
+export KUBECTL_CONTEXT="arn:aws:eks:us-west-2:123456789012:cluster/prod"
+preload_image "${IMG}" >/dev/null; rc=$?
+check "non-kind-context-is-a-noop" 0 "${rc}"
+check_absent "non-kind-context-skips-docker" "docker"
+
+# 8. Context names a cluster that does not exist -> no pull, no load.
+reset
+export STUB_CLUSTERS="aicr-kwok-test"
+export KUBECTL_CONTEXT="kind-missing-cluster"
+preload_image "${IMG}" >/dev/null; rc=$?
+check "unknown-cluster-is-a-noop" 0 "${rc}"
+check_absent "unknown-cluster-skips-pull" "docker pull"
+
+# 8b. A cluster whose name merely CONTAINS the target must not satisfy the
+#     existence check. `kind get clusters` is line-oriented, so a substring
+#     match would side-load into the wrong cluster's node.
+reset
+export STUB_CLUSTERS="aicr-kwok-test-two"
+export KUBECTL_CONTEXT="kind-aicr-kwok-test"
+preload_image "${IMG}" >/dev/null; rc=$?
+check "substring-cluster-name-is-not-a-match" 0 "${rc}"
+check_absent "substring-cluster-name-skips-load" "kind load"
+
+# 9. KWOK_CLUSTER is honored when no context is pinned.
+reset
+export STUB_CLUSTERS="custom-kwok"
+export KWOK_CLUSTER="custom-kwok"
+preload_image "${IMG}" >/dev/null; rc=$?
+check "kwok-cluster-env-selects-the-cluster" 0 "${rc}" "--name custom-kwok"
+
+# 10. Neither docker nor kind on PATH (a dev box driving a remote cluster).
+#     Must be a silent no-op rather than an error.
+reset
+rm -f "${STUB_DIR}/docker" "${STUB_DIR}/kind"
+preload_image "${IMG}" >/dev/null; rc=$?
+check "missing-tooling-is-a-noop" 0 "${rc}"
+write_stubs
+
+if (( fails > 0 )); then
+    echo "FAILED: ${fails} case(s)"
+    exit 1
+fi
+echo "All preload-image cases passed"


### PR DESCRIPTION
## Summary

Pull the KWOK lanes' registry and Gitea images on the runner and side-load them into the Kind node, instead of letting the kubelet pull them from a public registry inside a fixed 120s rollout budget.

## Motivation / Context

The KWOK lanes went red four consecutive times on `main` (`a9a1be6`, `d85b4ba`, `4e8a1c9`, `f74241f`), but a **different** recipe and deployer failed each run — `h100-eks-training`, `eks-inference`, `gb200-eks-ubuntu-training-slurm`, Tier 1 `eks-training`. A code regression would fail the same lane every time; this is an environmental fault.

The dominant pair across all four runs is `failing to pull image` followed by `timed out waiting for the condition`. From [run 33340006912](https://github.com/NVIDIA/aicr/actions/runs/33340006912):

```
Waiting for deployment "registry" rollout to finish: 0 of 1 updated replicas are available...
error: timed out waiting for the condition
[ERROR] Registry Deployment did not become Ready within 120s
Error from server (BadRequest): container "registry" in pod "registry-84db85bc7b-h85qs"
  is waiting to start: trying and failing to pull image
[ERROR] install-infra.sh failed (exit code 20)
```

The registry and Gitea Deployments are the only two workloads in these lanes whose images come from a public registry (`public.ecr.aws`), and `install_registry` / `install_gitea` applied the Deployment and gave the kubelet 120s with no retry. A single upstream blip cost a matrix cell.

Related: #843
Fixes: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `kwok/scripts`, `.github/workflows/kwok-recipes.yaml`

## Implementation Notes

`docker pull` on the host (3 attempts, 5s/10s backoff) then `kind load docker-image`, called before each Deployment is applied. Both Deployments already set `imagePullPolicy: IfNotPresent`, so a preloaded image is used as-is with no manifest change. Retrying on the host is what the 120s rollout budget could not do, and the runner's Docker cache carries across lanes in a job.

**Best effort by design.** Every failure path logs and returns 0, leaving the kubelet pull as the fallback exactly as today. The function removes a failure mode or it does nothing — a bug that makes it fail the lane would be strictly worse than not having it. So it is a no-op when `docker` or `kind` is missing (a dev box driving a remote cluster), when `KUBECTL_CONTEXT` names a non-Kind cluster, when the named cluster does not exist, and when the pull cannot succeed at all.

Extracted to `kwok/scripts/lib/preload-image.sh` following the `sync-budget.sh` / `profile-select.sh` pattern, so the retry and cluster-resolution logic is unit tested with stubbed `docker`/`kind` rather than only in a live lane.

**Not addressed here.** Two other root causes appeared once each in that run and are not this change: a Go module proxy reset during `goreleaser build`, and Flux's helm-controller hitting `client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline` on the cert-manager install. Both are worth their own look if they recur; neither is the dominant pattern.

## Testing

```bash
bash kwok/scripts/lib/preload-image_test.sh   # 16/16 pass
bash -n kwok/scripts/install-infra.sh         # syntax
actionlint -shellcheck= .github/workflows/kwok-recipes.yaml
yamllint .github/workflows/kwok-recipes.yaml
```

The new harness is wired into the same `Script unit tests (kwok/scripts/lib)` CI step as its siblings. It asserts `rc=0` in every case — the interesting assertions are on which stub commands ran — and covers: cached image skips the pull, two transient failures then success, exhausted pull does not fail the lane *and* does not attempt a side-load, side-load failure does not fail the lane, context-selected cluster, `KWOK_CLUSTER` override, non-Kind context, unknown cluster, substring-vs-exact cluster name, and missing tooling.

Mutation-verified:

| Mutation | Failures caught |
|---|---|
| `return 1` when the pull is exhausted | 2 |
| Drop the retry loop (single attempt) | 3 |
| `grep -q` instead of `grep -qx` for the cluster match | 2 |

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** CI-only; no product code touched. The worst case is that preloading does nothing and the lanes behave exactly as they do today.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go changes
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed — `KWOK_CLUSTER` documented in the script header
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
