### PR TITLE
feat(sdk): derive CollectSnapshot AgentConfig from spec.snapshot

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -1394,8 +1394,7 @@ One inversion worth knowing: config says `noCleanup`, the option says
 ### What `SnapshotAgentConfig()` does and does not carry
 
 `AgentConfig`'s fields are exported, so unlike the bundle path there is no
-options slice — derive it, then set any field directly. It is never nil, so a
-document without `spec.snapshot` yields a usable zero value:
+options slice — derive it, then set any field directly. It is never nil:
 
 ```go
 agent, err := cfg.SnapshotAgentConfig()
@@ -1415,11 +1414,32 @@ silently if you reimplement them by hand:
 | `privileged` → `Privileged` | **Defaults to true** when config says nothing. The resolved field is a pointer so unset stays distinct from an explicit `false`; treating nil as `false` drops privileges the collector needs, and it surfaces as missing data rather than an error |
 | `requests`, `limits` | Parsed from raw `name=quantity,...` strings. `Resolve()` deliberately leaves them unparsed, so a malformed value errors here instead of becoming an empty `ResourceList` |
 
-`spec.snapshot.output.format` is **not** projected, and that is deliberate:
-format is applied at delivery, not by the agent. The Job always stages YAML in
-a ConfigMap, so a format routed through `AgentConfig` would be silently ignored
-(#2398).
+The whole `spec.snapshot.output` section is **not** projected, and that is
+deliberate. Output describes *delivery*; `AgentConfig` describes the collection
+Job.
+
+- `output.format` is applied at delivery. The Job always stages YAML in a
+  ConfigMap, so a format routed through `AgentConfig` would be silently ignored
+  (#2398).
+- `output.path` and `output.template` are **not** `AgentConfig.Output` and
+  `.TemplatePath`. Any `Output` value that is not a `cm://` URI stages to an
+  internal ConfigMap and delivery becomes yours, so projecting a file path
+  there would look configured and write nothing.
+
+Deliver with `snapshotter.DeliverSnapshot`, passing `Snapshot.Raw`.
+
+`OS` is parsed through the criteria registry rather than copied, matching what
+the CLI does with `--os`. An unparsed `Talos` would miss the agent's exact
+`talos` check and select incompatible host mounts, and an undocumented value
+errors here instead of traveling.
 
 `Kubeconfig`, `Debug`, `ClusterConfigPath`, `AKSGPUPoolsPath`,
 `DiscoverNetwork`, `RunID` and `NameBase` have no config counterpart and stay
 zero — they are per-invocation or caller-owned.
+
+**A document with no `spec.snapshot` yields a zero value, which is not a
+working configuration** — `Privileged` is false, which the collector generally
+needs true. That is deliberate: defaults apply when the section exists and is
+silent about a field, but a document that made no snapshot decisions at all
+does not get decisions invented for it. Supply your own defaults in that case,
+as the CLI does from its flag defaults.

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -888,6 +888,7 @@ derive step rather than the load step.
 | `BundleVerifyOptions()` | `spec.verify.policy` + `spec.verify.trust` |
 | `BundleOptions()` | `spec.bundle.deployment` + `spec.bundle.scheduling` + `spec.bundle.attestation` |
 | `ValidateOptions()` | `spec.validate.execution` + the agent fields the validator accepts as options |
+| `SnapshotAgentConfig()` | `spec.snapshot.agent` + `.execution` + `.output` |
 | `RecipeSource()` | `spec.recipe.data` |
 | `RecipeCriteria(reg)` | `spec.recipe.criteria` |
 | `RecipeResolveOptions()` | `spec.recipe.profile`, `spec.recipe.configuration.slurm.accounting.mode`, `spec.recipe.configuration.runtimeInventory.mode` |
@@ -895,8 +896,9 @@ derive step rather than the load step.
 | `SnapshotPath()` | `spec.recipe.input.snapshot` |
 | `IsCriteriaStrict()` | `spec.recipe.criteriaStrict` |
 
