### PR TITLE
fix(ci): enable Argo CD server-side diff for k8s 1.37 KWOK lanes

### DIFF
--- a/kwok/scripts/install-infra.sh
+++ b/kwok/scripts/install-infra.sh
@@ -406,10 +406,18 @@ install_argocd() {
     # "true" in the `argocd-cmd-params-cm` ConfigMap — `configs.params` is a
     # stringly-typed map and the chart's `tpl` step drops bool-typed values,
     # which would leave the API server without `--insecure`.
+    #
+    # `controller.diff.server.side=true` makes the API server compute the merge
+    # rather than the controller's compiled-in schema. Chart 9.5.x predates
+    # Kubernetes 1.37 and so does not declare
+    # `CSIDriver.spec.preventPodSchedulingIfMissing`, which the 1.37 API server
+    # defaults onto the live object; without server-side diff every Argo CD lane
+    # fails comparison on aws-ebs-csi-driver (#2602).
     if ! hc upgrade --install "${ARGOCD_RELEASE}" "${ARGOCD_REPO_NAME}/argo-cd" \
             --namespace "${ARGOCD_NAMESPACE}" --create-namespace \
             --version "${chart_version}" \
             --set-string 'configs.params.server\.insecure=true' \
+            --set-string 'configs.params.controller\.diff\.server\.side=true' \
             --wait --timeout "${ARGOCD_HELM_TIMEOUT}"; then
         log_error "Argo CD Helm install failed"
         dump_argocd_diagnostics


### PR DESCRIPTION
## Summary

Enable Argo CD's server-side diff in the KWOK harness so the application
controller compares state using the API server's schema instead of its own
compiled-in one.

## Motivation / Context

Every KWOK lane that syncs through Argo CD has been failing since the bump to
`kindest/node:v1.37.0` (#2583). Kubernetes 1.37 adds
`preventPodSchedulingIfMissing` to `CSIDriver.spec`
(`k8s.io/api@v0.37.0/storage/v1/types.go:508`, beta behind the
`VolumeLimitScaling` gate). The 1.37 API server defaults the field onto the live
object, but the pinned Argo CD chart `9.5.14` (app `v3.4.2`, released
2026-05-13) predates 1.37 and its diff schema does not declare the field, so
building a typed value from the live resource fails:

```
Failed to compare desired state to live state: failed to calculate diff:
error calculating structured merge diff: error building typed value from live resource:
.spec.preventPodSchedulingIfMissing: field not declared in schema
```

The `aws-ebs-csi-driver` Application then reports `sync: Unknown` with a
`ComparisonError` — while `operation` is `successfully synced (all tasks run)`,
i.e. the sync works and only the comparison is broken — which fails
`assert-all-applications-pass` in `tests/chainsaw/kwok/argocd-git-sync`. 28 jobs
fail in the nightly run on `main`
([34078163570](https://github.com/NVIDIA/aicr/actions/runs/34078163570)).

Server-side diff delegates the merge to the API server, so the cluster's own
schema is authoritative and a field newer than Argo CD's bundled schema no
longer breaks comparison.

Fixes: #2602
Related: #2583

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: KWOK test harness (`kwok/scripts/install-infra.sh`)

## Implementation Notes

One `--set-string` alongside the existing `server.insecure`, using the same
escaping and string-typing rationale already documented in that block.

Two alternatives were considered and rejected. Disabling the
`VolumeLimitScaling` feature gate in `kwok/kind-config.yaml` would also stop the
API server defaulting the field, but it would make the test cluster stop
exercising a beta feature that is on by default in the Kubernetes version we
claim to validate against. Bumping `argocd_chart` does not help on its own: the
newest argo-helm release is `argo-cd-9.7.1` (2026-06-26), which also predates
1.37 and would carry the same gap.

This changes how the KWOK lanes diff, not what they assert, and it applies only
to the CI harness — no shipped recipe, chart pin, or product code is touched.

## Testing

```bash
make qualify
shellcheck -x kwok/scripts/install-infra.sh
bash -n kwok/scripts/install-infra.sh

# Confirm the param reaches the ConfigMap the controller reads
helm template argocd argo-cd --repo https://argoproj.github.io/argo-helm \
  --version 9.5.14 \
  --set-string 'configs.params.server\.insecure=true' \
  --set-string 'configs.params.controller\.diff\.server\.side=true'
```

The render confirms the value lands as a literal string and is actually plumbed
through in this chart version, rather than being silently accepted by the
free-form `configs.params` map:

```yaml
# ConfigMap/argocd-cmd-params-cm
data:
  controller.diff.server.side: "true"
  server.insecure: "true"
---
# StatefulSet/argocd-application-controller
- name: ARGOCD_APPLICATION_CONTROLLER_SERVER_SIDE_DIFF
  valueFrom:
    configMapKeyRef:
      name: argocd-cmd-params-cm
      key: controller.diff.server.side
      optional: true
```

`shellcheck` reports only a pre-existing info-level `SC1091` (it cannot resolve
a `source` path built from `${SCRIPT_DIR}`), unrelated to this change.

**Confirmed on this PR.** All 16 Tier 1 KWOK lanes and `KWOK Test Summary` pass,
including `eks-training (argocd-git)` — the exact lane that fails on `main` — and
the `argocd-oci` and `argocd-helm-oci` variants across `eks`, `eks-inference`,
and `eks-training`. Since I could not reproduce a 1.37 API server locally, this
run is the end-to-end evidence that server-side diff resolves the schema error.

Local `make qualify` cleared coverage, `go vet`, `golangci-lint` (0 issues),
license headers, the docs/MDX gates, chart-version pins, tuning-check, and the
BOM, then stopped in `e2e` on a missing local `helmfile` binary
(`cli-bundle-helmfile`: "helmfile binary not found on $PATH"). That is a
workstation tooling gap, not a regression — 8 of 9 e2e tests passed locally, and
`tests / E2E` and `tests / CLI E2E` pass in CI.

No Go source changed, so the coverage gate does not apply.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** CI-only; revert is a one-line removal. If server-side diff
turns out not to resolve the error, the fallback is the `VolumeLimitScaling`
feature-gate route described above.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — e2e's `cli-bundle-helmfile` needs a `helmfile` binary I do not have locally; green in CI
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A, harness config; the KWOK lanes are the test
- [ ] I updated docs if user-facing behavior changed — N/A, no user-facing behavior
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
