### PR TITLE
docs(catalog): add agentgateway upgrade guidance for operators

### DIFF
--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -340,6 +340,30 @@ aicr bundle -r recipe.yaml \
 
 This setting filters by source IP only; it does not add TLS or authentication to the gateway listener.
 
+### Upgrading agentgateway across breaking releases
+
+AICR pins the `agentgateway` and `agentgateway-crds` charts in `recipes/registry.yaml`, and a pin bump can cross an upstream release that documents breaking changes. What that means for you depends entirely on whether you author your own agentgateway resources.
+
+**AICR-generated bundles are unaffected.** AICR creates exactly two agentgateway resources: an `AgentgatewayParameters` carrying deployment and service shape only (`loadBalancerSourceRanges`, `nodeSelector`, `tolerations`, labels), and the `inference-gateway` `Gateway` itself. It ships no `AgentgatewayPolicy`, `AgentgatewayBackend`, or `AgentgatewayModel`, and no `HTTPRoute`. Upstream breaking changes to JWT claim enforcement, LLM token accounting, policy merging, cross-namespace route delegation, managed API-key metadata, and Istio identity all land on that unconfigured surface, so a regenerated bundle does not carry them.
+
+**Resources you author yourself are your responsibility.** If you have applied your own `AgentgatewayPolicy` or `AgentgatewayBackend` against an AICR-deployed gateway — to add authentication, rate limiting, prompt guarding, or model routing — those objects sit outside AICR's managed set. AICR can neither detect nor migrate them, and an upstream breaking change can silently alter their behavior when you apply a bundle built on a newer pin.
+
+Before adopting a bundle that bumps the agentgateway pin:
+
+1. Check whether you have any agentgateway resources AICR did not create:
+
+   ```shell
+   kubectl get agentgatewaypolicies,agentgatewaybackends,agentgatewaymodels -A
+   ```
+
+   If that returns nothing, the upgrade needs no action from you.
+
+2. If it returns anything, read the [upstream release notes](https://github.com/agentgateway/agentgateway/releases) for every version between your current pin and the new one, and validate those resources in a non-production cluster first.
+
+Check the pinned version for any release with `aicr query --selector components.agentgateway.version`, and see [Component Version Matrix](component-version-matrix.md) for the per-release history.
+
+**Note on validation coverage:** AICR's CI exercises fresh installs of the pinned chart, not in-place upgrades from an older pin. A green release validates that the new version deploys and passes health checks; it does not certify an in-place upgrade of an existing cluster.
+
 ### Exposure guardrails
 
 AICR enforces and surfaces inference-gateway exposure in two places:

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -373,16 +373,35 @@ Before adopting a bundle that bumps the agentgateway pin:
 1. Check whether you have any agentgateway resources AICR did not create. Ask the cluster which kinds exist rather than naming them, since the set grows across chart versions — `AgentgatewayModel`, for one, only exists from chart v1.4.0 onward, and naming it explicitly makes the command fail on older pins:
 
    ```shell
-   for kind in $(kubectl api-resources --api-group=agentgateway.dev -o name); do
-     kubectl get "$kind" -A
+   kinds=$(kubectl api-resources --api-group=agentgateway.dev -o name) || exit 1
+   for kind in $kinds; do
+     kubectl get "$kind" -A || exit 1
    done
    ```
 
-   AICR's own `AgentgatewayParameters` named `system-proxy` in `agentgateway-system` is expected in that output. If nothing else appears, the upgrade needs no action from you.
+   The `|| exit 1` guards matter: if an aggregated APIService is unhealthy — a down metrics-server or custom-metrics adapter, and `prometheus-adapter` is in AICR's own component set — `kubectl api-resources` exits non-zero and the substitution yields an empty list. Without the guard the loop body would never run and the check would report clean, which is the dangerous direction for a check whose whole purpose is to find something. Empty output *plus* an error means retry, not clear.
 
-2. If it returns anything, read the [upstream release notes](https://github.com/agentgateway/agentgateway/releases) for every version between your current pin and the new one, and validate those resources in a non-production cluster first.
+   AICR's own `AgentgatewayParameters` named `system-proxy` in `agentgateway-system` is expected. Anything else is yours.
 
-Check the pinned version for any release with `aicr query --selector components.agentgateway.version`, and see [Component Version Matrix](component-version-matrix.md) for the per-release history.
+2. Check for routes you attached to the AICR gateway. These live in the Gateway API group rather than `agentgateway.dev`, so the previous step does not see them — and they are exactly what the cross-namespace route delegation change affects:
+
+   ```shell
+   kubectl get httproutes,grpcroutes -A \
+     -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PARENTS:.spec.parentRefs[*].name' || exit 1
+   ```
+
+   Any row whose `PARENTS` names `inference-gateway` is a route you authored against the AICR gateway.
+
+3. If either step returns anything of yours, read the [upstream release notes](https://github.com/agentgateway/agentgateway/releases) for every version between your current pin and the new one, and validate those resources in a non-production cluster first.
+
+To see the pinned version for a release, query a recipe that includes the component — `agentgateway` is only present in inference recipes, so the criteria must resolve one:
+
+```shell
+aicr query --service eks --accelerator h100 --intent inference \
+  --selector components.agentgateway.version
+```
+
+`aicr query` rejects a command with no criteria, so the selector alone is not enough. See [Component Version Matrix](component-version-matrix.md) for the per-release history.
 
 **Note on validation coverage:** AICR's CI exercises fresh installs of the pinned chart, not in-place upgrades from an older pin. A green release validates that the new version deploys and passes health checks; it does not certify an in-place upgrade of an existing cluster.
 

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -344,7 +344,9 @@ This setting filters by source IP only; it does not add TLS or authentication to
 
 From agentgateway chart v1.5.0 the controller's write permissions are scoped by `rbac.gatewayNamespaces`, and AICR sets it to `agentgateway-system` — the single namespace it provisions the `inference-gateway` Gateway in.
 
-This matters if you add a Gateway of your own. Leaving the list empty is the chart's default and binds the controller's write role (Deployments, DaemonSets, Secrets, ServiceAccounts, ConfigMaps, Services, HPAs, PDBs) with a *ClusterRoleBinding*, giving a network-facing controller write access in every namespace — enough to create a privileged DaemonSet on every node. Scoping it costs nothing for AICR's own topology, so AICR scopes it.
+This matters if you add a Gateway of your own. Leaving the list empty is the chart's default and binds the controller's write role (Deployments, DaemonSets, Secrets, ServiceAccounts, ConfigMaps, Services, HPAs, PDBs) with a *ClusterRoleBinding*, so a network-facing controller can create and modify those objects, and read every Secret, in **every namespace on the cluster**. Scoping the list narrows that to the namespaces you name, which costs nothing for AICR's own topology.
+
+Be precise about what the scoping does and does not buy. It reduces the blast radius to a namespace set; it does not remove the node-wide primitive, because the role still grants `daemonsets` and a DaemonSet created in a permitted namespace still schedules pods onto every node. Scoping is worth doing — an unscoped binding also exposes Secrets cluster-wide — but treat the controller's namespace as privileged rather than as contained.
 
 The consequence is that **only Gateways in the listed namespaces are provisioned**. A Gateway you place in another namespace is accepted by the API server but never gets an address: the controller cannot create its Deployment or Service there, so the failure is silent apart from `forbidden` errors in the controller log. Note this is about where the *Gateway* lives — routes are unaffected, and `HTTPRoute`s in any namespace may still attach to the AICR gateway.
 
@@ -354,6 +356,15 @@ To place additional Gateways, add their namespaces:
 aicr bundle -r recipe.yaml \
   --set-json agentgateway:rbac.gatewayNamespaces='["agentgateway-system","my-gateways"]'
 ```
+
+**Before upgrading an existing cluster onto a scoped pin, inventory the Gateways you already have.** A Gateway that works today under the chart's unscoped default will stop reconciling once the list is scoped and its namespace is not on it — the controller loses write on the generated Deployment, Service, Secret and ServiceAccount, and the Gateway reports a failed reconciliation:
+
+```shell
+kubectl get gateways.gateway.networking.k8s.io -A \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,CLASS:.spec.gatewayClassName' || exit 1
+```
+
+Every namespace holding a Gateway with `CLASS: agentgateway` must appear in the list, not just `agentgateway-system`.
 
 Two constraints on that edit:
 

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -350,13 +350,15 @@ AICR pins the `agentgateway` and `agentgateway-crds` charts in `recipes/registry
 
 Before adopting a bundle that bumps the agentgateway pin:
 
-1. Check whether you have any agentgateway resources AICR did not create:
+1. Check whether you have any agentgateway resources AICR did not create. Ask the cluster which kinds exist rather than naming them, since the set grows across chart versions — `AgentgatewayModel`, for one, only exists from chart v1.4.0 onward, and naming it explicitly makes the command fail on older pins:
 
    ```shell
-   kubectl get agentgatewaypolicies,agentgatewaybackends,agentgatewaymodels -A
+   for kind in $(kubectl api-resources --api-group=agentgateway.dev -o name); do
+     kubectl get "$kind" -A
+   done
    ```
 
-   If that returns nothing, the upgrade needs no action from you.
+   AICR's own `AgentgatewayParameters` named `system-proxy` in `agentgateway-system` is expected in that output. If nothing else appears, the upgrade needs no action from you.
 
 2. If it returns anything, read the [upstream release notes](https://github.com/agentgateway/agentgateway/releases) for every version between your current pin and the new one, and validate those resources in a non-production cluster first.
 

--- a/docs/user/component-catalog.md
+++ b/docs/user/component-catalog.md
@@ -340,6 +340,26 @@ aicr bundle -r recipe.yaml \
 
 This setting filters by source IP only; it does not add TLS or authentication to the gateway listener.
 
+### Which namespaces the controller may provision Gateways in
+
+From agentgateway chart v1.5.0 the controller's write permissions are scoped by `rbac.gatewayNamespaces`, and AICR sets it to `agentgateway-system` — the single namespace it provisions the `inference-gateway` Gateway in.
+
+This matters if you add a Gateway of your own. Leaving the list empty is the chart's default and binds the controller's write role (Deployments, DaemonSets, Secrets, ServiceAccounts, ConfigMaps, Services, HPAs, PDBs) with a *ClusterRoleBinding*, giving a network-facing controller write access in every namespace — enough to create a privileged DaemonSet on every node. Scoping it costs nothing for AICR's own topology, so AICR scopes it.
+
+The consequence is that **only Gateways in the listed namespaces are provisioned**. A Gateway you place in another namespace is accepted by the API server but never gets an address: the controller cannot create its Deployment or Service there, so the failure is silent apart from `forbidden` errors in the controller log. Note this is about where the *Gateway* lives — routes are unaffected, and `HTTPRoute`s in any namespace may still attach to the AICR gateway.
+
+To place additional Gateways, add their namespaces:
+
+```shell
+aicr bundle -r recipe.yaml \
+  --set-json agentgateway:rbac.gatewayNamespaces='["agentgateway-system","my-gateways"]'
+```
+
+Two constraints on that edit:
+
+- **The namespaces must already exist.** The chart creates a `RoleBinding` in each one, and naming a namespace that has not been created yet fails the install.
+- **Use `--set-json`, not `--set`.** The key is a list; a plain `--set agentgateway:rbac.gatewayNamespaces=my-gateways` writes a bare string and the chart's `range` over it fails at render. This is the same list-versus-string trap described for `allowedSourceRanges` above.
+
 ### Upgrading agentgateway across breaking releases
 
 AICR pins the `agentgateway` and `agentgateway-crds` charts in `recipes/registry.yaml`, and a pin bump can cross an upstream release that documents breaking changes. What that means for you depends entirely on whether you author your own agentgateway resources.


### PR DESCRIPTION
## Summary

Adds two operator-facing sections to `docs/user/component-catalog.md`:

- **Which namespaces the controller may provision Gateways in** — what `rbac.gatewayNamespaces` scoping means for anyone adding a Gateway of their own.
- **Upgrading agentgateway across breaking releases** — what an agentgateway pin bump means, and how to tell whether you are exposed.

## Motivation / Context

AICR pins the `agentgateway` and `agentgateway-crds` charts in `recipes/registry.yaml`, and a pin bump can cross an upstream release that documents breaking changes — v1.4.0 and v1.5.0 between them document ten, covering JWT claim enforcement, LLM token accounting, policy merging, cross-namespace route delegation, managed API-key metadata, Istio identity, Gateway API/TCPRoute, MCP guardrails, standalone auth, and musl images.

Nothing in the product told operators how to reason about that. The gap matters asymmetrically:

- **AICR-generated bundles are unaffected.** AICR creates exactly two agentgateway resources — an `AgentgatewayParameters` carrying deployment and service shape only, and the `inference-gateway` `Gateway`. It ships no `AgentgatewayPolicy`, `AgentgatewayBackend`, `AgentgatewayModel`, or `HTTPRoute`, so every one of those breaking changes lands on surface AICR never populates.
- **Resources a user authors themselves are exposed**, and AICR can neither detect nor migrate them. That case had no warning anywhere.

Related: #2587 — bumps the `agentgateway` / `agentgateway-crds` pin from v1.3.1 to v1.5.0 (and scopes the controller's RBAC). This PR is the operator-facing documentation for what a bump like that means; #2587 is the bump. They touch disjoint files, so there is no conflict and **either can merge first**.

## Type of Change

- [x] Documentation update

## Component(s) Affected

- [x] Docs/examples (`docs/`, `examples/`)

## Implementation Notes

**Gateway namespace scoping.** From chart v1.5.0 the controller's write permissions are scoped by `rbac.gatewayNamespaces`, which #2587 sets to `agentgateway-system`. That is a user-visible behavior change with a silent failure mode — only Gateways in the listed namespaces are provisioned, and one placed elsewhere is accepted by the API server but never gets an address, with `forbidden` in the controller log as the only signal. The section records why the chart's empty default is unsafe (it binds the write role with a `ClusterRoleBinding`, giving a network-facing controller cluster-wide write including DaemonSets and Secrets), how to add namespaces, and the two constraints that make the naive edit fail: the namespaces must already exist, and the key is a list so it needs `--set-json` rather than `--set`.

This documentation lives here rather than in #2587 deliberately. The repo dismisses approvals on any push, so adding docs to #2587 after it is approved would dismiss that approval and force a second review cycle; keeping #2587 code-only lets it be approved and merged in one pass.

**Merge after #2587.** Both sections describe behavior that only exists once the v1.5.0 pin lands — `rbac.gatewayNamespaces` does not exist on the current v1.3.1 chart. The prose is written to name the version it applies from, but landing this after #2587 keeps the docs from describing a setting the repo does not yet use.


Written against pin bumps **generally** rather than v1.3.1 to v1.5.0 specifically, so it stays accurate at the next bump instead of aging into a dated changelog entry. It contains no hardcoded chart version and no dependency on #2587.

The section gives operators a detection command that discovers the kinds from the cluster rather than naming them:

```shell
for kind in $(kubectl api-resources --api-group=agentgateway.dev -o name); do
  kubectl get "$kind" -A
done
```

Discovery matters for correctness, not elegance. The API group grows across chart versions — `AgentgatewayModel` only exists from chart v1.4.0 onward — so naming the kinds explicitly would make the command fail with `the server doesn't have a resource type` on exactly the clusters that still run an older pin, which are the readers who most need to run it. Written this way it is correct on both sides of a bump. The loop is used instead of `xargs -r` because `-r` is GNU-only and silently differs on macOS.

AICR's own `AgentgatewayParameters` named `system-proxy` in `agentgateway-system` is expected in the output. Anything else is operator-authored, and means reading the upstream release notes for every version between the pins and validating off-production first.

It also records that AICR CI exercises fresh installs of a pinned chart, not in-place upgrades from an older pin — so a green release validates that the new version deploys and passes health checks, and is not an in-place upgrade certification.

## Testing

Docs-only. Per the repo's doc-only verification allowance, full `make qualify` was not run — no Go, recipe, or CI-config change can regress from prose. Checks run:

- `yamllint docs/` — clean
- Verified the one relative link target exists (`docs/user/component-version-matrix.md`)
- Verified the detection command's premise directly against the pulled charts: `agentgateway-crds` v1.3.1 ships three CRDs and v1.5.0 ships four, confirming `AgentgatewayModel` would break an explicitly-named command on the older pin
- Heading follows the `## Documentation Style` conventions: promoted to `###` under an existing `##` section, with more than eight content lines beneath it

The lychee link check runs in CI on any PR touching `docs/**` and is the authoritative check for the link.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

Prose only; no generated artifact, schema, or recipe is touched.

**Rollout notes:** None.

## Checklist

- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)