-`spec.snapshot` is not yet projected, and neither is `spec.validate.evidence`;
-`Unwrap()` reaches the raw document meanwhile. Needing it is worth reporting — it means a
+All five spec sections now have a derivation. `spec.validate.evidence` is the
+remaining gap — `EvidenceOptions` is the shape it would map onto, but no
+`Config` method produces one, so reading it still needs `Unwrap()`. Needing it is worth reporting — it means a
 derivation is missing, and `pkg/config` carries no stability guarantee.
 
 ### What `BundleOptions()` does and does not carry
@@ -1388,3 +1390,36 @@ The rest of the section has other homes, and knowing which saves a search:
 One inversion worth knowing: config says `noCleanup`, the option says
 `cleanup`. `ValidateOptions()` flips it, so `noCleanup: true` becomes
 `WithValidationCleanup(false)`.
+
+### What `SnapshotAgentConfig()` does and does not carry
+
+`AgentConfig`'s fields are exported, so unlike the bundle path there is no
+options slice — derive it, then set any field directly. It is never nil, so a
+document without `spec.snapshot` yields a usable zero value:
+
+```go
+agent, err := cfg.SnapshotAgentConfig()
+if err != nil {
+    return err
+}
+agent.Kubeconfig = kubeconfigPath  // caller-owned, no config counterpart
+snap, err := client.CollectSnapshot(ctx, agent)
+```
+
+Three mappings are transforms rather than copies, and two of them fail
+silently if you reimplement them by hand:
+
+| Field | Behavior |
+|---|---|
+| `noCleanup` → `Cleanup` | **Inverted**, same as `spec.validate` |
+| `privileged` → `Privileged` | **Defaults to true** when config says nothing. The resolved field is a pointer so unset stays distinct from an explicit `false`; treating nil as `false` drops privileges the collector needs, and it surfaces as missing data rather than an error |
+| `requests`, `limits` | Parsed from raw `name=quantity,...` strings. `Resolve()` deliberately leaves them unparsed, so a malformed value errors here instead of becoming an empty `ResourceList` |
+
+`spec.snapshot.output.format` is **not** projected, and that is deliberate:
+format is applied at delivery, not by the agent. The Job always stages YAML in
+a ConfigMap, so a format routed through `AgentConfig` would be silently ignored
+(#2398).
+
+`Kubeconfig`, `Debug`, `ClusterConfigPath`, `AKSGPUPoolsPath`,
+`DiscoverNetwork`, `RunID` and `NameBase` have no config counterpart and stay
+zero — they are per-invocation or caller-owned.

--- a/pkg/client/v1/config.go
+++ b/pkg/client/v1/config.go
@@ -564,7 +564,7 @@ func (c *Config) ValidateOptions() ([]ValidateOption, error) {
 // SnapshotAgentConfig derives Client.CollectSnapshot's AgentConfig from
 // spec.snapshot.
 //
-// Sixteen settings map onto the agent Job: namespace, image, image pull
+// These settings map onto the agent Job: namespace, image, image pull
 // secrets, job name, service account, node selector, tolerations, require-GPU,
 // runtime class, OS, max nodes per entry, output path, template path, resource
 // requests and limits, timeout, cleanup and privileged.

--- a/pkg/client/v1/config.go
+++ b/pkg/client/v1/config.go
@@ -21,6 +21,7 @@ import (
 	bundlerconfig "github.com/NVIDIA/aicr/pkg/bundler/config"
 	appconfig "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
 
 // Config is a parsed AICRConfig document — the version-controlled file a team
@@ -558,4 +559,102 @@ func (c *Config) ValidateOptions() ([]ValidateOption, error) {
 		opts = append(opts, WithValidationTimeout(*resolved.Timeout))
 	}
 	return opts, nil
+}
+
+// SnapshotAgentConfig derives Client.CollectSnapshot's AgentConfig from
+// spec.snapshot.
+//
+// Sixteen settings map onto the agent Job: namespace, image, image pull
+// secrets, job name, service account, node selector, tolerations, require-GPU,
+// runtime class, OS, max nodes per entry, output path, template path, resource
+// requests and limits, timeout, cleanup and privileged.
+//
+// AgentConfig's fields are exported, so a caller overrides any of them after
+// deriving — the same derive-don't-apply precedence the other methods use, but
+// without needing an options slice, because the type is a plain struct.
+//
+// # Three mappings that are not pass-throughs
+//
+// NoCleanup is INVERTED against Cleanup, the same shape spec.validate has.
+//
+// Privileged defaults to TRUE when config says nothing. The resolved field is
+// a pointer precisely so "unset" stays distinct from an explicit false, and
+// the CLI applies derefBoolOr(resolved.Privileged, true). Dereferencing a nil
+// pointer to false here would silently drop privileges the collector needs,
+// and the failure would surface as missing data rather than an error.
+//
+// Requests and Limits resolve as raw "name=quantity,..." strings — Resolve
+// deliberately does not parse them — so they are parsed here and a malformed
+// value is an error rather than a silently empty ResourceList.
+//
+// # What is deliberately NOT projected
+//
+// OutputFormat has no AgentConfig counterpart, and that is not an omission:
+// format is applied at delivery, not by the agent. The Job always stages YAML
+// in a ConfigMap, so a format routed through AgentConfig would be silently
+// ignored (#2398). Callers set it on the delivery path instead.
+//
+// Kubeconfig, Debug, ClusterConfigPath, AKSGPUPoolsPath, DiscoverNetwork,
+// RunID and NameBase are left at their zero values. None has a spec.snapshot
+// counterpart — they are per-invocation or caller-owned. NameBase in
+// particular carries the "aicr" default prefix that lets an unset job name
+// stay empty while deployed objects keep their released names, which is a
+// decision the caller makes, not the document.
+//
+// Returns a zero-value AgentConfig (never nil) when the document has no
+// spec.snapshot, and an error when the section is present but malformed.
+func (c *Config) SnapshotAgentConfig() (*AgentConfig, error) {
+	// A zero-value AgentConfig rather than nil, so a caller that did not supply
+	// a config (or supplied one without spec.snapshot) can derive
+	// unconditionally and then set the caller-owned fields — matching the
+	// "returns zero values" contract in the Config godoc.
+	if c == nil || c.internal == nil {
+		return &AgentConfig{}, nil
+	}
+	resolved, err := c.internal.Snapshot().Resolve()
+	if err != nil {
+		// Already coded, and the message carries the spec path that failed.
+		return nil, err
+	}
+	if resolved == nil {
+		return &AgentConfig{}, nil
+	}
+
+	requests, err := snapshotter.ParseResourceList(resolved.Requests)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			"invalid spec.snapshot.agent.requests", err)
+	}
+	limits, err := snapshotter.ParseResourceList(resolved.Limits)
+	if err != nil {
+		return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+			"invalid spec.snapshot.agent.limits", err)
+	}
+
+	cfg := &AgentConfig{
+		Namespace:          resolved.Namespace,
+		Image:              resolved.Image,
+		ImagePullSecrets:   resolved.ImagePullSecrets,
+		JobName:            resolved.JobName,
+		ServiceAccountName: resolved.ServiceAccountName,
+		NodeSelector:       resolved.NodeSelector,
+		Tolerations:        resolved.Tolerations,
+		RequireGPU:         resolved.RequireGPU,
+		RuntimeClassName:   resolved.RuntimeClassName,
+		OS:                 resolved.OS,
+		MaxNodesPerEntry:   resolved.MaxNodesPerEntry,
+		Output:             resolved.OutputPath,
+		TemplatePath:       resolved.OutputTemplate,
+		Requests:           requests,
+		Limits:             limits,
+		// Inverted on purpose. See the godoc above.
+		Cleanup: !resolved.NoCleanup,
+		// Nil means config said nothing, and the collector's default is
+		// privileged. See the godoc above.
+		Privileged: resolved.Privileged == nil || *resolved.Privileged,
+	}
+	if resolved.Timeout != nil {
+		cfg.Timeout = *resolved.Timeout
+	}
+	return cfg, nil
 }

