### PR TITLE
feat(sdk): derive evidence attestation options from AICRConfig

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -888,7 +888,7 @@ derive step rather than the load step.
 | `BundleVerifyOptions()` | `spec.verify.policy` + `spec.verify.trust` |
 | `BundleOptions()` | `spec.bundle.deployment` + `spec.bundle.scheduling` + `spec.bundle.attestation` |
 | `ValidateOptions()` | `spec.validate.execution` + the agent fields the validator accepts as options |
-| `SnapshotAgentConfig()` | `spec.snapshot.agent` + `.execution` + `.output` |
+| `SnapshotAgentConfig()` | `spec.snapshot.agent` + `.execution` (**not** `.output`) |
 | `RecipeSource()` | `spec.recipe.data` |
 | `RecipeCriteria(reg)` | `spec.recipe.criteria` |
 | `RecipeResolveOptions()` | `spec.recipe.profile`, `spec.recipe.configuration.slurm.accounting.mode`, `spec.recipe.configuration.runtimeInventory.mode` |

--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -889,6 +889,7 @@ derive step rather than the load step.
 | `BundleOptions()` | `spec.bundle.deployment` + `spec.bundle.scheduling` + `spec.bundle.attestation` |
 | `ValidateOptions()` | `spec.validate.execution` + the agent fields the validator accepts as options |
 | `SnapshotAgentConfig()` | `spec.snapshot.agent` + `.execution` (**not** `.output`) |
+| `EvidenceAttestationOptions()` | `spec.validate.evidence.attestation` (**not** `.cncf`) |
 | `RecipeSource()` | `spec.recipe.data` |
 | `RecipeCriteria(reg)` | `spec.recipe.criteria` |
 | `RecipeResolveOptions()` | `spec.recipe.profile`, `spec.recipe.configuration.slurm.accounting.mode`, `spec.recipe.configuration.runtimeInventory.mode` |
@@ -896,10 +897,13 @@ derive step rather than the load step.
 | `SnapshotPath()` | `spec.recipe.input.snapshot` |
 | `IsCriteriaStrict()` | `spec.recipe.criteriaStrict` |
 
-All five spec sections now have a derivation. `spec.validate.evidence` is the
-remaining gap — `EvidenceOptions` is the shape it would map onto, but no
-`Config` method produces one, so reading it still needs `Unwrap()`. Needing it is worth reporting — it means a
-derivation is missing, and `pkg/config` carries no stability guarantee.
+All five spec sections now have a derivation. The one remaining gap is
+`spec.validate.evidence.cncf`: unlike every other un-projected field, it is not
+a deliberate exclusion but a missing *destination* — no facade method emits
+CNCF AI Conformance evidence, so there is no options type for a derivation to
+produce. Reading it still needs `Unwrap()`. Needing `Unwrap()` anywhere is worth
+reporting — it means a derivation is missing, and `pkg/config` carries no
+stability guarantee.
 
 ### What `BundleOptions()` does and does not carry
 
@@ -1385,11 +1389,50 @@ The rest of the section has other homes, and knowing which saves a search:
 | `spec.validate.agent.image`, `.jobName`, `.serviceAccountName`, `.requireGpu` | `AgentConfig`. These configure the validator's Kubernetes Job; `pkg/validator` exposes no option for any of them, so a `WithValidation*` here would have nothing to translate into. |
 | `spec.validate.execution.failOnError` | Nowhere, deliberately. It decides whether a failed check makes the *caller* fail; the validator reports and does not act on it. Command-line-only for the same reason as `IgnoreTLog`: a checked-in file should not be able to make a failing run report success. |
 | `spec.validate.input.recipe`, `.snapshot` | Not projected — you already pass both to `ValidateState`. |
