### PR TITLE
fix(recipes): address VR200/RKE2 review follow-ups from #2520

### DIFF
--- a/pkg/bundler/testdata/stock_render_golden.yaml
+++ b/pkg/bundler/testdata/stock_render_golden.yaml
@@ -53,5 +53,5 @@ rtx-pro-6000-eks-ubuntu-inference-nim: 81f7308abb7628788f5f7f626af054fb4765fddf8
 rtx-pro-6000-eks-ubuntu-training-kubeflow: c8146f390263bf71386f21c5eb6efabce5a383dab998d62899ed771044fc7cb6
 rtx-pro-6000-lke-ubuntu-inference: 520fa8a7383145371581f39406eac0963b31b2d5f1e09718c3b11ab344f6473f
 rtx-pro-6000-lke-ubuntu-training: 9eede0962d1bd0a6e3a2c42f7efb917a5476c82523ecf5c27d8ce49387b09a75
-vr200-rke2-ubuntu-inference-dynamo: f6cd42e3f71e299b38762a8c444f240864ba8e08b34befe7ba023ded69c034a4
+vr200-rke2-ubuntu-inference-dynamo: 3f85546c437465d3fb5a094960942dee95d40556077ebf159e83bc8ad2bd8610
 vr200-rke2-ubuntu-training: 427f9c015c4af5b2faa3560fc1e8acf7e4b57de3897f611da91e8112b534c9f4

--- a/recipes/components/agentgateway-crds/manifests/tlsroute-crd.yaml
+++ b/recipes/components/agentgateway-crds/manifests/tlsroute-crd.yaml
@@ -1,8 +1,8 @@
 # TLSRoute CRD (Gateway API v1.2.1 experimental channel)
 # Source: https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml
-# Required by agentgateway v2.2.1 on RKE2: TLSRoute is not part of the
+# Required by agentgateway on RKE2: TLSRoute is not part of the
 # "standard" Gateway API channel vendored in gateway-api-crds.yaml, but
-# agentgateway v2.2.1's compiled watch requires it, serving v1alpha2. RKE2
+# agentgateway's compiled watch requires it, serving v1alpha2. RKE2
 # ships no LoadBalancer/Traefik-independent source for this CRD, so it is
 # vendored separately here rather than pulled in via the full experimental
 # bundle (which would also install backendlbpolicies, backendtlspolicies,

--- a/recipes/overlays/vr200-rke2-ubuntu-inference.yaml
+++ b/recipes/overlays/vr200-rke2-ubuntu-inference.yaml
@@ -184,6 +184,12 @@ spec:
     # while another is still rebooting for RDMA. Explicit Preview risk
     # acceptance — sequence deliberately on a live cluster. Tracked in
     # NVIDIA/aicr#2572.
+    #
+    # Node targeting also differs between the two: --accelerated-node-selector
+    # reaches the tuning CR but not dranet or rdma-netns-exclusive, which
+    # hardcode nodeSelector nvidia.com/gpu.present. Identical on the
+    # NFD-labeled reference clusters; only diverges if you narrow the GPU node
+    # set. See vr200-rke2-ubuntu-training for the full note.
     - name: nodewright-customizations
       type: Helm
       manifestFiles:

--- a/recipes/overlays/vr200-rke2-ubuntu-training.yaml
+++ b/recipes/overlays/vr200-rke2-ubuntu-training.yaml
@@ -163,6 +163,16 @@ spec:
     # lifecycle operations. Tracked in NVIDIA/aicr#2572, which carries the
     # pinned-v0.18 source trace and the candidate fixes (merge both packages
     # into one Skyhook CR vs. sequencing: "all" plus a dependency edge).
+    #
+    # Node targeting differs between the two rebooting CRs, which matters if
+    # you narrow the GPU node set. nodewright-customizations declares
+    # nodeScheduling.accelerated, so --accelerated-node-selector flows into
+    # the tuning CR; dranet and rdma-netns-exclusive declare no scheduling
+    # block and hardcode nodeSelector nvidia.com/gpu.present in their
+    # manifests, so those flags bypass them. On the NFD-labeled reference
+    # clusters all three agree and nothing changes. Narrow the selector and
+    # the tuning reboot retargets to the subset while the RDMA reboot and
+    # DraNet still fan out to every gpu.present node.
     # Health check override: the operator Deployment's name depends on how
     # nodewright got installed, and both paths are real here. The VR
     # reference clusters carry an out-of-band install (hand-written values,