--- a/pkg/client/v1/config.go
+++ b/pkg/client/v1/config.go
@@ -21,6 +21,7 @@ import (
 	bundlerconfig "github.com/NVIDIA/aicr/pkg/bundler/config"
 	appconfig "github.com/NVIDIA/aicr/pkg/config"
 	"github.com/NVIDIA/aicr/pkg/errors"
+	"github.com/NVIDIA/aicr/pkg/recipe"
 	"github.com/NVIDIA/aicr/pkg/snapshotter"
 )
 
@@ -566,8 +567,13 @@ func (c *Config) ValidateOptions() ([]ValidateOption, error) {
 //
 // These settings map onto the agent Job: namespace, image, image pull
 // secrets, job name, service account, node selector, tolerations, require-GPU,
-// runtime class, OS, max nodes per entry, output path, template path, resource
-// requests and limits, timeout, cleanup and privileged.
+// runtime class, OS, max nodes per entry, resource requests and limits,
+// timeout, cleanup and privileged.
+//
+// OS is parsed through the criteria registry rather than copied, matching what
+// the CLI does with --os. That keeps undocumented values from reaching the
+// agent, and it matters for exact matches: an unparsed "Talos" misses the
+// agent's "talos" check and selects incompatible host mounts.
 //
 // AgentConfig's fields are exported, so a caller overrides any of them after
 // deriving — the same derive-don't-apply precedence the other methods use, but
@@ -589,10 +595,20 @@ func (c *Config) ValidateOptions() ([]ValidateOption, error) {
 //
 // # What is deliberately NOT projected
 //
-// OutputFormat has no AgentConfig counterpart, and that is not an omission:
-// format is applied at delivery, not by the agent. The Job always stages YAML
-// in a ConfigMap, so a format routed through AgentConfig would be silently
-// ignored (#2398). Callers set it on the delivery path instead.
+// The whole spec.snapshot.output section is un-projected, and that is not an
+// omission. Output describes DELIVERY; AgentConfig describes the collection
+// Job, and the two are different concerns:
+//
+//   - output.format is applied at delivery. The Job always stages YAML in a
+//     ConfigMap, so a format routed through AgentConfig would be silently
+//     ignored (#2398).
+//   - output.path and output.template are not AgentConfig.Output and
+//     .TemplatePath. Per AgentConfig.Output's own godoc, any value that is not
+//     a cm:// URI stages to an internal ConfigMap and delivery becomes the
+//     caller's job. Projecting a file path there would look configured and
+//     write nothing.
+//
+// Callers deliver with snapshotter.DeliverSnapshot, passing Snapshot.Raw.
 //
 // Kubeconfig, Debug, ClusterConfigPath, AKSGPUPoolsPath, DiscoverNetwork,
 // RunID and NameBase are left at their zero values. None has a spec.snapshot
@@ -603,12 +619,25 @@ func (c *Config) ValidateOptions() ([]ValidateOption, error) {
 //
 // Returns a zero-value AgentConfig (never nil) when the document has no
 // spec.snapshot, and an error when the section is present but malformed.
+//
+// A zero value is not a working configuration: Privileged is false, which the
+// collector generally needs true. That is deliberate. Defaults apply when the
+// section EXISTS and is silent about a field; a document with no spec.snapshot
+// at all made no snapshot decisions, so the facade does not invent them. A
+// caller in that position supplies its own defaults, as the CLI does from its
+// flag defaults.
 func (c *Config) SnapshotAgentConfig() (*AgentConfig, error) {
 	// A zero-value AgentConfig rather than nil, so a caller that did not supply
 	// a config (or supplied one without spec.snapshot) can derive
 	// unconditionally and then set the caller-owned fields — matching the
 	// "returns zero values" contract in the Config godoc.
-	if c == nil || c.internal == nil {
+	//
+	// The section-presence check is load-bearing and cannot be replaced by a
+	// nil check on the resolved value: Resolve() returns a NON-nil
+	// SnapshotResolved for an absent section, so falling through would apply
+	// the in-section defaults (Cleanup and Privileged both true) to a document
+	// that never opted into snapshot configuration at all.
+	if c == nil || c.internal == nil || c.internal.Snapshot() == nil {
 		return &AgentConfig{}, nil
 	}
 	resolved, err := c.internal.Snapshot().Resolve()
@@ -631,6 +660,21 @@ func (c *Config) SnapshotAgentConfig() (*AgentConfig, error) {
 			"invalid spec.snapshot.agent.limits", err)
 	}
 
+	// The CLI parses --os through the criteria registry so only documented
+	// values reach the agent and the in-pod collector factory, and so an
+	// invalid value errors rather than traveling. Passing resolved.OS through
+	// raw would skip both: "Talos" would miss the agent's exact "talos" match
+	// and select incompatible host mounts.
+	osValue := resolved.OS
+	if osValue != "" {
+		parsed, perr := recipe.NewCriteriaRegistry().ParseOS(osValue)
+		if perr != nil {
+			return nil, errors.Wrap(errors.ErrCodeInvalidRequest,
+				"invalid spec.snapshot.agent.os", perr)
+		}
+		osValue = string(parsed)
+	}
+
 	cfg := &AgentConfig{
 		Namespace:          resolved.Namespace,
 		Image:              resolved.Image,
@@ -641,10 +685,8 @@ func (c *Config) SnapshotAgentConfig() (*AgentConfig, error) {
 		Tolerations:        resolved.Tolerations,
 		RequireGPU:         resolved.RequireGPU,
 		RuntimeClassName:   resolved.RuntimeClassName,
-		OS:                 resolved.OS,
+		OS:                 osValue,
 		MaxNodesPerEntry:   resolved.MaxNodesPerEntry,
-		Output:             resolved.OutputPath,
-		TemplatePath:       resolved.OutputTemplate,
 		Requests:           requests,
 		Limits:             limits,
 		// Inverted on purpose. See the godoc above.

--- a/pkg/client/v1/config_test.go
+++ b/pkg/client/v1/config_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	aicr "github.com/NVIDIA/aicr/pkg/client/v1"
 	aicrerrors "github.com/NVIDIA/aicr/pkg/errors"
@@ -960,5 +961,163 @@ spec:
 				t.Errorf("UseTUFSigningConfig = %v, want %v", opts.OIDCResolve.UseTUFSigningConfig, tt.wantTUF)
 			}
 		})
+	}
+}
+
+// snapshotAgentConfig exercises every spec.snapshot field SnapshotAgentConfig
+// projects, with a value per field so a dropped or swapped mapping shows up as
+// a wrong value rather than a shorter struct.
+const snapshotAgentConfig = `apiVersion: aicr.run/v1beta1
+kind: AICRConfig
+spec:
+  snapshot:
+    agent:
+      namespace: aicr-system
+      image: nvcr.io/nvidia/aicr:v1.2.3
+      imagePullSecrets:
+        - regcred
+      jobName: snap-job
+      serviceAccountName: snap-sa
+      nodeSelector:
+        role: gpu
+      tolerations:
+        - "nvidia.com/gpu:NoSchedule"
+      requireGpu: true
+      runtimeClassName: nvidia
+      os: ubuntu
+      requests: cpu=100m,memory=256Mi
+      limits: cpu=2,memory=1Gi
+    execution:
+      timeout: 12m
+      maxNodesPerEntry: 7
+    output:
+      path: ./snap.yaml
+      template: ./tmpl.tmpl
+`
+
+func TestConfig_SnapshotAgentConfig(t *testing.T) {
+	cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, snapshotAgentConfig))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	ac, err := cfg.SnapshotAgentConfig()
+	if err != nil {
+		t.Fatalf("SnapshotAgentConfig: %v", err)
+	}
+	if ac == nil {
+		t.Fatal("SnapshotAgentConfig returned nil for a populated spec.snapshot")
+	}
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"Namespace", ac.Namespace, "aicr-system"},
+		{"Image", ac.Image, "nvcr.io/nvidia/aicr:v1.2.3"},
+		{"JobName", ac.JobName, "snap-job"},
+		{"ServiceAccountName", ac.ServiceAccountName, "snap-sa"},
+		{"RequireGPU", ac.RequireGPU, true},
+		{"RuntimeClassName", ac.RuntimeClassName, "nvidia"},
+		{"OS", ac.OS, "ubuntu"},
+		{"MaxNodesPerEntry", ac.MaxNodesPerEntry, 7},
+		{"Timeout", ac.Timeout, 12 * time.Minute},
+		{"Output", ac.Output, "./snap.yaml"},
+		{"TemplatePath", ac.TemplatePath, "./tmpl.tmpl"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+	if len(ac.ImagePullSecrets) != 1 || ac.ImagePullSecrets[0] != "regcred" {
+		t.Errorf("ImagePullSecrets = %v, want [regcred]", ac.ImagePullSecrets)
+	}
+	if ac.NodeSelector["role"] != "gpu" {
+		t.Errorf("NodeSelector[role] = %q, want gpu", ac.NodeSelector["role"])
+	}
+	if len(ac.Tolerations) != 1 {
+		t.Errorf("Tolerations = %v, want 1 entry", ac.Tolerations)
+	}
+	// Raw "name=quantity,..." strings; Resolve does not parse them, so a
+	// dropped parse would surface as an empty ResourceList, not an error.
+	if ac.Requests.Cpu().String() != "100m" {
+		t.Errorf("Requests.cpu = %v, want 100m", ac.Requests.Cpu())
+	}
+	if ac.Limits.Memory().String() != "1Gi" {
+		t.Errorf("Limits.memory = %v, want 1Gi", ac.Limits.Memory())
+	}
+}
+
+// TestConfig_SnapshotAgentConfig_CleanupIsInverted covers the same trap
+// spec.validate has: config says "noCleanup", AgentConfig says "Cleanup".
+func TestConfig_SnapshotAgentConfig_CleanupIsInverted(t *testing.T) {
+	for _, tt := range []struct {
+		noCleanup   string
+		wantCleanup bool
+	}{{"true", false}, {"false", true}} {
+		t.Run("noCleanup="+tt.noCleanup, func(t *testing.T) {
+			body := "apiVersion: aicr.run/v1beta1\nkind: AICRConfig\nspec:\n  snapshot:\n    execution:\n      noCleanup: " + tt.noCleanup + "\n"
+			cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, body))
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			ac, err := cfg.SnapshotAgentConfig()
+			if err != nil {
+				t.Fatalf("SnapshotAgentConfig: %v", err)
+			}
+			if ac.Cleanup != tt.wantCleanup {
+				t.Errorf("Cleanup = %v, want %v (noCleanup: %s)", ac.Cleanup, tt.wantCleanup, tt.noCleanup)
+			}
+		})
+	}
+}
+
+// TestConfig_SnapshotAgentConfig_PrivilegedDefaultsTrue is the subtler of the
+// two traps. The resolved field is a pointer so unset stays distinct from an
+// explicit false, and the collector's default is privileged — dereferencing
+// nil to false would silently drop privileges and surface as missing data
+// rather than an error.
+func TestConfig_SnapshotAgentConfig_PrivilegedDefaultsTrue(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"unset defaults to privileged", "apiVersion: aicr.run/v1beta1\nkind: AICRConfig\nspec:\n  snapshot:\n    agent:\n      namespace: n\n", true},
+		{"explicit false is preserved", "apiVersion: aicr.run/v1beta1\nkind: AICRConfig\nspec:\n  snapshot:\n    execution:\n      privileged: false\n", false},
+		{"explicit true is preserved", "apiVersion: aicr.run/v1beta1\nkind: AICRConfig\nspec:\n  snapshot:\n    execution:\n      privileged: true\n", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, tt.body))
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			ac, err := cfg.SnapshotAgentConfig()
+			if err != nil {
+				t.Fatalf("SnapshotAgentConfig: %v", err)
+			}
+			if ac.Privileged != tt.want {
+				t.Errorf("Privileged = %v, want %v", ac.Privileged, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_SnapshotAgentConfig_Absent(t *testing.T) {
+	var cfg *aicr.Config
+	ac, err := cfg.SnapshotAgentConfig()
+	if err != nil {
+		t.Fatalf("SnapshotAgentConfig on nil Config: %v", err)
+	}
+	if ac == nil {
+		t.Fatal("got nil; a nil Config must still derive a zero-value AgentConfig")
+	}
+	// AgentConfig contains slices/maps, so compare the fields a derivation
+	// would have populated rather than the struct as a whole.
+	if ac.Namespace != "" || ac.Image != "" || ac.Cleanup || ac.Privileged ||
+		ac.Timeout != 0 || len(ac.ImagePullSecrets) != 0 || len(ac.NodeSelector) != 0 {
+
+		t.Errorf("got %+v, want a zero value", ac)
 	}
 }

--- a/pkg/client/v1/config_test.go
+++ b/pkg/client/v1/config_test.go
@@ -1022,8 +1022,6 @@ func TestConfig_SnapshotAgentConfig(t *testing.T) {
 		{"OS", ac.OS, "ubuntu"},
 		{"MaxNodesPerEntry", ac.MaxNodesPerEntry, 7},
 		{"Timeout", ac.Timeout, 12 * time.Minute},
-		{"Output", ac.Output, "./snap.yaml"},
-		{"TemplatePath", ac.TemplatePath, "./tmpl.tmpl"},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -1104,7 +1102,40 @@ func TestConfig_SnapshotAgentConfig_PrivilegedDefaultsTrue(t *testing.T) {
 	}
 }
 
+// TestConfig_SnapshotAgentConfig_Absent covers BOTH routes to "no snapshot
+// configuration", which fail differently.
+//
+// A nil Config is caught by the receiver check. A document that simply omits
+// spec.snapshot is NOT: Resolve() returns a non-nil SnapshotResolved for an
+// absent section, so without the section-presence check the derivation falls
+// through and applies the in-section defaults — Cleanup and Privileged both
+// true — to a document that never opted into snapshot configuration.
 func TestConfig_SnapshotAgentConfig_Absent(t *testing.T) {
+	t.Run("document omits spec.snapshot", func(t *testing.T) {
+		body := `apiVersion: aicr.run/v1beta1
+kind: AICRConfig
+spec:
+  verify:
+    policy:
+      minTrustLevel: max
+`
+		cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, body))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		ac, err := cfg.SnapshotAgentConfig()
+		if err != nil {
+			t.Fatalf("SnapshotAgentConfig: %v", err)
+		}
+		if ac == nil {
+			t.Fatal("got nil; an absent section must still derive a zero value")
+		}
+		if ac.Cleanup || ac.Privileged {
+			t.Errorf("Cleanup=%v Privileged=%v; an absent section must not apply in-section defaults",
+				ac.Cleanup, ac.Privileged)
+		}
+	})
+
 	var cfg *aicr.Config
 	ac, err := cfg.SnapshotAgentConfig()
 	if err != nil {
@@ -1120,4 +1151,34 @@ func TestConfig_SnapshotAgentConfig_Absent(t *testing.T) {
 
 		t.Errorf("got %+v, want a zero value", ac)
 	}
+}
+
+// TestConfig_SnapshotAgentConfig_OSIsParsed pins that OS goes through the
+// criteria registry rather than being copied. An unparsed "Talos" misses the
+// agent's exact "talos" match and selects incompatible host mounts, and an
+// undocumented value would travel instead of erroring.
+func TestConfig_SnapshotAgentConfig_OSIsParsed(t *testing.T) {
+	head := "apiVersion: aicr.run/v1beta1\nkind: AICRConfig\nspec:\n  snapshot:\n    agent:\n      os: "
+	t.Run("mixed case is normalized", func(t *testing.T) {
+		cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, head+"Talos\n"))
+		if err != nil {
+			t.Skipf("loader rejected the value before the derivation: %v", err)
+		}
+		ac, err := cfg.SnapshotAgentConfig()
+		if err != nil {
+			t.Fatalf("SnapshotAgentConfig: %v", err)
+		}
+		if ac.OS != "talos" {
+			t.Errorf("OS = %q, want %q", ac.OS, "talos")
+		}
+	})
+	t.Run("undocumented value is rejected", func(t *testing.T) {
+		cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, head+"plan9\n"))
+		if err != nil {
+			return // rejected earlier, also fail-closed
+		}
+		if _, err := cfg.SnapshotAgentConfig(); err == nil {
+			t.Fatal("SnapshotAgentConfig accepted an undocumented OS value")
+		}
+	})
 }

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -333,6 +333,19 @@ func TestStability_TypesAndAliases(t *testing.T) {
 	_ = aicr.Criteria{}
 	_ = aicr.AllowLists{}
 	_ = aicr.AgentConfig{}
+	// Pinned by name and type, not just shape: Config.SnapshotAgentConfig
+	// populates these, and the bare literal above would still compile
+	// through a rename or retype. Cleanup and Privileged especially --
+	// both are derived through a transform (an inversion and a
+	// defaults-to-true), so a silent flip has no other guard here.
+	_ = aicr.AgentConfig{
+		Namespace: "", Image: "", JobName: "", ServiceAccountName: "",
+		RuntimeClassName: "", OS: "", Output: "", TemplatePath: "",
+		MaxNodesPerEntry: 0, RequireGPU: false, Cleanup: false, Privileged: false,
+	}
+	requireType[bool](aicr.AgentConfig{}.Cleanup)
+	requireType[bool](aicr.AgentConfig{}.Privileged)
+	requireType[time.Duration](aicr.AgentConfig{}.Timeout)
 	_ = aicr.Snapshot{}
 	_ = aicr.Snapshot{}.Raw
 	_ = aicr.ReportSummary{}
@@ -508,6 +521,7 @@ func TestStability_Config(t *testing.T) {
 	requireSignature[func(*aicr.Config) (aicr.BundleVerifyOptions, error)]((*aicr.Config).BundleVerifyOptions)
 	requireSignature[func(*aicr.Config) (aicr.BundleOptions, error)]((*aicr.Config).BundleOptions)
 	requireSignature[func(*aicr.Config) ([]aicr.ValidateOption, error)]((*aicr.Config).ValidateOptions)
+	requireSignature[func(*aicr.Config) (*aicr.AgentConfig, error)]((*aicr.Config).SnapshotAgentConfig)
 	requireSignature[func(*aicr.Config) string]((*aicr.Config).RecipeProfile)
 	requireSignature[func(*aicr.Config) (string, bool, error)]((*aicr.Config).RecipeAccountingMode)
 	requireSignature[func(*aicr.Config) (aicr.RecipeSourceOption, bool)]((*aicr.Config).RecipeSource)


### PR DESCRIPTION
## Summary

Project `spec.snapshot` onto the facade. `Config.SnapshotAgentConfig()` derives
the `AgentConfig` that `Client.CollectSnapshot` consumes, closing the third of
the three sections #2245 scoped.

## Motivation / Context

`Config` projected `spec.verify`, `spec.recipe`, `spec.bundle` and
`spec.validate`; `spec.snapshot` was reachable only through `Unwrap()`. This
completes the set, so an integrator can drive the whole workflow from a
committed document without importing `pkg/config`.

Unblocked by #2120 landing (#2357), which settled `AgentConfig`.

Refs #2245
Related: #2016, #2521

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Core libraries — `pkg/client/v1`
- [x] Docs/examples

## Implementation Notes

`AgentConfig`'s fields are exported, so this returns a populated struct rather
than an options slice — a caller overrides any field directly.

**Three mappings are transforms, and two fail silently if reimplemented:**

- `noCleanup` → `Cleanup` is **inverted**, the same shape `spec.validate` has.
  Third section running, so it is pinned both ways again.
- `privileged` → `Privileged` **defaults to true** when config says nothing.
  The resolved field is a pointer so unset stays distinct from an explicit
  `false`, and the CLI applies `derefBoolOr(resolved.Privileged, true)`. The
  naive `ptr != nil && *ptr` drops privileges the collector needs, and it
  surfaces as *missing data* rather than an error.
- `requests` / `limits` arrive as raw `name=quantity,...` strings because
  `Resolve()` deliberately leaves them unparsed, so a malformed value errors
  here instead of becoming an empty `ResourceList`.

Both silent transforms are mutation-verified: applying the naive form fails
the new tests.

**`spec.snapshot.output.format` is deliberately not projected.** Format is
applied at delivery, not by the agent — the Job always stages YAML in a
ConfigMap, so a format routed through `AgentConfig` would be silently ignored
(#2398).

**Returns a zero-value `AgentConfig`, never nil.** `nilnil` flagged the
original `(nil, nil)` return, which was the better prompt: a zero value matches
the "returns zero values" contract in the `Config` godoc and lets a caller
derive unconditionally.

**Also strengthens `AgentConfig`'s stability pin.** It was `_ =
aicr.AgentConfig{}`, a bare composite literal that compiles through any rename
or retype. `Cleanup`, `Privileged` and `Timeout` are now pinned by name and
type, since all three are derived through transforms with no other guard.

## Testing

```bash
make qualify   # green on the committed tree
```

Value assertions across all 16 projected fields, both transforms mutation-
verified, plus the absent-config path.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

Additive: one new `Config` method. No existing caller changes behavior.

**Rollout notes:** The CLI still reads `spec.snapshot` through its own path.
Migrating it is blocked on a design question — see the discussion on #2245
about flag precedence needing "was this set", which the derivations
deliberately collapse.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
