### PR TITLE
fix(ci): pull the KWOK images once per run instead of once per job

### DIFF
--- a/.github/actions/kwok-test/action.yml
+++ b/.github/actions/kwok-test/action.yml
@@ -167,6 +167,70 @@ runs:
         make build
         ls -la dist/
 
+    # ── Image cache: load the public images this lane needs from the tarball
+    # the prime-images job saved, instead of pulling them here (#2483).
+    #
+    # preload_image checks the host Docker cache before every pull attempt, so
+    # an image loaded here means the lane never contacts the registry at all —
+    # which is the point: 127 concurrent jobs pulling the same image is what
+    # trips the per-IP throttle.
+    #
+    # BEST EFFORT, unlike the prime job that fills the cache. Every step below
+    # tolerates a miss (fail-on-cache-miss defaults to false, and the load step
+    # swallows a non-zero), because the fallback is intact: preload_image pulls,
+    # and the kubelet pulls behind that. A fork PR whose cache scope differs, or
+    # a first run after a pin bump, must degrade to today's behavior rather than
+    # fail. The gate lives in prime-images, not here.
+    #
+    # Placed after setup-build-tools because resolving the pins needs yq.
+    - name: Resolve image pins and cache keys
+      id: images
+      shell: bash
+      run: |
+        set -euo pipefail
+        bash kwok/scripts/lib/image-cache.sh settings .settings.yaml | tee -a "$GITHUB_OUTPUT"
+
+    - name: Restore registry image
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+      with:
+        path: /tmp/kwok-image-cache/registry
+        key: ${{ steps.images.outputs.registry_key }}
+
+    # Gitea is installed only for the *-git deployers (see install-infra.sh), so
+    # the other lanes skip a ~250MB restore they would never use.
+    - name: Restore Gitea image
+      if: endsWith(inputs.deployer, '-git')
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+      with:
+        path: /tmp/kwok-image-cache/gitea
+        key: ${{ steps.images.outputs.gitea_key }}
+
+    - name: Load cached images
+      shell: bash
+      env:
+        REGISTRY_IMAGE: ${{ steps.images.outputs.registry_image }}
+        GITEA_IMAGE: ${{ steps.images.outputs.gitea_image }}
+        DEPLOYER: ${{ inputs.deployer }}
+      run: |
+        set -uo pipefail
+
+        # A miss is not fatal — preload_image still pulls — but it does mean
+        # this lane is back to contending for the registry, which is the whole
+        # point of #2483. Annotate it: a key that drifts from the prime job's
+        # would otherwise leave every lane pulling again, green, with the fix
+        # silently inert and nothing to notice it by.
+        load_image() { # <dir> <image>
+          if bash kwok/scripts/lib/image-cache.sh load "$1" "$2"; then
+            return 0
+          fi
+          echo "::warning::Image cache miss for $2 — this lane will pull it from the registry"
+        }
+
+        load_image /tmp/kwok-image-cache/registry "${REGISTRY_IMAGE}"
+        if [[ "${DEPLOYER}" == *-git ]]; then
+          load_image /tmp/kwok-image-cache/gitea "${GITEA_IMAGE}"
+        fi
+
     - name: Run KWOK recipe test
       id: validate
       shell: bash

--- a/.github/workflows/kwok-recipes.yaml
+++ b/.github/workflows/kwok-recipes.yaml
@@ -76,7 +76,13 @@ jobs:
     name: Discover Recipes
     if: github.event_name != 'schedule' || github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Raised from 5→10 when image-cache_test.sh joined the script unit tests
+    # below. Those suites are deliberately wall-clock bound — they assert that
+    # a hanging pull or an exhausted budget stays inside its deadline, which
+    # costs real seconds — and the block now runs ~90s locally before this job
+    # even starts classifying recipes. A discovery job that times out would be
+    # exactly the kind of self-inflicted red this change exists to remove.
+    timeout-minutes: 10
     outputs:
       tier1_pairs: ${{ steps.classify.outputs.tier1_pairs }}
       tier2_pairs: ${{ steps.classify.outputs.tier2_pairs }}
@@ -98,6 +104,7 @@ jobs:
           bash kwok/scripts/lib/sync-budget_test.sh
           bash kwok/scripts/lib/profile-select_test.sh
           bash kwok/scripts/lib/preload-image_test.sh
+          bash kwok/scripts/lib/image-cache_test.sh
           bash kwok/scripts/run-all-recipes_test.sh
 
       - name: Classify recipes into tiers
@@ -375,12 +382,75 @@ jobs:
           if (( dropped_count > 0 )); then
             echo "Filtered from matrix: ${dropped_count} recipe(s) with no matching KWOK profile — $(echo "$dropped" | jq -r 'join(", ")')"
           fi
