### PR TITLE
fix(recipe): let a profile value tighten a composed constraint

### DIFF
--- a/docs/contributor/validator.md
+++ b/docs/contributor/validator.md
@@ -75,7 +75,8 @@ per-value constraints, which are verified at snapshot-based generation
 (criteria-only generation has no snapshot evaluator and defers entirely
 to the pre-flight) AND re-evaluated by the same readiness pre-flight.)
 
-**Supported operators** (`pkg/constraints/constraint.go`):
+**Supported operators** (`pkg/constraints/expr/expr.go`, re-exported
+from `pkg/constraints`):
 
 | Operator | Use | Notes |
 |----------|-----|-------|
@@ -116,7 +117,7 @@ encodings, unknown service, service with no declared universe label).
 
 **Adding a new operator:**
 
-1. Add an `Operator` constant in `pkg/constraints/constraint.go`.
+1. Add an `Operator` constant in `pkg/constraints/expr/expr.go`.
 2. Insert it in the operator slice in `ParseConstraintExpression` —
    **longest prefix first** (e.g. `~=` before `~`).
 3. Add a `case` arm in `(*ParsedConstraint).Evaluate`. Return an

--- a/docs/design/015-recipe-configuration-profiles.md
+++ b/docs/design/015-recipe-configuration-profiles.md
@@ -4,7 +4,8 @@
 
 **Accepted** — 2026-07-21 (proposed 2026-07-14). Amended
 2026-07-27 to stage the service-agnostic mechanism through an AKS-first,
