### PR TITLE
ci: skip the hourly Rekor monitor in forks

### DIFF
--- a/.github/workflows/rekor-monitor.yaml
+++ b/.github/workflows/rekor-monitor.yaml
@@ -133,6 +133,10 @@ env:
 jobs:
   monitor:
     name: AICR release identity + log consistency (Rekor v2)
+    # Upstream only: forks that enable Actions would otherwise run this hourly,
+    # burning minutes and going red (no checkpoint history, no release identity
+    # to monitor) and opening alert/degraded issues in the fork.
+    if: github.repository == 'nvidia/aicr'
     runs-on: ubuntu-latest
     # Backstop the per-pass context timeout in the tool (defaultTimeout, 45m):
     # the job is killed if a network stall somehow outlives it. Sized so the


### PR DESCRIPTION
## Summary

Add a repository guard (`if: ${{ github.repository == 'NVIDIA/aicr' }}`) to the `monitor` job in `rekor-monitor.yaml` so the hourly Rekor v2 transparency-log monitor only runs in the upstream repository, not in forks.



## Motivation / Context

Any fork that enables GitHub Actions inherits this hourly schedule. In a fork the job can only fail, there is no checkpoint history, and the fork has no release identity to monitor, so it burns Actions minutes every hour, keeps the fork's
Actions tab permanently red, and can open alert/degraded issues inside the fork. Every other scheduled workflow in the repo (`stale.yaml`, `vuln-scan.yaml`, `vuln-scan-images.yaml`, `issue-report.yaml`, `lock-threads.yaml`, ...) already carries this guard; this brings `rekor-monitor.yaml` in line.

It spams also the mailbox with:
<img width="436" height="284" alt="image" src="https://github.com/user-attachments/assets/2f65d58c-8bc0-47aa-acc5-de25c2932e54" />


Fixes: N/A
Related: N/A

## Type of Change

- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: CI workflows (`.github/workflows/rekor-monitor.yaml`)

## Implementation Notes

- Job-level `if:` rather than a step-level guard, matching the pattern used by
  the repo's other scheduled workflows — in forks the job shows as *skipped*
  instead of failing.
- The guard also skips `workflow_dispatch` runs in forks, consistent with the
  peer workflows.
- Upstream behavior is unchanged: the hourly schedule, classification branching,
  and issue/Slack notification paths are untouched.

## Testing

```bash
yamllint .github/workflows/rekor-monitor.yaml   # passes, no findings
