### PR TITLE
docs(sdk): scope the evidence-options security rationale to the artifact

### DIFF
--- a/docs/integrator/go-library.md
+++ b/docs/integrator/go-library.md
@@ -888,8 +888,8 @@ derive step rather than the load step.
 | `BundleVerifyOptions()` | `spec.verify.policy` + `spec.verify.trust` |
 | `BundleOptions()` | `spec.bundle.deployment` + `spec.bundle.scheduling` + `spec.bundle.attestation` |
 | `ValidateOptions()` | `spec.validate.execution` + the agent fields the validator accepts as options |
-| `SnapshotAgentConfig()` | `spec.snapshot.agent` + `.execution` (**not** `.output`) |
 | `EvidenceAttestationOptions()` | `spec.validate.evidence.attestation` (**not** `.cncf`) |
+| `SnapshotAgentConfig()` | `spec.snapshot.agent` + `.execution` (**not** `.output`) |
 | `RecipeSource()` | `spec.recipe.data` |
 | `RecipeCriteria(reg)` | `spec.recipe.criteria` |
 | `RecipeResolveOptions()` | `spec.recipe.profile`, `spec.recipe.configuration.slurm.accounting.mode`, `spec.recipe.configuration.runtimeInventory.mode` |
@@ -1426,7 +1426,40 @@ rest of `EvidenceOptions` stays yours, and the reasons differ:
 |---|---|
 | `Commit` | Names the running binary, not the document. It selects the validator catalog the bundle's BOM is built against. Set it after deriving. |
 | `OIDCResolve` | Excluded by the spec itself. A keyless-signing identity token is a short-lived secret and must not sit in a version-controlled file; resolve it at sign time. |
