### PR TITLE
fix(tools): install ctlptl, goreleaser, oasdiff from binary releases

### DIFF
--- a/tools/setup-tools
+++ b/tools/setup-tools
@@ -790,15 +790,42 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
         if prompt_continue; then
             if [[ "${OS}" == "darwin" ]]; then
                 brew install tilt-dev/tap/ctlptl
+                log_success "ctlptl installed"
             elif [[ "${OS}" == "linux" ]]; then
-                if command_exists go; then
-                    GOFLAGS= go install github.com/tilt-dev/ctlptl/cmd/ctlptl@v"${CTLPTL_VERSION}"
-                    sudo cp "$(go env GOPATH)/bin/ctlptl" /usr/local/bin/
+                # Binary release rather than `go install`: the latter builds
+                # outside this module, so go.sum covers none of ctlptl's
+                # dependencies and every one is authenticated against
+                # sum.golang.org over the network. A checksum-database outage
+                # then fails the install -- and did, breaking the v0.21.1
+                # release (#2664). ctlptl pulls the whole Docker client tree,
+                # so it is the widest such exposure we had.
+                CTLPTL_ASSET_ARCH="x86_64"
+                if [[ "${GO_ARCH}" == "arm64" ]]; then
+                    CTLPTL_ASSET_ARCH="arm64"
+                fi
+                CTLPTL_TAR="ctlptl.${CTLPTL_VERSION}.linux.${CTLPTL_ASSET_ARCH}.tar.gz"
+                CTLPTL_BASE="https://github.com/tilt-dev/ctlptl/releases/download/v${CTLPTL_VERSION}"
+                if verify_download_url "${CTLPTL_BASE}/${CTLPTL_TAR}" "ctlptl ${CTLPTL_VERSION} for Linux ${GO_ARCH}"; then
+                    CTLPTL_TMP=$(mktemp -d)
+                    curl -fsSL -o "${CTLPTL_TMP}/${CTLPTL_TAR}" "${CTLPTL_BASE}/${CTLPTL_TAR}"
+                    curl -fsSL -o "${CTLPTL_TMP}/checksums.txt" "${CTLPTL_BASE}/checksums.txt"
+                    CTLPTL_EXPECTED=$(grep "  ${CTLPTL_TAR}$" "${CTLPTL_TMP}/checksums.txt" | awk '{print $1}')
+                    if [[ -n "${CTLPTL_EXPECTED}" ]]; then
+                        verify_sha256 "${CTLPTL_TMP}/${CTLPTL_TAR}" "${CTLPTL_EXPECTED}"
+                    else
+                        log_error "Could not extract checksum for ${CTLPTL_TAR} from checksums file; aborting install"
+                        rm -rf "$CTLPTL_TMP"
+                        exit 1
+                    fi
+                    tar -xzC "$CTLPTL_TMP" -f "${CTLPTL_TMP}/${CTLPTL_TAR}"
+                    sudo mv "$CTLPTL_TMP/ctlptl" /usr/local/bin/ctlptl
+                    sudo chmod +x /usr/local/bin/ctlptl
+                    rm -rf "$CTLPTL_TMP"
+                    log_success "ctlptl installed"
                 else
-                    log_warning "Go not installed, skipping ctlptl"
+                    log_error "Failed to install ctlptl. Please install manually."
                 fi
             fi
-            log_success "ctlptl installed"
         fi
     fi
 
@@ -934,15 +961,37 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
         if prompt_continue; then
             if [[ "${OS}" == "darwin" ]]; then
                 brew install goreleaser
+                log_success "goreleaser installed"
             elif [[ "${OS}" == "linux" ]]; then