-GKE-second rollout.
+GKE-second rollout; amended 2026-09-08 (#2512) to intersect, rather than
+reject, a profile constraint that tightens a composed version range.
 
 Originated from an internal GKE device-plugin ownership discussion
 (2026-07-14) and
@@ -488,7 +489,27 @@ to the surviving composition:
    collides with a chain or mixin constraint rejects at resolution —
    constraints don't compose, the same rule `mergeMixins` already
    enforces. Values of one declaration may reuse a constraint name
-   across values (only one is ever selected). Then evaluate
+   across values (only one is ever selected).
+
+   *Amended 2026-09-08
+   ([#2512](https://github.com/NVIDIA/aicr/issues/2512)): version ranges
+   intersect.* The blanket rejection left a value gated on a feature with
+   its own Kubernetes floor — DRA on GKE requires `>= 1.35` — with nowhere
+   to state it. The chain already carries `K8s.server.version`, and raising
+   it there raises it for every value of the declaration, where a later
+   overlay can restate and lower it again. Where the composed expression
+   and the profile's are **both version ranges** — one clause of `>=`, `>`,
+   `<=`, `<` terms — resolution now replaces the composed entry with the
+   intersection of the two, and the profile may only narrow it. Three cases
+   keep failing closed: a candidate that would widen the range is dropped
+   rather than applied; an intersection no version can satisfy is rejected;
+   and a pair with no ordering to intersect — an exact match, `!=`, a
+   node-set label predicate, or an expression carrying `||` alternatives —
+   is rejected as a collision, as are two same-direction bounds written at
+   different precisions, which `pkg/version` compares at the lower of the
+   two so that neither can be called stricter. `mergeMixins` is unchanged.
+
+   Then evaluate
    **profile-contributed constraints** fail-closed: under a
    provided snapshot, a failing profile constraint fails recipe generation
    with the constraint diagnostics — it does not exclude anything or fall
@@ -1353,7 +1374,8 @@ recurrence — the shape the Problem section expects.
     declaration or drop it — external `--data` overlays inheriting the
     converted base need the same review by their owners. The same
     review covers constraint names a value reuses (the mixin collision
-    rule rejects those loudly at resolution).
+    rule rejects those loudly at resolution, except where step 5's
+    amendment intersects two version ranges).
   - **Declaration survival (step 2)**: a snapshot that excludes every
     declaring chain now fails generation instead of silently emitting
     the base configuration.

--- a/docs/design/015-recipe-configuration-profiles.md
+++ b/docs/design/015-recipe-configuration-profiles.md
@@ -501,7 +501,7 @@ to the surviving composition:
    and the profile's are **both version ranges** — one clause of `>=`, `>`,
    `<=`, `<` terms — resolution now replaces the composed entry with the
    intersection of the two, and the profile may only narrow it. Three cases
-   keep failing closed: a candidate that would widen the range is dropped
+   keep failing closed: a candidate that adds no restriction is dropped
    rather than applied; an intersection no version can satisfy is rejected;
    and a pair with no ordering to intersect — an exact match, `!=`, a
    node-set label predicate, or an expression carrying `||` alternatives —

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -697,6 +697,21 @@ Profile declarations are intentionally narrow:
   for later validation. This qualification rule is enforced during catalog
   review; core admission does not infer whether arbitrary readings
   semantically distinguish two modes.
+- A profile constraint may reuse a constraint name the composition already
+  carries **only to tighten it**. Both expressions must be version ranges
+  written as a single clause of `>=`, `>`, `<=`, `<` terms; the composition
+  then takes their intersection, so a chain floor of `>= 1.32` under a value
+  declaring `>= 1.35` resolves to `>= 1.35`, and `>= 1.34.1 < 1.36.0` under
+  `>= 1.35` resolves to `>= 1.35 < 1.36.0`. Use this when a value is gated on
+  a feature with its own floor (DRA on GKE) that the other values do not
+  need. Three cases keep failing closed: a candidate that would widen the
+  range is ignored, an empty intersection is rejected, and any pair that does
+  not order — an exact match, `!=`, a node-set label predicate, or an
+  expression with `||` alternatives — is rejected as a collision. Two
+  same-direction bounds written at different precisions (`>= 1.34` against
+  `>= 1.34.1`) are rejected too, with their own message: versions compare at
+  the lower precision, so those two read as equal and neither can be called
+  stricter. Restate one at the other's precision when you mean to tighten.
 - A profile value may declare `advertiser: external` (the GKE `gke-default`
   shape) to record a provider-managed plugin outside the recipe as THE
   `nvidia.com/gpu` advertiser; the vocabulary is closed (empty or

--- a/docs/integrator/recipe-development.md
+++ b/docs/integrator/recipe-development.md
@@ -704,8 +704,8 @@ Profile declarations are intentionally narrow:
   declaring `>= 1.35` resolves to `>= 1.35`, and `>= 1.34.1 < 1.36.0` under
   `>= 1.35` resolves to `>= 1.35 < 1.36.0`. Use this when a value is gated on
   a feature with its own floor (DRA on GKE) that the other values do not
-  need. Three cases keep failing closed: a candidate that would widen the
-  range is ignored, an empty intersection is rejected, and any pair that does
+  need. Three cases keep failing closed: a candidate that adds no restriction
+  is ignored, an empty intersection is rejected, and any pair that does
   not order — an exact match, `!=`, a node-set label predicate, or an
   expression with `||` alternatives — is rejected as a collision. Two
   same-direction bounds written at different precisions (`>= 1.34` against

--- a/pkg/constraints/expr/expr.go
+++ b/pkg/constraints/expr/expr.go
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package constraints
+// Package expr parses constraint expressions ("<operator> <value>") and
+// evaluates them against a single actual value.
+//
+// It is a leaf package: it depends only on pkg/errors and pkg/version. The
+// parent pkg/constraints imports pkg/recipe for snapshot-aware evaluation,
+// so pkg/recipe cannot import it back; keeping the pure expression grammar
+// here lets both sides share one parser instead of reimplementing it. The
+// parent re-exports every symbol declared here, so external callers keep
+// using pkg/constraints.
+package expr
 
 import (
 	"fmt"

--- a/pkg/constraints/expr/expr.go
+++ b/pkg/constraints/expr/expr.go
@@ -75,7 +75,7 @@ type ParsedConstraint struct {
 // Examples:
 //   - ">= 1.32.4" -> {Operator: ">=", Value: "1.32.4", IsVersionComparison: true}
 //   - "ubuntu" -> {Operator: "", Value: "ubuntu", IsVersionComparison: false}
-//   - "== 24.04" -> {Operator: "==", Value: "24.04", IsVersionComparison: false}
+//   - "== 24.04" -> {Operator: "==", Value: "24.04", IsVersionComparison: true}
 func ParseConstraintExpression(expr string) (*ParsedConstraint, error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {

--- a/pkg/constraints/expr/expr_test.go
+++ b/pkg/constraints/expr/expr_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package constraints
+package expr
 
 import (
 	stderrors "errors"

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -248,7 +248,7 @@ func boundsSatisfiable(lower, upper *bound) bool {
 	if cmp == 0 {
 		return lowAdmitted && highAdmitted
 	}
-	return true
+	return buildsLeaveRoom(low, high, lowAdmitted, highAdmitted)
 }
 
 // limit returns the full-precision version where the bound's half-line ends,
@@ -268,11 +268,19 @@ func (b *bound) limit() (version.Version, bool) {
 		return b.parsed, b.inclusive()
 	}
 
+	// Compare stops at the lower of the two precisions and only reaches the
+	// GKE build dimension once whole numeric cores match, so a bound written
+	// below full precision never has its own suffix consulted when it is
+	// evaluated. Carrying that suffix into the endpoint would invent an
+	// ordering the evaluator does not apply.
+	coarse := b.parsed
+	coarse.Extras = ""
+
 	isLower := b.operator == OperatorGTE || b.operator == OperatorGT
 	if b.operator == OperatorGT || b.operator == OperatorLTE {
-		return bumpLastSignificant(b.parsed), isLower
+		return bumpLastSignificant(coarse), isLower
 	}
-	return atFullPrecision(b.parsed), isLower
+	return atFullPrecision(coarse), isLower
 }
 
 // atFullPrecision returns v with every component significant, so a bound
@@ -295,4 +303,36 @@ func bumpLastSignificant(v version.Version) version.Version {
 	v.Patch = 0
 	v.Precision = fullPrecision
 	return v
+}
+
+// buildsLeaveRoom reports whether two ordered endpoints on the same numeric
+// core leave a GKE build between them.
+//
+// Build numbers are integers and are the finest dimension pkg/version orders,
+// so an open interval between adjacent builds is empty even though the
+// endpoints compare as ordered — nothing sits between -gke.100 and -gke.101.
+// The numeric components need no such treatment: a bare core and the next one
+// always have the -gke.N builds of the first between them.
+//
+// Endpoints that are not both GKE builds on one core have room by ordering
+// alone, so they report true.
+func buildsLeaveRoom(low, high version.Version, lowAdmitted, highAdmitted bool) bool {
+	lowBuild, lowIsGKE := version.ExtractGKEBuild(low.Extras)
+	highBuild, highIsGKE := version.ExtractGKEBuild(high.Extras)
+	if !lowIsGKE || !highIsGKE || !sameCore(low, high) {
+		return true
+	}
+
+	if !lowAdmitted {
+		lowBuild++
+	}
+	if !highAdmitted {
+		highBuild--
+	}
+	return lowBuild <= highBuild
+}
+
+// sameCore reports whether two versions share every numeric component.
+func sameCore(a, b version.Version) bool {
+	return a.Major == b.Major && a.Minor == b.Minor && a.Patch == b.Patch
 }

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -230,10 +230,16 @@ func strongerBound(existing, candidate *bound) (stronger *bound, narrowed, ok bo
 	return existing, false, true
 }
 
-// boundsSatisfiable reports whether some version satisfies both bounds. An
-// open side is always satisfiable; a closed range is empty when the floor
-// sits above the ceiling, or on it with either endpoint excluded. Both
-// endpoints are taken at full precision so the comparison is exact.
+// boundsSatisfiable reports whether some version satisfies both bounds.
+//
+// An open side is always satisfiable. A closed range is decided on the order
+// pkg/version.Compare defines, over full-precision endpoints keyed by their
+// position in it — including the GKE build dimension, where the bare numeric
+// core precedes every build of itself. Working in that order rather than
+// approximating it is what keeps the adjacent cases honest: nothing sits
+// between "-gke.100" and "-gke.101", nor between a bare core and its
+// "-gke.0", while a bare core and the next patch always have builds between
+// them.
 func boundsSatisfiable(lower, upper *bound) bool {
 	if lower == nil || upper == nil {
 		return true
@@ -241,14 +247,19 @@ func boundsSatisfiable(lower, upper *bound) bool {
 	low, lowAdmitted := lower.limit()
 	high, highAdmitted := upper.limit()
 
-	cmp := low.Compare(high)
-	if cmp > 0 {
-		return false
+	// Normalize the floor to the first version it admits, which the discrete
+	// finest dimension always makes representable, and then read the answer
+	// straight off the order.
+	first := versionKeyOf(low)
+	if !lowAdmitted {
+		first = first.next()
 	}
-	if cmp == 0 {
-		return lowAdmitted && highAdmitted
+
+	cmp := first.compare(versionKeyOf(high))
+	if highAdmitted {
+		return cmp <= 0
 	}
-	return buildsLeaveRoom(low, high, lowAdmitted, highAdmitted)
+	return cmp < 0
 }
 
 // limit returns the full-precision version where the bound's half-line ends,
@@ -305,34 +316,59 @@ func bumpLastSignificant(v version.Version) version.Version {
 	return v
 }
 
-// buildsLeaveRoom reports whether two ordered endpoints on the same numeric
-// core leave a GKE build between them.
+// versionKey is a full-precision version's position in the total order
+// pkg/version.Compare defines, as a tuple ordered lexicographically.
 //
-// Build numbers are integers and are the finest dimension pkg/version orders,
-// so an open interval between adjacent builds is empty even though the
-// endpoints compare as ordered — nothing sits between -gke.100 and -gke.101.
-// The numeric components need no such treatment: a bare core and the next one
-// always have the -gke.N builds of the first between them.
-//
-// Endpoints that are not both GKE builds on one core have room by ordering
-// alone, so they report true.
-func buildsLeaveRoom(low, high version.Version, lowAdmitted, highAdmitted bool) bool {
-	lowBuild, lowIsGKE := version.ExtractGKEBuild(low.Extras)
-	highBuild, highIsGKE := version.ExtractGKEBuild(high.Extras)
-	if !lowIsGKE || !highIsGKE || !sameCore(low, high) {
-		return true
-	}
-
-	if !lowAdmitted {
-		lowBuild++
-	}
-	if !highAdmitted {
-		highBuild--
-	}
-	return lowBuild <= highBuild
+// The build component carries the whole GKE dimension. Compare ranks a
+// "-gke.N" build above the bare numeric core it builds on and orders two
+// builds numerically, so ranking a bare core 0 and a build N at N+1
+// reproduces that order exactly. Extras that are not a valid GKE build are
+// never compared, which the same rank of 0 expresses.
+type versionKey struct {
+	major int
+	minor int
+	patch int
+	build int64
 }
 
-// sameCore reports whether two versions share every numeric component.
-func sameCore(a, b version.Version) bool {
-	return a.Major == b.Major && a.Minor == b.Minor && a.Patch == b.Patch
+func versionKeyOf(v version.Version) versionKey {
+	key := versionKey{major: v.Major, minor: v.Minor, patch: v.Patch}
+	if build, isGKE := version.ExtractGKEBuild(v.Extras); isGKE {
+		key.build = build + 1
+	}
+	return key
+}
+
+// next returns the version immediately after k. The build component is a
+// non-negative integer and is the finest dimension ordered, so every key has
+// an immediate successor: the one after a bare core is its "-gke.0" build.
+// That is what lets an exclusive floor be restated as the inclusive floor one
+// step up, which in turn makes emptiness a plain comparison.
+func (k versionKey) next() versionKey {
+	k.build++
+	return k
+}
+
+func (k versionKey) compare(other versionKey) int {
+	switch {
+	case k.major != other.major:
+		return compareInt(int64(k.major), int64(other.major))
+	case k.minor != other.minor:
+		return compareInt(int64(k.minor), int64(other.minor))
+	case k.patch != other.patch:
+		return compareInt(int64(k.patch), int64(other.patch))
+	default:
+		return compareInt(k.build, other.build)
+	}
+}
+
+func compareInt(a, b int64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -85,18 +85,22 @@ func Tighten(existing, candidate string) (string, TightenOutcome) {
 	if !boundsSatisfiable(lower, upper) {
 		return "", TightenUnsatisfiable
 	}
-	if !lowerNarrowed && !upperNarrowed {
-		return existing, TightenUnchanged
-	}
 
 	terms := make([]string, 0, 4)
-	terms = appendBound(terms, lower, droppedBound(existingLower, candidateLower, lower))
-	terms = appendBound(terms, upper, droppedBound(existingUpper, candidateUpper, upper))
+	terms, lowerKept := appendBound(terms, lower, droppedBound(existingLower, candidateLower, lower))
+	terms, upperKept := appendBound(terms, upper, droppedBound(existingUpper, candidateUpper, upper))
+
+	// A retained loser still restricts, so it narrows even when the winning
+	// bound came from the composition. Reporting Unchanged there would drop
+	// the profile's own restriction.
+	if !lowerNarrowed && !upperNarrowed && !lowerKept && !upperKept {
+		return existing, TightenUnchanged
+	}
 	return strings.Join(terms, " "), TightenNarrowed
 }
 
 // appendBound writes the winning bound and, where dropping the loser could
-// widen the range, the loser as well.
+// widen the range, the loser as well. It reports whether the loser was kept.
 //
 // pkg/version compares at the lower of two precisions, so an actual written
 // with fewer components than the bounds can satisfy ">= 1.34.1" while failing
@@ -106,15 +110,15 @@ func Tighten(existing, candidate string) (string, TightenOutcome) {
 // redundant when it is inclusive, or when the winner is exclusive too: only
 // an exclusive bound can reject a version its own neighborhood admits, so
 // only an inclusive winner can lose that exclusion.
-func appendBound(terms []string, winner, dropped *bound) []string {
+func appendBound(terms []string, winner, dropped *bound) ([]string, bool) {
 	if winner == nil {
-		return terms
+		return terms, false
 	}
 	terms = append(terms, winner.String())
 	if dropped != nil && !dropped.inclusive() && winner.inclusive() {
-		terms = append(terms, dropped.String())
+		return append(terms, dropped.String()), true
 	}
-	return terms
+	return terms, false
 }
 
 // droppedBound returns the same-direction bound that lost to winner, or nil
@@ -229,20 +233,29 @@ func boundsSatisfiable(lower, upper *bound) bool {
 	if lower == nil || upper == nil {
 		return true
 	}
-	cmp := lower.parsed.Compare(upper.parsed)
+	// Bounds written at different precisions read as equal under Compare
+	// (">= 1.36" against "< 1.36.0"), which says nothing about emptiness.
+	// Comparing them padded to full precision does: a bound's omitted
+	// components admit versions from its zero-padded form upward, so the
+	// padded pair orders exactly as the ranges do.
+	low, high := lower.parsed, upper.parsed
+	if low.Precision != high.Precision {
+		low, high = atFullPrecision(low), atFullPrecision(high)
+	}
+
+	cmp := low.Compare(high)
 	if cmp > 0 {
 		return false
 	}
 	if cmp == 0 {
-		// Equal at the lower of the two precisions (">= 1.35" against
-		// "< 1.35.2") does not mean the range is empty, so an emptiness
-		// verdict is only safe when both bounds carry the same precision.
-		// Where it is not, the range is allowed through and constraint
-		// evaluation — which fails closed — remains the backstop.
-		if lower.parsed.Precision != upper.parsed.Precision {
-			return true
-		}
 		return lower.inclusive() && upper.inclusive()
 	}
 	return true
+}
+
+// atFullPrecision returns v with every component significant, so a bound
+// written as "1.36" compares as the "1.36.0" its range starts at.
+func atFullPrecision(v version.Version) version.Version {
+	v.Precision = 3
+	return v
 }

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -20,6 +20,10 @@ import (
 	"github.com/NVIDIA/aicr/pkg/version"
 )
 
+// fullPrecision is the component count pkg/version treats as fully
+// significant (major.minor.patch).
+const fullPrecision = 3
+
 // TightenOutcome reports how two same-named constraint expressions relate.
 type TightenOutcome int
 
@@ -227,35 +231,68 @@ func strongerBound(existing, candidate *bound) (stronger *bound, narrowed, ok bo
 }
 
 // boundsSatisfiable reports whether some version satisfies both bounds. An
-// open side is always satisfiable; a closed range is empty when the floor is
-// above the ceiling, or equal to it with either side exclusive.
+// open side is always satisfiable; a closed range is empty when the floor
+// sits above the ceiling, or on it with either endpoint excluded. Both
+// endpoints are taken at full precision so the comparison is exact.
 func boundsSatisfiable(lower, upper *bound) bool {
 	if lower == nil || upper == nil {
 		return true
 	}
-	// Bounds written at different precisions read as equal under Compare
-	// (">= 1.36" against "< 1.36.0"), which says nothing about emptiness.
-	// Comparing them padded to full precision does: a bound's omitted
-	// components admit versions from its zero-padded form upward, so the
-	// padded pair orders exactly as the ranges do.
-	low, high := lower.parsed, upper.parsed
-	if low.Precision != high.Precision {
-		low, high = atFullPrecision(low), atFullPrecision(high)
-	}
+	low, lowAdmitted := lower.limit()
+	high, highAdmitted := upper.limit()
 
 	cmp := low.Compare(high)
 	if cmp > 0 {
 		return false
 	}
 	if cmp == 0 {
-		return lower.inclusive() && upper.inclusive()
+		return lowAdmitted && highAdmitted
 	}
 	return true
+}
+
+// limit returns the full-precision version where the bound's half-line ends,
+// and whether that version is itself admitted.
+//
+// A bound written at full precision is its own endpoint. A coarser one
+// quantifies over a whole band of versions, and zero-padding it is only
+// right for half the operators: ">= 1.35" does start at 1.35.0, but
+// "> 1.35" excludes every 1.35.x — pkg/version compares an actual at the
+// bound's precision, so 1.35.9 reads as equal to 1.35 and fails — which
+// makes its true endpoint 1.36.0. Symmetrically "< 1.35" ends at 1.35.0
+// while "<= 1.35" runs to just below 1.36.0. Bumping the last significant
+// component covers the two that step past their own band; the endpoint of a
+// coarse bound is then admitted exactly when it is a lower bound.
+func (b *bound) limit() (version.Version, bool) {
+	if b.parsed.Precision >= fullPrecision {
+		return b.parsed, b.inclusive()
+	}
+
+	isLower := b.operator == OperatorGTE || b.operator == OperatorGT
+	if b.operator == OperatorGT || b.operator == OperatorLTE {
+		return bumpLastSignificant(b.parsed), isLower
+	}
+	return atFullPrecision(b.parsed), isLower
 }
 
 // atFullPrecision returns v with every component significant, so a bound
 // written as "1.36" compares as the "1.36.0" its range starts at.
 func atFullPrecision(v version.Version) version.Version {
-	v.Precision = 3
+	v.Precision = fullPrecision
+	return v
+}
+
+// bumpLastSignificant returns the next version after v's band: the component
+// v's precision stops at is incremented and the rest zeroed, so "1.35"
+// becomes 1.36.0 and "1" becomes 2.0.0.
+func bumpLastSignificant(v version.Version) version.Version {
+	if v.Precision <= 1 {
+		v.Major++
+		v.Minor = 0
+	} else {
+		v.Minor++
+	}
+	v.Patch = 0
+	v.Precision = fullPrecision
 	return v
 }

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expr
+
+import (
+	"strings"
+
+	"github.com/NVIDIA/aicr/pkg/version"
+)
+
+// TightenOutcome reports how two same-named constraint expressions relate.
+type TightenOutcome int
+
+const (
+	// TightenIncomparable means the pair is not a bounded version range on
+	// both sides — an exact match, an equality or inequality term, an OR
+	// alternative, or a value the version parser cannot read. Callers must
+	// not merge these: "stricter" is undefined for them.
+	TightenIncomparable TightenOutcome = iota
+
+	// TightenUnchanged means the candidate admits everything the existing
+	// expression already admits, so the intersection is the existing one.
+	TightenUnchanged
+
+	// TightenNarrowed means the intersection is strictly smaller than the
+	// existing expression; the returned expression is that intersection.
+	TightenNarrowed
+
+	// TightenUnsatisfiable means the two expressions have no version in
+	// common, so no cluster could satisfy both.
+	TightenUnsatisfiable
+
+	// TightenPrecisionMismatch means both sides bound the same direction but
+	// are written at different precisions (">= 1.34" against ">= 1.34.1"), so
+	// pkg/version compares them at the lower precision and reports them equal.
+	// Which one is stricter is unknowable from the expressions alone.
+	TightenPrecisionMismatch
+)
+
+// Tighten intersects two same-named constraint expressions and returns the
+// combined expression together with how it relates to existing.
+//
+// Only bounded version ranges intersect: every term on both sides must use
+// >=, >, <=, or < and neither side may carry an OR alternative. That covers
+// the version floors and ceilings recipes actually compose (">= 1.34.1
+// < 1.36.0" tightened by ">= 1.35" yields ">= 1.35 < 1.36.0") while leaving
+// predicates whose values do not order — the node-set label constraints,
+// exact matches, "!=", and same-direction bounds written at different
+// precisions — reported as TightenIncomparable so the caller keeps rejecting
+// them rather than silently merging a contradiction.
+//
+// The returned expression is written in the same grammar it was parsed from
+// (a single AND clause), so it round-trips through ParseCompoundConstraint.
+func Tighten(existing, candidate string) (string, TightenOutcome) {
+	existingLower, existingUpper, ok := versionBounds(existing)
+	if !ok {
+		return "", TightenIncomparable
+	}
+	candidateLower, candidateUpper, ok := versionBounds(candidate)
+	if !ok {
+		return "", TightenIncomparable
+	}
+
+	lower, lowerNarrowed, ok := strongerBound(existingLower, candidateLower)
+	if !ok {
+		return "", TightenPrecisionMismatch
+	}
+	upper, upperNarrowed, ok := strongerBound(existingUpper, candidateUpper)
+	if !ok {
+		return "", TightenPrecisionMismatch
+	}
+
+	if !boundsSatisfiable(lower, upper) {
+		return "", TightenUnsatisfiable
+	}
+	if !lowerNarrowed && !upperNarrowed {
+		return existing, TightenUnchanged
+	}
+
+	terms := make([]string, 0, 4)
+	terms = appendBound(terms, lower, droppedBound(existingLower, candidateLower, lower))
+	terms = appendBound(terms, upper, droppedBound(existingUpper, candidateUpper, upper))
+	return strings.Join(terms, " "), TightenNarrowed
+}
+
+// appendBound writes the winning bound and, where dropping the loser could
+// widen the range, the loser as well.
+//
+// pkg/version compares at the lower of two precisions, so an actual written
+// with fewer components than the bounds can satisfy ">= 1.34.1" while failing
+// "> 1.34.0" — dropping the exclusive term would then admit a version the
+// composition excluded. Both terms are AND-joined in the same clause, so
+// keeping the loser states the intersection exactly. The loser is dropped as
+// redundant when it is inclusive, or when the winner is exclusive too: only
+// an exclusive bound can reject a version its own neighborhood admits, so
+// only an inclusive winner can lose that exclusion.
+func appendBound(terms []string, winner, dropped *bound) []string {
+	if winner == nil {
+		return terms
+	}
+	terms = append(terms, winner.String())
+	if dropped != nil && !dropped.inclusive() && winner.inclusive() {
+		terms = append(terms, dropped.String())
+	}
+	return terms
+}
+
+// droppedBound returns the same-direction bound that lost to winner, or nil
+// when there was no contest.
+func droppedBound(existing, candidate, winner *bound) *bound {
+	if existing == nil || candidate == nil {
+		return nil
+	}
+	if winner == candidate {
+		return existing
+	}
+	return candidate
+}
+
+// bound is one ordering term of a version range, kept with its parsed
+// version so comparisons do not re-parse.
+type bound struct {
+	operator Operator
+	parsed   version.Version
+	term     ParsedConstraint
+}
+
+func (b *bound) String() string {
+	return b.term.String()
+}
+
+// inclusive reports whether the bound admits its own version (">=" and "<=").
+func (b *bound) inclusive() bool {
+	return b.operator == OperatorGTE || b.operator == OperatorLTE
+}
+
+// versionBounds reduces an expression to at most one lower and one upper
+// bound. It reports false for anything that is not a single AND clause of
+// parseable ordering terms, including a clause that repeats a direction in a
+// way the caller should not silently reconcile.
+func versionBounds(expression string) (lower, upper *bound, ok bool) {
+	compound, err := ParseCompoundConstraint(expression)
+	if err != nil || len(compound.Alternatives) != 1 {
+		return nil, nil, false
+	}
+
+	for _, term := range compound.Alternatives[0] {
+		parsed, err := version.ParseVersion(term.Value)
+		if err != nil {
+			return nil, nil, false
+		}
+		b := &bound{operator: term.Operator, parsed: parsed, term: term}
+		var ok bool
+		switch term.Operator {
+		case OperatorGTE, OperatorGT:
+			if lower, _, ok = strongerBound(lower, b); !ok {
+				return nil, nil, false
+			}
+		case OperatorLTE, OperatorLT:
+			if upper, _, ok = strongerBound(upper, b); !ok {
+				return nil, nil, false
+			}
+		case OperatorEQ, OperatorNE, OperatorExact:
+			return nil, nil, false
+		default:
+			return nil, nil, false
+		}
+	}
+	if lower == nil && upper == nil {
+		return nil, nil, false
+	}
+	return lower, upper, true
+}
+
+// strongerBound returns the more restrictive of two bounds in the same
+// direction and reports whether that is the candidate. A nil bound is the
+// absence of a limit, so the non-nil one always wins.
+//
+// It reports ok=false when the two versions are not orderable against each
+// other: pkg/version compares at the lower of the two precisions, so ">= 1.32"
+// and ">= 1.32.4" compare equal even though the second is strictly stricter.
+// Picking either would be a guess, and the fail-open direction — silently
+// keeping ">= 1.32" — would admit clusters the profile means to exclude, so
+// the pair is reported unorderable and the caller keeps rejecting it.
+func strongerBound(existing, candidate *bound) (stronger *bound, narrowed, ok bool) {
+	switch {
+	case candidate == nil:
+		return existing, false, true
+	case existing == nil:
+		return candidate, true, true
+	}
+
+	cmp := candidate.parsed.Compare(existing.parsed)
+	if cmp == 0 && candidate.parsed.Precision != existing.parsed.Precision {
+		return nil, false, false
+	}
+
+	if candidate.operator == OperatorGTE || candidate.operator == OperatorGT {
+		// Lower bounds: the higher version wins; at the same version the
+		// exclusive form ">" admits strictly less than ">=".
+		if cmp > 0 || (cmp == 0 && existing.inclusive() && !candidate.inclusive()) {
+			return candidate, true, true
+		}
+		return existing, false, true
+	}
+	// Upper bounds: the lower version wins; "<" admits less than "<=".
+	if cmp < 0 || (cmp == 0 && existing.inclusive() && !candidate.inclusive()) {
+		return candidate, true, true
+	}
+	return existing, false, true
+}
+
+// boundsSatisfiable reports whether some version satisfies both bounds. An
+// open side is always satisfiable; a closed range is empty when the floor is
+// above the ceiling, or equal to it with either side exclusive.
+func boundsSatisfiable(lower, upper *bound) bool {
+	if lower == nil || upper == nil {
+		return true
+	}
+	cmp := lower.parsed.Compare(upper.parsed)
+	if cmp > 0 {
+		return false
+	}
+	if cmp == 0 {
+		// Equal at the lower of the two precisions (">= 1.35" against
+		// "< 1.35.2") does not mean the range is empty, so an emptiness
+		// verdict is only safe when both bounds carry the same precision.
+		// Where it is not, the range is allowed through and constraint
+		// evaluation — which fails closed — remains the backstop.
+		if lower.parsed.Precision != upper.parsed.Precision {
+			return true
+		}
+		return lower.inclusive() && upper.inclusive()
+	}
+	return true
+}

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -15,6 +15,7 @@
 package expr
 
 import (
+	"math"
 	"strings"
 
 	"github.com/NVIDIA/aicr/pkg/version"
@@ -288,7 +289,11 @@ func boundsSatisfiable(lower, upper *bound) bool {
 	// straight off the order.
 	first := versionKeyOf(low)
 	if !lowAdmitted {
-		first = first.next()
+		above, exists := first.next()
+		if !exists {
+			return false
+		}
+		first = above
 	}
 
 	cmp := first.compare(versionKeyOf(high))
@@ -335,11 +340,19 @@ func (b *bound) limit() (version.Version, bool) {
 // v's precision stops at is incremented and the rest zeroed, so "1.35"
 // becomes 1.36.0 and "1" becomes 2.0.0.
 func bumpLastSignificant(v version.Version) version.Version {
-	if v.Precision <= 1 {
-		v.Major++
+	// Saturating rather than wrapping: a component already at the maximum has
+	// no band above it, and a wrapped endpoint would order below the bound it
+	// came from.
+	switch {
+	case v.Precision <= 1:
+		if v.Major != math.MaxInt {
+			v.Major++
+		}
 		v.Minor = 0
-	} else {
+	case v.Minor != math.MaxInt:
 		v.Minor++
+	case v.Major != math.MaxInt:
+		v.Minor, v.Major = 0, v.Major+1
 	}
 	v.Patch = 0
 	return v
@@ -357,25 +370,54 @@ type versionKey struct {
 	major int
 	minor int
 	patch int
-	build int64
+	// hasBuild carries the bare-core-versus-build distinction on its own
+	// rather than folding it into build as build+1, which would overflow at
+	// the maximum build number.
+	hasBuild bool
+	build    int64
 }
 
 func versionKeyOf(v version.Version) versionKey {
 	key := versionKey{major: v.Major, minor: v.Minor, patch: v.Patch}
 	if build, isGKE := version.ExtractGKEBuild(v.Extras); isGKE {
-		key.build = build + 1
+		key.hasBuild, key.build = true, build
 	}
 	return key
 }
 
-// next returns the version immediately after k. The build component is a
-// non-negative integer and is the finest dimension ordered, so every key has
-// an immediate successor: the one after a bare core is its "-gke.0" build.
-// That is what lets an exclusive floor be restated as the inclusive floor one
-// step up, which in turn makes emptiness a plain comparison.
-func (k versionKey) next() versionKey {
-	k.build++
-	return k
+// next returns the version immediately after k, and whether one exists.
+//
+// The build is the finest dimension ordered, so the successor of a bare core
+// is its "-gke.0" build and the successor of a build is the next one. That is
+// what lets an exclusive floor be restated as the inclusive floor one step
+// up, which in turn makes emptiness a plain comparison.
+//
+// The dimensions are finite. Past the largest build a core can carry, the
+// next version is the next core with no build at all, and past the largest
+// core there is no next version — a floor there admits nothing, which is a
+// verdict rather than a wrap.
+func (k versionKey) next() (versionKey, bool) {
+	switch {
+	case !k.hasBuild:
+		k.hasBuild, k.build = true, 0
+		return k, true
+	case k.build != math.MaxInt64:
+		k.build++
+		return k, true
+	}
+
+	k.hasBuild, k.build = false, 0
+	switch {
+	case k.patch != math.MaxInt:
+		k.patch++
+	case k.minor != math.MaxInt:
+		k.patch, k.minor = 0, k.minor+1
+	case k.major != math.MaxInt:
+		k.patch, k.minor, k.major = 0, 0, k.major+1
+	default:
+		return k, false
+	}
+	return k, true
 }
 
 func (k versionKey) compare(other versionKey) int {
@@ -386,6 +428,12 @@ func (k versionKey) compare(other versionKey) int {
 		return compareInt(int64(k.minor), int64(other.minor))
 	case k.patch != other.patch:
 		return compareInt(int64(k.patch), int64(other.patch))
+	case k.hasBuild != other.hasBuild:
+		// A build sorts above the bare core it builds on.
+		if k.hasBuild {
+			return 1
+		}
+		return -1
 	default:
 		return compareInt(k.build, other.build)
 	}

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -170,16 +170,24 @@ func versionBounds(expression string) (lower, upper *bound, ok bool) {
 			return nil, nil, false
 		}
 		b := &bound{operator: term.Operator, parsed: parsed, term: term}
-		var ok bool
+
+		// One bound per direction. A clause stating two — which is the shape
+		// this package itself emits when it retains an exclusive loser —
+		// cannot be reduced to one without losing a restriction, and picking
+		// the stronger would silently drop the other. Refusing keeps that
+		// failure closed; the expression still evaluates normally, it just
+		// does not take part in another intersection.
 		switch term.Operator {
 		case OperatorGTE, OperatorGT:
-			if lower, _, ok = strongerBound(lower, b); !ok {
+			if lower != nil {
 				return nil, nil, false
 			}
+			lower = b
 		case OperatorLTE, OperatorLT:
-			if upper, _, ok = strongerBound(upper, b); !ok {
+			if upper != nil {
 				return nil, nil, false
 			}
+			upper = b
 		case OperatorEQ, OperatorNE, OperatorExact:
 			return nil, nil, false
 		default:

--- a/pkg/constraints/expr/tighten.go
+++ b/pkg/constraints/expr/tighten.go
@@ -38,8 +38,12 @@ const (
 	// expression already admits, so the intersection is the existing one.
 	TightenUnchanged
 
-	// TightenNarrowed means the intersection is strictly smaller than the
-	// existing expression; the returned expression is that intersection.
+	// TightenNarrowed means the returned expression is the intersection
+	// restated, because a bound moved or a term had to be retained. It is
+	// never wider than the existing expression, but it is not always
+	// strictly narrower: two bounds can differ textually and admit the same
+	// versions (">= 1.32 < 1.35" against "<= 1.34"), and restating them is
+	// still correct.
 	TightenNarrowed
 
 	// TightenUnsatisfiable means the two expressions have no version in
@@ -111,18 +115,37 @@ func Tighten(existing, candidate string) (string, TightenOutcome) {
 // "> 1.34.0" — dropping the exclusive term would then admit a version the
 // composition excluded. Both terms are AND-joined in the same clause, so
 // keeping the loser states the intersection exactly. The loser is dropped as
-// redundant when it is inclusive, or when the winner is exclusive too: only
-// an exclusive bound can reject a version its own neighborhood admits, so
-// only an inclusive winner can lose that exclusion.
+// redundant when it is inclusive, when the winner is exclusive too (only an
+// exclusive bound can reject a version its own neighborhood admits, so only
+// an inclusive winner can lose that exclusion), or when no reading could
+// compare equal to both.
 func appendBound(terms []string, winner, dropped *bound) ([]string, bool) {
 	if winner == nil {
 		return terms, false
 	}
 	terms = append(terms, winner.String())
-	if dropped != nil && !dropped.inclusive() && winner.inclusive() {
+	if dropped != nil && !dropped.inclusive() && winner.inclusive() && canCompareEqual(winner, dropped) {
 		return append(terms, dropped.String()), true
 	}
 	return terms, false
+}
+
+// canCompareEqual reports whether any reading can compare equal to both
+// bounds, which is the only way the dropped one can exclude something the
+// winner admits.
+//
+// Compare truncates to the shorter precision, so that needs a truncation the
+// two bounds survive identically: a reading coarser than they are, agreeing
+// from the major component down. Two precision-1 bounds have nothing coarser
+// to be read at, and two bounds with different majors never collapse
+// together — so for those, retaining the loser would add a term that cannot
+// bite, report a narrowing that narrows nothing, and leave behind an
+// expression this package then refuses to intersect again.
+func canCompareEqual(a, b *bound) bool {
+	if min(a.parsed.Precision, b.parsed.Precision) < 2 {
+		return false
+	}
+	return a.parsed.Major == b.parsed.Major
 }
 
 // droppedBound returns the same-direction bound that lost to winner, or nil
@@ -240,6 +263,11 @@ func strongerBound(existing, candidate *bound) (stronger *bound, narrowed, ok bo
 
 // boundsSatisfiable reports whether some version satisfies both bounds.
 //
+// The verdict is taken over full-precision versions. A reading coarser than
+// the bounds behaves as a band and can satisfy two ranges that are disjoint
+// at full precision, so a range refused here may still have a coarse witness;
+// refusing it is the fail-closed reading of an incoherent pair.
+//
 // An open side is always satisfiable. A closed range is decided on the order
 // pkg/version.Compare defines, over full-precision endpoints keyed by their
 // position in it — including the GKE build dimension, where the bare numeric
@@ -299,14 +327,8 @@ func (b *bound) limit() (version.Version, bool) {
 	if b.operator == OperatorGT || b.operator == OperatorLTE {
 		return bumpLastSignificant(coarse), isLower
 	}
-	return atFullPrecision(coarse), isLower
-}
-
-// atFullPrecision returns v with every component significant, so a bound
-// written as "1.36" compares as the "1.36.0" its range starts at.
-func atFullPrecision(v version.Version) version.Version {
-	v.Precision = fullPrecision
-	return v
+	// The omitted components are already zero, which is where the band starts.
+	return coarse, isLower
 }
 
 // bumpLastSignificant returns the next version after v's band: the component
@@ -320,7 +342,6 @@ func bumpLastSignificant(v version.Version) version.Version {
 		v.Minor++
 	}
 	v.Patch = 0
-	v.Precision = fullPrecision
 	return v
 }
 

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -170,6 +170,7 @@ func TestTightenNeverWidens(t *testing.T) {
 		"1.34.3-gke.100", "1.34.3-gke.900", "1.35.0-gke.100", "1.35.0-gke.101",
 		"1.35.0-gke.0", "1.35.0-gke.1", "1.35-gke.100", "2", "1",
 		"150", "300", "2000", "4000",
+		"1.35.0-gke.9223372036854775807",
 	}
 	ranges := []string{
 		">= 1.34.1 < 1.36.0", ">= 1.32 < 1.35", "> 1.34.0 <= 1.35.2",
@@ -410,6 +411,26 @@ func TestTightenGKEBuildDimension(t *testing.T) {
 			existing:    "> 1.35.0",
 			candidate:   "< 1.35.0-gke.0",
 			wantOutcome: TightenUnsatisfiable,
+		},
+		{
+			name:        "no version exists past the largest build",
+			existing:    "> 1.35.0-gke.9223372036854775807",
+			candidate:   "< 1.35.1",
+			wantOutcome: TightenUnsatisfiable,
+		},
+		{
+			name:        "the next core past the largest build is reachable",
+			existing:    "> 1.35.0-gke.9223372036854775807",
+			candidate:   "<= 1.35.1",
+			wantValue:   "> 1.35.0-gke.9223372036854775807 <= 1.35.1",
+			wantOutcome: TightenNarrowed,
+		},
+		{
+			name:        "the largest build itself is reachable",
+			existing:    ">= 1.35.0-gke.9223372036854775807",
+			candidate:   "<= 1.35.0-gke.9223372036854775807",
+			wantValue:   ">= 1.35.0-gke.9223372036854775807 <= 1.35.0-gke.9223372036854775807",
+			wantOutcome: TightenNarrowed,
 		},
 		{
 			name:        "the first build itself is reachable",

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -43,6 +43,8 @@ func TestTighten(t *testing.T) {
 		{"floor above ceiling", "<= 1.30", ">= 1.35", "", TightenUnsatisfiable},
 		{"exclusive bounds meeting at one version", ">= 1.35", "< 1.35", "", TightenUnsatisfiable},
 		{"disjoint closed ranges", ">= 1.30 < 1.32", ">= 1.34 < 1.36", "", TightenUnsatisfiable},
+		{"floor meeting an omitted-component ceiling", ">= 1.34.1 < 1.36.0", ">= 1.36", "", TightenUnsatisfiable},
+		{"floor below an omitted-component ceiling", ">= 1.34.1 < 1.36.5", ">= 1.36", ">= 1.36 < 1.36.5", TightenNarrowed},
 
 		{"exact match has no ordering", "ubuntu", ">= 1.35", "", TightenIncomparable},
 		{"equality has no ordering", ">= 1.32", "== 1.35", "", TightenIncomparable},
@@ -53,6 +55,7 @@ func TestTighten(t *testing.T) {
 		{"alternatives are not intersected", ">= 1.34 < 1.35 || >= 1.35.1", ">= 1.35", "", TightenIncomparable},
 		{"unparseable version", ">= 1.32", ">= not-a-version", "", TightenIncomparable},
 		{"an exclusive loser is kept, not dropped", "> 1.34.0", ">= 1.34.1", ">= 1.34.1 > 1.34.0", TightenNarrowed},
+		{"a losing exclusive candidate still restricts", ">= 24.04.1", "> 24.04.0", ">= 24.04.1 > 24.04.0", TightenNarrowed},
 		{"empty candidate", ">= 1.32", "", "", TightenIncomparable},
 	}
 
@@ -107,8 +110,9 @@ func TestTightenResultParses(t *testing.T) {
 	}
 }
 
-// TestTightenNeverWidens is the invariant the recipe merge depends on: a
-// tightened expression must admit no version the composed expression rejected.
+// TestTightenNeverWidens is the invariant the recipe merge depends on: the
+// result is an intersection, so it must admit no version that either input
+// rejected — neither the composed expression nor the profile's own.
 // It is asserted by exhaustion rather than by argument because pkg/version
 // compares at the lower of two precisions, which makes "stricter" subtle
 // enough that reasoning about it has already been wrong once (an exclusive
@@ -152,8 +156,18 @@ func TestTightenNeverWidens(t *testing.T) {
 				continue
 			}
 			for _, actual := range actuals {
-				if admits(t, merged, actual) && !admits(t, existing, actual) {
-					t.Errorf("Tighten(%q, %q) = %q widened: it admits %q, which the composed expression rejects",
+				if !admits(t, merged, actual) {
+					continue
+				}
+				// The result is an intersection, so it must imply BOTH
+				// inputs. Checking only the composed side would miss a
+				// result that silently discards the profile's own bound.
+				if !admits(t, existing, actual) {
+					t.Errorf("Tighten(%q, %q) = %q admits %q, which the composed expression rejects",
+						existing, candidate, merged, actual)
+				}
+				if !admits(t, candidate, actual) {
+					t.Errorf("Tighten(%q, %q) = %q admits %q, which the profile's own expression rejects",
 						existing, candidate, merged, actual)
 				}
 			}

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -131,9 +131,13 @@ func TestTightenNeverWidens(t *testing.T) {
 	operators := []string{">=", ">", "<=", "<"}
 	versions := []string{
 		"1.34", "1.34.0", "1.34.1", "1.35", "1.35.0", "1.35.2",
-		"1.34.3-gke.100", "1.34.3-gke.900", "2", "1",
+		"1.34.3-gke.100", "1.34.3-gke.900", "1.35.0-gke.100", "1.35.0-gke.101",
+		"1.35-gke.100", "2", "1",
 	}
-	ranges := []string{">= 1.34.1 < 1.36.0", ">= 1.32 < 1.35", "> 1.34.0 <= 1.35.2"}
+	ranges := []string{
+		">= 1.34.1 < 1.36.0", ">= 1.32 < 1.35", "> 1.34.0 <= 1.35.2",
+		">= 1.34.3-gke.100 < 1.35.0", "> 1.35.0-gke.100 <= 1.35.0-gke.900",
+	}
 	expressions := make([]string, 0, len(ranges)+len(operators)*len(versions))
 	expressions = append(expressions, ranges...)
 	for _, operator := range operators {
@@ -141,7 +145,10 @@ func TestTightenNeverWidens(t *testing.T) {
 			expressions = append(expressions, operator+" "+version)
 		}
 	}
-	actuals := append([]string{"1.33", "1.33.9", "1.36", "1.36.0", "0.9"}, versions...)
+	actuals := append([]string{
+		"1.33", "1.33.9", "1.36", "1.36.0", "0.9",
+		"1.35.0-gke.99", "1.35.0-gke.150", "1.36.0-gke.10", "1.34.3-gke.500",
+	}, versions...)
 
 	admits := func(t *testing.T, expression, actual string) bool {
 		t.Helper()
@@ -195,7 +202,10 @@ func TestTightenRejectsEmptyRanges(t *testing.T) {
 	t.Parallel()
 
 	operators := []string{">=", ">", "<=", "<"}
-	versions := []string{"1", "1.35", "1.35.0", "1.35.2", "1.36", "1.36.0", "2"}
+	versions := []string{
+		"1", "1.35", "1.35.0", "1.35.2", "1.36", "1.36.0", "2",
+		"1.35-gke.100", "1.35.0-gke.100", "1.35.0-gke.101", "1.36.0-gke.50",
+	}
 	// Readings carry at least major.minor (Kubernetes "1.34.1", Ubuntu
 	// "24.04"), and emptiness is decided over that domain. A bare-major
 	// actual is degenerate under pkg/version — "1" compares equal to every
@@ -206,6 +216,10 @@ func TestTightenRejectsEmptyRanges(t *testing.T) {
 		"1.34", "1.34.9", "1.35", "1.35.0", "1.35.1", "1.35.2", "1.35.9",
 		"1.36", "1.36.0", "1.36.1", "1.36.9", "1.37", "1.37.0",
 		"2.0", "2.0.0", "2.1", "3.0.0",
+		// A GKE build sorts after the bare core it builds on, and the
+		// build number is the finest dimension pkg/version orders.
+		"1.35.0-gke.99", "1.35.0-gke.100", "1.35.0-gke.101", "1.35.0-gke.150",
+		"1.36.0-gke.10", "1.36.0-gke.50", "1.36.0-gke.51",
 	}
 
 	expressions := make([]string, 0, len(operators)*len(versions))
@@ -252,7 +266,7 @@ func TestTightenRejectsEmptyRanges(t *testing.T) {
 			// refusing that range is the fail-closed reading of an
 			// incoherent pair, not a false rejection to fix.
 			for _, actual := range actuals {
-				if strings.Count(actual, ".") != fullPrecision-1 {
+				if !isFullPrecision(actual) {
 					continue
 				}
 				if admitsBoth(t, existing, candidate, actual) {
@@ -281,4 +295,63 @@ func admitsBoth(t *testing.T, first, second, actual string) bool {
 		}
 	}
 	return true
+}
+
+// isFullPrecision reports whether an actual names every numeric component,
+// with or without a build suffix ("1.35.0", "1.35.0-gke.100").
+func isFullPrecision(actual string) bool {
+	core, _, _ := strings.Cut(actual, "-")
+	return strings.Count(core, ".") == fullPrecision-1
+}
+
+// TestTightenGKEBuildDimension pins the two ways the build suffix breaks the
+// numeric-only model: a coarse bound never has its suffix consulted, and
+// adjacent builds leave no room between them.
+func TestTightenGKEBuildDimension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		existing    string
+		candidate   string
+		wantValue   string
+		wantOutcome TightenOutcome
+	}{
+		{
+			name:     "adjacent builds leave no room",
+			existing: "> 1.35.0-gke.100", candidate: "< 1.35.0-gke.101",
+			wantOutcome: TightenUnsatisfiable,
+		},
+		{
+			name:     "separated builds do",
+			existing: "> 1.35.0-gke.100", candidate: "< 1.35.0-gke.150",
+			wantValue: "> 1.35.0-gke.100 < 1.35.0-gke.150", wantOutcome: TightenNarrowed,
+		},
+		{
+			name:     "a coarse bound ignores its own suffix",
+			existing: "> 1.35-gke.100", candidate: "< 1.36.0-gke.50",
+			wantValue: "> 1.35-gke.100 < 1.36.0-gke.50", wantOutcome: TightenNarrowed,
+		},
+		{
+			name:     "a build sorts after its bare core",
+			existing: "> 1.35.0", candidate: "< 1.35.1",
+			wantValue: "> 1.35.0 < 1.35.1", wantOutcome: TightenNarrowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			value, outcome := Tighten(tt.existing, tt.candidate)
+			if outcome != tt.wantOutcome {
+				t.Fatalf("Tighten(%q, %q) outcome = %v, want %v",
+					tt.existing, tt.candidate, outcome, tt.wantOutcome)
+			}
+			if value != tt.wantValue {
+				t.Fatalf("Tighten(%q, %q) = %q, want %q",
+					tt.existing, tt.candidate, value, tt.wantValue)
+			}
+		})
+	}
 }

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -14,7 +14,10 @@
 
 package expr
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTighten(t *testing.T) {
 	t.Parallel()
@@ -44,6 +47,10 @@ func TestTighten(t *testing.T) {
 		{"exclusive bounds meeting at one version", ">= 1.35", "< 1.35", "", TightenUnsatisfiable},
 		{"disjoint closed ranges", ">= 1.30 < 1.32", ">= 1.34 < 1.36", "", TightenUnsatisfiable},
 		{"floor meeting an omitted-component ceiling", ">= 1.34.1 < 1.36.0", ">= 1.36", "", TightenUnsatisfiable},
+		{"exclusive coarse floor skips its own band", "> 1.35", "< 1.35.2", "", TightenUnsatisfiable},
+		{"exclusive coarse floor clears the next band", "> 1.35", "< 1.36.2", "> 1.35 < 1.36.2", TightenNarrowed},
+		{"inclusive coarse ceiling covers its own band", ">= 1.35.2", "<= 1.35", ">= 1.35.2 <= 1.35", TightenNarrowed},
+		{"exclusive coarse ceiling excludes its own band", ">= 1.35.2", "< 1.35", "", TightenUnsatisfiable},
 		{"floor below an omitted-component ceiling", ">= 1.34.1 < 1.36.5", ">= 1.36", ">= 1.36 < 1.36.5", TightenNarrowed},
 
 		{"exact match has no ordering", "ubuntu", ">= 1.35", "", TightenIncomparable},
@@ -173,4 +180,105 @@ func TestTightenNeverWidens(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestTightenRejectsEmptyRanges is the complement of TestTightenNeverWidens,
+// which cannot see this class: implication holds vacuously for a result no
+// version satisfies, so an empty range accepted as narrowed passes it. Here
+// every pair reported satisfiable must be satisfied by some version, and
+// every pair reported unsatisfiable by none.
+//
+// It matters because the criteria-only generation path evaluates constraints
+// with a nil evaluator: an empty range accepted here is not caught later, it
+// ships in the recipe.
+func TestTightenRejectsEmptyRanges(t *testing.T) {
+	t.Parallel()
+
+	operators := []string{">=", ">", "<=", "<"}
+	versions := []string{"1", "1.35", "1.35.0", "1.35.2", "1.36", "1.36.0", "2"}
+	// Readings carry at least major.minor (Kubernetes "1.34.1", Ubuntu
+	// "24.04"), and emptiness is decided over that domain. A bare-major
+	// actual is degenerate under pkg/version — "1" compares equal to every
+	// 1.x bound and so satisfies mutually exclusive ranges — which is a
+	// property of the comparison, not of this solver.
+	actuals := []string{
+		"0.9", "0.9.9",
+		"1.34", "1.34.9", "1.35", "1.35.0", "1.35.1", "1.35.2", "1.35.9",
+		"1.36", "1.36.0", "1.36.1", "1.36.9", "1.37", "1.37.0",
+		"2.0", "2.0.0", "2.1", "3.0.0",
+	}
+
+	expressions := make([]string, 0, len(operators)*len(versions))
+	for _, operator := range operators {
+		for _, version := range versions {
+			expressions = append(expressions, operator+" "+version)
+		}
+	}
+
+	for _, existing := range expressions {
+		for _, candidate := range expressions {
+			merged, outcome := Tighten(existing, candidate)
+			if outcome != TightenNarrowed && outcome != TightenUnchanged && outcome != TightenUnsatisfiable {
+				continue
+			}
+
+			satisfiable := false
+			if outcome != TightenUnsatisfiable {
+				compound, err := ParseCompoundConstraint(merged)
+				if err != nil {
+					t.Fatalf("ParseCompoundConstraint(%q) error = %v", merged, err)
+				}
+				for _, actual := range actuals {
+					passed, err := compound.Evaluate(actual)
+					if err != nil {
+						t.Fatalf("Evaluate(%q against %q) error = %v", actual, merged, err)
+					}
+					if passed {
+						satisfiable = true
+						break
+					}
+				}
+				if !satisfiable {
+					t.Errorf("Tighten(%q, %q) = %q reported outcome %v, but no version satisfies it",
+						existing, candidate, merged, outcome)
+				}
+				continue
+			}
+
+			// Reported unsatisfiable: no full-precision version may satisfy
+			// both inputs. The check stops there deliberately. A coarser
+			// actual can straddle two disjoint fine-grained bounds — "1.35"
+			// compares equal to both ">= 1.35.2" and "<= 1.35.0" — and
+			// refusing that range is the fail-closed reading of an
+			// incoherent pair, not a false rejection to fix.
+			for _, actual := range actuals {
+				if strings.Count(actual, ".") != fullPrecision-1 {
+					continue
+				}
+				if admitsBoth(t, existing, candidate, actual) {
+					t.Errorf("Tighten(%q, %q) reported TightenUnsatisfiable, but %q satisfies both",
+						existing, candidate, actual)
+				}
+			}
+		}
+	}
+}
+
+func admitsBoth(t *testing.T, first, second, actual string) bool {
+	t.Helper()
+
+	for _, expression := range []string{first, second} {
+		compound, err := ParseCompoundConstraint(expression)
+		if err != nil {
+			t.Fatalf("ParseCompoundConstraint(%q) error = %v", expression, err)
+		}
+		passed, err := compound.Evaluate(actual)
+		if err != nil {
+			t.Fatalf("Evaluate(%q against %q) error = %v", actual, expression, err)
+		}
+		if !passed {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -132,7 +132,7 @@ func TestTightenNeverWidens(t *testing.T) {
 	versions := []string{
 		"1.34", "1.34.0", "1.34.1", "1.35", "1.35.0", "1.35.2",
 		"1.34.3-gke.100", "1.34.3-gke.900", "1.35.0-gke.100", "1.35.0-gke.101",
-		"1.35-gke.100", "2", "1",
+		"1.35.0-gke.0", "1.35.0-gke.1", "1.35-gke.100", "2", "1",
 	}
 	ranges := []string{
 		">= 1.34.1 < 1.36.0", ">= 1.32 < 1.35", "> 1.34.0 <= 1.35.2",
@@ -147,7 +147,8 @@ func TestTightenNeverWidens(t *testing.T) {
 	}
 	actuals := append([]string{
 		"1.33", "1.33.9", "1.36", "1.36.0", "0.9",
-		"1.35.0-gke.99", "1.35.0-gke.150", "1.36.0-gke.10", "1.34.3-gke.500",
+		"1.35.0-gke.0", "1.35.0-gke.1", "1.35.0-gke.99", "1.35.0-gke.150",
+		"1.36.0-gke.10", "1.34.3-gke.500",
 	}, versions...)
 
 	admits := func(t *testing.T, expression, actual string) bool {
@@ -204,7 +205,8 @@ func TestTightenRejectsEmptyRanges(t *testing.T) {
 	operators := []string{">=", ">", "<=", "<"}
 	versions := []string{
 		"1", "1.35", "1.35.0", "1.35.2", "1.36", "1.36.0", "2",
-		"1.35-gke.100", "1.35.0-gke.100", "1.35.0-gke.101", "1.36.0-gke.50",
+		"1.35-gke.100", "1.35.0-gke.0", "1.35.0-gke.100", "1.35.0-gke.101",
+		"1.36.0-gke.50",
 	}
 	// Readings carry at least major.minor (Kubernetes "1.34.1", Ubuntu
 	// "24.04"), and emptiness is decided over that domain. A bare-major
@@ -218,7 +220,8 @@ func TestTightenRejectsEmptyRanges(t *testing.T) {
 		"2.0", "2.0.0", "2.1", "3.0.0",
 		// A GKE build sorts after the bare core it builds on, and the
 		// build number is the finest dimension pkg/version orders.
-		"1.35.0-gke.99", "1.35.0-gke.100", "1.35.0-gke.101", "1.35.0-gke.150",
+		"1.35.0-gke.0", "1.35.0-gke.1", "1.35.0-gke.99", "1.35.0-gke.100",
+		"1.35.0-gke.101", "1.35.0-gke.150",
 		"1.36.0-gke.10", "1.36.0-gke.50", "1.36.0-gke.51",
 	}
 
@@ -336,6 +339,19 @@ func TestTightenGKEBuildDimension(t *testing.T) {
 			name:     "a build sorts after its bare core",
 			existing: "> 1.35.0", candidate: "< 1.35.1",
 			wantValue: "> 1.35.0 < 1.35.1", wantOutcome: TightenNarrowed,
+		},
+		{
+			name:        "nothing sits between a bare core and its first build",
+			existing:    "> 1.35.0",
+			candidate:   "< 1.35.0-gke.0",
+			wantOutcome: TightenUnsatisfiable,
+		},
+		{
+			name:        "the first build itself is reachable",
+			existing:    "> 1.35.0",
+			candidate:   "<= 1.35.0-gke.0",
+			wantValue:   "> 1.35.0 <= 1.35.0-gke.0",
+			wantOutcome: TightenNarrowed,
 		},
 	}
 

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -34,6 +34,8 @@ func TestTighten(t *testing.T) {
 		{"equal floor is dropped", ">= 1.35", ">= 1.35", ">= 1.35", TightenUnchanged},
 		{"exclusive beats inclusive at the same version", ">= 1.35", "> 1.35", "> 1.35", TightenNarrowed},
 		{"inclusive loses to exclusive at the same version", "> 1.35", ">= 1.35", "> 1.35", TightenUnchanged},
+		{"exclusive ceiling beats inclusive at the same version", "<= 1.35", "< 1.35", "< 1.35", TightenNarrowed},
+		{"inclusive ceiling loses to exclusive at the same version", "< 1.35", "<= 1.35", "< 1.35", TightenUnchanged},
 		{"differing precision is not orderable", ">= 1.32", ">= 1.32.4", "", TightenPrecisionMismatch},
 		{"same precision at patch level", ">= 1.32.1", ">= 1.32.4", ">= 1.32.4", TightenNarrowed},
 		{"ceiling survives a raised floor", ">= 1.34.1 < 1.36.0", ">= 1.35", ">= 1.35 < 1.36.0", TightenNarrowed},
@@ -62,9 +64,13 @@ func TestTighten(t *testing.T) {
 		{"alternatives are not intersected", ">= 1.34 < 1.35 || >= 1.35.1", ">= 1.35", "", TightenIncomparable},
 		{"unparseable version", ">= 1.32", ">= not-a-version", "", TightenIncomparable},
 		{"a clause repeating a direction is not reduced", ">= 1.34.1 > 1.34.0", "< 1.36", "", TightenIncomparable},
+		{"a clause repeating the upper direction is not reduced", "<= 1.34.0 < 1.35", ">= 1.30", "", TightenIncomparable},
 		{"a repeated direction on the candidate side too", "< 1.36", ">= 1.34.1 > 1.34.0", "", TightenIncomparable},
 		{"an exclusive loser is kept, not dropped", "> 1.34.0", ">= 1.34.1", ">= 1.34.1 > 1.34.0", TightenNarrowed},
 		{"a losing exclusive candidate still restricts", ">= 24.04.1", "> 24.04.0", ">= 24.04.1 > 24.04.0", TightenNarrowed},
+		{"a loser that cannot bite is dropped", ">= 300", "> 150", ">= 300", TightenUnchanged},
+		{"an unbitable ceiling loser is dropped too", "< 4000", "<= 2000", "<= 2000", TightenNarrowed},
+		{"a loser one component down still bites", ">= 1.35.0", "> 1.34.0", ">= 1.35.0 > 1.34.0", TightenNarrowed},
 		{"empty candidate", ">= 1.32", "", "", TightenIncomparable},
 	}
 
@@ -98,6 +104,34 @@ func TestTightenResultParses(t *testing.T) {
 	compound, err := ParseCompoundConstraint(value)
 	if err != nil {
 		t.Fatalf("ParseCompoundConstraint(%q) error = %v", value, err)
+	}
+
+	// The retained-loser clause is the shape this change introduces, so it
+	// is the one whose round-trip matters: two same-direction terms must
+	// survive splitAndTerms and still evaluate as the intersection.
+	retained, outcome := Tighten("> 1.34.0", ">= 1.34.1")
+	if outcome != TightenNarrowed {
+		t.Fatalf("Tighten() outcome = %v, want TightenNarrowed", outcome)
+	}
+	retainedCompound, err := ParseCompoundConstraint(retained)
+	if err != nil {
+		t.Fatalf("ParseCompoundConstraint(%q) error = %v", retained, err)
+	}
+	for _, tc := range []struct {
+		actual string
+		want   bool
+	}{
+		{"1.34", false},
+		{"1.34.0", false},
+		{"1.34.1", true},
+	} {
+		got, err := retainedCompound.Evaluate(tc.actual)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", tc.actual, err)
+		}
+		if got != tc.want {
+			t.Errorf("%q against %q = %v, want %v", tc.actual, retained, got, tc.want)
+		}
 	}
 
 	for _, tc := range []struct {
@@ -135,12 +169,14 @@ func TestTightenNeverWidens(t *testing.T) {
 		"1.34", "1.34.0", "1.34.1", "1.35", "1.35.0", "1.35.2",
 		"1.34.3-gke.100", "1.34.3-gke.900", "1.35.0-gke.100", "1.35.0-gke.101",
 		"1.35.0-gke.0", "1.35.0-gke.1", "1.35-gke.100", "2", "1",
+		"150", "300", "2000", "4000",
 	}
 	ranges := []string{
 		">= 1.34.1 < 1.36.0", ">= 1.32 < 1.35", "> 1.34.0 <= 1.35.2",
 		">= 1.34.3-gke.100 < 1.35.0", "> 1.35.0-gke.100 <= 1.35.0-gke.900",
 		// The shape appendBound emits when it retains an exclusive loser.
 		">= 1.34.1 > 1.34.0", ">= 24.04.1 > 24.04.0",
+		"<= 1.35.2 < 1.35.0",
 	}
 	expressions := make([]string, 0, len(ranges)+len(operators)*len(versions))
 	expressions = append(expressions, ranges...)
@@ -151,6 +187,7 @@ func TestTightenNeverWidens(t *testing.T) {
 	}
 	actuals := append([]string{
 		"1.33", "1.33.9", "1.36", "1.36.0", "0.9",
+		"150", "300", "2000", "4000", "3000",
 		"1.35.0-gke.0", "1.35.0-gke.1", "1.35.0-gke.99", "1.35.0-gke.150",
 		"1.36.0-gke.10", "1.34.3-gke.500",
 	}, versions...)
@@ -188,6 +225,30 @@ func TestTightenNeverWidens(t *testing.T) {
 				if !admits(t, candidate, actual) {
 					t.Errorf("Tighten(%q, %q) = %q admits %q, which the profile's own expression rejects",
 						existing, candidate, merged, actual)
+				}
+			}
+
+			// The converse: an intersection must keep everything both
+			// inputs admit. Without this, returning some arbitrary
+			// narrower range would satisfy every other assertion here.
+			for _, actual := range actuals {
+				if admits(t, existing, actual) && admits(t, candidate, actual) && !admits(t, merged, actual) {
+					t.Errorf("Tighten(%q, %q) = %q drops %q, which both inputs admit",
+						existing, candidate, merged, actual)
+				}
+			}
+
+			// Intersection is commutative. The outcome label may differ by
+			// argument order, but the set of admitted versions may not —
+			// and the retained-loser rule is written in terms of a winner
+			// and a loser, so it is the rule most likely to break this.
+			swapped, swappedOutcome := Tighten(candidate, existing)
+			if swappedOutcome == TightenNarrowed || swappedOutcome == TightenUnchanged {
+				for _, actual := range actuals {
+					if admits(t, merged, actual) != admits(t, swapped, actual) {
+						t.Errorf("Tighten(%q, %q) = %q and Tighten(%q, %q) = %q disagree on %q",
+							existing, candidate, merged, candidate, existing, swapped, actual)
+					}
 				}
 			}
 		}

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -61,6 +61,8 @@ func TestTighten(t *testing.T) {
 			"", TightenIncomparable},
 		{"alternatives are not intersected", ">= 1.34 < 1.35 || >= 1.35.1", ">= 1.35", "", TightenIncomparable},
 		{"unparseable version", ">= 1.32", ">= not-a-version", "", TightenIncomparable},
+		{"a clause repeating a direction is not reduced", ">= 1.34.1 > 1.34.0", "< 1.36", "", TightenIncomparable},
+		{"a repeated direction on the candidate side too", "< 1.36", ">= 1.34.1 > 1.34.0", "", TightenIncomparable},
 		{"an exclusive loser is kept, not dropped", "> 1.34.0", ">= 1.34.1", ">= 1.34.1 > 1.34.0", TightenNarrowed},
 		{"a losing exclusive candidate still restricts", ">= 24.04.1", "> 24.04.0", ">= 24.04.1 > 24.04.0", TightenNarrowed},
 		{"empty candidate", ">= 1.32", "", "", TightenIncomparable},
@@ -137,6 +139,8 @@ func TestTightenNeverWidens(t *testing.T) {
 	ranges := []string{
 		">= 1.34.1 < 1.36.0", ">= 1.32 < 1.35", "> 1.34.0 <= 1.35.2",
 		">= 1.34.3-gke.100 < 1.35.0", "> 1.35.0-gke.100 <= 1.35.0-gke.900",
+		// The shape appendBound emits when it retains an exclusive loser.
+		">= 1.34.1 > 1.34.0", ">= 24.04.1 > 24.04.0",
 	}
 	expressions := make([]string, 0, len(ranges)+len(operators)*len(versions))
 	expressions = append(expressions, ranges...)

--- a/pkg/constraints/expr/tighten_test.go
+++ b/pkg/constraints/expr/tighten_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expr
+
+import "testing"
+
+func TestTighten(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		existing    string
+		candidate   string
+		wantValue   string
+		wantOutcome TightenOutcome
+	}{
+		{"raises the floor", ">= 1.30", ">= 1.35", ">= 1.35", TightenNarrowed},
+		{"lower floor is dropped", ">= 1.35", ">= 1.30", ">= 1.35", TightenUnchanged},
+		{"equal floor is dropped", ">= 1.35", ">= 1.35", ">= 1.35", TightenUnchanged},
+		{"exclusive beats inclusive at the same version", ">= 1.35", "> 1.35", "> 1.35", TightenNarrowed},
+		{"inclusive loses to exclusive at the same version", "> 1.35", ">= 1.35", "> 1.35", TightenUnchanged},
+		{"differing precision is not orderable", ">= 1.32", ">= 1.32.4", "", TightenPrecisionMismatch},
+		{"same precision at patch level", ">= 1.32.1", ">= 1.32.4", ">= 1.32.4", TightenNarrowed},
+		{"ceiling survives a raised floor", ">= 1.34.1 < 1.36.0", ">= 1.35", ">= 1.35 < 1.36.0", TightenNarrowed},
+		{"floor survives a lowered ceiling", ">= 1.32 < 1.36.0", "< 1.35.0", ">= 1.32 < 1.35.0", TightenNarrowed},
+		{"a ceiling closes an open range", ">= 1.32", "< 1.35", ">= 1.32 < 1.35", TightenNarrowed},
+		{"a floor closes an open range", "< 1.35", ">= 1.32", ">= 1.32 < 1.35", TightenNarrowed},
+		{"single shared version is satisfiable", ">= 1.35", "<= 1.35", ">= 1.35 <= 1.35", TightenNarrowed},
+		{"bounds equal only at the lower precision stay open", ">= 1.35", "< 1.35.2", ">= 1.35 < 1.35.2", TightenNarrowed},
+
+		{"floor above ceiling", "<= 1.30", ">= 1.35", "", TightenUnsatisfiable},
+		{"exclusive bounds meeting at one version", ">= 1.35", "< 1.35", "", TightenUnsatisfiable},
+		{"disjoint closed ranges", ">= 1.30 < 1.32", ">= 1.34 < 1.36", "", TightenUnsatisfiable},
+
+		{"exact match has no ordering", "ubuntu", ">= 1.35", "", TightenIncomparable},
+		{"equality has no ordering", ">= 1.32", "== 1.35", "", TightenIncomparable},
+		{"inequality has no ordering", ">= 1.32", "!= 1.35", "", TightenIncomparable},
+		{"node-set label predicates have no ordering",
+			"gke-no-default-nvidia-gpu-device-plugin=true", "!gke-no-default-nvidia-gpu-device-plugin",
+			"", TightenIncomparable},
+		{"alternatives are not intersected", ">= 1.34 < 1.35 || >= 1.35.1", ">= 1.35", "", TightenIncomparable},
+		{"unparseable version", ">= 1.32", ">= not-a-version", "", TightenIncomparable},
+		{"an exclusive loser is kept, not dropped", "> 1.34.0", ">= 1.34.1", ">= 1.34.1 > 1.34.0", TightenNarrowed},
+		{"empty candidate", ">= 1.32", "", "", TightenIncomparable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			value, outcome := Tighten(tt.existing, tt.candidate)
+			if outcome != tt.wantOutcome {
+				t.Fatalf("Tighten(%q, %q) outcome = %v, want %v",
+					tt.existing, tt.candidate, outcome, tt.wantOutcome)
+			}
+			if value != tt.wantValue {
+				t.Fatalf("Tighten(%q, %q) = %q, want %q",
+					tt.existing, tt.candidate, value, tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestTightenResultParses guards the promise the recipe merge relies on: a
+// tightened expression is written in the same grammar it came from, so it
+// round-trips through the evaluator that reads the hydrated recipe.
+func TestTightenResultParses(t *testing.T) {
+	t.Parallel()
+
+	value, outcome := Tighten(">= 1.34.1 < 1.36.0", ">= 1.35")
+	if outcome != TightenNarrowed {
+		t.Fatalf("Tighten() outcome = %v, want TightenNarrowed", outcome)
+	}
+	compound, err := ParseCompoundConstraint(value)
+	if err != nil {
+		t.Fatalf("ParseCompoundConstraint(%q) error = %v", value, err)
+	}
+
+	for _, tc := range []struct {
+		actual string
+		want   bool
+	}{
+		{"1.34.5", false},
+		{"1.35.0", true},
+		{"1.35.9", true},
+		{"1.36.0", false},
+	} {
+		got, err := compound.Evaluate(tc.actual)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", tc.actual, err)
+		}
+		if got != tc.want {
+			t.Errorf("%q against %q = %v, want %v", tc.actual, value, got, tc.want)
+		}
+	}
+}
+
+// TestTightenNeverWidens is the invariant the recipe merge depends on: a
+// tightened expression must admit no version the composed expression rejected.
+// It is asserted by exhaustion rather than by argument because pkg/version
+// compares at the lower of two precisions, which makes "stricter" subtle
+// enough that reasoning about it has already been wrong once (an exclusive
+// bound dropped in favor of a higher inclusive one admitted a shorter actual
+// that the exclusive bound rejected).
+func TestTightenNeverWidens(t *testing.T) {
+	t.Parallel()
+
+	operators := []string{">=", ">", "<=", "<"}
+	versions := []string{
+		"1.34", "1.34.0", "1.34.1", "1.35", "1.35.0", "1.35.2",
+		"1.34.3-gke.100", "1.34.3-gke.900", "2", "1",
+	}
+	ranges := []string{">= 1.34.1 < 1.36.0", ">= 1.32 < 1.35", "> 1.34.0 <= 1.35.2"}
+	expressions := make([]string, 0, len(ranges)+len(operators)*len(versions))
+	expressions = append(expressions, ranges...)
+	for _, operator := range operators {
+		for _, version := range versions {
+			expressions = append(expressions, operator+" "+version)
+		}
+	}
+	actuals := append([]string{"1.33", "1.33.9", "1.36", "1.36.0", "0.9"}, versions...)
+
+	admits := func(t *testing.T, expression, actual string) bool {
+		t.Helper()
+		compound, err := ParseCompoundConstraint(expression)
+		if err != nil {
+			t.Fatalf("ParseCompoundConstraint(%q) error = %v", expression, err)
+		}
+		passed, err := compound.Evaluate(actual)
+		if err != nil {
+			t.Fatalf("Evaluate(%q against %q) error = %v", actual, expression, err)
+		}
+		return passed
+	}
+
+	for _, existing := range expressions {
+		for _, candidate := range expressions {
+			merged, outcome := Tighten(existing, candidate)
+			if outcome != TightenNarrowed && outcome != TightenUnchanged {
+				continue
+			}
+			for _, actual := range actuals {
+				if admits(t, merged, actual) && !admits(t, existing, actual) {
+					t.Errorf("Tighten(%q, %q) = %q widened: it admits %q, which the composed expression rejects",
+						existing, candidate, merged, actual)
+				}
+			}
+		}
+	}
+}

--- a/pkg/constraints/expression.go
+++ b/pkg/constraints/expression.go
@@ -58,7 +58,7 @@ const (
 // Examples:
 //   - ">= 1.32.4" -> {Operator: ">=", Value: "1.32.4", IsVersionComparison: true}
 //   - "ubuntu" -> {Operator: "", Value: "ubuntu", IsVersionComparison: false}
-//   - "== 24.04" -> {Operator: "==", Value: "24.04", IsVersionComparison: false}
+//   - "== 24.04" -> {Operator: "==", Value: "24.04", IsVersionComparison: true}
 func ParseConstraintExpression(expression string) (*ParsedConstraint, error) {
 	return expr.ParseConstraintExpression(expression)
 }

--- a/pkg/constraints/expression.go
+++ b/pkg/constraints/expression.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constraints
+
+import "github.com/NVIDIA/aicr/pkg/constraints/expr"
+
+// The expression grammar lives in the leaf package pkg/constraints/expr so
+// pkg/recipe can parse constraint values without importing this package,
+// which imports pkg/recipe. These aliases keep the grammar reachable at its
+// original import path for every existing caller.
+
+// Operator represents a comparison operator in constraint expressions.
+type Operator = expr.Operator
+
+// ParsedConstraint represents a parsed constraint expression.
+type ParsedConstraint = expr.ParsedConstraint
+
+// CompoundConstraint represents a constraint expression with OR alternatives
+// of AND-joined terms.
+type CompoundConstraint = expr.CompoundConstraint
+
+const (
+	// OperatorGTE represents ">=" (greater than or equal).
+	OperatorGTE = expr.OperatorGTE
+
+	// OperatorLTE represents "<=" (less than or equal).
+	OperatorLTE = expr.OperatorLTE
+
+	// OperatorGT represents ">" (greater than).
+	OperatorGT = expr.OperatorGT
+
+	// OperatorLT represents "<" (less than).
+	OperatorLT = expr.OperatorLT
+
+	// OperatorEQ represents "==" (exact match).
+	OperatorEQ = expr.OperatorEQ
+
+	// OperatorNE represents "!=" (not equal).
+	OperatorNE = expr.OperatorNE
+
+	// OperatorExact represents no operator (exact string match).
+	OperatorExact = expr.OperatorExact
+)
+
+// ParseConstraintExpression parses a constraint value expression.
+// Examples:
+//   - ">= 1.32.4" -> {Operator: ">=", Value: "1.32.4", IsVersionComparison: true}
+//   - "ubuntu" -> {Operator: "", Value: "ubuntu", IsVersionComparison: false}
+//   - "== 24.04" -> {Operator: "==", Value: "24.04", IsVersionComparison: false}
+func ParseConstraintExpression(expression string) (*ParsedConstraint, error) {
+	return expr.ParseConstraintExpression(expression)
+}
+
+// ParseCompoundConstraint parses a compound constraint expression that may
+// contain OR clauses ("||") and AND groups (space-separated sub-expressions).
+//
+// Example: ">= 1.34.3-gke.1318000 < 1.35.0 || >= 1.35.0-gke.2745000"
+func ParseCompoundConstraint(expression string) (*CompoundConstraint, error) {
+	return expr.ParseCompoundConstraint(expression)
+}

--- a/pkg/recipe/profile_resolution.go
+++ b/pkg/recipe/profile_resolution.go
@@ -146,14 +146,14 @@ func tightenProfileConstraint(profileName, valueName string, existing, candidate
 		merged.Value = tightened
 		// The profile's guidance is the specific one: it explains the value
 		// the operator selected, not the baseline every value shares.
+		//
+		// Only the guidance is taken. Severity is deliberately left as the
+		// composition states it: a value fragment must not relax a
+		// requirement the recipe makes of every value, and letting a
+		// candidate carry severity across would do exactly that on a merge
+		// whose whole purpose is to narrow.
 		if candidate.Remediation != "" {
 			merged.Remediation = candidate.Remediation
-		}
-		if candidate.Severity != "" {
-			merged.Severity = candidate.Severity
-		}
-		if candidate.Unit != "" {
-			merged.Unit = candidate.Unit
 		}
 		slog.Debug("profile constraint tightened the composed recipe",
 			"profile", profileName, "value", valueName, "constraint", existing.Name,

--- a/pkg/recipe/profile_resolution.go
+++ b/pkg/recipe/profile_resolution.go
@@ -183,7 +183,8 @@ func tightenProfileConstraint(profileName, valueName string, existing, candidate
 	case expr.TightenIncomparable:
 		return Constraint{}, errors.New(errors.ErrCodeInvalidRequest,
 			fmt.Sprintf("profile %q value %q constraint %q collides with the composed recipe: "+
-				"%q and %q are not both version ranges, so there is no intersection to take",
+				"%q and %q are not both simple version ranges (one clause, at most one bound "+
+				"per direction), so there is no intersection to take",
 				profileName, valueName, candidate.Name, candidate.Value, existing.Value))
 
 	default:

--- a/pkg/recipe/profile_resolution.go
+++ b/pkg/recipe/profile_resolution.go
@@ -16,10 +16,12 @@ package recipe
 
 import (
 	"fmt"
+	"log/slog"
 	"maps"
 	"slices"
 	"sort"
 
+	"github.com/NVIDIA/aicr/pkg/constraints/expr"
 	"github.com/NVIDIA/aicr/pkg/errors"
 	"github.com/NVIDIA/aicr/pkg/serializer"
 )
@@ -121,6 +123,145 @@ func (s *MetadataStore) resolveAppliedProfileDeclaration(
 	return s.resolveProfileDeclaration(survivingOverlays)
 }
 
+// tightenProfileConstraint resolves a profile-value constraint whose name the
+// composed recipe already carries.
+//
+// Constraints are keyed by name and one name holds one expression, so the two
+// cannot simply coexist. Where both sides are bounded version ranges the
+// intersection is well defined and the composition takes it: a profile value
+// gated on a feature with its own Kubernetes floor (DRA on GKE, issue #2512)
+// can raise the floor for itself alone without the chain having to raise it
+// for every value. Everything else — the node-set label predicates, exact
+// matches, "!=" — has no ordering to intersect, so it keeps failing closed.
+//
+// The profile only ever narrows. A candidate that would widen the composed
+// range is dropped, not applied, because a value fragment must not relax a
+// requirement the recipe states for every value of the declaration.
+func tightenProfileConstraint(profileName, valueName string, existing, candidate Constraint) (Constraint, error) {
+	tightened, outcome := expr.Tighten(existing.Value, candidate.Value)
+
+	switch outcome {
+	case expr.TightenNarrowed:
+		merged := existing
+		merged.Value = tightened
+		// The profile's guidance is the specific one: it explains the value
+		// the operator selected, not the baseline every value shares.
+		if candidate.Remediation != "" {
+			merged.Remediation = candidate.Remediation
+		}
+		if candidate.Severity != "" {
+			merged.Severity = candidate.Severity
+		}
+		if candidate.Unit != "" {
+			merged.Unit = candidate.Unit
+		}
+		slog.Debug("profile constraint tightened the composed recipe",
+			"profile", profileName, "value", valueName, "constraint", existing.Name,
+			"was", existing.Value, "now", merged.Value)
+		return merged, nil
+
+	case expr.TightenUnchanged:
+		slog.Debug("profile constraint is already covered by the composed recipe",
+			"profile", profileName, "value", valueName, "constraint", existing.Name,
+			"recipe", existing.Value, "profile constraint", candidate.Value)
+		return existing, nil
+
+	case expr.TightenUnsatisfiable:
+		return Constraint{}, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile %q value %q constraint %q requires %q, which no version can satisfy "+
+				"alongside the composed recipe's %q",
+				profileName, valueName, candidate.Name, candidate.Value, existing.Value))
+
+	case expr.TightenPrecisionMismatch:
+		return Constraint{}, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile %q value %q constraint %q states %q against the composed recipe's %q; "+
+				"same-direction bounds written at different precisions cannot be ordered "+
+				"(versions compare at the lower precision, so 1.34 and 1.34.1 read as equal). "+
+				"Restate one of them at the other's precision",
+				profileName, valueName, candidate.Name, candidate.Value, existing.Value))
+
+	case expr.TightenIncomparable:
+		return Constraint{}, errors.New(errors.ErrCodeInvalidRequest,
+			fmt.Sprintf("profile %q value %q constraint %q collides with the composed recipe: "+
+				"%q and %q are not both version ranges, so there is no intersection to take",
+				profileName, valueName, candidate.Name, candidate.Value, existing.Value))
+
+	default:
+		return Constraint{}, errors.NewWithContext(errors.ErrCodeInternal,
+			"unknown constraint intersection outcome",
+			map[string]any{"profile": profileName, keyValue: valueName, constraintContextKey: candidate.Name})
+	}
+}
+
+// mergeProfileConstraints folds the selected value's constraints into the
+// composition, resolving a name the composition already carries through
+// tightenProfileConstraint, and evaluates each resolved constraint fail
+// closed. A rejection returns immediately, so mergedSpec may already carry
+// the constraints resolved before it; callers discard the spec on error.
+func mergeProfileConstraints(
+	mergedSpec *RecipeMetadataSpec,
+	profileName, valueName string,
+	declaredConstraints []Constraint,
+	evaluator ConstraintEvaluatorFunc,
+) error {
+
+	constraintIndex := make(map[string]int, len(mergedSpec.Constraints))
+	for i, constraint := range mergedSpec.Constraints {
+		constraintIndex[constraint.Name] = i
+	}
+	for _, declared := range declaredConstraints {
+		existingIndex, collision := constraintIndex[declared.Name]
+		constraint := declared
+		if collision {
+			resolved, err := tightenProfileConstraint(
+				profileName, valueName,
+				mergedSpec.Constraints[existingIndex], declared)
+			if err != nil {
+				return err
+			}
+			constraint = resolved
+		}
+		if evaluator != nil {
+			result := evaluator(constraint)
+			switch {
+			case result.Error != nil && isNotFoundEvalError(result.Error):
+				return errors.NewWithContext(
+					errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %s=%s cannot be validated because reading %q is unavailable",
+						profileName, valueName, constraint.Name),
+					map[string]any{
+						constraintContextKey: constraint.Name,
+						"expected":           constraint.Value,
+						"actual":             result.Actual,
+						"cause":              result.Error.Error(),
+					},
+				)
+			case result.Error != nil:
+				return errors.PropagateOrWrap(result.Error, errors.ErrCodeInternal,
+					fmt.Sprintf("failed to evaluate profile constraint %q", constraint.Name))
+			case !result.Passed:
+				return errors.NewWithContext(
+					errors.ErrCodeInvalidRequest,
+					fmt.Sprintf("profile %s=%s constraint %q failed",
+						profileName, valueName, constraint.Name),
+					map[string]any{
+						constraintContextKey: constraint.Name,
+						"expected":           constraint.Value,
+						"actual":             result.Actual,
+					},
+				)
+			}
+		}
+		if collision {
+			mergedSpec.Constraints[existingIndex] = constraint
+			continue
+		}
+		constraintIndex[constraint.Name] = len(mergedSpec.Constraints)
+		mergedSpec.Constraints = append(mergedSpec.Constraints, constraint)
+	}
+	return nil
+}
+
 func applyEffectiveProfile(
 	mergedSpec *RecipeMetadataSpec,
 	effective *effectiveProfileDeclaration,
@@ -179,49 +320,9 @@ func applyEffectiveProfile(
 		}
 	}
 
-	constraintNames := make(map[string]struct{}, len(mergedSpec.Constraints))
-	for _, constraint := range mergedSpec.Constraints {
-		constraintNames[constraint.Name] = struct{}{}
-	}
-	for _, constraint := range value.Constraints {
-		if _, collision := constraintNames[constraint.Name]; collision {
-			return nil, errors.New(errors.ErrCodeInvalidRequest,
-				fmt.Sprintf("profile %q value %q constraint %q collides with the composed recipe",
-					effective.Declaration.Name, valueName, constraint.Name))
-		}
-		constraintNames[constraint.Name] = struct{}{}
-		if evaluator != nil {
-			result := evaluator(constraint)
-			switch {
-			case result.Error != nil && isNotFoundEvalError(result.Error):
-				return nil, errors.NewWithContext(
-					errors.ErrCodeInvalidRequest,
-					fmt.Sprintf("profile %s=%s cannot be validated because reading %q is unavailable",
-						effective.Declaration.Name, valueName, constraint.Name),
-					map[string]any{
-						constraintContextKey: constraint.Name,
-						"expected":           constraint.Value,
-						"actual":             result.Actual,
-						"cause":              result.Error.Error(),
-					},
-				)
-			case result.Error != nil:
-				return nil, errors.PropagateOrWrap(result.Error, errors.ErrCodeInternal,
-					fmt.Sprintf("failed to evaluate profile constraint %q", constraint.Name))
-			case !result.Passed:
-				return nil, errors.NewWithContext(
-					errors.ErrCodeInvalidRequest,
-					fmt.Sprintf("profile %s=%s constraint %q failed",
-						effective.Declaration.Name, valueName, constraint.Name),
-					map[string]any{
-						constraintContextKey: constraint.Name,
-						"expected":           constraint.Value,
-						"actual":             result.Actual,
-					},
-				)
-			}
-		}
-		mergedSpec.Constraints = append(mergedSpec.Constraints, constraint)
+	if err := mergeProfileConstraints(
+		mergedSpec, effective.Declaration.Name, valueName, value.Constraints, evaluator); err != nil {
+		return nil, err
 	}
 	sort.Slice(mergedSpec.Constraints, func(i, j int) bool {
 		return mergedSpec.Constraints[i].Name < mergedSpec.Constraints[j].Name

--- a/pkg/recipe/profile_test.go
+++ b/pkg/recipe/profile_test.go
@@ -1801,11 +1801,13 @@ func TestValidateProfileValuesRejectsInvalidBaseline(t *testing.T) {
 	}
 }
 
-// TestApplyEffectiveProfileConstraints covers the two constraint outcomes of a
-// selection: a name already present in the composed recipe is rejected rather
-// than silently shadowing it, and a fresh name is appended in sorted order.
+// TestApplyEffectiveProfileConstraints covers the constraint outcomes of a
+// selection: a fresh name is appended in sorted order, a name the composition
+// already carries is intersected when both sides are version ranges (issue
+// #2512), and anything else — a widening range, an empty intersection, or a
+// predicate with no ordering — leaves the recipe's own constraint intact.
 func TestApplyEffectiveProfileConstraints(t *testing.T) {
-	newDecl := func(constraintName string) *effectiveProfileDeclaration {
+	newDecl := func(constraintName, constraintValue string) *effectiveProfileDeclaration {
 		return &effectiveProfileDeclaration{
 			Source: "test-overlay",
 			Declaration: &ProfileDeclaration{
@@ -1816,22 +1818,97 @@ func TestApplyEffectiveProfileConstraints(t *testing.T) {
 							Name:      "gpu-operator",
 							Overrides: map[string]any{"driver": map[string]any{"enabled": false}},
 						}},
-						Constraints: []Constraint{{Name: constraintName, Value: ">= 1.32"}},
+						Constraints: []Constraint{{
+							Name:        constraintName,
+							Value:       constraintValue,
+							Remediation: "create the pool on a newer cluster",
+						}},
 					},
 				},
 			},
 		}
 	}
-	newSpec := func() *RecipeMetadataSpec {
+	newSpec := func(recipeConstraint Constraint) *RecipeMetadataSpec {
 		return &RecipeMetadataSpec{
 			ComponentRefs: []ComponentRef{{Name: "gpu-operator", Type: ComponentTypeHelm}},
-			Constraints:   []Constraint{{Name: "K8s.server.version", Value: ">= 1.30"}},
+			Constraints:   []Constraint{recipeConstraint},
 		}
 	}
+	k8sFloor := func(value string) Constraint {
+		return Constraint{Name: "K8s.server.version", Value: value}
+	}
 
-	t.Run("collision with the composed recipe is rejected", func(t *testing.T) {
-		spec := newSpec()
-		_, err := applyEffectiveProfile(spec, newDecl("K8s.server.version"), "", nil)
+	t.Run("stricter version floor tightens the composed recipe", func(t *testing.T) {
+		spec := newSpec(k8sFloor(">= 1.30"))
+		if _, err := applyEffectiveProfile(spec, newDecl("K8s.server.version", ">= 1.35"), "", nil); err != nil {
+			t.Fatalf("applyEffectiveProfile() error = %v", err)
+		}
+		if len(spec.Constraints) != 1 {
+			t.Fatalf("composed constraints = %v, want one entry per name", spec.Constraints)
+		}
+		if spec.Constraints[0].Value != ">= 1.35" {
+			t.Fatalf("constraint value = %q, want %q", spec.Constraints[0].Value, ">= 1.35")
+		}
+		if spec.Constraints[0].Remediation != "create the pool on a newer cluster" {
+			t.Fatalf("remediation = %q, want the profile's own guidance", spec.Constraints[0].Remediation)
+		}
+	})
+
+	t.Run("tightening preserves the composed ceiling", func(t *testing.T) {
+		spec := newSpec(k8sFloor(">= 1.34.1 < 1.36.0"))
+		if _, err := applyEffectiveProfile(spec, newDecl("K8s.server.version", ">= 1.35"), "", nil); err != nil {
+			t.Fatalf("applyEffectiveProfile() error = %v", err)
+		}
+		if got, want := spec.Constraints[0].Value, ">= 1.35 < 1.36.0"; got != want {
+			t.Fatalf("constraint value = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("weaker version floor leaves the composed recipe alone", func(t *testing.T) {
+		spec := newSpec(k8sFloor(">= 1.34"))
+		if _, err := applyEffectiveProfile(spec, newDecl("K8s.server.version", ">= 1.30"), "", nil); err != nil {
+			t.Fatalf("applyEffectiveProfile() error = %v", err)
+		}
+		if got, want := spec.Constraints[0].Value, ">= 1.34"; got != want {
+			t.Fatalf("constraint value = %q, want the recipe's own floor %q", got, want)
+		}
+		if spec.Constraints[0].Remediation != "" {
+			t.Fatalf("remediation = %q, want the recipe's own left intact", spec.Constraints[0].Remediation)
+		}
+	})
+
+	t.Run("empty intersection is rejected", func(t *testing.T) {
+		spec := newSpec(k8sFloor("<= 1.30"))
+		_, err := applyEffectiveProfile(spec, newDecl("K8s.server.version", ">= 1.35"), "", nil)
+		if err == nil || !strings.Contains(err.Error(), "no version can satisfy") {
+			t.Fatalf("applyEffectiveProfile() error = %v, want an unsatisfiable-range rejection", err)
+		}
+		if !stderrors.Is(err, aicrerrors.New(aicrerrors.ErrCodeInvalidRequest, "")) {
+			t.Fatalf("applyEffectiveProfile() error = %v, want ErrCodeInvalidRequest", err)
+		}
+		if len(spec.Constraints) != 1 || spec.Constraints[0].Value != "<= 1.30" {
+			t.Fatalf("composed constraints = %v, want the recipe's own left intact", spec.Constraints)
+		}
+	})
+
+	t.Run("bounds at different precisions are rejected as unorderable", func(t *testing.T) {
+		spec := newSpec(k8sFloor(">= 1.34"))
+		_, err := applyEffectiveProfile(spec, newDecl("K8s.server.version", ">= 1.34.1"), "", nil)
+		if err == nil || !strings.Contains(err.Error(), "different precisions cannot be ordered") {
+			t.Fatalf("applyEffectiveProfile() error = %v, want a precision-mismatch rejection", err)
+		}
+		if strings.Contains(err.Error(), "not both version ranges") {
+			t.Fatalf("applyEffectiveProfile() error = %v, must not claim these are not version ranges", err)
+		}
+		if len(spec.Constraints) != 1 || spec.Constraints[0].Value != ">= 1.34" {
+			t.Fatalf("composed constraints = %v, want the recipe's own left intact", spec.Constraints)
+		}
+	})
+
+	t.Run("collision with no ordering is rejected", func(t *testing.T) {
+		spec := newSpec(Constraint{Name: "NodeTopology.gpu-nodes.label", Value: "gke-no-default-nvidia-gpu-device-plugin=true"})
+		_, err := applyEffectiveProfile(spec,
+			newDecl("NodeTopology.gpu-nodes.label", "!gke-no-default-nvidia-gpu-device-plugin"), "", nil)
 		if err == nil || !strings.Contains(err.Error(), "collides with the composed recipe") {
 			t.Fatalf("applyEffectiveProfile() error = %v, want collision", err)
 		}
@@ -1844,8 +1921,8 @@ func TestApplyEffectiveProfileConstraints(t *testing.T) {
 	})
 
 	t.Run("distinct constraint is merged", func(t *testing.T) {
-		spec := newSpec()
-		selected, err := applyEffectiveProfile(spec, newDecl("Driver.gpu.mode"), "", nil)
+		spec := newSpec(k8sFloor(">= 1.30"))
+		selected, err := applyEffectiveProfile(spec, newDecl("Driver.gpu.mode", ">= 1.32"), "", nil)
 		if err != nil {
 			t.Fatalf("applyEffectiveProfile() error = %v", err)
 		}


### PR DESCRIPTION
## Summary

A profile value may now tighten a constraint the composed recipe already carries, instead of being rejected for reusing the name. Where both expressions are version ranges, resolution takes their intersection; the profile may only narrow it.

## Motivation / Context

A `gpuStack` value gated on a feature with its own Kubernetes floor had nowhere to state that floor. DRA on GKE Standard requires >= 1.35, but the GKE-COS chain already carries `K8s.server.version`, and a profile value restating that name was rejected outright:

```console
$ aicr recipe --data ./catalog --service gke --os cos --intent inference --profile gpuStack=dra
[INVALID_REQUEST] profile "gpuStack" value "dra" constraint "K8s.server.version"
  collides with the composed recipe
```

Raising the floor in the overlay's own `spec.constraints` does not hold either: constraint merge is union-by-name with overlay-wins, so a later overlay in the chain restates the name and wins. In the shipped catalog `gke-cos` declares `>= 1.32` and `gke-cos-inference` restates `>= 1.32`; raising only the parent would be silently overwritten by the child. So a value-conditional floor had no home, and the only outlet was forking the overlay on a new criteria value.

Fixes: #2512
Related: #2402 (the same "missing-requirement-expression" pattern one level up)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [x] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [x] Core libraries (`pkg/errors`, `pkg/k8s`) — `pkg/constraints`
- [x] Docs/examples (`docs/`, `examples/`)
- [ ] Other: ____________

## Implementation Notes

**What intersects.** Both sides must be a single clause of `>=`, `>`, `<=`, `<` terms. `>= 1.32` under a value declaring `>= 1.35` resolves to `>= 1.35`; `>= 1.34.1 < 1.36.0` under `>= 1.35` resolves to `>= 1.35 < 1.36.0`. The composed entry is replaced in place, so one name still holds one expression, and the tightened value — not the declared one — is what the fail-closed evaluator sees and what lands in the hydrated recipe for `aicr validate`.

**What keeps failing closed.** A candidate that would widen the range is dropped rather than applied, because a value fragment must not relax a requirement the recipe states for every value. An empty intersection is rejected naming both expressions. Anything without an ordering is rejected as before: exact matches, `!=`, node-set label predicates (`NodeTopology.gpu-nodes.label` values such as `key=true` versus `!key`), and expressions carrying `||` alternatives.

**Precision is its own rejection.** `pkg/version` compares at the lower of two precisions, so `>= 1.34` and `>= 1.34.1` read as equal and neither can be called stricter. Picking either would be a guess, and the fail-open direction would admit clusters the profile means to exclude. Such a pair is rejected with a message that says so and asks the author to restate one bound at the other's precision.

**Precision is what makes this subtle.** `pkg/version` compares an actual at the lower of the two precisions, so a bound written below full precision quantifies over a whole band rather than a point. `>= 1.35` starts at 1.35.0, but `> 1.35` excludes every 1.35.x and really begins at 1.36.0; symmetrically `< 1.35` ends at 1.35.0 while `<= 1.35` runs to just below 1.36.0. Each bound resolves to the full-precision endpoint of its band plus whether that endpoint is admitted. Two same-direction bounds at different precisions cannot be ordered at all (`>= 1.34` against `>= 1.34.1` read as equal), so that pair is rejected with a message saying so.

**Emptiness is decided on the order `Compare` defines, not an approximation of it.** Endpoints are keyed by their position in that order: the numeric components, then the GKE build dimension, where a bare numeric core ranks below every `-gke.N` build of itself and builds rank numerically. Because the build component is a non-negative integer and is the finest dimension ordered, every key has an immediate successor — so an exclusive floor restates as the inclusive floor one step up, and emptiness reduces to a single comparison against the ceiling. That matters at the adjacent cases: nothing sits between `-gke.100` and `-gke.101`, nor between a bare core and its `-gke.0`, while a bare core and the next patch always have the former's builds between them. A bound below full precision never has its own suffix consulted when it is evaluated, so its endpoint drops the suffix rather than inventing an ordering.

**Two properties are asserted by exhaustion, not argued.** `TestTightenNeverWidens` checks that a merged expression implies *both* inputs — it is an intersection, so admitting anything either side rejected is a defect, whether the discarded restriction came from the recipe or from the profile. `TestTightenRejectsEmptyRanges` covers what implication cannot: it holds vacuously for a range nothing satisfies, so every pair reported satisfiable must be satisfied by some version and every pair reported unsatisfiable by none. Both earn their keep — each caught a distinct real defect during review, and the second exists because the first provably could not see that class.

**Package move.** `pkg/constraints` imports `pkg/recipe`, so `pkg/recipe` cannot import it back. The expression grammar moves to the new leaf package `pkg/constraints/expr` (depends only on `pkg/errors` and `pkg/version`), and `pkg/constraints/expression.go` re-exports every symbol as aliases, so external callers and their import paths are unchanged.

**Scope.** Overlay and mixin merge semantics are untouched, and no recipe, overlay, or mixin changes. Making the overlay chain intersect rather than overwrite is a separate question that belongs with #2402; worth noting that all 82 chains restating `K8s.server.version` today tighten it, none loosens, so that change would be behavior-preserving on the current catalog.

**ADR-015** records the new rule as a dated amendment to step 5, following the amendment convention the ADR already uses, leaving the original decision text intact.

## Testing

```bash
make qualify
go test -race ./pkg/constraints/... ./pkg/recipe/...
golangci-lint run -c .golangci.yaml ./pkg/constraints/... ./pkg/recipe/...
```

`go test -race` passes on `pkg/constraints`, `pkg/constraints/expr`, and `pkg/recipe`; `golangci-lint` reports 0 issues on both trees. Coverage on the touched packages: `pkg/constraints` 97.9%, `pkg/constraints/expr` 95.4%, `pkg/recipe` 90.0%, against a repo total of 84.3% and an 83% threshold.

New coverage: `TestTighten` (table-driven over narrow / unchanged / unsatisfiable / incomparable / precision-mismatch outcomes, including the coarse-bound and mixed-precision edges), `TestTightenGKEBuildDimension` (the build-suffix boundaries, including the bare core against its own first build), `TestTightenNeverWidens` and `TestTightenRejectsEmptyRanges` (the two exhaustive properties above, whose corpora carry build suffixes), `TestTightenResultParses` (the rendered expression round-trips through `ParseCompoundConstraint` and evaluates as the intersection), and `TestApplyEffectiveProfileConstraints` rewritten from two cases to seven, keeping a node-set label case that asserts the collision rejection still fires.

**Validated end to end against a real AKS H100 cluster** (`aicr-uat-31034819439`, Kubernetes v1.35.6, 2x `Standard_ND96isr_H100_v5`). The AKS chain carries `K8s.server.version: ">= 1.34"` at three levels, so a real snapshot from that cluster exercises every outcome. No shipped profile value declares a constraint whose name collides with a chain constraint — AKS's values declare `K8s.aks-gpu-pools.gpu-driver` and GKE's declare `NodeTopology.gpu-nodes.label` — so this used a `--data` catalog copy with the constraint added to `azure-managed`. The path goes live with a value like the one proposed in #2517.

| Profile value declares | Result on v1.35.6 |
|---|---|
| `>= 1.35` | resolves; the hydrated recipe carries `>= 1.35` as a single entry |
| `>= 1.36` | `profile gpuStack=azure-managed constraint "K8s.server.version" failed` |
| `>= 1.34.1` | rejected as unorderable against the chain's `>= 1.34`, with the precision diagnostic |
| `>= 1.30` | resolves; the recipe keeps its own `>= 1.34` |

The last row is the control that matters: a weaker profile floor must not widen the composition, and it shows the artifact is not simply echoing the profile's value. `aicr validate -r recipe.yaml -s snapshot.yaml --no-cluster` then re-evaluates the tightened constraint (`readiness constraint passed: name=K8s.server.version expected=>= 1.35 actual=v1.35.6`), and hand-editing that artifact to `>= 1.36` makes validate fail — the control proving validate reads the tightened value rather than the chain's.

Note for reviewers reproducing locally: `tools/api-diff_test.sh` fails under a sandboxed shell because its fixture `mktemp` is denied, which collapses every fixture path to `/`. Run the gate unsandboxed.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Behavior only changes for a profile value that reuses a constraint name, which previously failed generation outright — every input that resolved before resolves identically. No recipe artifact changes without a profile value that opts in. The package move is source-compatible through the re-export shim.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