-| `NoSign`, `Full` | Command-line-only, for the same reason as `IgnoreTLog` and `failOnError`. Both **weaken** a run — `NoSign` pushes an unsigned bundle, `Full` ships unredacted payloads — and a checked-in file that can silently disable signing is a supply-chain downgrade no reviewer would see in a diff. |
+| `NoSign`, `Full` | Command-line-only, for the same reason as `IgnoreTLog` and `failOnError`. Both weaken the **artifact** — `NoSign` pushes an unsigned bundle, `Full` ships unredacted payloads — and a checked-in file that can silently disable signing is a supply-chain downgrade no reviewer would see in a diff. |
+
+**Why `plainHTTP` and `insecureTLS` project anyway.** They weaken a run too, so
+the rule above is not "config may never weaken anything" — stated that broadly
+it would be contradicted by two of the five fields that do project. The line is
+the *artifact* versus the *hop*.
+
+Both configure the transport to a registry the same document already names in
+`push`. A document trusted to choose the destination is trusted to describe how
+to reach it, which is why `EvidenceOptions` and `SignOptions` carry these while
+the bundler's own options do not — `MakeBundle` never reaches a registry (see
+[`spec.bundle.registry`](#what-bundleoptions-does-and-does-not-carry)).
+
+Neither field changes what the bundle attests or whether it is signed, and that
+is structural rather than a promise: both reach only the OCI transport, never
+the Fulcio/Rekor signing call and never predicate or redaction construction.
+
+How the subject digest is pinned differs by path, and neither path reads it back
+from the weakened hop. Emit-and-push binds the digest computed locally while
+packaging, before any push begins. Signing an already-pushed artifact
+(`aicr evidence sign`) resolves the digest at pull time instead, but the pull is
+content-addressed and the materialized digest is checked for equality against
+the value the original packaging run recorded, failing closed on mismatch.
+
+So a tampered hop can corrupt or break the transfer; it cannot make the
+signature vouch for content that was never packaged.
+
+That is narrower than "harmless". A committed `plainHTTP` or `insecureTLS` does
+weaken that hop, and it widens the threat model rather than just restating it:
+redirecting `push` needs a malicious document, whereas downgrading TLS on a
+destination the operator believes is protected only needs someone on the
+network path. It is accepted because the destination is already the document's
+call. Treat it as a reviewable transport decision, not as evidence that
+excluding `NoSign` and `Full` is arbitrary.
 
 **`spec.validate.evidence.cncf` is not projected**, and this one is a genuine
 gap rather than a decision. There is no `Client.Emit*` that consumes

--- a/pkg/client/v1/config.go
+++ b/pkg/client/v1/config.go
@@ -587,11 +587,48 @@ func (c *Config) ValidateOptions() ([]ValidateOption, error) {
 //     token is a short-lived secret and must not live in a version-controlled
 //     file. The caller resolves it at sign time.
 //   - NoSign and Full are command-line-only, for the same reason FailOnError
-//     and IgnoreTLog are. Both WEAKEN a run — NoSign pushes an unsigned
-//     bundle, Full ships unredacted payloads — and a checked-in file that can
+//     and IgnoreTLog are. Both weaken the ARTIFACT: NoSign pushes an unsigned
+//     bundle, Full ships unredacted payloads. A checked-in file that can
 //     quietly turn off signing is a supply-chain downgrade no reviewer would
-//     see in a diff. Adding spec fields for them would close a "gap" that is
-//     actually a control.
+//     see in a diff, so adding spec fields for them would close a "gap" that
+//     is actually a control.
+//
+// # Why plainHTTP and insecureTLS project anyway
+//
+// They weaken a run too, so the NoSign rule above is not "config may never
+// weaken anything" — stated that broadly it would be contradicted by the two
+// fields three lines into the return below. The line is the ARTIFACT versus
+// the HOP.
+//
+// PlainHTTP and InsecureTLS configure the transport to a registry the same
+// document already names in push. A document trusted to choose the push
+// destination is trusted to describe how to reach it, which is why
+// EvidenceOptions and SignOptions carry these at all while the bundler's own
+// options do not — MakeBundle never reaches a registry.
+//
+// Neither field changes what the bundle attests or whether it is signed, and
+// that is structural rather than a promise: both reach only the OCI transport,
+// never SignStatement's Fulcio/Rekor call and never predicate or redaction
+// construction.
+//
+// How the subject digest is pinned differs by path, and neither path reads it
+// back from the weakened hop. Emit-and-push binds the digest computed locally
+// while packaging, before any push begins. Signing an already-pushed artifact
+// resolves the digest at pull time instead, but the pull is content-addressed
+// and the materialized digest is checked for equality against the value the
+// original packaging run recorded, failing closed on mismatch.
+//
+// So a tampered hop can corrupt or break the transfer; it cannot make the
+// signature vouch for content that was never packaged.
+//
+// That is a narrower claim than "harmless". A committed plainHTTP or
+// insecureTLS does weaken that hop, and it widens the threat model rather than
+// just restating it: redirecting push needs a malicious document, whereas
+// downgrading TLS on a destination the operator believes is protected only
+// needs someone on the network path. It is accepted here because the
+// destination is already the document's call. Treat it as a reviewable
+// transport decision, not as evidence that excluding NoSign and Full is
+// arbitrary.
 //
 // # spec.validate.evidence.cncf is NOT projected
 //


### PR DESCRIPTION
## Summary

Corrects the security rationale on `Config.EvidenceAttestationOptions()`, added
in #2542, which asserted a blanket rule the same function contradicts four lines
later.

## Motivation / Context

#2542's godoc justified keeping `NoSign`/`Full` un-derived with a general
principle: both "WEAKEN a run", and a checked-in file that weakens a run is a
supply-chain downgrade. The same function projects `PlainHTTP` and `InsecureTLS`
from that same committed document, and those weaken a run too. So the stated
boundary was not the boundary the code implements.

Found by running the five-lens review process retroactively on #2542 after it
merged. `make qualify`, golangci-lint, `-race`, coverage and mutation testing
all passed on that PR and none of them can catch a rationale that contradicts
its own function body.

Fixes: N/A
Related: #2542, #2245

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [x] Docs/examples (`docs/`, `examples/`)
- [x] Other: SDK facade godoc (`pkg/client/v1`)

## Implementation Notes

**No behavior change.** Comments and markdown only. The config-settable
`plainHTTP`/`insecureTLS` capability is inherited unchanged from
`EvidenceAttestationSpec` and the CLI's existing mapping; this PR corrects what
the docs claim about it.

**The distinction the rationale now draws** is the artifact versus the hop.
`NoSign`/`Full` alter the artifact's own trust properties and stay
command-line-only. `plainHTTP`/`insecureTLS` configure transport to a registry
the same document already names in `push`, which is why `EvidenceOptions` carries
them while the bundler's options do not — `MakeBundle` never reaches a registry.
This connects to the rationale already stated for `spec.bundle.registry`
(go-library.md line ~921), which the #2542 section failed to reference.

**Two claims are now stated as structural facts, and both were source-traced
rather than asserted:**

1. `PlainHTTP`/`InsecureTLS` reach only the OCI transport — never
   `SignStatement`'s Fulcio/Rekor call, never predicate or redaction
   construction.
2. Neither path reads the subject digest back from the weakened hop.
   Emit-and-push binds the digest computed locally during packaging, before any
   push begins (`pkg/oci/push.go`, `pkg/oci/reference.go`). Signing an
   already-pushed artifact resolves it at pull time instead
   (`SignExistingOptions.Artifact`, "resolved at pull time"), but the pull is
   content-addressed and cross-checked for equality at
   `pkg/evidence/verifier/fetch.go:183-187`, which fails closed.

The second point is deliberately split by path. An earlier draft of this PR
stated the local-packaging mechanism as covering both, which is false for the
`aicr evidence sign` leg — the end security property holds there, but via a
different mechanism.

**Also states the residual risk rather than implying safety.** A committed
`plainHTTP`/`insecureTLS` does weaken that hop, and it widens the threat model:
redirecting `push` needs a malicious document, whereas downgrading TLS on a
destination the operator believes is protected only needs someone on the network
path.

**Declined, recorded here rather than silently:** the text says
"`EvidenceOptions` and `SignOptions` carry these". No type named `SignOptions`
actually carries those fields — the real ones are `EvidencePublishOptions` (SDK)
and `SignExistingOptions` (CLI). But that shorthand is pre-existing at
`go-library.md:921`, `bundle.go:83` and `config.go:353`; correcting it only in
the new sentence would leave three existing uses inconsistent. Worth a separate
cleanup.

One table row also moves: `EvidenceAttestationOptions()` now sits with the other
`spec.validate.*` derivation instead of after the `spec.snapshot.*` row, matching
the order of the "does and does not carry" subsections below it.

## Testing

```bash
go build ./...
golangci-lint run -c .golangci.yaml ./pkg/client/v1/...
go test ./pkg/client/v1/...
make check-docs-mdx check-docs-mdx-parse
```

All pass. No test changes: the diff is comments and markdown, so there is no new
behavior to cover and coverage is unchanged.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Comments and markdown only; no code paths, signatures, or
generated artifacts change. N/A for migration.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, comments and markdown only
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`) — [GPG signing info](https://docs.github.com/en/authentication/managing-commit-signature-verification)