-                if command_exists go; then
-                    GOFLAGS= go install github.com/goreleaser/goreleaser/v2@"${GORELEASER_VERSION}"
-                    sudo cp "$(go env GOPATH)/bin/goreleaser" /usr/local/bin/
+                # Binary release rather than `go install`; see the ctlptl block
+                # above for why (#2664). The asset name carries no version.
+                GORELEASER_ASSET_ARCH="x86_64"
+                if [[ "${GO_ARCH}" == "arm64" ]]; then
+                    GORELEASER_ASSET_ARCH="arm64"
+                fi
+                GORELEASER_TAR="goreleaser_Linux_${GORELEASER_ASSET_ARCH}.tar.gz"
+                GORELEASER_BASE="https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}"
+                if verify_download_url "${GORELEASER_BASE}/${GORELEASER_TAR}" "goreleaser ${GORELEASER_VERSION} for Linux ${GO_ARCH}"; then
+                    GORELEASER_TMP=$(mktemp -d)
+                    curl -fsSL -o "${GORELEASER_TMP}/${GORELEASER_TAR}" "${GORELEASER_BASE}/${GORELEASER_TAR}"
+                    curl -fsSL -o "${GORELEASER_TMP}/checksums.txt" "${GORELEASER_BASE}/checksums.txt"
+                    GORELEASER_EXPECTED=$(grep "  ${GORELEASER_TAR}$" "${GORELEASER_TMP}/checksums.txt" | awk '{print $1}')
+                    if [[ -n "${GORELEASER_EXPECTED}" ]]; then
+                        verify_sha256 "${GORELEASER_TMP}/${GORELEASER_TAR}" "${GORELEASER_EXPECTED}"
+                    else
+                        log_error "Could not extract checksum for ${GORELEASER_TAR} from checksums file; aborting install"
+                        rm -rf "$GORELEASER_TMP"
+                        exit 1
+                    fi
+                    tar -xzC "$GORELEASER_TMP" -f "${GORELEASER_TMP}/${GORELEASER_TAR}"
+                    sudo mv "$GORELEASER_TMP/goreleaser" /usr/local/bin/goreleaser
+                    sudo chmod +x /usr/local/bin/goreleaser
+                    rm -rf "$GORELEASER_TMP"
+                    log_success "goreleaser installed"
                 else
-                    log_warning "Go not installed, skipping goreleaser"
+                    log_error "Failed to install goreleaser. Please install manually."
                 fi
             fi
-            log_success "goreleaser installed"
         fi
     fi
 
@@ -1042,8 +1091,31 @@ if [[ "${SKIP_TOOLS}" == "false" ]] && command_exists go; then
         fi
         log_info "Installing oasdiff ${OASDIFF_VERSION}..."
         if prompt_continue; then
-            GOFLAGS= go install github.com/oasdiff/oasdiff@"${OASDIFF_VERSION}"
-            log_success "oasdiff ${OASDIFF_VERSION} installed"
+            # Binary release rather than `go install`; see the ctlptl block
+            # above for why (#2664).
+            OASDIFF_VERSION_NUM="${OASDIFF_VERSION#v}"
+            OASDIFF_TAR="oasdiff_${OASDIFF_VERSION_NUM}_linux_${GO_ARCH}.tar.gz"
+            OASDIFF_BASE="https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION_NUM}"
+            if verify_download_url "${OASDIFF_BASE}/${OASDIFF_TAR}" "oasdiff ${OASDIFF_VERSION} for Linux ${GO_ARCH}"; then
+                OASDIFF_TMP=$(mktemp -d)
+                curl -fsSL -o "${OASDIFF_TMP}/${OASDIFF_TAR}" "${OASDIFF_BASE}/${OASDIFF_TAR}"
+                curl -fsSL -o "${OASDIFF_TMP}/checksums.txt" "${OASDIFF_BASE}/checksums.txt"
+                OASDIFF_EXPECTED=$(grep "  ${OASDIFF_TAR}$" "${OASDIFF_TMP}/checksums.txt" | awk '{print $1}')
+                if [[ -n "${OASDIFF_EXPECTED}" ]]; then
+                    verify_sha256 "${OASDIFF_TMP}/${OASDIFF_TAR}" "${OASDIFF_EXPECTED}"
+                else
+                    log_error "Could not extract checksum for ${OASDIFF_TAR} from checksums file; aborting install"
+                    rm -rf "$OASDIFF_TMP"
+                    exit 1
+                fi
+                tar -xzC "$OASDIFF_TMP" -f "${OASDIFF_TMP}/${OASDIFF_TAR}"
+                sudo mv "$OASDIFF_TMP/oasdiff" /usr/local/bin/oasdiff
+                sudo chmod +x /usr/local/bin/oasdiff
+                rm -rf "$OASDIFF_TMP"
+                log_success "oasdiff ${OASDIFF_VERSION} installed"
+            else
+                log_error "Failed to install oasdiff. Please install manually."
+            fi
         fi
     fi
 

