### PR TITLE
fix(testgrid): derive renamed GCS bucket for testgrid-publish

### DIFF
--- a/.github/workflows/testgrid-publish.yml
+++ b/.github/workflows/testgrid-publish.yml
@@ -31,11 +31,13 @@
 # Auth:
 #   WIF pool:  aicr-testgrid[-<env>]-github   (aicr-testgrid Terraform)
 #   SA:        aicr-testgrid[-<env>]-publish@<project>
-#   Scope:     objectCreator on gs://aicr-testgrid[-<env>]/groups/ prefix only
+#   Scope:     objectCreator on gs://dgxc-aicr-testgrid[-<env>]/groups/ prefix only
 #   For prod, <env> is empty (cluster_name = "aicr-testgrid", unsuffixed);
-#   for staging, <env> = "staging". This mirrors terraform/variables.tf and
-#   wif-publish.tf in the aicr-testgrid repo exactly — verify there before
-#   changing the naming logic in "Resolve GCP config" below.
+#   for staging, <env> = "staging". Buckets are named dgxc-<cluster> (renamed
+#   for the eidosx → nv-testgrid migration; GCS names are globally unique).
+#   This mirrors terraform/variables.tf in the testgrid repo
+#   (dgxcloud/release-automation/testgrid, aicr/terraform) — verify there
+#   before changing the naming logic in "Resolve GCP config" below.
 #
 # Configuration (GitHub repo variables — no secrets in source):
 #   vars.TESTGRID_PUBLISH_ENABLED   'true' to enable (see gate above)
@@ -129,14 +131,18 @@ jobs:
           else
             CLUSTER="aicr-testgrid-${TG_ENV}"
           fi
+          # Buckets were renamed for the eidosx → nv-testgrid migration
+          # (dgxc- prefix family, alongside dgxc-testgrid); clusters keep
+          # their names.
+          BUCKET="dgxc-${CLUSTER}"
           {
             echo "cluster=${CLUSTER}"
-            echo "bucket=${CLUSTER}"
+            echo "bucket=${BUCKET}"
             echo "wif_provider=projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${CLUSTER}-github/providers/github-actions"
             echo "wif_sa=${CLUSTER}-publish@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
           } >> "${GITHUB_OUTPUT}"
           # Note: `environment` is fully encoded in `bucket` (bucket ==
-          # cluster == aicr-testgrid[-<env>]) and is not passed to
+          # dgxc-aicr-testgrid[-<env>]) and is not passed to
           # testgrid-publish separately — the tool only needs --bucket.
 
       - name: Load versions

--- a/.github/workflows/testgrid-publish.yml
+++ b/.github/workflows/testgrid-publish.yml
@@ -31,9 +31,9 @@
 # Auth:
 #   WIF pool:  aicr-testgrid[-<env>]-github   (aicr-testgrid Terraform)
 #   SA:        aicr-testgrid[-<env>]-publish@<project>
-#   Scope:     objectCreator on gs://dgxc-aicr-testgrid[-<env>]/groups/ prefix only
+#   Scope:     objectCreator on gs://nv-aicr-testgrid[-<env>]/groups/ prefix only
 #   For prod, <env> is empty (cluster_name = "aicr-testgrid", unsuffixed);
-#   for staging, <env> = "staging". Buckets are named dgxc-<cluster> (renamed
+#   for staging, <env> = "staging". Buckets are named nv-<cluster> (renamed
 #   for the eidosx → nv-testgrid migration; GCS names are globally unique).
 #   This mirrors terraform/variables.tf in the testgrid repo
 #   (dgxcloud/release-automation/testgrid, aicr/terraform) — verify there
@@ -134,7 +134,7 @@ jobs:
           # Buckets were renamed for the eidosx → nv-testgrid migration
           # (dgxc- prefix family, alongside dgxc-testgrid); clusters keep
           # their names.
-          BUCKET="dgxc-${CLUSTER}"
+          BUCKET="nv-${CLUSTER}"
           {
             echo "cluster=${CLUSTER}"
             echo "bucket=${BUCKET}"
@@ -142,7 +142,7 @@ jobs:
             echo "wif_sa=${CLUSTER}-publish@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
           } >> "${GITHUB_OUTPUT}"
           # Note: `environment` is fully encoded in `bucket` (bucket ==
-          # dgxc-aicr-testgrid[-<env>]) and is not passed to
+          # nv-aicr-testgrid[-<env>]) and is not passed to
           # testgrid-publish separately — the tool only needs --bucket.
 
       - name: Load versions

--- a/.github/workflows/testgrid-publish.yml
+++ b/.github/workflows/testgrid-publish.yml
@@ -131,9 +131,10 @@ jobs:
           else
             CLUSTER="aicr-testgrid-${TG_ENV}"
           fi
-          # Buckets were renamed for the eidosx → nv-testgrid migration
-          # (dgxc- prefix family, alongside dgxc-testgrid); clusters keep
-          # their names.
+          # Buckets were renamed for the eidosx → nv-testgrid migration:
+          # nv-aicr-testgrid[-<env>] (nv- prefix, NVIDIA-neutral — the old
+          # aicr-testgrid[-<env>] names stay in eidosx). Clusters keep their
+          # names.
           BUCKET="nv-${CLUSTER}"
           {
             echo "cluster=${CLUSTER}"


### PR DESCRIPTION
## Why

The AICR TestGrid buckets are renamed `aicr-testgrid[-<env>]` → `nv-aicr-testgrid[-<env>]` for the migration from the `eidosx` GCP project to `nv-testgrid-20260305173754` (GCS bucket names are globally unique; renaming avoids a delete/recreate name-release race at cutover. The `nv-` prefix is NVIDIA-neutral — AICR TestGrid is OSS/public-facing, not DGXC). Migration plan: `plan-aicr-testgrid-migration.md` in dgxcloud/release-automation/testgrid (GitLab MR !116); Jira NKX-15605 / epic NKX-11656.

Clusters, WIF pool/provider/SA IDs, and the TG5 trust policy are unchanged — only the bucket derivation changes. At cutover, the `GCP_PROJECT_ID` / `GCP_PROJECT_NUMBER` repo variables flip to the new project (no other workflow change).

The evidence workflows (`evidence-ingest`, `evidence-dashboard-publish`, `results/` prefix) are **not** part of the move — they stay in eidosx and are deliberately untouched here.

## What

`testgrid-publish.yml` "Resolve GCP config": `bucket = nv-<cluster>` (prod → `nv-aicr-testgrid`, staging → `nv-aicr-testgrid-staging`), plus matching header-comment updates.

## Verification

- Full `make qualify` passes locally (exit 0): all 118 test packages incl. race detector, lint (golangci-lint v2.13.1 pinned), lint-yaml, license-check, chainsaw e2e, grype scan (no blocking vulns), api-diff, openapi-diff
- Commits are SSH-signed + DCO sign-off
- Draft: merges only inside the migration cutover window (after the new buckets exist and data is copied)