--- a/validators/performance/nccl_test.go
+++ b/validators/performance/nccl_test.go
@@ -914,9 +914,17 @@ func TestNVLSRuntimeYAMLReferencesIMEXClaim(t *testing.T) {
 	// creates via buildComputeDomain. If these drift, the DRA driver
 	// generates one name and the worker pods reference another, and
 	// pod admission fails with an opaque "claim not found" error.
-	paths := []string{
-		filepath.Join("testdata", "gb200", "eks", "runtime-nvls.yaml"),
-		filepath.Join("testdata", "gb200", "oke", "runtime-nvls.yaml"),
+	// Derived by globbing rather than listed, so a new accelerator/service
+	// runtime is covered the moment its template lands. An explicit list
+	// silently excludes anything added later, which is how vr200/rke2 was
+	// left uncovered when it was introduced.
+	paths, err := filepath.Glob(filepath.Join("testdata", "*", "*", "runtime-nvls.yaml"))
+	if err != nil {
+		t.Fatalf("glob runtime-nvls templates: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no runtime-nvls.yaml templates found — the glob matched nothing, " +
+			"so this guard would pass without checking anything")
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {


### PR DESCRIPTION
## Summary

**Follow-up to #2520.** Addresses the three bounded review findings from that PR's approval; the fourth is deliberately left to an issue (see below).

## Motivation / Context

#2520 merged with a multi-persona review reporting 0 blockers and 0 majors, plus two 🟡 Minors and a 🔵 Nitpick explicitly called "safe-to-defer polish." This PR clears them while they are still fresh, rather than leaving them to rot in a merged PR's thread.

Follow-up to: #2520
Related: #2572, #2587

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Component(s) Affected

- [x] Recipe engine / data (`pkg/recipe`)
- [x] Validator (`pkg/validator`, `validators/performance`)

## Implementation Notes

**Stale v2.2.1 provenance** (`tlsroute-crd.yaml`). The header still credited "agentgateway v2.2.1" as the reason the CRD is vendored. Those were the last `v2.2.1` strings in the tree after #2520 dropped the pins, and the risk is not cosmetic — a maintainer trusting that provenance could revert the registry toward the v2.2.x line, which still declares 39 unbounded `rule: matches(self, ...)` CEL rules that a Kubernetes 1.37 apiserver rejects. That is precisely the breakage #2587 fixed and #2520's pin-drop preserved. The line-1 "Gateway API v1.2.1 experimental channel" reference is the CRD's own upstream source and is left alone.

**Drift guard did not cover vr200/rke2** (`validators/performance/nccl_test.go`). `TestNVLSRuntimeYAMLReferencesIMEXClaim` listed `gb200/eks` and `gb200/oke` explicitly, so the `vr200/rke2` runtime added in #2520 was never checked. That guard exists because a name mismatch between the template and `ncclIMEXClaimTemplateName` produces an opaque "claim not found" pod-admission failure rather than a test failure — so a mistyped name would pass every unit test and surface only on live VR hardware.

Rather than appending one path, the set is now derived by glob, so the next accelerator or service is covered the moment its template lands. A zero-match guard fails the test if the glob matches nothing, so it cannot pass while checking nothing. The guard now runs three subtests where it ran two.

**Node targeting differs between the rebooting CRs** (both VR200 leaves). `nodewright-customizations` declares `nodeScheduling.accelerated`, so `--accelerated-node-selector` flows into the tuning Skyhook CR; `dranet` and `rdma-netns-exclusive` declare no scheduling block and hardcode `nodeSelector: nvidia.com/gpu.present`, so those flags bypass them. On the NFD-labeled reference clusters all three selectors agree and nothing changes — it only diverges when an operator narrows the GPU node set, at which point the tuning reboot retargets to the subset while the RDMA reboot and DraNet still fan out to every `gpu.present` node. Documented in the caveat that already discusses the reboots, rather than templating the selectors, which would be a behavior change beyond this PR's scope.

## Deliberately not addressed here

The review's remaining nitpick — that tuning evidence is `status: complete`-only, so the three documented-inert `nvidia-tuned` settings ride as no-ops while evidence records "tuning applied" — is not in this PR. It touches `recipes/checks/nodewright-customizations/health-check.yaml`, which neither #2520 nor this PR modifies, and the fix is an AICR-side effective-state assertion rather than a comment. The reviewer framed it as a tracking-issue item gating GA, and it belongs with the other Preview-to-GA conditions in #2572 rather than expanding this diff.

The two-Skyhook concurrent-reboot hazard is likewise out of scope and remains tracked in #2572.

## Testing

```bash
go test ./validators/performance/ ./pkg/recipe/... ./pkg/bundler/
golangci-lint run -c .golangci.yaml ./validators/performance/...
make update-goldens
yamllint recipes/overlays/
```

All pass; `golangci-lint` reports 0 issues. `TestNVLSRuntimeYAMLReferencesIMEXClaim` now covers `gb200/eks`, `gb200/oke` and `vr200/rke2` — three subtests where it previously ran two.

The render golden moved for `vr200-rke2-ubuntu-inference-dynamo` only, and the cause is the CRD header rather than the overlays: `tlsroute-crd.yaml` is copied verbatim into the bundle through `rke2-inference.yaml`'s `manifestFiles`, so its header comment is part of the rendered bytes. The overlay comment edits do not move any golden — the YAML loader parses those away. That also accounts for the asymmetry: `vr200-rke2-ubuntu-inference-dynamo` is the only leaf in the chain that pulls `tlsroute-crd.yaml`, so a one-line delta is both correct and complete.

`TestCatalogParityGolden`, the BOM freshness tests, and the registry inventory are unchanged, which is expected — resolution records which values file a component points at rather than its content, and the BOM renders chart templates rather than vendored manifests.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert

Two comment-only edits and one test-coverage widening. No recipe behavior, pin, or generated artifact semantics change.

**Rollout notes:** None.

## Checklist

- [x] Tests pass locally
- [x] Linter passes
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — widened the IMEX drift guard
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