+  # ── Image cache priming: one pull per run, not one per matrix job (#2483) ──
+  #
+  # The KWOK lanes need two public images — an in-cluster OCI registry, and
+  # Gitea for the *-git deployers. Every matrix job used to pull them itself.
+  # In run 33350102144, 127 jobs pulled registry:3.1.1 at the same moment from
+  # the shared GitHub-runner egress IPs; 125 succeeded and the one that was
+  # shed reddened main. That is a per-IP throttle, not an outage, so retrying
+  # harder cannot fix it — #2496 narrowed the window, it did not close it. The
+  # fix is to stop making 127 requests.
+  #
+  # This job makes one, saves a tarball, and lets actions/cache carry it to the
+  # matrix, which loads it from disk (see .github/actions/kwok-test). On a warm
+  # cache not even this job pulls.
+  #
+  # HARD GATE by design, unlike the best-effort preload it feeds: if an image is
+  # genuinely unreachable, failing one job in a minute beats 127 jobs each
+  # burning a rollout timeout. The summary job fails with it — without that, a
+  # failed prime would skip the tiers and the run would report green.
+  #
+  # One job per image (rather than one job for both) so a Gitea failure cannot
+  # discard a registry pull that already succeeded: actions/cache saves at the
+  # end of a job only when that job succeeds.
+  prime-images:
+    name: 'Prime Image Cache (${{ matrix.image }})'
+    if: github.event_name != 'schedule' || github.repository == 'nvidia/aicr'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # Must match IMAGE_CACHE_IMAGES in kwok/scripts/lib/image-cache.sh.
+        image: [registry, gitea]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      # .settings.yaml stays the single source of truth for the pins; the key
+      # derivation is shared with the consuming side through image-cache.sh, so
+      # the two cannot drift into never agreeing on a key.
+      - name: Resolve image pins and cache keys
+        id: images
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash kwok/scripts/lib/image-cache.sh settings .settings.yaml | tee -a "$GITHUB_OUTPUT"
+
+      - name: Cache image tarball
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+        with:
+          path: /tmp/kwok-image-cache/${{ matrix.image }}
+          key: ${{ steps.images.outputs[format('{0}_key', matrix.image)] }}
+
+      - name: Prime image
+        shell: bash
+        env:
+          IMAGE: ${{ steps.images.outputs[format('{0}_image', matrix.image)] }}
+          CACHE_DIR: /tmp/kwok-image-cache/${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          bash kwok/scripts/lib/image-cache.sh save "${CACHE_DIR}" "${IMAGE}"
+
   # Thin caller of the shared kwok-test-run.yaml reusable workflow (#1172).
   # tier1_pairs is well under 256 entries, so it's passed in a single call —
   # no batching needed.
   test-tier1:
     name: 'Tier 1'
-    needs: discover
+    needs: [discover, prime-images]
     if: >-
       github.event_name != 'schedule' &&
       needs.discover.outputs.tier1_pairs != '[]' &&
@@ -393,7 +463,7 @@ jobs:
   # Helm-only by deliberate policy — see ADR-003 "Tier 2 deployer coverage".
   test-tier2:
     name: 'Tier 2'
-    needs: discover
+    needs: [discover, prime-images]
     if: >-
       github.event_name == 'pull_request' &&
       needs.discover.outputs.tier2_pairs != '[]' &&
@@ -411,7 +481,7 @@ jobs:
   # single run in its own group so they all run in parallel.
   test-tier3:
     name: 'Tier 3'
-    needs: discover
+    needs: [discover, prime-images]
     concurrency:
       group: kwok-tier3-${{ github.sha }}-${{ matrix.batch.id }}
       cancel-in-progress: false
@@ -430,7 +500,7 @@ jobs:
   # ── Summary: aggregate all tiers ──
   summary:
     name: KWOK Test Summary
-    needs: [test-tier1, test-tier2, test-tier3]
+    needs: [prime-images, test-tier1, test-tier2, test-tier3]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
@@ -440,18 +510,30 @@ jobs:
           echo "## KWOK Cluster Validation Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
+          prime="${{ needs.prime-images.result }}"
           tier1="${{ needs.test-tier1.result }}"
           tier2="${{ needs.test-tier2.result }}"
           tier3="${{ needs.test-tier3.result }}"
 
-          echo "| Tier | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "| Stage | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Image cache priming | ${prime} |" >> $GITHUB_STEP_SUMMARY
           echo "| Tier 1 (generic) | ${tier1} |" >> $GITHUB_STEP_SUMMARY
           echo "| Tier 2 (diff-aware) | ${tier2} |" >> $GITHUB_STEP_SUMMARY
           echo "| Tier 3 (full matrix) | ${tier3} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           failed=false
+
+          # Priming gates every tier, so its failure must be checked HERE and
+          # not inferred from the tiers. A failed prime leaves them "skipped",
+          # and the tier checks below deliberately tolerate "skipped" — so
+          # without this the whole run would report green having validated
+          # nothing.
+          if [[ "$prime" == "failure" || "$prime" == "cancelled" ]]; then
+            echo "Image cache priming failed or was cancelled — no tier ran" >> $GITHUB_STEP_SUMMARY
+            failed=true
+          fi
 
           # Tier 1 must pass (unless skipped on schedule-only with no recipes)
           if [[ "$tier1" == "failure" || "$tier1" == "cancelled" ]]; then

--- a/kwok/README.md
+++ b/kwok/README.md
@@ -231,6 +231,24 @@ Manual trigger:
 gh workflow run kwok-recipes.yaml -f recipe=your-recipe-name
 ```
 
+### Public image cache
+
+The lanes need two images from public registries — the in-cluster OCI registry and, for the `*-git` deployers, Gitea. Both are pinned in `.settings.yaml` under `testing_tools`.
+
+A full Tier 3 run fans out to well over a hundred concurrent jobs, and a job that pulls these itself competes with every sibling for the same per-IP quota at the registry: 127 jobs pulling at once reliably gets one or two shed, which reddens the run with nothing wrong in the repo (#2483). So CI pulls each image exactly once, in the `prime-images` job, and carries it to the matrix as a tarball in `actions/cache`. Each test job loads from that tarball, and `preload_image` then finds the image already in the host Docker cache and never contacts the registry.
+
+`kwok/scripts/lib/image-cache.sh` owns both ends, so the priming job and the test jobs derive the cache key from the same code:
+
+```bash
+bash kwok/scripts/lib/image-cache.sh settings .settings.yaml   # resolve pins + keys
+bash kwok/scripts/lib/image-cache.sh save <dir> <image>        # pull once, write the tarball
+bash kwok/scripts/lib/image-cache.sh load <dir> <image>        # restore it into Docker
+```
+
+Priming is a hard gate: if an image is genuinely unreachable, the run fails there rather than in every lane. Loading is best effort — a cache miss falls back to `preload_image`'s pull, and the kubelet pull behind that, so a cold cache degrades to the old behavior instead of failing.
+
+Local runs (`make kwok-test-all`) do not use the cache; they pull through `preload_image` as before.
+
 ## Troubleshooting
 
 **Pods stuck Pending** — check tolerations and node selectors:

--- a/kwok/scripts/lib/image-cache.sh
+++ b/kwok/scripts/lib/image-cache.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# image-cache.sh - pull once, load many: a tarball cache for the public images
+# the KWOK lanes need, so a run does not depend on an unauthenticated
+# third-party registry pull at job time (#2483).
+#
+# The problem this solves is a per-IP registry throttle, not an outage. In the
+# run that motivated it, 127 concurrent matrix jobs each pulled
+# public.ecr.aws/docker/library/registry:3.1.1 at the same moment from the same
+# runner egress IPs; 125 succeeded and 1 was shed, reddening main. Retrying
+# harder cannot fix a quota shared across the matrix -- the fix is to stop
+# making 127 requests. One job pulls and saves a tarball, actions/cache carries
+# it, and every matrix job loads from disk.
+#
+# Used by:
+#   .github/workflows/kwok-recipes.yaml  (prime-images job -> `save`)
+#   .github/actions/kwok-test/action.yml (matrix jobs      -> `key` and `load`)
+#
+# Both sides derive the cache key from the same function here rather than from
+# a value threaded through the reusable workflow: if the two could disagree,
+# every restore would miss and the cache would silently do nothing while
+# reporting success.
+#
+# Sourced by image-cache_test.sh (with stubbed docker); executed directly by
+# the workflow. `save` and `load` differ deliberately in how loud they are:
+#
+#   save  is a GATE. The prime job runs it once so the matrix never touches the
+#         registry, so a save that reports success without producing a usable
+#         tarball is worse than no cache at all -- it sends all 127 jobs back to
+#         the pull with the gate lit green. Every failure path returns non-zero.
+#
+#   load  is BEST EFFORT, like preload_image. A miss returns non-zero for the
+#         caller to shrug at: preload_image still pulls, and the kubelet still
+#         pulls behind that. A cache miss must never fail a lane.
+
+IMAGE_CACHE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# preload_remaining / preload_have_image / preload_pull_retry. The retry
+# schedule is deliberately shared rather than reimplemented: it is the one
+# tuned against the observed throttle (#2496), and a second copy here would
+# drift from it.
+# shellcheck source=preload-image.sh
+source "${IMAGE_CACHE_SCRIPT_DIR}/preload-image.sh"
+
+# Callers that source this file supply log_* (install-infra.sh does, and so
+# does the test harness). A direct invocation from the workflow does not, so
+# define only what is missing.
+declare -F log_info  >/dev/null || log_info()  { echo "[INFO]  $*"; }
+declare -F log_warn  >/dev/null || log_warn()  { echo "[WARN]  $*"; }
+declare -F log_error >/dev/null || log_error() { echo "[ERROR] $*" >&2; }
+
+# Wall-clock budget for one save or load, across every retry. Generous compared
+# to preload_image's 180s because this runs ONCE per workflow run in a job of
+# its own, rather than inside a 20-minute lane that still has a recipe to
+# validate: spending ten minutes here to spare 127 jobs a throttled pull is a
+# good trade, and the pull it is retrying is the one being rate-limited.
+#
+# Read at CALL time, not source time, so a caller (or a test) can change it
+# between invocations.
+IMAGE_CACHE_BUDGET_DEFAULT=600
+
+# image_cache_sha256 hashes stdin. sha256sum is GNU/Linux (the CI runners);
+# shasum is what macOS ships, and this library runs locally too.
+image_cache_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | cut -d' ' -f1
+    else
+        shasum -a 256 | cut -d' ' -f1
+    fi
+}
+
+# image_cache_key prints the actions/cache key for IMAGE.
+#
+# Shape: kwok-image-<name>-<16 hex>. The name is for the human reading the
+# cache list; the hash is the actual identity and covers the FULL ref, so a
+# tag bump misses (rather than restoring the stale image, which would test the
+# wrong version) and two registries hosting the same name do not collide.
+#
+# The sanitizing is load-bearing: the ref is full of '/' and ':', and GitHub
+# rejects a cache key containing a comma.
+image_cache_key() {
+    local image="$1" name hash
+    name="${image%%:*}"   # drop the tag
+    name="${name##*/}"    # keep the last path segment
+    name="$(printf '%s' "${name}" | tr -c 'a-zA-Z0-9._-' '-' | tr -s '-')"
+    hash="$(printf '%s' "${image}" | image_cache_sha256 | cut -c1-16)"
+    printf 'kwok-image-%s-%s' "${name}" "${hash}"
+}
+
+# image_cache_file prints the tarball path for IMAGE inside DIR. The key is in
+# the filename so a restored directory from a previous pin cannot be mistaken
+# for a hit on the current one.
+image_cache_file() {
+    printf '%s/%s.tar' "$1" "$(image_cache_key "$2")"
+}
+
+# image_cache_tools_ready reports whether docker and timeout are both usable.
+#
+# `timeout` is required, not optional, for the same reason preload_image
+# requires it: without it every docker call is unbounded and a stalled daemon
+# holds the job for its entire budget.
+#
+# Uses only shell builtins, so it is safe to call before anything else -- the
+# caller must not compute a deadline (which needs `date`) on a PATH where the
+# tooling is missing.
+image_cache_tools_ready() {
+    command -v docker &>/dev/null && command -v timeout &>/dev/null
+}
+
+# image_cache_save DIR IMAGE ensures DIR holds a loadable tarball of IMAGE,
+# pulling it first if the host does not have it. Returns non-zero on every
+# failure -- see the gate/best-effort note at the top of this file.
+image_cache_save() {
+    local dir="$1" image="$2" file tmp budget deadline remaining
+
+    if ! image_cache_tools_ready; then
+        log_error "docker or timeout unavailable — cannot prime the image cache for ${image}"
+        return 1
+    fi
+
+    file="$(image_cache_file "${dir}" "${image}")"
+    if [[ -s "${file}" ]]; then
+        log_info "Cache hit: ${image} already saved at ${file}"
+        return 0
+    fi
+
+    if ! mkdir -p "${dir}"; then
+        log_error "Could not create the image cache directory ${dir}"
+        return 1
+    fi
+
+    budget="${KWOK_IMAGE_CACHE_BUDGET_SECONDS:-${IMAGE_CACHE_BUDGET_DEFAULT}}"
+    deadline=$(( $(date +%s) + budget ))
+
+    # preload_pull_retry owns the reporting of WHY a pull failed, so this path
+    # only has to say what the failure means.
+    if ! preload_pull_retry "${image}" "${deadline}"; then
+        log_error "Could not pull ${image} within ${budget}s — the KWOK image cache cannot be primed"
+        return 1
+    fi
+
+    if ! remaining=$(preload_remaining "${deadline}"); then
+        log_error "Budget spent before ${image} could be saved"
+        return 1
+    fi
+
+    # Save to scratch and publish with a rename.
+    #
+    # A `docker save` killed partway still leaves bytes on disk. Writing
+    # straight to the final path would let actions/cache upload that stump,
+    # every later run would take it as a hit, and `docker load` would then fail
+    # in all 127 jobs -- with this job green, because it did pull the image.
+    # Publishing only a complete save is what makes that impossible.
+    tmp="${file}.tmp"
+    rm -f "${tmp}"
+    if ! timeout "${remaining}" docker save -o "${tmp}" "${image}"; then
+        log_error "docker save failed for ${image}"
+        rm -f "${tmp}"
+        return 1
+    fi
+    if [[ ! -s "${tmp}" ]]; then
+        log_error "docker save produced an empty tarball for ${image}"
+        rm -f "${tmp}"
+        return 1
+    fi
+    if ! mv "${tmp}" "${file}"; then
+        log_error "Could not publish the tarball for ${image} at ${file}"
+        rm -f "${tmp}"
+        return 1
+    fi
+
+    log_info "Saved ${image} to ${file} ($(du -h "${file}" 2>/dev/null | cut -f1))"
+    return 0
+}
+
+# image_cache_load DIR IMAGE makes IMAGE present in the host Docker cache from
+# a previously saved tarball. Returns non-zero when it cannot -- best effort,
+# see the note at the top of this file.
+#
+# A hit here is what removes the registry from the job's critical path:
+# preload_image checks the host cache before every pull attempt, so an image
+# loaded here means it never pulls at all.
+image_cache_load() {
+    local dir="$1" image="$2" file budget deadline remaining
+
+    if ! image_cache_tools_ready; then
+        log_warn "docker or timeout unavailable — leaving ${image} to the pull path"
+        return 1
+    fi
+
+    budget="${KWOK_IMAGE_CACHE_BUDGET_SECONDS:-${IMAGE_CACHE_BUDGET_DEFAULT}}"
+    deadline=$(( $(date +%s) + budget ))
+
+    if preload_have_image "${image}" "${deadline}"; then
+        log_info "${image} is already present on the host — nothing to load"
+        return 0
+    fi
+
+    file="$(image_cache_file "${dir}" "${image}")"
+    if [[ ! -s "${file}" ]]; then
+        log_warn "No cached tarball for ${image} at ${file} — the pull path will handle it"
+        return 1
+    fi
+
+    if ! remaining=$(preload_remaining "${deadline}"); then
+        log_warn "Budget spent before ${image} could be loaded"
+        return 1
+    fi
+
+    if ! timeout "${remaining}" docker load -i "${file}"; then
+        log_warn "docker load failed for ${image} from ${file}"
+        return 1
+    fi
+
+    # Verify the image is actually present rather than trusting the exit code.
+    # A truncated or wrong-image tarball can load "successfully" and leave the
+    # image absent; reporting that as a hit would tell the caller to skip a
+    # pull it still needs.
+    if ! preload_have_image "${image}" "${deadline}"; then
+        log_warn "${image} is still not present after loading ${file}"
+        return 1
+    fi
+
+    log_info "Loaded ${image} from ${file}"
+    return 0
+}
+
+# The public images the KWOK lanes preload. Must match what install-infra.sh
+# actually installs -- it reads these same two settings.
+IMAGE_CACHE_IMAGES=(registry gitea)
+
+# image_cache_settings reads the pinned image refs out of SETTINGS_FILE and
+# prints `<name>_image=` / `<name>_key=` lines, ready to append to
+# $GITHUB_OUTPUT.
+#
+# Exists so the prime job and the 127 matrix jobs resolve images and keys
+# through ONE tested code path instead of two copies of yq in two YAML files.
+# .settings.yaml stays the single source of truth for the pins.
+#
+# Fails closed on a missing or empty pin: a renamed setting would otherwise
+# yield an empty image ref, a key over the empty string, and a cache that
+# reports success while holding nothing.
+image_cache_settings() {
+    local file="$1" name image
+
+    if ! command -v yq &>/dev/null; then
+        log_error "yq is required to read image pins from ${file}"
+        return 1
+    fi
+    if [[ ! -r "${file}" ]]; then
+        log_error "Cannot read ${file}"
+        return 1
+    fi
+
+    for name in "${IMAGE_CACHE_IMAGES[@]}"; do
+        image="$(yq eval ".testing_tools.${name}_image" "${file}")"
+        if [[ -z "${image}" || "${image}" == "null" ]]; then
+            log_error "testing_tools.${name}_image is missing from ${file}"
+            return 1
+        fi
+        # These lines are appended to $GITHUB_OUTPUT, which is line-oriented
+        # `name=value`. A ref carrying whitespace — a typo, a stray newline from
+        # a folded YAML scalar — would write a line the runner parses as
+        # something else entirely. Reject it here, where the message names the
+        # setting, rather than downstream where it looks like a cache bug.
+        if [[ "${image}" =~ [[:space:]] ]]; then
+            log_error "testing_tools.${name}_image in ${file} contains whitespace: '${image}'"
+            return 1
+        fi
+        printf '%s_image=%s\n' "${name}" "${image}"
+        printf '%s_key=%s\n' "${name}" "$(image_cache_key "${image}")"
+    done
+}
+
+image_cache_usage() {
+    cat >&2 <<'EOF'
+usage: image-cache.sh <verb> [args]
+
+  key      <image>          print the actions/cache key for <image>
+  file     <dir> <image>    print the tarball path for <image> inside <dir>
+  save     <dir> <image>    ensure <dir> holds a loadable tarball of <image>
+  load     <dir> <image>    load <image> into the host Docker cache from <dir>
+  settings <settings-file>  print <name>_image= / <name>_key= for each pinned
+                            KWOK image, for $GITHUB_OUTPUT
+EOF
+}
+
+# An unknown verb or a missing argument must fail rather than silently no-op:
+# a typo in the workflow YAML would otherwise produce a green job that cached
+# nothing, which is the failure this whole library exists to make impossible.
+image_cache_main() {
+    case "${1:-}" in
+        key)
+            (( $# == 2 )) || { image_cache_usage; return 2; }
+            image_cache_key "$2"
+            ;;
+        file)
+            (( $# == 3 )) || { image_cache_usage; return 2; }
+            image_cache_file "$2" "$3"
+            ;;
+        save)
+            (( $# == 3 )) || { image_cache_usage; return 2; }
+            image_cache_save "$2" "$3"
+            ;;
+        load)
+            (( $# == 3 )) || { image_cache_usage; return 2; }
+            image_cache_load "$2" "$3"
+            ;;
+        settings)
+            (( $# == 2 )) || { image_cache_usage; return 2; }
+            image_cache_settings "$2"
+            ;;
+        *)
+            image_cache_usage
+            return 2
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -uo pipefail
+    image_cache_main "$@"
+fi

--- a/kwok/scripts/lib/image-cache_test.sh
+++ b/kwok/scripts/lib/image-cache_test.sh
@@ -1,0 +1,505 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unit harness for lib/image-cache.sh (pull-once / load-many image cache).
+#
+# The property under test is the mirror image of preload-image_test.sh. There,
+# every case asserts rc=0 because preload_image must never fail the lane. Here,
+# image_cache_save is a GATE: the CI prime job runs it once so 127 matrix jobs
+# never touch the upstream registry, and a save that reports success without
+# producing a usable tarball would send all 127 back to the pull it exists to
+# remove -- with the gate lit green. So the interesting assertions are that
+# failures are LOUD, and that a partial tarball is never published.
+#
+# image_cache_load keeps the best-effort contract: a miss returns non-zero for
+# the caller to shrug at, because the kubelet pull is still behind it.
+#
+# Run directly: bash kwok/scripts/lib/image-cache_test.sh
+# Wired into CI by the kwok-recipes discover job.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The subject expects its caller to supply these (install-infra.sh does); the
+# harness supplies its own so log output does not pollute the assertions.
+log_info()  { echo "INFO: $*"; }
+log_warn()  { echo "WARN: $*"; }
+log_debug() { echo "DEBUG: $*"; }
+
+# Resolve the subject SCRIPT_DIR-relative — never a deployed copy.
+# shellcheck source=image-cache.sh
+source "${SCRIPT_DIR}/image-cache.sh"
+
+fails=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; fails=$((fails + 1)); }
+
+check_rc() { # <name> <want_rc> <got_rc>
+    if [[ "$3" == "$2" ]]; then
+        pass "$1"
+    else
+        fail "$1 (want rc=$2, got rc=$3)"
+    fi
+}
+
+check_rc_nonzero() { # <name> <got_rc>
+    if [[ "$2" != "0" ]]; then
+        pass "$1"
+    else
+        fail "$1 (want a non-zero rc, got 0)"
+    fi
+}
+
+check_trace() { # <name> <must_contain>
+    if grep -q -- "$2" "${TRACE}"; then
+        pass "$1"
+    else
+        fail "$1 (trace missing '$2'; trace was: $(tr '\n' '|' < "${TRACE}"))"
+    fi
+}
+
+check_trace_absent() { # <name> <must_not_contain>
+    if grep -q -- "$2" "${TRACE}"; then
+        fail "$1 (trace unexpectedly contains '$2'; trace was: $(tr '\n' '|' < "${TRACE}"))"
+    else
+        pass "$1"
+    fi
+}
+
+# Asserts the call finished within its CONFIGURED budget rather than some loose
+# ceiling, for the same reason preload-image_test.sh does: a generous threshold
+# would let a backoff regression push the real ceiling well past the budget and
+# still pass. The margin covers process spawn and scheduling only.
+BOUND_MARGIN_SECONDS=3
+check_bounded() { # <name> <budget> <elapsed>
+    if (( $3 <= $2 + BOUND_MARGIN_SECONDS )); then
+        pass "$1 ($3s, budget $2s)"
+    else
+        fail "$1 (took $3s, budget $2s + ${BOUND_MARGIN_SECONDS}s margin)"
+    fi
+}
+
+STUB_DIR="$(mktemp -d)"
+CACHE_DIR="${STUB_DIR}/cache"
+TRACE="${STUB_DIR}/trace"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+PATH="${STUB_DIR}:${PATH}"
+
+# Stub behavior is driven by these, reset before each case. Each must be
+# EXPORTED: the stubs are separate processes, so a plain assignment would leave
+# them at their defaults and quietly make a case pass over the wrong scenario.
+#   STUB_INSPECT_RC   docker image inspect exit code (1 = not cached locally)
+#   STUB_PULL_FAILS   number of leading `docker pull` attempts that fail
+#   STUB_PULL_HANGS   non-empty makes every `docker pull` hang forever
+#   STUB_SAVE_RC      `docker save` exit code
+#   STUB_SAVE_PARTIAL non-empty writes bytes to the output path, then fails
+#   STUB_SAVE_STALL   non-empty writes bytes to the output path, then stalls,
+#                     leaving a save in flight for the caller to kill
+#   STUB_LOAD_RC      `docker load` exit code
+#   STUB_LOAD_CORRUPT non-empty makes `docker load` succeed without the image
+#                     becoming present — a truncated or wrong-image tarball
+write_stubs() {
+    cat > "${STUB_DIR}/docker" <<'EOF'
+#!/usr/bin/env bash
+echo "docker $*" >> "${TRACE}"
+case "$1 $2" in
+    "image inspect")
+        # Once a pull or load has landed the image is present, so later
+        # inspects must succeed too — otherwise no loop could terminate.
+        if [[ -f "${STUB_DIR}/have" ]]; then exit 0; fi
+        exit "${STUB_INSPECT_RC:-1}"
+        ;;
+esac
+case "$1" in
+    pull)
+        n=$(( $(cat "${STUB_DIR}/pulls" 2>/dev/null || echo 0) + 1 ))
+        echo "${n}" > "${STUB_DIR}/pulls"
+        # A pull that never returns — the registry accepts the connection and
+        # then goes quiet. Only `timeout` ends this.
+        if [[ -n "${STUB_PULL_HANGS:-}" ]]; then sleep 3600; fi
+        if (( n <= ${STUB_PULL_FAILS:-0} )); then
+            # Real docker writes the cause here; the subject must forward it.
+            echo "toomanyrequests: Rate exceeded" >&2
+            exit 1
+        fi
+        touch "${STUB_DIR}/have"
+        exit 0
+        ;;
+    save)
+        # docker save -o <file> <image>
+        out="$3"
+        if [[ -n "${STUB_SAVE_STALL:-}" ]]; then
+            # Bytes on disk, then still running: the state the process is in
+            # when a runner cancels the job.
+            printf 'partial' > "${out}"
+            sleep 5
+            exit 0
+        fi
+        if [[ -n "${STUB_SAVE_PARTIAL:-}" ]]; then
+            # A save killed midway still leaves bytes on disk. The subject must
+            # not publish them as a complete tarball.
+            printf 'truncated' > "${out}"
+            exit 1
+        fi
+        if [[ "${STUB_SAVE_RC:-0}" != "0" ]]; then
+            echo "no such image" >&2
+            exit "${STUB_SAVE_RC}"
+        fi
+        printf 'tarball-bytes' > "${out}"
+        exit 0
+        ;;
+    load)
+        if [[ "${STUB_LOAD_RC:-0}" != "0" ]]; then
+            echo "invalid tar header" >&2
+            exit "${STUB_LOAD_RC}"
+        fi
+        if [[ -z "${STUB_LOAD_CORRUPT:-}" ]]; then
+            touch "${STUB_DIR}/have"
+        fi
+        exit 0
+        ;;
+esac
+exit 0
+EOF
+    chmod +x "${STUB_DIR}/docker"
+}
+
+reset() {
+    : > "${TRACE}"
+    rm -rf "${CACHE_DIR}"
+    mkdir -p "${CACHE_DIR}"
+    rm -f "${STUB_DIR}/pulls" "${STUB_DIR}/have"
+    unset STUB_INSPECT_RC STUB_PULL_FAILS STUB_PULL_HANGS
+    unset STUB_SAVE_RC STUB_SAVE_PARTIAL STUB_SAVE_STALL STUB_LOAD_RC STUB_LOAD_CORRUPT
+    unset KWOK_IMAGE_CACHE_BUDGET_SECONDS
+    export STUB_DIR TRACE
+    write_stubs
+}
+
+IMG="public.ecr.aws/docker/library/registry:3.1.1"
+GITEA="docker.gitea.com/gitea:1.27.0-rootless"
+
+# ── image_cache_key ──────────────────────────────────────────────────────────
+
+# 1. Deterministic. The prime job and the 127 matrix jobs each compute the key
+#    independently from .settings.yaml; if the two sides could disagree, every
+#    restore would miss and the cache would silently do nothing.
+reset
+k1=$(image_cache_key "${IMG}")
+k2=$(image_cache_key "${IMG}")
+if [[ "${k1}" == "${k2}" && -n "${k1}" ]]; then
+    pass "key-is-deterministic"
+else
+    fail "key-is-deterministic (${k1} != ${k2})"
+fi
+
+# 2. A tag bump must change the key, or a renovate pin bump would restore the
+#    OLD image and the lane would test the wrong version — worse than a miss.
+if [[ "$(image_cache_key "${IMG}")" != "$(image_cache_key "public.ecr.aws/docker/library/registry:3.1.2")" ]]; then
+    pass "key-changes-with-the-tag"
+else
+    fail "key-changes-with-the-tag (a pin bump would restore the stale image)"
+fi
+
+# 3. Same trailing name from a different registry must not collide. The key is
+#    derived from the FULL ref for exactly this reason.
+if [[ "$(image_cache_key "${GITEA}")" != "$(image_cache_key "ghcr.io/nvidia/gitea:1.27.0-rootless")" ]]; then
+    pass "key-changes-with-the-registry"
+else
+    fail "key-changes-with-the-registry (two distinct images share a cache entry)"
+fi
+
+# 4. GitHub rejects a cache key containing a comma, and anything outside this
+#    set is asking for quoting trouble in YAML. The key embeds an image ref
+#    full of '/' and ':', so the sanitizing is load-bearing.
+if [[ "${k1}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    pass "key-is-safe-for-actions-cache"
+else
+    fail "key-is-safe-for-actions-cache (got '${k1}')"
+fi
+
+# 5. Human-readable: an operator reading the cache list should see which image
+#    an entry is for without hashing anything themselves.
+if [[ "${k1}" == *"registry"* && "$(image_cache_key "${GITEA}")" == *"gitea"* ]]; then
+    pass "key-names-the-image"
+else
+    fail "key-names-the-image (got '${k1}')"
+fi
+
+# 6. Distinct images get distinct tarballs inside one cache dir, and the paths
+#    stay under it.
+reset
+f1=$(image_cache_file "${CACHE_DIR}" "${IMG}")
+f2=$(image_cache_file "${CACHE_DIR}" "${GITEA}")
+if [[ "${f1}" != "${f2}" && "${f1}" == "${CACHE_DIR}/"* && "${f2}" == "${CACHE_DIR}/"* ]]; then
+    pass "file-is-per-image-and-inside-the-dir"
+else
+    fail "file-is-per-image-and-inside-the-dir (${f1} / ${f2})"
+fi
+
+# ── image_cache_save ─────────────────────────────────────────────────────────
+
+# 7. Cold cache: pull once, write the tarball.
+reset
+image_cache_save "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc "save-cold-succeeds" 0 "${rc}"
+check_trace "save-cold-pulls" "docker pull"
+check_trace "save-cold-saves" "docker save"
+if [[ -s "$(image_cache_file "${CACHE_DIR}" "${IMG}")" ]]; then
+    pass "save-cold-writes-the-tarball"
+else
+    fail "save-cold-writes-the-tarball (no tarball at $(image_cache_file "${CACHE_DIR}" "${IMG}"))"
+fi
+
+# 8. Warm cache (actions/cache restored the tarball): no registry contact at
+#    all. This is the whole point of #2483 — a warm run must not pull.
+reset
+printf 'tarball-bytes' > "$(image_cache_file "${CACHE_DIR}" "${IMG}")"
+image_cache_save "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc "save-warm-succeeds" 0 "${rc}"
+check_trace_absent "save-warm-does-not-pull" "docker pull"
+check_trace_absent "save-warm-does-not-resave" "docker save"
+
+# 9. Every pull fails -> LOUD. This is the gate: reporting success here would
+#    green-light the prime job and hand all 127 matrix jobs the pull back.
+reset
+export STUB_PULL_FAILS=99
+export KWOK_IMAGE_CACHE_BUDGET_SECONDS=5
+out=$(image_cache_save "${CACHE_DIR}" "${IMG}" 2>&1); rc=$?
+check_rc_nonzero "save-pull-exhausted-fails" "${rc}"
+if [[ "${out}" == *"toomanyrequests"* ]]; then
+    pass "save-pull-exhausted-reports-the-error"
+else
+    fail "save-pull-exhausted-reports-the-error (docker's stderr was not forwarded: ${out})"
+fi
+if [[ -e "$(image_cache_file "${CACHE_DIR}" "${IMG}")" ]]; then
+    fail "save-pull-exhausted-leaves-no-tarball (an empty tarball would be restored as a cache hit)"
+else
+    pass "save-pull-exhausted-leaves-no-tarball"
+fi
+
+# 10. `docker save` fails after writing bytes. The partial file must NOT be
+#     published: actions/cache would upload it, every later run would take it
+#     as a hit, and `docker load` would fail in all 127 jobs with the prime
+#     job green. Publishing only after a complete save is what prevents that.
+reset
+export STUB_SAVE_PARTIAL=1
+export KWOK_IMAGE_CACHE_BUDGET_SECONDS=10
+image_cache_save "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "save-partial-fails" "${rc}"
+if [[ -e "$(image_cache_file "${CACHE_DIR}" "${IMG}")" ]]; then
+    fail "save-partial-publishes-nothing (a truncated tarball would be cached as good)"
+else
+    pass "save-partial-publishes-nothing"
+fi
+if compgen -G "${CACHE_DIR}/*.tmp" >/dev/null; then
+    fail "save-partial-leaves-no-scratch (a .tmp file would be uploaded with the cache)"
+else
+    pass "save-partial-leaves-no-scratch"
+fi
+
+# 10b. The save is KILLED mid-write — a cancelled job, a runner reclaimed. No
+#      cleanup runs, so the only thing standing between the partial bytes and
+#      actions/cache is where they were written. Case 10 cannot prove this:
+#      there `docker save` exits, so the function's own `rm -f` removes the
+#      stump and a non-atomic implementation passes anyway. (Confirmed by
+#      mutation: pointing the scratch path at the final path fails only here.)
+reset
+export STUB_SAVE_STALL=1
+export KWOK_IMAGE_CACHE_BUDGET_SECONDS=60
+bash "${SCRIPT_DIR}/image-cache.sh" save "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1 &
+save_pid=$!
+# Wait for the stub to write its bytes, so the kill lands during the save and
+# not before it. Bounded so a stub that never writes cannot hang the suite.
+for _ in $(seq 1 100); do
+    compgen -G "${CACHE_DIR}/*" >/dev/null 2>&1 && break
+    sleep 0.1
+done
+kill -9 "${save_pid}" 2>/dev/null
+wait "${save_pid}" 2>/dev/null
+if compgen -G "${CACHE_DIR}/*.tmp" >/dev/null 2>&1; then
+    pass "save-killed-wrote-to-scratch"
+else
+    fail "save-killed-wrote-to-scratch (no in-flight save to observe — the case proved nothing)"
+fi
+if [[ -e "$(image_cache_file "${CACHE_DIR}" "${IMG}")" ]]; then
+    fail "save-killed-publishes-nothing (partial bytes sit at the published path; actions/cache would upload them as a good tarball)"
+else
+    pass "save-killed-publishes-nothing"
+fi
+unset STUB_SAVE_STALL KWOK_IMAGE_CACHE_BUDGET_SECONDS
+
+# 11. A hanging pull must not hold the prime job open. Same failure class the
+#     preload budget exists for; the budget is squeezed so the assertion is
+#     about the bound existing, not its production value.
+reset
+export STUB_PULL_HANGS=1
+export KWOK_IMAGE_CACHE_BUDGET_SECONDS=3
+started=$(date +%s)
+image_cache_save "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+elapsed=$(( $(date +%s) - started ))
+check_rc_nonzero "save-hanging-pull-fails" "${rc}"
+check_bounded "save-hanging-pull-is-bounded" "${KWOK_IMAGE_CACHE_BUDGET_SECONDS}" "${elapsed}"
+
+# 12. No docker (or no timeout) -> fail closed. preload_image treats missing
+#     tooling as a silent no-op because it is best-effort; the prime job cannot,
+#     or it would report a cache it never wrote.
+reset
+mkdir -p "${STUB_DIR}/no-tools"
+saved_path="${PATH}"
+# shellcheck disable=SC2123  # Replacing PATH is the point: it is what makes
+# `command -v docker` fail. Restored two lines down.
+PATH="${STUB_DIR}/no-tools"
+image_cache_save "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+PATH="${saved_path}"
+check_rc_nonzero "save-without-docker-fails" "${rc}"
+
+# ── image_cache_load ─────────────────────────────────────────────────────────
+
+# 13. Tarball present -> load it, no pull.
+reset
+printf 'tarball-bytes' > "$(image_cache_file "${CACHE_DIR}" "${IMG}")"
+image_cache_load "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc "load-succeeds" 0 "${rc}"
+check_trace "load-runs-docker-load" "docker load"
+check_trace_absent "load-does-not-pull" "docker pull"
+
+# 14. Cache miss -> non-zero, and nothing attempted. Non-fatal by contract: the
+#     caller falls back to preload_image, which pulls.
+reset
+image_cache_load "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "load-miss-reports-miss" "${rc}"
+check_trace_absent "load-miss-runs-nothing" "docker load"
+
+# 15. `docker load` exits 0 but the image is still absent — a truncated or
+#     wrong-image tarball. Trusting the exit code would report a preloaded
+#     image that is not there, and the kubelet pull we were avoiding would run
+#     anyway, now unexpectedly. Verify presence, not exit status.
+reset
+printf 'tarball-bytes' > "$(image_cache_file "${CACHE_DIR}" "${IMG}")"
+export STUB_LOAD_CORRUPT=1
+image_cache_load "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "load-verifies-the-image-is-present" "${rc}"
+
+# 16. `docker load` itself fails -> non-zero, and no exception thrown at the
+#     caller: the lane still has its fallback.
+reset
+printf 'tarball-bytes' > "$(image_cache_file "${CACHE_DIR}" "${IMG}")"
+export STUB_LOAD_RC=1
+image_cache_load "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "load-failure-reports-failure" "${rc}"
+
+# 17. An image already present on the host needs no load at all — lanes share a
+#     runner within a job.
+reset
+printf 'tarball-bytes' > "$(image_cache_file "${CACHE_DIR}" "${IMG}")"
+export STUB_INSPECT_RC=0
+image_cache_load "${CACHE_DIR}" "${IMG}" >/dev/null 2>&1; rc=$?
+check_rc "load-already-present-succeeds" 0 "${rc}"
+check_trace_absent "load-already-present-skips-docker-load" "docker load"
+
+# ── image_cache_settings ─────────────────────────────────────────────────────
+
+# 18. Both pins resolve, and each key matches what image_cache_key produces for
+#     that ref. The prime job and the matrix jobs both go through this, so a
+#     disagreement here is a cache that misses every time while looking healthy.
+reset
+SETTINGS="${STUB_DIR}/settings.yaml"
+cat > "${SETTINGS}" <<EOF
+testing_tools:
+  registry_image: '${IMG}'
+  gitea_image: '${GITEA}'
+EOF
+out=$(image_cache_settings "${SETTINGS}" 2>&1); rc=$?
+check_rc "settings-succeeds" 0 "${rc}"
+want="registry_image=${IMG}
+registry_key=$(image_cache_key "${IMG}")
+gitea_image=${GITEA}
+gitea_key=$(image_cache_key "${GITEA}")"
+if [[ "${out}" == "${want}" ]]; then
+    pass "settings-emits-images-and-matching-keys"
+else
+    fail "settings-emits-images-and-matching-keys (got: ${out})"
+fi
+
+# 19. A renamed or dropped pin must fail, not emit an empty ref. An empty ref
+#     hashes fine, so the cache would key on nothing, "hit", and hold no image
+#     — a green prime job protecting nothing.
+reset
+cat > "${SETTINGS}" <<EOF
+testing_tools:
+  registry_image: '${IMG}'
+EOF
+image_cache_settings "${SETTINGS}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "settings-missing-pin-fails" "${rc}"
+
+cat > "${SETTINGS}" <<EOF
+testing_tools:
+  registry_image: ''
+  gitea_image: '${GITEA}'
+EOF
+image_cache_settings "${SETTINGS}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "settings-empty-pin-fails" "${rc}"
+
+image_cache_settings "${STUB_DIR}/does-not-exist.yaml" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "settings-missing-file-fails" "${rc}"
+
+# 19b. A ref carrying whitespace would write a $GITHUB_OUTPUT line the runner
+#      parses as something other than one key=value pair. Caught here, where
+#      the message names the setting.
+cat > "${SETTINGS}" <<EOF
+testing_tools:
+  registry_image: 'public.ecr.aws/docker/library/registry :3.1.1'
+  gitea_image: '${GITEA}'
+EOF
+image_cache_settings "${SETTINGS}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "settings-whitespace-in-pin-fails" "${rc}"
+
+# 20. Against the REAL .settings.yaml. This is the coupling that breaks
+#     silently: rename testing_tools.registry_image and every case above still
+#     passes on its fixture while CI caches nothing.
+reset
+REAL_SETTINGS="$(cd "${SCRIPT_DIR}/../../.." && pwd)/.settings.yaml"
+if [[ -r "${REAL_SETTINGS}" ]]; then
+    out=$(image_cache_settings "${REAL_SETTINGS}" 2>&1); rc=$?
+    check_rc "settings-reads-the-real-settings-file" 0 "${rc}"
+    if [[ "${out}" == *"registry_image=public.ecr.aws/"* && "${out}" == *"gitea_image=docker.gitea.com/"* ]]; then
+        pass "settings-resolves-the-pinned-registries"
+    else
+        fail "settings-resolves-the-pinned-registries (got: ${out})"
+    fi
+else
+    fail "settings-reads-the-real-settings-file (no .settings.yaml at ${REAL_SETTINGS})"
+fi
+
+# ── CLI surface ──────────────────────────────────────────────────────────────
+
+# 18. The workflow calls this file as a command, not as a library. An unknown
+#     verb or a missing argument must fail rather than silently no-op, or a
+#     typo in the YAML would produce a green job that cached nothing.
+reset
+out=$(bash "${SCRIPT_DIR}/image-cache.sh" key "${IMG}" 2>&1); rc=$?
+check_rc "cli-key-succeeds" 0 "${rc}"
+if [[ "${out}" == "${k1}" ]]; then
+    pass "cli-key-matches-the-library"
+else
+    fail "cli-key-matches-the-library (cli '${out}' != lib '${k1}')"
+fi
+
+bash "${SCRIPT_DIR}/image-cache.sh" bogus-verb >/dev/null 2>&1; rc=$?
+check_rc_nonzero "cli-unknown-verb-fails" "${rc}"
+
+bash "${SCRIPT_DIR}/image-cache.sh" save "${CACHE_DIR}" >/dev/null 2>&1; rc=$?
+check_rc_nonzero "cli-missing-argument-fails" "${rc}"
+
+if (( fails > 0 )); then
+    echo "FAILED: ${fails} case(s)"
+    exit 1
+fi
+echo "All image-cache cases passed"

--- a/kwok/scripts/lib/preload-image.sh
+++ b/kwok/scripts/lib/preload-image.sh
@@ -85,60 +85,32 @@ preload_have_image() {
     timeout "${remaining}" docker image inspect "${image}" &>/dev/null
 }
 
-preload_image() {
-    local image="$1"
+# preload_pull_retry gets IMAGE into the host's Docker cache before DEADLINE,
+# retrying a failed pull until the budget is spent. Returns 0 when the image is
+# cached on return, 1 when it is not — and logs the reason in that case.
+#
+# Split out from preload_image so the CI image-cache priming step
+# (kwok/scripts/lib/image-cache.sh) reuses this exact retry schedule instead of
+# growing a second one. The two callers differ only in what a failure means:
+# preload_image degrades to the kubelet pull, priming fails its job.
+#
+# Retry until the BUDGET is spent, not for a fixed number of attempts.
+#
+# The fixed three-attempt schedule this replaces gave up in ~17s while holding a
+# 180s budget (#2483): each pull failed in about a second, the backoff was 5s
+# then 10s, and ~163s went unused. Against a per-IP registry throttle that is
+# close to the worst possible schedule — it retries fast enough to stay inside
+# the same throttle window, then stops long before the window would reset.
+#
+# Evidence it is a throttle and not an outage: in the run that motivated this,
+# 125 of 127 concurrent matrix jobs pulled the same image successfully at the
+# same moment. The pull is not broken; a few callers are being shed.
+#
+# Backoff doubles from PRELOAD_BACKOFF_START and is capped, so a long budget
+# spends most of its time waiting rather than hammering.
+preload_pull_retry() {
+    local image="$1" deadline="$2"
 
-    # `timeout` is required, not optional. Without it every docker/kind call is
-    # unbounded, and a stalled pull would hold the lane for the whole job — the
-    # precise failure this function exists to prevent, in a new place. If it is
-    # missing, skip preloading rather than risk that.
-    if ! command -v docker &>/dev/null || ! command -v kind &>/dev/null ||
-        ! command -v timeout &>/dev/null; then
-        log_debug "docker, kind, or timeout unavailable — leaving ${image} to the kubelet"
-        return 0
-    fi
-
-    # One deadline for the whole function; every operation below draws from it.
-    local budget="${KWOK_PRELOAD_BUDGET_SECONDS:-${KWOK_PRELOAD_BUDGET_DEFAULT}}"
-    local deadline=$(( $(date +%s) + budget ))
-
-    # Kind names the context "kind-<cluster>", so the cluster name is the
-    # context with that prefix stripped. Fall back to the same default
-    # run-all-recipes.sh uses when no context is pinned.
-    local cluster="${KWOK_CLUSTER:-aicr-kwok-test}"
-    if [[ -n "${KUBECTL_CONTEXT:-}" ]]; then
-        if [[ "${KUBECTL_CONTEXT}" != kind-* ]]; then
-            log_debug "context ${KUBECTL_CONTEXT} is not a Kind cluster — leaving ${image} to the kubelet"
-            return 0
-        fi
-        cluster="${KUBECTL_CONTEXT#kind-}"
-    fi
-
-    if ! preload_remaining "${deadline}" >/dev/null; then
-        log_warn "Preload budget exhausted before resolving the cluster; the kubelet will pull ${image}"
-        return 0
-    fi
-
-    if ! timeout "$(preload_remaining "${deadline}")" kind get clusters 2>/dev/null | grep -qx "${cluster}"; then
-        log_debug "Kind cluster ${cluster} not found — leaving ${image} to the kubelet"
-        return 0
-    fi
-
-    # Retry until the BUDGET is spent, not for a fixed number of attempts.
-    #
-    # The fixed three-attempt schedule this replaces gave up in ~17s while
-    # holding a 180s budget (#2483): each pull failed in about a second, the
-    # backoff was 5s then 10s, and ~163s went unused. Against a per-IP registry
-    # throttle that is close to the worst possible schedule — it retries fast
-    # enough to stay inside the same throttle window, then stops long before the
-    # window would reset.
-    #
-    # Evidence it is a throttle and not an outage: in the run that motivated
-    # this, 125 of 127 concurrent matrix jobs pulled the same image successfully
-    # at the same moment. The pull is not broken; a few callers are being shed.
-    #
-    # Backoff doubles from PRELOAD_BACKOFF_START and is capped, so a long budget
-    # spends most of its time waiting rather than hammering.
     local attempt=0 remaining backoff="${PRELOAD_BACKOFF_START}" pull_err last_err=""
     pull_err="$(mktemp)"
     while :; do
@@ -182,12 +154,60 @@ preload_image() {
     # consumed the last of the budget lost its own error message. Reporting
     # here, from a variable captured at failure time, is what makes that
     # impossible rather than merely fixed.
-    if ! preload_have_image "${image}" "${deadline}"; then
-        if [[ -n "${last_err}" ]]; then
-            log_warn "${image} is not cached after ${attempt} attempt(s); last error: ${last_err}"
-        else
-            log_warn "${image} is not cached and no pull was attempted (the budget ran out first)"
+    if preload_have_image "${image}" "${deadline}"; then
+        return 0
+    fi
+    if [[ -n "${last_err}" ]]; then
+        log_warn "${image} is not cached after ${attempt} attempt(s); last error: ${last_err}"
+    else
+        log_warn "${image} is not cached and no pull was attempted (the budget ran out first)"
+    fi
+    return 1
+}
+
+preload_image() {
+    local image="$1"
+
+    # `timeout` is required, not optional. Without it every docker/kind call is
+    # unbounded, and a stalled pull would hold the lane for the whole job — the
+    # precise failure this function exists to prevent, in a new place. If it is
+    # missing, skip preloading rather than risk that.
+    if ! command -v docker &>/dev/null || ! command -v kind &>/dev/null ||
+        ! command -v timeout &>/dev/null; then
+        log_debug "docker, kind, or timeout unavailable — leaving ${image} to the kubelet"
+        return 0
+    fi
+
+    # One deadline for the whole function; every operation below draws from it.
+    local budget="${KWOK_PRELOAD_BUDGET_SECONDS:-${KWOK_PRELOAD_BUDGET_DEFAULT}}"
+    local deadline=$(( $(date +%s) + budget ))
+
+    # Kind names the context "kind-<cluster>", so the cluster name is the
+    # context with that prefix stripped. Fall back to the same default
+    # run-all-recipes.sh uses when no context is pinned.
+    local cluster="${KWOK_CLUSTER:-aicr-kwok-test}"
+    if [[ -n "${KUBECTL_CONTEXT:-}" ]]; then
+        if [[ "${KUBECTL_CONTEXT}" != kind-* ]]; then
+            log_debug "context ${KUBECTL_CONTEXT} is not a Kind cluster — leaving ${image} to the kubelet"
+            return 0
         fi
+        cluster="${KUBECTL_CONTEXT#kind-}"
+    fi
+
+    if ! preload_remaining "${deadline}" >/dev/null; then
+        log_warn "Preload budget exhausted before resolving the cluster; the kubelet will pull ${image}"
+        return 0
+    fi
+
+    if ! timeout "$(preload_remaining "${deadline}")" kind get clusters 2>/dev/null | grep -qx "${cluster}"; then
+        log_debug "Kind cluster ${cluster} not found — leaving ${image} to the kubelet"
+        return 0
+    fi
+
+    # The retry schedule lives in preload_pull_retry, which also owns the single
+    # reporting site for a pull that never lands. Here a failure is not fatal:
+    # the kubelet pull is still the fallback, exactly as before.
+    if ! preload_pull_retry "${image}" "${deadline}"; then
         log_warn "The kubelet will retry ${image} in-cluster"
         return 0
     fi


### PR DESCRIPTION
## Summary

Pull the two public images the KWOK lanes need once per run, in a dedicated priming job, and carry them to the matrix as tarballs in `actions/cache` — instead of having every one of ~127 matrix jobs pull them itself.

## Motivation / Context

**It is a per-IP throttle, not an outage, and not something retrying can fix.** In [run 33350102144](https://github.com/NVIDIA/aicr/actions/runs/33350102144):

| Tier jobs | Result |
|---|---|
| 127 | total |
| 125 | success |
| 1 | failure |

125 jobs pulled `public.ecr.aws/docker/library/registry:3.1.1` successfully at the same moment, from the same runner pool, in the same run. That rules out an outage, a bad pin, and a broken image. What is left is anonymous per-IP rate limiting under a 127-job concurrent matrix — which also explains the 2026-08-30 streak where a *different* lane failed each run.

#2496 fixed the retry schedule (it was giving up in ~17s while holding a 180s budget). That narrowed the window; it could not close it, because no retry schedule fixes a quota shared across the whole matrix. The fix is to stop making 127 requests.

So: one pull, one tarball, 127 loads from disk. `preload_image` already checks the host Docker cache before every pull attempt, so an image loaded from the tarball means the lane never contacts the registry at all.

Fixes: N/A
Related: #2483, #2496, #2480, #843

**Deliberately `Related`, not a closing reference.** This meets the first two of #2483's acceptance criteria — no unauthenticated third-party pull at job time, and the pull failure reason in the log (that one landed in #2496). The third is "several consecutive green KWOK runs on `main`", which can only be met by observation: with a 1-in-127 intermittent failure, one green run proves nothing. #2483 stays open until the runs accumulate.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `kwok/scripts/lib`, `.github/workflows/kwok-recipes.yaml`, `.github/actions/kwok-test`

## Implementation Notes

**`kwok/scripts/lib/image-cache.sh` (new).** Verbs `key` / `file` / `save` / `load` / `settings`. Sourceable by its unit harness with stubbed `docker`, executable by the workflow. Both workflow sites derive the cache key from `image_cache_key` here rather than from a value threaded through the reusable workflow — if the two could disagree, every restore would miss and the cache would silently do nothing while reporting success.

**`save` is a gate, `load` is best effort.** The asymmetry is deliberate. `save` runs once so the matrix never touches the registry, so a save that reports success without producing a usable tarball is worse than no cache at all — it sends all 127 jobs back to the pull with the gate lit green. Every failure path returns non-zero. `load` keeps `preload_image`'s contract: a miss returns non-zero for the caller to shrug at, because the pull path is still intact behind it. A cold cache or a fork PR whose cache scope differs must degrade to today's behavior, not fail.

**A miss is annotated, not silent.** The load step emits `::warning::` on a miss. Without it, a cache key that ever drifts from the prime job's would leave every lane pulling again, green, with the fix inert and nothing to notice it by.

**Partial tarballs are never published.** `save` writes to scratch and publishes with a rename. A `docker save` killed partway (cancelled job, reclaimed runner) leaves bytes on disk; writing straight to the final path would let `actions/cache` upload that stump, every later run would take it as a hit, and `docker load` would fail in all 127 jobs — with the prime job green, because it *did* pull the image.

**One prime job per image.** `actions/cache` saves at the end of a job only when that job succeeds, so a single job priming both would discard a registry pull that had already worked if Gitea failed. Gitea is also restored only for the `*-git` lanes, which are the only ones `install-infra.sh` installs it for.

**Summary false-green fix.** A failed prime leaves every tier `skipped`, and the tier checks deliberately tolerate `skipped` (that is how a schedule-only run with no recipes passes). Without an explicit check on the prime result, the whole run would have reported green having validated nothing.

**`preload_pull_retry` extraction.** The retry loop moves out of `preload_image` so the prime job reuses the schedule tuned against the observed throttle in #2496 rather than growing a second copy. `preload_image`'s behavior is unchanged — its existing suite passes unmodified, which is the regression guard.

**`discover` timeout 5 → 10 min.** The script-test block now runs ~90s locally before classification starts; those suites are deliberately wall-clock bound (they assert a hanging pull stays inside its deadline, which costs real seconds). A discovery job that times out would be exactly the self-inflicted red this PR exists to remove.

## Testing

```bash
make qualify          # exit 0
make lint             # re-run after the final edits, clean
bash kwok/scripts/lib/image-cache_test.sh     # 45 cases
bash kwok/scripts/lib/preload-image_test.sh   # 32 cases, unmodified
```

All five KWOK script suites green (130 cases). The new suite is wired into the `discover` job alongside the existing four.

**The new suite was mutation-tested.** Four mutations of the implementation; three were caught immediately:

| Mutation | Caught by |
|---|---|
| Drop the post-`docker load` presence verify | `load-verifies-the-image-is-present` |
| Key on the image name without hashing the full ref | `key-changes-with-the-tag`, `key-changes-with-the-registry` |
| `save` returns 0 when the pull never lands | `save-pull-exhausted-fails`, `save-hanging-pull-fails` |
| Write straight to the final path (no atomic publish) | **initially not caught** |

The fourth exposed a real gap: the partial-save case let `docker save` exit normally, so the function's own `rm -f` cleaned up the stump and a non-atomic implementation passed anyway. Added a case that kills the process mid-save, where no cleanup runs — that mutation now fails two assertions. Both cases are kept, and the one that only bites under a kill says so in a comment.

No Go source changed, so the coverage gate does not apply.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

CI-only. Every new path degrades to current behavior on failure except the prime job itself, which is a deliberate gate. Reverting the two workflow files restores today's behavior with no other cleanup.

**Not exercised locally:** no Docker on the authoring machine, so the real `docker save` / `docker load` round-trip is covered by stubs only. The flags are standard, but the first CI run is the real proof — that is part of why this is a draft.

**Rollout notes:** The first run after merge is a cold cache: the prime job pulls, and the matrix restores from the cache it just wrote. Local runs (`make kwok-test-all`) are unaffected and still pull through `preload_image`.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
