### PR TITLE
chore: refresh THIRD_PARTY_NOTICES.md for the k8s 0.37.0 bump

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -227,12 +227,12 @@ surfaces are covered:
 | `gopkg.in/inf.v0` | BSD-3-Clause | https://github.com/go-inf/inf/blob/v0.9.1/LICENSE |
 | `gopkg.in/yaml.v2` | Apache-2.0 | https://github.com/go-yaml/yaml/blob/v2.4.0/LICENSE |
 | `gopkg.in/yaml.v3` | MIT | https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE |
-| `k8s.io/api` | Apache-2.0 | https://github.com/kubernetes/api/blob/v0.36.4/LICENSE |
+| `k8s.io/api` | Apache-2.0 | https://github.com/kubernetes/api/blob/v0.37.0/LICENSE |
 | `k8s.io/apiextensions-apiserver/pkg/apis/apiextensions` | Apache-2.0 | https://github.com/kubernetes/apiextensions-apiserver/blob/v0.36.4/LICENSE |
-| `k8s.io/apimachinery/pkg` | Apache-2.0 | https://github.com/kubernetes/apimachinery/blob/v0.36.4/LICENSE |
-| `k8s.io/apimachinery/third_party/forked/golang` | BSD-3-Clause | https://github.com/kubernetes/apimachinery/blob/v0.36.4/third_party/forked/golang/LICENSE |
+| `k8s.io/apimachinery/pkg` | Apache-2.0 | https://github.com/kubernetes/apimachinery/blob/v0.37.0/LICENSE |
+| `k8s.io/apimachinery/third_party/forked/golang` | BSD-3-Clause | https://github.com/kubernetes/apimachinery/blob/v0.37.0/third_party/forked/golang/LICENSE |
 | `k8s.io/apiserver/pkg` | Apache-2.0 | https://github.com/kubernetes/apiserver/blob/v0.36.4/LICENSE |
-| `k8s.io/client-go` | Apache-2.0 | https://github.com/kubernetes/client-go/blob/v0.36.4/LICENSE |
+| `k8s.io/client-go` | Apache-2.0 | https://github.com/kubernetes/client-go/blob/v0.37.0/LICENSE |
 | `k8s.io/component-base` | Apache-2.0 | https://github.com/kubernetes/component-base/blob/v0.36.4/LICENSE |
 | `k8s.io/klog/v2` | Apache-2.0 | https://github.com/kubernetes/klog/blob/v2.140.0/LICENSE |
 | `k8s.io/kube-openapi/pkg` | Apache-2.0 | https://github.com/kubernetes/kube-openapi/blob/be32def86098/LICENSE |
@@ -242,7 +242,7 @@ surfaces are covered:
 | `k8s.io/kube-openapi/pkg/validation/spec` | Apache-2.0 | https://github.com/kubernetes/kube-openapi/blob/be32def86098/pkg/validation/spec/LICENSE |
 | `k8s.io/kube-openapi/pkg/validation/strfmt` | Apache-2.0 | https://github.com/kubernetes/kube-openapi/blob/be32def86098/pkg/validation/strfmt/LICENSE |
 | `k8s.io/kubernetes/pkg/apis/core` | Apache-2.0 | https://github.com/kubernetes/kubernetes/blob/v1.36.4/LICENSE |
-| `k8s.io/streaming/pkg` | Apache-2.0 | https://github.com/kubernetes/streaming/blob/v0.36.4/LICENSE |
+| `k8s.io/streaming/pkg` | Apache-2.0 | https://github.com/kubernetes/streaming/blob/v0.37.0/LICENSE |
 | `k8s.io/utils` | Apache-2.0 | https://github.com/kubernetes/utils/blob/cf1189d6abe3/LICENSE |
 | `k8s.io/utils/internal/third_party/forked/golang/net` | BSD-3-Clause | https://github.com/kubernetes/utils/blob/cf1189d6abe3/internal/third_party/forked/golang/LICENSE |
 | `oras.land/oras-go/v2` | Apache-2.0 | https://github.com/oras-project/oras-go/blob/v2.6.2/LICENSE |
@@ -31021,7 +31021,7 @@ limitations under the License.
 ### k8s.io/api
 
 * License: Apache-2.0
-* Source: https://github.com/kubernetes/api/blob/v0.36.4/LICENSE
+* Source: https://github.com/kubernetes/api/blob/v0.37.0/LICENSE
 
 #### LICENSE
 