--- a/tools/setup-tools_test.sh
+++ b/tools/setup-tools_test.sh
@@ -21,19 +21,40 @@ SETUP_TOOLS="${SCRIPT_DIR}/setup-tools"
 
 bash -n "${SETUP_TOOLS}"
 
-expected_installs=(
-    'github.com/tilt-dev/ctlptl/cmd/ctlptl@v"${CTLPTL_VERSION}"'
-    'github.com/goreleaser/goreleaser/v2@"${GORELEASER_VERSION}"'
-    'golang.org/x/exp/cmd/apidiff@"${APIDIFF_VERSION}"'
-    'github.com/google/addlicense@"${ADDLICENSE_VERSION}"'
-    'github.com/google/go-licenses/v2@"${GO_LICENSES_VERSION}"'
+# Scan every `go install` rather than checking a named list. A positive list
+# goes stale in the direction that matters: it cannot catch a *new* install
+# added without the GOFLAGS reset, which is the regression this guards against.
+# It also fails whenever an install is legitimately removed -- as #2664 did,
+# replacing three of them with binary-release downloads.
+#
+# Anchor on start-of-line or whitespace before `go`, not on "some character then
+# whitespace": the latter cannot see an unindented `go install` at column 1,
+# which is exactly the shape this guard exists to catch. Requiring whitespace
+# (rather than any non-`#` character) also keeps `cargo install` from matching.
+#
+# Comment lines are excluded so prose mentioning `go install` does not trip it.
+mapfile -t install_lines < <(
+    grep -nE '(^|[[:space:]])go install ' "${SETUP_TOOLS}" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' || true
 )
 
-for install_target in "${expected_installs[@]}"; do
-    if ! grep -Fq "GOFLAGS= go install ${install_target}" "${SETUP_TOOLS}"; then
-        echo "FAIL: versioned go install does not clear GOFLAGS: ${install_target}" >&2
-        exit 1
+# A floor, so removing every `go install` cannot make this pass vacuously.
+# Three remain: apidiff, addlicense, and go-licenses, none of which publishes a
+# binary release (see .github/actions/install-go-licenses for that contract).
+readonly MIN_INSTALLS=3
+if [[ "${#install_lines[@]}" -lt "${MIN_INSTALLS}" ]]; then
+    echo "FAIL: found ${#install_lines[@]} 'go install' lines, expected at least ${MIN_INSTALLS};" >&2
+    echo "      if an install was intentionally removed, lower MIN_INSTALLS with it" >&2
+    exit 1
+fi
+
+failed=0
+for line in "${install_lines[@]}"; do
+    if [[ "${line}" != *"GOFLAGS= go install "* ]]; then
+        echo "FAIL: 'go install' does not clear GOFLAGS: ${line}" >&2
+        failed=1
     fi
 done
+[[ "${failed}" -eq 0 ]] || exit 1
 
-echo "All versioned Go tool installs clear GOFLAGS"
+echo "All ${#install_lines[@]} versioned Go tool installs clear GOFLAGS"


### PR DESCRIPTION
## Summary

Install `ctlptl`, `goreleaser`, and `oasdiff` from their upstream binary releases with sha256 verification, instead of `go install <pkg>@<version>`.

## Motivation / Context

`go install pkg@version` builds **outside the main module**, so `go.sum` covers none of the tool's transitive dependencies and each must be authenticated against `sum.golang.org` over the network. There is no local fallback, so a checksum-database outage fails the install outright.

That is what broke the v0.21.1 release. `tests / E2E` died in 2m36s with:

```
github.com/moby/moby/api@v1.52.0: verifying module:
  reading https://sum.golang.org/tile/8/0/x180/452:
  stream error: stream ID 131; INTERNAL_ERROR; received from peer
```

repeated across ~17 packages. `github.com/moby/moby` is **not an AICR dependency** — `grep -c '^github.com/moby/moby/api ' go.sum` returns `0`, and it appears nowhere in `go.mod`. It was reachable only through `go install ctlptl`, which pulls the Docker client tree.

The E2E job reaches this script via `.github/actions/e2e` → `install-e2e-tools` → `AUTO_MODE=true ./tools/setup-tools --skip-go --skip-docker --upgrade`.

Fixes: #2664

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: developer/CI tool installation (`tools/setup-tools`)

## Implementation Notes

**Follows the `flux` block already in this file** — download to a file, fetch the release's `checksums.txt`, extract the entry, fail closed if it is missing, `verify_sha256`, then extract and install. Not the weaker `ko`/`crane` shape, which verifies reachability only.

This matters for the trade-off: `go install` did authenticate every module through the sumdb. Replacing it with an unverified download would have been a net loss of integrity. Verifying each artifact against the publisher's own `checksums.txt` keeps a cryptographic check on the path, using the helper (`verify_sha256`) this file already uses seven times.

**Three different upstream version conventions**, each handled:

| Tool | Pin | Tag | Asset |
|---|---|---|---|
| ctlptl | `0.9.5` (no `v`) | `v0.9.5` | `ctlptl.0.9.5.linux.{x86_64,arm64}.tar.gz` |
| goreleaser | `v2.18.0` | `v2.18.0` | `goreleaser_Linux_{x86_64,arm64}.tar.gz` (no version) |
| oasdiff | `v1.31.0` | `v1.31.0` | `oasdiff_1.31.0_linux_{amd64,arm64}.tar.gz` |

**`setup-tools_test.sh` is inverted, not trimmed.** It asserted `GOFLAGS=` against a hardcoded list of five `go install` targets, so removing three broke it. The allowlist form could never have caught the regression it exists for — a *new* `go install` added without the reset. It now scans every `go install` line, with a floor so removing them all cannot make it pass vacuously.

**Left on `go install` deliberately:** `apidiff`, `addlicense`, `go-licenses` — none publishes a binary release. `.github/actions/install-go-licenses` records that contract. Routing those through Artifactory is #2664's other half and belongs with the CI action.

## Testing

```bash
make qualify   # QUALIFY_EXIT=0, zero failures
bash tools/setup-tools_test.sh
```

Verified against the real releases rather than the pattern — all six URLs (3 tools x 2 arches) return 200, and the checksum extracted by the script's exact `grep`/`awk` matches the downloaded artifact:

```
ctlptl-amd64      MATCH  cf5f0f918c34de06…
goreleaser-amd64  MATCH  41cdf49b653784b0…
oasdiff-amd64     MATCH  0177d4bc0bf04f40…
```

Test behaviour confirmed in all three directions:

```
missing GOFLAGS=       exit 1   (catches the regression)
all installs removed   exit 1   (no vacuous pass)
current tree           exit 0
```

Also confirmed `go version -m` on the downloaded oasdiff binary reports `mod github.com/oasdiff/oasdiff v1.31.0`, so `tools/check-tools`'s `go_binary_module_version` strict-exact check still passes against a release binary rather than a locally built one.

No Go source changed; the coverage gate is unaffected.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Linux paths only; macOS still uses `brew` and is untouched. `.settings.yaml` pins and their Renovate management are unchanged — the checksum is fetched live against the pinned version, so no new pin or refresh hook is introduced (and no interaction with #2658). This adds three more unretried download sites, enlarging the surface #2482 covers; noted there rather than fixed here.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality
- [x] I updated docs if user-facing behavior changed
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