-| `spec.validate.evidence` | **Not projected.** `EvidenceOptions` is the shape it would map onto, but no `Config` derivation produces one yet, so reading it still needs `Unwrap()`. |
+| `spec.validate.evidence.attestation` | `EvidenceAttestationOptions()`, which targets `EmitRecipeEvidence` rather than `ValidateState` — see below. |
+| `spec.validate.evidence.cncf` | **Not projected.** No facade method emits CNCF AI Conformance evidence, so there is nothing for a derivation to feed. Reading it still needs `Unwrap()`. |
 
 One inversion worth knowing: config says `noCleanup`, the option says
 `cleanup`. `ValidateOptions()` flips it, so `noCleanup: true` becomes
 `WithValidationCleanup(false)`.
+
+### What `EvidenceAttestationOptions()` does and does not carry
+
+`spec.validate.evidence` carries two kinds of evidence. This method covers one
+of them, and the name says which, so it cannot quietly grow to imply both:
+
+```go
+opts, ok, err := cfg.EvidenceAttestationOptions()
+if err != nil {
+    return err
+}
+if ok {
+    opts.Commit = buildCommit  // caller-owned, no config counterpart
+    err = client.EmitRecipeEvidence(ctx, rec, snap, results, opts)
+}
+```
+
+**`out` is the enable gate.** An empty `out` leaves the path off even when
+`bom`/`push`/`plainHTTP`/`insecureTLS` are set, matching the spec field's own
+contract and what the CLI does. So `ok == false` means "not configured", never
+"misconfigured" — a malformed section returns an error instead. That is why
+there is a `bool` at all: `EmitRecipeEvidence` rejects an empty `OutDir`, so a
+zero-value `EvidenceOptions` could not tell you which of the two happened.
+
+Five fields project: `out`, `bom`, `push`, `plainHTTP`, `insecureTLS`. The
+rest of `EvidenceOptions` stays yours, and the reasons differ:
+
+| Field | Why it is not derived |
+|---|---|
+| `Commit` | Names the running binary, not the document. It selects the validator catalog the bundle's BOM is built against. Set it after deriving. |
+| `OIDCResolve` | Excluded by the spec itself. A keyless-signing identity token is a short-lived secret and must not sit in a version-controlled file; resolve it at sign time. |
+| `NoSign`, `Full` | Command-line-only, for the same reason as `IgnoreTLog` and `failOnError`. Both **weaken** a run — `NoSign` pushes an unsigned bundle, `Full` ships unredacted payloads — and a checked-in file that can silently disable signing is a supply-chain downgrade no reviewer would see in a diff. |
+
+**`spec.validate.evidence.cncf` is not projected**, and this one is a genuine
+gap rather than a decision. There is no `Client.Emit*` that consumes
+`dir`/`cncfSubmission`/`features`, so a derivation would have nothing to
+produce. Projecting it means designing the emission API first. Read that half
+through `Unwrap()` until then.
 
 ### What `SnapshotAgentConfig()` does and does not carry
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -395,7 +395,12 @@ func recipeClientFromCmd(
 	} else if configured, ok := aicr.WrapConfig(cfg).RecipeSource(); ok {
 		// spec.recipe.data, derived through the facade so an SDK caller
 		// building a Client from the same document gets the same source.
-		slog.Info("initializing external data provider", "source", "spec.recipe.data")
+		// Log the concrete directory as the --data branch does: the audit line
+		// exists so an operator can tell which catalog a run actually read, and
+		// naming only the spec field leaves that unanswered. Read from the same
+		// accessor RecipeSource() uses, so the two cannot disagree.
+		slog.Info("initializing external data provider",
+			"directory", cfg.Recipe().DataDir(), "source", "spec.recipe.data")
 		source = configured
 	}
 	client, err := aicr.NewClientContext(ctx,

--- a/pkg/client/v1/config.go
+++ b/pkg/client/v1/config.go
@@ -497,10 +497,12 @@ func (c *Config) BundleOptions() (BundleOptions, error) {
 //     failing run report success.
 //   - RecipePath and SnapshotPath name what to validate. The caller already
 //     passes both to ValidateState.
-//   - EvidenceCNCF and EvidenceAttestation configure evidence emission.
-//     EvidenceOptions is the shape they would map onto, but no derivation
-//     produces one yet, so reading them still needs Unwrap(). Tracked as a
-//     remaining gap rather than a decided exclusion.
+//   - EvidenceAttestation configures the recipe-evidence bundle.
+//     EvidenceAttestationOptions derives it; it is not folded in here because
+//     it targets Client.EmitRecipeEvidence rather than ValidateState.
+//   - EvidenceCNCF configures the CNCF AI Conformance markdown path, which has
+//     no facade emission method to receive it. See EvidenceAttestationOptions
+//     for why that half stays un-projected.
 //
 // # Two mappings that are not pass-throughs
 //
@@ -560,6 +562,78 @@ func (c *Config) ValidateOptions() ([]ValidateOption, error) {
 		opts = append(opts, WithValidationTimeout(*resolved.Timeout))
 	}
 	return opts, nil
+}
+
+// EvidenceAttestationOptions derives Client.EmitRecipeEvidence's options from
+// spec.validate.evidence.attestation, and reports whether the document asked
+// for a recipe-evidence bundle at all.
+//
+// Out is the enable gate, matching the spec field's own contract: an empty
+// out leaves the path off even when bom/push/plainHTTP/insecureTLS are
+// populated, so a half-filled section does not start emitting evidence. False
+// therefore means "not configured", not "misconfigured" — a malformed section
+// is an error instead. That is why this returns a bool rather than a
+// zero-value EvidenceOptions: EmitRecipeEvidence rejects an empty OutDir with
+// ErrCodeInvalidRequest, so a zero value alone could not tell a caller whether
+// the document declined the bundle or fumbled it.
+//
+// Five fields project (out, bom, push, plainHTTP, insecureTLS). The rest of
+// EvidenceOptions is deliberately caller-owned:
+//
+//   - Commit has no spec counterpart. It selects the validator catalog the
+//     bundle's BOM is built against, and it is a property of the running
+//     binary rather than of the document. Set it after deriving.
+//   - OIDCResolve is excluded by the spec itself: a keyless-signing identity
+//     token is a short-lived secret and must not live in a version-controlled
+//     file. The caller resolves it at sign time.
+//   - NoSign and Full are command-line-only, for the same reason FailOnError
+//     and IgnoreTLog are. Both WEAKEN a run — NoSign pushes an unsigned
+//     bundle, Full ships unredacted payloads — and a checked-in file that can
+//     quietly turn off signing is a supply-chain downgrade no reviewer would
+//     see in a diff. Adding spec fields for them would close a "gap" that is
+//     actually a control.
+//
+// # spec.validate.evidence.cncf is NOT projected
+//
+// The evidence section carries two kinds; this method covers one. CNCF AI
+// Conformance emission has no facade entry point at all — there is no
+// Client.Emit* that consumes dir/cncfSubmission/features — so there is
+// nothing for a derivation to feed. Projecting it would mean designing the
+// emission API, not mapping config onto an existing one. Reading that half
+// still needs Unwrap(), and this method is named for the half it carries so
+// the name cannot drift into covering both.
+//
+// Returns (zero, false, nil) for a nil Config, an absent spec.validate, an
+// absent evidence.attestation, or an empty out, and an error when the section
+// is present but malformed.
+func (c *Config) EvidenceAttestationOptions() (EvidenceOptions, bool, error) {
+	if c == nil || c.internal == nil {
+		return EvidenceOptions{}, false, nil
+	}
+	resolved, err := c.internal.Validation().Resolve()
+	if err != nil {
+		// Already coded, and the message carries the spec path that failed.
+		return EvidenceOptions{}, false, err
+	}
+	if resolved == nil || resolved.EvidenceAttestation == nil {
+		return EvidenceOptions{}, false, nil
+	}
+	att := resolved.EvidenceAttestation
+	// The spec's own gate, not an extra one: EvidenceAttestationSpec.Out
+	// documents that setting Out enables the path and an empty Out leaves it
+	// off regardless of the other fields. The CLI applies the same rule in
+	// buildRecipeEvidenceConfig, so honoring it here keeps a config-driven run
+	// and a flag-driven run from diverging on the same document.
+	if att.Out == "" {
+		return EvidenceOptions{}, false, nil
+	}
+	return EvidenceOptions{
+		OutDir:      att.Out,
+		BOMPath:     att.BOM,
+		Push:        att.Push,
+		PlainHTTP:   att.PlainHTTP,
+		InsecureTLS: att.InsecureTLS,
+	}, true, nil
 }
 
 // SnapshotAgentConfig derives Client.CollectSnapshot's AgentConfig from

--- a/pkg/client/v1/config_options_internal_test.go
+++ b/pkg/client/v1/config_options_internal_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aicr
+
+import (
+	stderrors "errors"
+	"testing"
+
+	appconfig "github.com/NVIDIA/aicr/pkg/config"
+	"github.com/NVIDIA/aicr/pkg/errors"
+)
+
+// RecipeResolveOptions returns opaque functional options. The external
+// aicr_test package can only count them, and a count passes while a value is
+// wrong — WithProfile and WithAccountingMode could be swapped, or either could
+// fold an empty string, and len(opts) == 2 either way. Applying them here
+// against the internal capture struct is the cheapest assertion that actually
+// reads the folded values; the alternative is a full resolve round-trip, which
+// needs a catalog and a DataProvider to say the same thing.
+func TestConfig_RecipeResolveOptions_FoldsValuesNotJustCount(t *testing.T) {
+	t.Parallel()
+
+	cfg := WrapConfig(&appconfig.AICRConfig{
+		Spec: appconfig.Spec{
+			Recipe: &appconfig.RecipeSpec{
+				Profile: "gpuStack=operator-managed",
+				// Distinct values on purpose. Both enums accept "disabled", so
+				// using it twice would let the two folds be swapped without any
+				// assertion noticing.
+				Configuration: &appconfig.RecipeConfigurationSpec{
+					Slurm: &appconfig.SlurmConfigurationSpec{
+						Accounting: &appconfig.SlurmAccountingSpec{Mode: "customer-managed"},
+					},
+					RuntimeInventory: &appconfig.RuntimeInventorySpec{Mode: "enabled"},
+				},
+			},
+		},
+	})
+
+	opts, err := cfg.RecipeResolveOptions()
+	if err != nil {
+		t.Fatalf("RecipeResolveOptions: %v", err)
+	}
+
+	applied, err := resolveRecipeConfig(opts...)
+	if err != nil {
+		t.Fatalf("applying derived options: %v", err)
+	}
+
+	if applied.profile != "gpuStack=operator-managed" {
+		t.Errorf("profile = %q, want gpuStack=operator-managed; a swapped or "+
+			"empty fold still returns the same option count",
+			applied.profile)
+	}
+	if applied.accountingMode == nil {
+		t.Fatal("accountingMode not folded; the document sets one")
+	}
+	if got := string(*applied.accountingMode); got != "customer-managed" {
+		t.Errorf("accountingMode = %q, want customer-managed", got)
+	}
+	if applied.runtimeInventoryMode == nil {
+		t.Fatal("runtimeInventoryMode not folded; the document sets one")
+	}
+	if got := string(*applied.runtimeInventoryMode); got != "enabled" {
+		t.Errorf("runtimeInventoryMode = %q, want enabled", got)
+	}
+}
+
+// The error returns on these three derivations are unreachable through
+// LoadConfig — validate() rejects a malformed verify/accounting/inventory spec
+// before the document becomes a Config — but they ARE reachable through the
+// public WrapConfig, which takes a hand-built document no loader has seen.
+//
+// That asymmetry is the point: an SDK caller assembling an AICRConfig in Go
+// gets no loader validation, so these branches are its only guard. Pinning
+// them also pins WHERE the check lives. If one ever moved into LoadConfig,
+// the corresponding case here would start returning a nil error and silently
+// hand back options built from an unvalidated value.
+func TestConfig_ErrorBranches_ReachableThroughWrapConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec appconfig.Spec
+		call func(*Config) error
+	}{
+		{
+			name: "BundleVerifyOptions rejects an invalid minTrustLevel",
+			spec: appconfig.Spec{
+				Verify: &appconfig.VerifySpec{
+					Policy: &appconfig.VerifyPolicySpec{MinTrustLevel: "sorta-trusted"},
+				},
+			},
+			call: func(c *Config) error {
+				_, err := c.BundleVerifyOptions()
+				return err
+			},
+		},
+		{
+			name: "RecipeResolveOptions rejects an invalid accounting mode",
+			spec: appconfig.Spec{
+				Recipe: &appconfig.RecipeSpec{
+					Configuration: &appconfig.RecipeConfigurationSpec{
+						Slurm: &appconfig.SlurmConfigurationSpec{
+							Accounting: &appconfig.SlurmAccountingSpec{Mode: "sometimes"},
+						},
+					},
+				},
+			},
+			call: func(c *Config) error {
+				_, err := c.RecipeResolveOptions()
+				return err
+			},
+		},
+		{
+			name: "RecipeResolveOptions rejects an invalid runtimeInventory mode",
+			spec: appconfig.Spec{
+				Recipe: &appconfig.RecipeSpec{
+					Configuration: &appconfig.RecipeConfigurationSpec{
+						RuntimeInventory: &appconfig.RuntimeInventorySpec{Mode: "maybe"},
+					},
+				},
+			},
+			call: func(c *Config) error {
+				_, err := c.RecipeResolveOptions()
+				return err
+			},
+		},
+		{
+			name: "RecipeAccountingMode rejects an invalid accounting mode",
+			spec: appconfig.Spec{
+				Recipe: &appconfig.RecipeSpec{
+					Configuration: &appconfig.RecipeConfigurationSpec{
+						Slurm: &appconfig.SlurmConfigurationSpec{
+							Accounting: &appconfig.SlurmAccountingSpec{Mode: "sometimes"},
+						},
+					},
+				},
+			},
+			call: func(c *Config) error {
+				_, _, err := c.RecipeAccountingMode()
+				return err
+			},
+		},
+		{
+			name: "EvidenceAttestationOptions propagates a malformed spec.validate",
+			spec: appconfig.Spec{
+				Validate: &appconfig.ValidateSpec{
+					Execution: &appconfig.ValidateExecutionSpec{
+						Phases: []string{"deploymnt"},
+					},
+					Evidence: &appconfig.EvidenceSpec{
+						Attestation: &appconfig.EvidenceAttestationSpec{Out: "./evidence"},
+					},
+				},
+			},
+			call: func(c *Config) error {
+				_, _, err := c.EvidenceAttestationOptions()
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.call(WrapConfig(&appconfig.AICRConfig{Spec: tt.spec}))
+			if err == nil {
+				t.Fatal("accepted an invalid value from an unvalidated document; " +
+					"WrapConfig bypasses the loader, so this branch is the only guard")
+			}
+			if !stderrors.Is(err, errors.New(errors.ErrCodeInvalidRequest, "")) {
+				t.Errorf("error = %v, want code %v", err, errors.ErrCodeInvalidRequest)
+			}
+		})
+	}
+}