@@ -31449,7 +31449,7 @@ limitations under the License.
 ### k8s.io/apimachinery/pkg
 
 * License: Apache-2.0
-* Source: https://github.com/kubernetes/apimachinery/blob/v0.36.4/LICENSE
+* Source: https://github.com/kubernetes/apimachinery/blob/v0.37.0/LICENSE
 
 #### LICENSE
 
@@ -31663,7 +31663,7 @@ limitations under the License.
 ### k8s.io/apimachinery/third_party/forked/golang
 
 * License: BSD-3-Clause
-* Source: https://github.com/kubernetes/apimachinery/blob/v0.36.4/third_party/forked/golang/LICENSE
+* Source: https://github.com/kubernetes/apimachinery/blob/v0.37.0/third_party/forked/golang/LICENSE
 
 #### LICENSE
 
@@ -31916,7 +31916,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/client-go
 
 * License: Apache-2.0
-* Source: https://github.com/kubernetes/client-go/blob/v0.36.4/LICENSE
+* Source: https://github.com/kubernetes/client-go/blob/v0.37.0/LICENSE
 
 #### LICENSE
 
@@ -33688,7 +33688,7 @@ SOFTWARE.
 ### k8s.io/streaming/pkg
 
 * License: Apache-2.0
-* Source: https://github.com/kubernetes/streaming/blob/v0.36.4/LICENSE
+* Source: https://github.com/kubernetes/streaming/blob/v0.37.0/LICENSE
 
 #### LICENSE
 


### PR DESCRIPTION
## Summary

Regenerates `THIRD_PARTY_NOTICES.md`, which still points at the `v0.36.4` license URLs for `k8s.io/api`, `apimachinery`, `client-go` and `streaming` while `go.mod` has moved them to `v0.37.0`. Ten license links; no other change.

## Motivation / Context

`main` is currently failing its own `notices-freshness` gate. Running `make notices-check` on a clean checkout of `f71bd8bbe` reports the committed file is stale, and `make notices` reproduces exactly the ten-link delta in this PR.

Although `notices-freshness` is path-gated, #2493 **did** trigger it — the PR changed `go.mod` and `go.sum`, both of which the filter already watches. The Merge Gate run selected the job and it failed. The PR merged before that job began, so the failure arrived too late to block the merge. The gate was correct; the timing was not. See the Follow-up section and #2506.

The stale file then stayed invisible until a PR happened to touch a watched path. #2439 hit it while changing `gpu_operator_chart_version` in `.settings.yaml` — a chart pin with no relationship to the Go dependency graph. Fixing it here rather than there keeps that PR to its stated scope and unblocks any future PR that trips the same gate.

Fixes: N/A
Related: #2439, #2506

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `THIRD_PARTY_NOTICES.md` (generated artifact)

## Follow-up

This PR fixes the **symptom** only. The cause is tracked separately in **#2506**.

The stale file landed because #2493 was merged four seconds after its Merge Gate run was created and eleven seconds before `notices-freshness` started — the gate was correct, it just reported too late to block. `gate` is already a required status check on the `main` ruleset with no bypass actors configured, so this is a rule that did not hold rather than a missing rule, and it is not fixable in a pull request.

Deliberately **not** included here:

- **Merge-gate enforcement** — repository/ruleset configuration, not code. Owner action.
- **Making the dependency bot run `make tidy`** — a Renovate/workflow change that would reduce how often this recurs, but not the class. It belongs in its own PR rather than bundled with a one-file artifact refresh.
- **`vendor/modules.txt` drift** — same root cause (#2493 did not re-vendor), so `go test -mod=vendor` fails on a clean `main`. CI does not use vendor mode, so it only affects local runs. Tracked in #2506.

## Implementation Notes

Generated with `make notices` — the file is not hand-edited. The diff is confined to the four `k8s.io` modules whose versions moved; the module and package counts are unchanged (238 Go modules, 130 Python packages).

## Testing

```bash
make notices        # regenerate
make notices-check  # verify
```

`make notices-check` reports **`THIRD_PARTY_NOTICES.md is up to date`** on this branch, and fails on `main` at the same commit — which is the defect this fixes.

Full `make qualify` was not run: this changes one generated Markdown artifact with no Go, YAML, recipe or docs-page content, so the test, lint, e2e and BOM stages cannot be affected by it. The gate that governs this file is `notices-check`, and it is run and green above.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

**Rollout notes:** N/A — a generated notices file with no runtime effect.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`)
- [ ] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — N/A
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)


