### PR TITLE
fix(ci): refresh helm-diff checksums for v3.15.12

### DIFF
--- a/.settings.yaml
+++ b/.settings.yaml
@@ -97,10 +97,10 @@ testing_tools:
   # The darwin_* keys name GOOS (matching the sibling blocks); upstream labels
   # those release assets "macos".
   helm_diff_checksums:
-    linux_amd64: 'ed54aa5a14a51a6e44cf8ab6020aaa9e56779b4d33bc2adf07abea6b240a5e7c'
-    linux_arm64: '1c38c487ec348fe5ef2b10c61deddff79f0fa5bfbab762b302874578e6dc2d2c'
-    darwin_amd64: '833e1054d0cfe28bbd6f2edc4c1d5b786968b7732f8df6fe99b67c3bf12bf7bb'
-    darwin_arm64: 'ba489cc4a5998ad259fbc18c454f2319da26ba4c8f469e7acb587a07e61072cd'
+    linux_amd64: '977f92cd82269585a3ee7744d646462142333bb0be573fd8be0c983973175fc7'
+    linux_arm64: 'c3d240d4b284b57b6ab76bbfe47ac84edbf0de239f15c4ff759152fa2b7777f8'
+    darwin_amd64: 'b0f836ad0ca146f896d0da16ffd03bde4d414cd2e2920b11455cd551f3adf933'
+    darwin_arm64: 'cb9e5b6cb157e17bc70ca0f719635914fa9c39e89b82d67a0b78c4538632b580'
   # renovate: datasource=github-releases depName=helmfile/helmfile depType=testing_tools
   helmfile: 'v1.7.4'
   # helmfile_checksums are refreshed automatically by tools/update-helmfile-checksums


### PR DESCRIPTION
## Summary

Refreshes the four `testing_tools.helm_diff_checksums` values in `.settings.yaml` to the real v3.15.12 SHA256 digests. #2539 bumped the pin to v3.15.12 but left the v3.15.11 checksums, so every helm-diff install verified the new tarball against the old digest and aborted.

## Motivation / Context

`main` cannot complete a UAT install phase today. UAT AWS bringup on `main` reaches "Install AICR bundle" and dies verifying the helm-diff plugin:

```
checksum mismatch: got 977f92cd82269585a3ee7744d646462142333bb0be573fd8be0c983973175fc7
```

That is not a corrupt download — it is the correct v3.15.12 digest being compared against v3.15.11's `ed54aa5a…`. This blocks the nightly install phase and any `lifecycle=daytime-up` hold from `main`, since daytime-up tears the cluster down when a phase fails.

Regenerated with the repo's own tool:

```bash
tools/update-helm-diff-checksums v3.15.12
```

The refreshed `linux_amd64` value matches the digest the failing runner computed byte-for-byte, which confirms the upstream tarball is intact and only the pin was stale.

Root cause worth a follow-up: the Renovate `postUpgradeTasks` hook that exists precisely to prevent this is configured for `databus23/helm-diff` in `.github/renovate.json5`, but it did not run on #2539. Until that is understood, the sibling `helmfile` and `chainsaw` checksum blocks can drift the same way on their next bump. Not fixed here — this PR only unblocks `main`.

Fixes: N/A
Related: #2539

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.settings.yaml` tool pins (UAT / bundle install path)

## Implementation Notes

Generated, not hand-edited. `tools/update-helm-diff-checksums` refuses to write checksums for any release other than the one pinned in `.settings.yaml`, fetches the upstream `helm-diff_3.15.12_checksums.txt`, rewrites only the four lines inside the `helm_diff_checksums:` block, and then verifies both that each key took the new value and that no helm-diff digest leaked into the sibling `chainsaw_checksums` / `helmfile_checksums` blocks. No other key in `.settings.yaml` changes.

## Testing

```bash
tools/update-helm-diff-checksums v3.15.12   # idempotent; re-run yields no diff
make lint                                    # pass
make tuning-check license-check api-diff openapi-diff   # pass
make test-coverage                           # see note below
```

- `make lint` — clean: 0 golangci-lint issues, yamllint, license headers, agents sync, docs filename/MDX gates, chart-version pins.
- `api-diff` — no incompatible SDK facade or transparent-alias target changes since v0.20.0.
- `openapi-diff` — 0 breaking changes to the REST contract.
- `tuning-check`, `license-check` — pass.
- `make test-coverage` — all packages pass except `TestHelmPinnedVersionExplicitVersionPull`, which asserts the *locally installed* helm binary equals the pin (`installed v4.2.3, want v4.2.4`). That is local toolchain drift on my machine, independent of this change; CI runs the pinned toolchain.
- `e2e` and `scan` were not run locally (no Docker daemon available); both run in CI.

No Go source changed, so the coverage-delta gate does not apply.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Four data-only lines. Wrong values fail closed and loudly (checksum mismatch at plugin install), which is exactly the symptom being fixed — so a mistake here cannot pass silently. Reverting restores the current broken state, nothing worse.

**Rollout notes:** None. Takes effect on the next helm-diff install; no migration, flag, or compatibility concern.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — one pre-existing local-toolchain failure noted above
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, no new functionality
- [ ] I updated docs if user-facing behavior changed — N/A, no user-facing behavior change
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