--- a/pkg/client/v1/config_test.go
+++ b/pkg/client/v1/config_test.go
@@ -398,7 +398,12 @@ func TestConfig_RawAccessors(t *testing.T) {
 		t.Errorf("RecipeAccountingMode = %q, want disabled", mode)
 	}
 
-	// Both values present means the options form must carry both.
+	// Both values present means the options form must carry both. This
+	// package cannot see WHAT they carry — RecipeResolveOption is an opaque
+	// func, so a count is the most an external test can assert, and a count
+	// passes while a value is swapped or emptied. The folded values are
+	// pinned in TestConfig_RecipeResolveOptions_FoldsValuesNotJustCount,
+	// which applies them against the internal capture struct.
 	opts, err := cfg.RecipeResolveOptions()
 	if err != nil {
 		t.Fatalf("RecipeResolveOptions: %v", err)
@@ -1179,6 +1184,170 @@ func TestConfig_SnapshotAgentConfig_OSIsParsed(t *testing.T) {
 		}
 		if _, err := cfg.SnapshotAgentConfig(); err == nil {
 			t.Fatal("SnapshotAgentConfig accepted an undocumented OS value")
+		}
+	})
+}
+
+const evidenceAttestationConfig = `apiVersion: aicr.run/v1beta1
+kind: AICRConfig
+metadata:
+  name: test
+spec:
+  validate:
+    evidence:
+      attestation:
+        out: ./evidence
+        bom: ./sbom.cdx.json
+        push: ghcr.io/example/evidence:run-1
+        plainHTTP: true
+        insecureTLS: true
+`
+
+// TestConfig_EvidenceAttestationOptions covers the five fields that project
+// and, just as importantly, the four that must NOT: Commit and OIDCResolve are
+// per-invocation, and NoSign/Full are command-line-only because both weaken a
+// run and a checked-in file must not be able to do that silently.
+func TestConfig_EvidenceAttestationOptions(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, evidenceAttestationConfig))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	opts, ok, err := cfg.EvidenceAttestationOptions()
+	if err != nil {
+		t.Fatalf("EvidenceAttestationOptions: %v", err)
+	}
+	if !ok {
+		t.Fatal("reported not configured, but the document sets attestation.out")
+	}
+
+	if opts.OutDir != "./evidence" {
+		t.Errorf("OutDir = %q, want ./evidence", opts.OutDir)
+	}
+	if opts.BOMPath != "./sbom.cdx.json" {
+		t.Errorf("BOMPath = %q, want ./sbom.cdx.json", opts.BOMPath)
+	}
+	if opts.Push != "ghcr.io/example/evidence:run-1" {
+		t.Errorf("Push = %q, want ghcr.io/example/evidence:run-1", opts.Push)
+	}
+	if !opts.PlainHTTP {
+		t.Error("PlainHTTP = false, want true")
+	}
+	if !opts.InsecureTLS {
+		t.Error("InsecureTLS = false, want true")
+	}
+
+	// The un-projected half. NoSign and Full staying false is a control, not
+	// an oversight: a document that could flip either would weaken signing or
+	// redaction without showing up as a flag in the run's command line.
+	if opts.NoSign {
+		t.Error("NoSign = true, but it has no spec counterpart and must stay command-line-only")
+	}
+	if opts.Full {
+		t.Error("Full = true, but it has no spec counterpart and must stay command-line-only")
+	}
+	if opts.Commit != "" {
+		t.Errorf("Commit = %q, want empty; it names the running binary, not the document", opts.Commit)
+	}
+	if opts.OIDCResolve.IdentityToken != "" {
+		t.Error("OIDCResolve.IdentityToken populated; a signing token is a secret " +
+			"and must never come from a version-controlled document")
+	}
+}
+
+// TestConfig_EvidenceAttestationOptions_OutIsTheGate pins the spec's own rule:
+// out enables the path, and an out-less section stays off no matter how much
+// else is filled in. Without the gate a document that set only `push` would
+// derive ok=true and hand EmitRecipeEvidence an empty OutDir, turning a
+// half-written section into an ErrCodeInvalidRequest at emit time instead of a
+// clean "not configured".
+func TestConfig_EvidenceAttestationOptions_OutIsTheGate(t *testing.T) {
+	t.Parallel()
+
+	const outless = `apiVersion: aicr.run/v1beta1
+kind: AICRConfig
+metadata:
+  name: test
+spec:
+  validate:
+    evidence:
+      attestation:
+        push: ghcr.io/example/evidence:run-1
+        plainHTTP: true
+`
+	cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, outless))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	opts, ok, err := cfg.EvidenceAttestationOptions()
+	if err != nil {
+		t.Fatalf("EvidenceAttestationOptions: %v", err)
+	}
+	if ok {
+		t.Error("reported configured with an empty out; the spec says out is the enable gate")
+	}
+	if opts != (aicr.EvidenceOptions{}) {
+		t.Errorf("opts = %+v, want the zero value when not enabled", opts)
+	}
+}
+
+// TestConfig_EvidenceAttestationOptions_Absent covers every route to "no
+// attestation configured": no document, no spec.validate, and a spec.validate
+// with no evidence section. All three must be a quiet false, not an error —
+// the CLI derives unconditionally, before it knows whether --config was given.
+func TestConfig_EvidenceAttestationOptions_Absent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
+		var cfg *aicr.Config
+		_, ok, err := cfg.EvidenceAttestationOptions()
+		if err != nil {
+			t.Fatalf("EvidenceAttestationOptions on nil Config: %v", err)
+		}
+		if ok {
+			t.Error("reported configured for a nil Config")
+		}
+	})
+
+	t.Run("no spec.validate", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, recipeConfig))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		_, ok, err := cfg.EvidenceAttestationOptions()
+		if err != nil {
+			t.Fatalf("EvidenceAttestationOptions: %v", err)
+		}
+		if ok {
+			t.Error("reported configured for a document with no spec.validate")
+		}
+	})
+
+	t.Run("spec.validate without evidence", func(t *testing.T) {
+		t.Parallel()
+		const noEvidence = `apiVersion: aicr.run/v1beta1
+kind: AICRConfig
+metadata:
+  name: test
+spec:
+  validate:
+    execution:
+      timeout: 5m
+`
+		cfg, err := aicr.LoadConfig(context.Background(), writeConfig(t, noEvidence))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		_, ok, err := cfg.EvidenceAttestationOptions()
+		if err != nil {
+			t.Fatalf("EvidenceAttestationOptions: %v", err)
+		}
+		if ok {
+			t.Error("reported configured for a spec.validate with no evidence section")
 		}
 	})
 }

