### PR TITLE
fix(uat): capture driver-dead GPU nodes (#1860) and MOFED/NCCL crash logs

### DIFF
--- a/tests/uat/lib/collect-debug.sh
+++ b/tests/uat/lib/collect-debug.sh
@@ -72,7 +72,15 @@ CLUSTER_DEBUG_LOG_TAIL="${CLUSTER_DEBUG_LOG_TAIL:-2000}"
 # that fail). Other namespaces still get get/describe/events, just not every log —
 # keeps the bundle focused on the GPU/tuning stack that drives deployment-phase
 # failures. Space-separated; overridable.
-CLUSTER_DEBUG_LOG_NAMESPACES="${CLUSTER_DEBUG_LOG_NAMESPACES:-skyhook gpu-operator nvidia-dra-driver nvsentinel node-feature-discovery kai-scheduler cert-manager monitoring}"
+#
+# nvidia-network-operator (MOFED/DOCA driver-build pods) and aicr-validation (the
+# NCCL launcher/worker + check Jobs) carry the crash logs behind two failure
+# modes the operator namespaces alone cannot explain: an RDMA driver that never
+# reaches .driver-ready, and a CUJ Job that crash-loops to its deadline. Both run
+# NVIDIA/AICR workloads, not third-party tenants; heed the Privacy note above
+# before adding a namespace that runs token-bearing workloads (e.g. a served
+# model), whose logs can carry app-emitted credentials into the public artifact.
+CLUSTER_DEBUG_LOG_NAMESPACES="${CLUSTER_DEBUG_LOG_NAMESPACES:-skyhook gpu-operator nvidia-dra-driver nvidia-network-operator nvsentinel node-feature-discovery kai-scheduler aicr-validation cert-manager monitoring}"
 
 # Cluster-scoped custom resources most relevant to a deployment-phase failure.
 # Skyhook is first: its status.status is the non-monotonic signal the readiness
@@ -175,7 +183,11 @@ capture_skyhook_snapshot() {
 
 # _cd_gpu_driver_state writes a per-GPU-node census of advertised GPUs and, when
 # any GPU node advertises fewer than the cohort max (a capacity shortfall — e.g.
-# an H100 node enumerating 7 of 8 GPUs), captures DRIVER-LEVEL state on each short
+# an H100 node enumerating 7 of 8 GPUs) OR a GPU-marked node advertises none at
+# all (the driver-dead 0/total case, #1860 — invisible to a plain allocatable
+# scan because the resource key is absent, so such a node is identified instead
+# by its GPU taint/label or NVIDIA PCI presence and surfaced as 0), captures
+# DRIVER-LEVEL state on each short
 # node: nvidia-smi -L, per-GPU PCI/serial, the host NVIDIA PCI census, and dmesg
 # NVRM/Xid lines. The Kubernetes API only shows the *symptom* (allocatable count);
 # this exec-based capture — via the privileged on-node nvidia-dcgm pod — is what
@@ -202,15 +214,27 @@ _cd_gpu_driver_state() {
     local ns="${CLUSTER_DEBUG_GPU_NAMESPACE}"
     census="$(_cd_bounded kubectl get nodes -o json 2>/dev/null \
       | jq -r --arg r "${res}" '.items[]
-          | select(.status.allocatable[$r] != null)
-          | "\(.metadata.name) \(.status.allocatable[$r])"' 2>/dev/null)"
+          # A GPU node advertises the resource, OR is marked as GPU hardware by
+          # taint/label while advertising none — the #1860 driver-dead case the
+          # census must still surface (as 0), not silently drop.
+          | select(
+              (.status.allocatable[$r] != null)
+              or (.status.capacity[$r] != null)
+              or (any(.spec.taints[]?; .key == $r))
+              or (.metadata.labels["feature.node.kubernetes.io/pci-10de.present"] == "true")
+            )
+          | "\(.metadata.name) \(.status.allocatable[$r] // "0")"' 2>/dev/null)"
     # NOTE: "cohort max" is computed across ALL GPU nodes, with no per-product /
     # per-pool segmentation. Correct for UAT's homogeneous single-SKU GPU pools;
     # a heterogeneous pool (e.g. a 1-GPU utility node beside 8-GPU workers) would
     # false-flag the smaller node as short. Best-effort diagnostics, so the only
     # cost of a false positive is one extra bounded exec + a marker.
     maxc="$(printf '%s\n' "${census}" | awk '{if($2+0>m)m=$2+0}END{print m+0}')"
-    short="$(printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && $2+0 < m {print $1}')"
+    # Short = below cohort max, OR advertising 0 regardless of max. The `== 0`
+    # arm is #1860: when every GPU node is driver-dead the max is also 0, so a
+    # plain `< max` test would flag nothing; a GPU node advertising 0 is always a
+    # shortfall (it is known GPU hardware, per the census select above).
+    short="$(printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && ($2+0 < m || $2+0 == 0) {print $1}')"
 
     local captured=0
     echo "::group::Collect GPU driver state"
@@ -224,8 +248,8 @@ _cd_gpu_driver_state() {
       fi
       echo
       if [[ -n "${short}" ]]; then
-        echo "----- GPU-count SHORTFALL: node(s) below cohort max ${maxc} -----"
-        printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && $2+0 < m {print "  "$1" advertises "$2"/"m}'
+        echo "----- GPU-count SHORTFALL: node(s) below cohort max ${maxc} (or advertising none) -----"
+        printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && ($2+0 < m || $2+0 == 0) {print "  "$1" advertises "$2"/"m}'
         echo
         # shellcheck disable=SC2086 # intentional word-split of the node list
         for node in ${short}; do
@@ -263,7 +287,7 @@ _cd_gpu_driver_state() {
     if [[ -n "${short}" ]]; then
       {
         echo "GPU-count shortfall @ $(date -u +%Y-%m-%dT%H:%M:%SZ); cohort max=${maxc}"
-        printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && $2+0 < m {print $1" "$2"/"m}'
+        printf '%s\n' "${census}" | awk -v m="${maxc}" 'NF>=2 && ($2+0 < m || $2+0 == 0) {print $1" "$2"/"m}'
       } > "${CLUSTER_DEBUG_DIR}/gpu-shortfall.txt" 2>/dev/null || true
     fi
     exit 0


### PR DESCRIPTION
## Summary

Make the UAT cluster-debug collector surface a *driver-dead* GPU node (advertising zero `nvidia.com/gpu`, not just a 7/8 partial) as a shortfall, and capture the MOFED/DOCA and NCCL crash logs behind the two recurring UAT failure modes.

## Motivation / Context

Two diagnosis gaps kept turning "why did this fail" into a dead end:

1. **`collect-debug.sh` census dropped 0-GPU nodes.** `select(.status.allocatable[$r] != null)` excludes any node advertising no `nvidia.com/gpu`, so a node whose driver never came up — the 0/total case — was never flagged short, and neither the driver-level capture (`nvidia-smi`/PCI/`dmesg`) nor the `gpu-shortfall.txt` marker fired. Only the 7/8 partial case was caught. This is exactly the AKS node that failed to build MOFED (0 GPUs) and the GB200-prep "no nodes advertise" case.
2. **The full-log namespace allowlist omitted the crash sources.** `nvidia-network-operator` (MOFED/DOCA driver-build pods) and `aicr-validation` (NCCL launcher/worker + check Jobs) were not in `CLUSTER_DEBUG_LOG_NAMESPACES`, so the RDMA-driver-never-ready and NCCL-launcher-crash failures could only be inferred from events, never read from the failing container's own logs.

Fixes: #1860
Related: N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: UAT debug collector (`tests/uat/lib/collect-debug.sh`)

## Implementation Notes

- **GPU-node identification** now = advertises the resource **OR** carries the `nvidia.com/gpu` taint **OR** has the NVIDIA-PCI NFD label (`feature.node.kubernetes.io/pci-10de.present`). A non-advertising GPU node is emitted in the census as `0`, and any GPU node at `0` is treated as short **even when the cohort max is also 0** (the all-dead case a plain `< max` test would miss). No false positives on CPU/system nodes (none carry those markers).
- **Allowlist** gains `nvidia-network-operator` and `aicr-validation` — both NVIDIA/AICR workloads, not token-bearing tenants. Deliberately did **not** add `dynamo-workload` (vLLM can emit model/token config into this public-repo artifact — see the collector's Privacy note and CLAUDE.md Secrets section); that decision is tracked separately.
- **Known limitation (follow-up filed):** the driver-level `exec` targets the on-node `nvidia-dcgm` pod, which is often absent on a fully driver-dead node, so the deep `nvidia-smi`/`dmesg` capture may still report "(no on-node nvidia-dcgm pod)". The census + marker now fire regardless, which is the #1860 ask.

## Testing

```bash
shellcheck tests/uat/lib/collect-debug.sh   # clean
bash -n   tests/uat/lib/collect-debug.sh    # parses
```

Unit-tested the census/short jq+awk against four node shapes — healthy (8), taint-only-dead (0), PCI-label-dead (0), and all-dead (max=0) — plus a pure-CPU node: the three GPU cases flag short (all-dead flags both nodes, previously nothing), the CPU node is excluded. `make qualify` not run (shell-only change, no Go/YAML touched).

## Risk Assessment

- [x] **Low** — One best-effort diagnostic script; self-bounding, never fails the run. Widening the census/allowlist only adds capture; the only cost of a mis-identified GPU node is one extra bounded exec + a marker.

**Rollout notes:** Takes effect on the next UAT failure that collects a bundle. N/A migration.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no Go
- [x] Linter passes — shellcheck clean, `bash -n` clean
- [x] I did not skip/disable tests to make CI green
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