--- a/pkg/client/v1/stability_test.go
+++ b/pkg/client/v1/stability_test.go
@@ -522,6 +522,11 @@ func TestStability_Config(t *testing.T) {
 	requireSignature[func(*aicr.Config) (aicr.BundleOptions, error)]((*aicr.Config).BundleOptions)
 	requireSignature[func(*aicr.Config) ([]aicr.ValidateOption, error)]((*aicr.Config).ValidateOptions)
 	requireSignature[func(*aicr.Config) (*aicr.AgentConfig, error)]((*aicr.Config).SnapshotAgentConfig)
+	// The bool is load-bearing, not decoration: it separates "the document
+	// declined the bundle" from "the document fumbled it", which a zero
+	// EvidenceOptions alone cannot express. Dropping it would compile at every
+	// call site that ignores it.
+	requireSignature[func(*aicr.Config) (aicr.EvidenceOptions, bool, error)]((*aicr.Config).EvidenceAttestationOptions)
 	requireSignature[func(*aicr.Config) string]((*aicr.Config).RecipeProfile)
 	requireSignature[func(*aicr.Config) (string, bool, error)]((*aicr.Config).RecipeAccountingMode)
 	requireSignature[func(*aicr.Config) (aicr.RecipeSourceOption, bool)]((*aicr.Config).RecipeSource)


### PR DESCRIPTION
## Summary

Adds `Config.EvidenceAttestationOptions()`, the derivation for
`spec.validate.evidence.attestation`, and clears the three review nits deferred
from #2243.

## Motivation / Context

#2538 landed the last of the three facade derivations (slices 1-3 of #2245).
This picks up the pieces that were scoped into #2245 but not delivered with
them: the evidence derivation the `spec.validate` breakdown calls for, and the
three nits the issue folds in "because they are cheaper to do alongside this
work than on their own".

Also corrects a docs table row from #2538 that claimed `SnapshotAgentConfig()`
reads `spec.snapshot.output`. It does not, and the godoc plus the detailed
section both say so explicitly — the summary table was the only place that
disagreed.

Fixes: N/A
Related: #2245, #2243, #2538

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [x] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK facade (`pkg/client/v1`)

## Implementation Notes

**Why `EvidenceAttestationOptions()` and not `EvidenceOptions()`.**
`spec.validate.evidence` carries two kinds — `cncf` and `attestation` — and
`EvidenceOptions` maps only to the attestation half. There is no facade entry
point that emits CNCF AI Conformance evidence, so a method named for the whole
section would advertise coverage it does not have. Naming it for the half it
carries also leaves room for an `EvidenceCNCFOptions()` later without a
breaking rename.

**Why it returns a `bool`.** `out` is the enable gate, matching
`EvidenceAttestationSpec.Out`'s own contract: an empty `out` leaves the path off
even when the other fields are populated. `EmitRecipeEvidence` rejects an empty
`OutDir` with `ErrCodeInvalidRequest`, so a zero-value `EvidenceOptions` alone
could not tell a caller whether the document declined the bundle or fumbled it.
The `bool` separates the two; a malformed section is still an error.

**Four fields stay caller-owned, and two of them are a control, not a gap.**
`Commit` names the running binary and `OIDCResolve` is a short-lived secret the
spec deliberately excludes. `NoSign` and `Full` are command-line-only for the
same reason as `IgnoreTLog` and `failOnError`: both *weaken* a run, and a
checked-in file that can silently disable signing is a supply-chain downgrade
no reviewer would see in a diff. That reasoning is in the godoc so it does not
get "fixed" later.

**Known duplication.** `buildRecipeEvidenceConfig` (`pkg/cli/validate_evidence.go`)
still maps the same five fields inline. Migrating it is slice 4's job, which
#2245 defers on purpose; the coupling is noted in the godoc so a change to one
prompts a look at the other.

**Nits from #2243:**

1. `pkg/cli/root.go` now logs the concrete `directory` on the `spec.recipe.data`
   branch, as the `--data` branch already did. Read from the same
   `Recipe().DataDir()` accessor `RecipeSource()` uses, so the two cannot
   disagree. Deliberately did *not* add a `Config.RecipeDataDir()` accessor for
   this — new SDK surface for a log line is the wrong trade this close to the
   freeze, and slice 4 is the right place to revisit it.
2. `TestConfig_RawAccessors` could only count opaque options. The folded values
   are now asserted in a new internal test that applies them against
   `recipeResolveConfig`. Uses `customer-managed` + `enabled` rather than
   `disabled` twice, since both enums accept `disabled` and a same-value fixture
   would not catch a swap.
3. The `WrapConfig`-reachable error branches on `BundleVerifyOptions`,
   `RecipeResolveOptions`, and `RecipeAccountingMode` now have a table-driven
   test asserting `ErrCodeInvalidRequest`, with the new derivation covered by
   the same table.

## Testing

```bash
make qualify
golangci-lint run -c .golangci.yaml ./pkg/client/v1/... ./pkg/cli/...
go test -race ./pkg/client/v1/... ./pkg/cli/...
```

`make qualify` passes. `api-diff` reports `(*Config).EvidenceAttestationOptions: added`
under **Compatible changes**, with "No incompatible SDK facade or transparent-alias
target changes since v0.20.0" — the new surface is purely additive. `openapi-diff`
reports 0 breaking changes. golangci-lint: 0 issues. Race tests pass on both
changed packages.

Coverage, measured against `origin/main` via a baseline worktree:

- `pkg/client/v1`: 84.1% → **84.4%** (+0.3%)
- `pkg/cli`: 75.8% → **75.8%** (0.0%)

`EvidenceAttestationOptions` is at 100% statement coverage.

The new tests were mutation-checked rather than assumed: removing the `out`
gate fails `TestConfig_EvidenceAttestationOptions_OutIsTheGate`, and swapping
`BOMPath`/`Push` fails `TestConfig_EvidenceAttestationOptions`.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Purely additive to the SDK facade — one new method, no
signature or behavior changes to existing surface, confirmed by `api-diff`
against `v0.20.0`. The only behavior change outside `pkg/client/v1` is one
additional `slog` key on an existing INFO line. N/A for migration.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
