### PR TITLE
fix(ci): stop fork runs writing caches from lint, e2e and cli-e2e

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -28,6 +28,17 @@ executable bits or `./script.sh` invocation.
 - `oasdiff_sha256` (**required**): pinned linux/amd64 SHA256 for the oasdiff release archive, from `load-versions`. The install fails closed when it is missing or malformed rather than falling back to the release's own `checksums.txt`
 - `privileged_ci` (optional): whether the checked-out ref is trusted (default: `"true"`). Only trusted runs save the Go cache; restore is unconditional. `ok-to-test` passes `false` because it runs an untrusted PR head inside the default branch's cache scope
 
+`go-lint`, `e2e`, and `install-e2e-tools` take a `privileged_ci` input too, but
+each gates a different cache, so the name alone does not tell you what stops:
+`go-lint` gates only golangci-lint's own `~/.cache/golangci-lint` entry,
+`install-e2e-tools` gates its `/usr/local/bin` tool cache, and `e2e` only
+forwards the value. None of the three writes the Go module or build cache —
+they restore `go-test`'s entry and never save it. In all four, the input
+suppresses the writes an ordinary fork run makes by default; on the `ok-to-test`
+path these action files are themselves checked out from the fork, so the gate is
+not a boundary against a crafted PR. Job-level skipping in `qualification.yaml`
+(`cli-e2e`, `security-scan`) is the control that holds there.
+
 Callers that set `apidiff_version` must check out full history with
 `fetch-depth: 0` so `make api-diff` can resolve a reachable stable release tag.
 

--- a/.github/actions/cli-e2e/action.yml
+++ b/.github/actions/cli-e2e/action.yml
@@ -52,8 +52,35 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
       with:
+        # Caching is done explicitly below, for the reasons in go-lint.
+        cache: false
         go-version: '${{ inputs.go_version }}'
-        cache: true
+
+    - name: Resolve Go cache paths
+      id: gocache
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "modcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "buildcache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+
+    # Restore-only against go-test's key, like lint and e2e. This job is
+    # already skipped on the fork path (`if: inputs.privileged_ci` on the job
+    # in qualification.yaml), so the motive here is storage rather than trust:
+    # setup-go was banking a second copy of these same two directories under
+    # `setup-go-*` on every go.sum change, and this repo's cache scope is over
+    # its ceiling and evicting. That eviction falls on the single `go-` entry
+    # lint and e2e now depend on entirely, so reclaiming the duplicate protects
+    # them rather than just saving space.
+    - name: Restore Go modules and build output
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: |
+          ${{ steps.gocache.outputs.modcache }}
+          ${{ steps.gocache.outputs.buildcache }}
+        key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
 
     - name: Install Cosign
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4.0.0

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: 'Number of days to retain debug artifacts'
     required: false
     default: '7'
+  privileged_ci:
+    description: >-
+      Whether this run checked out trusted content. Forwarded to
+      install-e2e-tools, which gates its tool-binary cache save on it. The Go
+      cache below is restore-only and needs no gate. Restore is unconditional
+      either way.
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -35,13 +43,47 @@ runs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
       with:
         go-version: ${{ inputs.go_version }}
-        cache: true
+        # Caching is done explicitly below, for the reasons in go-lint.
+        cache: false
+
+    - name: Resolve Go cache paths
+      id: gocache
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "modcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "buildcache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+
+    # Restore-only, for the reasons spelled out in go-lint: this job shares
+    # go-test's key, entries are immutable, and a save here could take that key
+    # with a GOCACHE that has none of the -race test objects go-test gates its
+    # own save on. The prefix fallback keeps this near-warm without writing.
+    #
+    # Restore-only applies to THIS cache, not to the job: install-e2e-tools
+    # below saves a tool-binary cache, which is why the action still takes a
+    # privileged_ci input to forward.
+    #
+    # E2E benefits less than lint does: `make test` banks -race objects, while
+    # this job's compiles (`ko build`, and the -trimpath/CGO_ENABLED=0 host
+    # builds) use different flags, so those ActionIDs miss. GOMODCACHE still
+    # lands in full, which is the part that dominates a cold run.
+    - name: Restore Go modules and build output
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: |
+          ${{ steps.gocache.outputs.modcache }}
+          ${{ steps.gocache.outputs.buildcache }}
+        key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
 
     - name: Prep runner for Kind
       uses: ./.github/actions/prep-kind-runner
 
     - name: Install E2E testing tools
       uses: ./.github/actions/install-e2e-tools
+      with:
+        privileged_ci: ${{ inputs.privileged_ci }}
 
     - name: Create Kind cluster and deploy aicrd
       shell: bash

--- a/.github/actions/go-lint/action.yml
+++ b/.github/actions/go-lint/action.yml
@@ -30,6 +30,14 @@ inputs:
     description: 'Lint timeout duration'
     required: false
     default: ''
+  privileged_ci:
+    description: >-
+      Whether this run checked out trusted content. Only trusted runs write any
+      cache: ok-to-test executes an untrusted PR head inside the default
+      branch's cache scope, so a write from there can plant an entry a later
+      trusted run consumes. Restore is unconditional either way.
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -38,10 +46,57 @@ runs:
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
       with:
         go-version: '${{ inputs.go_version }}'
-        cache: true
-        cache-dependency-path: |
-          go.sum
+        # Caching is done explicitly below. setup-go's `cache` input cannot
+        # separate restore from save, and this job runs fork-controlled code
+        # under ok-to-test, whose `github.ref` is the default branch -- so its
+        # writes land in main's cache scope (#2670).
+        cache: false
         check-latest: true
+
+    - name: Resolve Go cache paths
+      id: gocache
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "modcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "buildcache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+
+    # Restore-only, deliberately: there is no companion cache/save step, not
+    # even a privileged-gated one.
+    #
+    # This job shares go-test's key rather than owning a namespace, and cache
+    # entries are immutable, so whichever job saves first owns that key until
+    # go.sum moves. go-test gates its own save on `make test` having run,
+    # precisely so the banked GOCACHE contains the -race test objects; a lint
+    # run reaching the key first would bank a GOCACHE without them and every
+    # later go-test run would rebuild all of ./... under -race (#2663).
+    # Giving lint its own key prefix avoids that collision but adds another
+    # multi-GB entry, and this repo's cache scope is already over its storage
+    # ceiling and evicting (`gh api repos/NVIDIA/aicr/actions/cache/usage`), so
+    # a second copy of the same two directories is not free.
+    #
+    # Restore-only is cheap here because the prefix fallback matches go-test's
+    # most recent entry for the same Go version, so a go.sum change degrades to
+    # a near-warm cache rather than a cold one. That fallback is what makes
+    # reading another job's entry viable, and it is safe for the same reason it
+    # is safe in go-test: both directories are content-addressed, so Go
+    # consults what still matches and refetches or rebuilds what does not.
+    #
+    # The cost of the shared key is that three jobs now depend on one
+    # conditional writer. When go-test does not reach the end of `make test`
+    # -- a red `go mod tidy -diff`, a failed tool install, a timeout -- nothing
+    # banks the new go.sum, and lint keeps falling back to a progressively
+    # older entry against a 10-minute budget. It self-heals on the next
+    # completed test run, so this degrades rather than breaks.
+    - name: Restore Go modules and build output
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: |
+          ${{ steps.gocache.outputs.modcache }}
+          ${{ steps.gocache.outputs.buildcache }}
+        key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
 
     - name: Lint Go
       if: hashFiles('.golangci.yaml') != ''
@@ -49,6 +104,14 @@ runs:
       with:
         version: ${{ inputs.golangci_lint_version }}
         args: --timeout=${{ inputs.lint_timeout || '5m' }}
+        # This action keeps its own cache, separate from the two directories
+        # restored above, and saves it by default -- a second write into main's
+        # scope from a fork-controlled checkout that #2670 does not enumerate.
+        # `skip-save-cache` suppresses only the write; restore still happens,
+        # so unprivileged runs keep the speedup without being able to plant
+        # anything. Its key namespace does not collide with `go-`, so trusted
+        # runs still save normally.
+        skip-save-cache: ${{ inputs.privileged_ci != 'true' }}
 
     - name: Lint YAML
       if: hashFiles('.yamllint.yaml') != ''

--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -105,13 +105,18 @@ runs:
     # by accident; a prefix fallback would not, which is why adding the fallback
     # and gating the write belong in the same change.
     #
-    # This gates THIS job only, and does not make the fork path safe on its own.
-    # qualification.yaml's `lint` and `e2e` jobs are ungated and reach setup-go
-    # with `cache: true`, which saves the same two directories into the same
-    # scope while running the same untrusted checkout. Closing that means giving
-    # them this restore/save split too -- setup-go's `cache` input cannot
-    # separate the two halves, and turning it off outright would make fork runs
-    # pay a cold cache against a 10-minute lint budget. Tracked in #2670.
+    # This job is the only writer of the `go-` key: #2670 moved qualification's
+    # `lint` and `e2e` onto it as restore-only consumers, so the save gated
+    # below decides the contents every later run restores -- which is why it
+    # waits for `make test` rather than banking a GOCACHE with no -race test
+    # objects in it.
+    #
+    # Note what this gate is and is not. On the ok-to-test path the action file
+    # you are reading is itself checked out from the fork (ok-to-test.yaml
+    # documents this), so a crafted PR can edit the gate away. It stops the
+    # default-on writes an ordinary fork run would make; it is not a boundary
+    # against an attacker. The boundary that holds is job-level: skipping the
+    # job in qualification.yaml, as cli-e2e and security-scan do.
     - name: Restore Go modules and build output
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       id: gocache-restore

--- a/.github/actions/install-e2e-tools/action.yml
+++ b/.github/actions/install-e2e-tools/action.yml
@@ -19,11 +19,38 @@ description: 'Installs development tools for E2E testing using the shared setup 
 # local development and CI environments. The same script, same versions,
 # same installation logic - no more "works on my machine" issues.
 
+inputs:
+  privileged_ci:
+    description: >-
+      Whether this run checked out trusted content. Only trusted runs save the
+      tool cache; restore is unconditional. ok-to-test executes an untrusted PR
+      head inside the default branch's cache scope, and this cache stores
+      executables rather than content-addressed objects.
+    required: false
+    default: 'true'
+
 runs:
   using: "composite"
   steps:
-    - name: Cache development tools
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+    # Split restore/save rather than the combined `actions/cache`, and the save
+    # is gated. This cache stores executables by path, so a restored entry is
+    # run directly -- a strictly worse payload than the content-addressed Go
+    # caches #2670 gated, where a planted entry is only consulted when its
+    # ActionID matches. `ok-to-test` runs on `issue_comment`, so its
+    # `github.ref` is the default branch and its writes land in main's scope
+    # while the checkout is an untrusted PR head.
+    #
+    # `--upgrade` below is not a sufficient defence, which is why the write is
+    # gated instead of relied upon:
+    #   - tools/setup-tools:229 runs `yq --version` (via is_mikefarah_yq) on the
+    #     RESTORED binary, before the reinstall at :238 replaces it.
+    #   - a failed download calls log_error, which prints and returns without
+    #     exiting (tools/common:56), leaving the restored binary in place.
+    # Both would have to keep holding for overwrite-before-use to protect
+    # anything, and neither is stated as a security property where it lives.
+    - name: Restore development tools
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      id: tools-restore
       with:
         path: |
           /usr/local/bin/ctlptl
@@ -74,3 +101,26 @@ runs:
           tools_check_rc=$?
           printf '%s\n' "::warning title=Non-gating tool check failed::make tools-check exited with status ${tools_check_rc}; E2E continues because its required-tool contract is narrower."
         fi
+
+    # Saved here rather than by a combined `actions/cache` post step, so the
+    # write can be gated. Skipped entirely when the checkout is untrusted; the
+    # restore above is unconditional, so a fork run keeps the speedup.
+    #
+    # Runs after the install step on purpose: what is banked is what
+    # setup-tools produced at the pinned versions, not whatever the restore
+    # left behind.
+    - name: Save development tools
+      if: >-
+        inputs.privileged_ci == 'true'
+        && steps.tools-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: |
+          /usr/local/bin/ctlptl
+          /usr/local/bin/kind
+          /usr/local/bin/kubectl
+          /usr/local/bin/tilt
+          /usr/local/bin/ko
+          /usr/local/bin/helm
+          /usr/local/bin/yq
+        key: ${{ steps.tools-restore.outputs.cache-primary-key }}

--- a/.github/actions/install-e2e-tools/action.yml
+++ b/.github/actions/install-e2e-tools/action.yml
@@ -102,6 +102,53 @@ runs:
           printf '%s\n' "::warning title=Non-gating tool check failed::make tools-check exited with status ${tools_check_rc}; E2E continues because its required-tool contract is narrower."
         fi
 
+    # Verify what is about to be banked actually matches the pins, because
+    # "setup-tools ran" is not the same as "setup-tools installed".
+    # verify_download_url failing calls log_error, which prints and returns
+    # without exiting (tools/common:56), so a transient download failure leaves
+    # the RESTORED binary in place -- possibly one a prefix-key fallback pulled
+    # from an older .settings.yaml. The report step above only warns, so
+    # without this the save below would promote that stale binary to the new
+    # exact key and every later run would restore it.
+    #
+    # Scoped to the seven paths this action caches rather than deferring to
+    # `make tools-check`: that covers the whole toolchain, so an unrelated
+    # mismatch would stop the cache from ever being written, and it compares
+    # helm on major only, which would not notice a v4.2.4 pin serving v4.3.0.
+    #
+    # Mismatch skips the save; it does not fail the job. E2E's required-tool
+    # contract is narrower than this cache, and a cold next run is the correct
+    # penalty for an unverifiable one.
+    - name: Verify tool versions before caching
+      id: verify-tools
+      shell: bash
+      run: |
+        set -uo pipefail
+        ok=true
+        check() {
+          local name="$1" want="$2" got="$3"
+          want="${want#v}"; got="${got#v}"
+          if [ -z "$got" ]; then
+            echo "::warning::${name}: could not read installed version (pinned ${want})"
+            ok=false
+          elif [ "$want" != "$got" ]; then
+            echo "::warning::${name}: installed ${got}, pinned ${want}"
+            ok=false
+          fi
+        }
+        pin() { yq "$1" .settings.yaml; }
+        check ctlptl  "$(pin '.testing_tools.ctlptl')"  "$(ctlptl version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        check kind    "$(pin '.testing_tools.kind')"    "$(kind version 2>/dev/null | awk '{print $2}')"
+        check kubectl "$(pin '.testing_tools.kubectl')" "$(kubectl version --client -o json 2>/dev/null | grep gitVersion | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        check tilt    "$(pin '.testing_tools.tilt')"    "$(tilt version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        check ko      "$(pin '.build_tools.ko')"        "$(ko version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        check helm    "$(pin '.testing_tools.helm')"    "$(helm version --template '{{.Version}}' 2>/dev/null)"
+        check yq      "$(pin '.testing_tools.yq')"      "$(yq --version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        echo "verified=${ok}" >> "$GITHUB_OUTPUT"
+        if [ "$ok" != "true" ]; then
+          echo "::warning title=Tool cache not saved::at least one binary does not match its .settings.yaml pin"
+        fi
+
     # Saved here rather than by a combined `actions/cache` post step, so the
     # write can be gated. Skipped entirely when the checkout is untrusted; the
     # restore above is unconditional, so a fork run keeps the speedup.
@@ -112,6 +159,7 @@ runs:
     - name: Save development tools
       if: >-
         inputs.privileged_ci == 'true'
+        && steps.verify-tools.outputs.verified == 'true'
         && steps.tools-restore.outputs.cache-hit != 'true'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:

--- a/.github/workflows/qualification.yaml
+++ b/.github/workflows/qualification.yaml
@@ -100,6 +100,7 @@ jobs:
           golangci_lint_version: ${{ steps.versions.outputs.golangci_lint }}
           addlicense_version: ${{ steps.versions.outputs.addlicense }}
           lint_timeout: ${{ steps.versions.outputs.lint_timeout }}
+          privileged_ci: ${{ inputs.privileged_ci }}
 
   cli-e2e:
     name: CLI E2E
@@ -152,6 +153,7 @@ jobs:
         uses: ./.github/actions/e2e
         with:
           go_version: ${{ steps.versions.outputs.go }}
+          privileged_ci: ${{ inputs.privileged_ci }}
 
   security-scan:
     name: Security Scan


### PR DESCRIPTION
## Summary

Everything in `qualification.yaml` except `go-test` was writing caches into the
default branch's scope while running a fork-controlled checkout. `lint`, `e2e`
and `cli-e2e` are now restore-only against `go-test`'s key, and the two
remaining writers reachable from that path — golangci-lint's own cache and the
e2e tool-binary cache — are gated on `privileged_ci`.

## Motivation / Context

`ok-to-test.yaml` triggers on `issue_comment`, so `github.ref` resolves to the
default branch and every cache write from that run lands in **main's** scope. It
then checks out the PR head and calls `qualification.yaml`. Go does not
re-verify `GOCACHE` on read, so a restored entry is trusted build output. #2673
closed this for `go-test`; the rest of the workflow still wrote.

Fixes: #2670
Fixes: #2679
Related: #2663, #2673, #2681

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `.github/actions/{go-lint,e2e,cli-e2e,go-test,install-e2e-tools}`, `.github/workflows/qualification.yaml`, `.github/actions/README.md`

## Implementation Notes

### What this gate is, and what it is not

Read this first, because it bounds every claim below. On the `ok-to-test` path
the action files in this PR are themselves checked out **from the fork** —
`uses: ./.github/actions/*` resolves against `$GITHUB_WORKSPACE` after
`actions/checkout` has fetched the PR head. `ok-to-test.yaml:17-19` already
states this in the repo's own words.

So a crafted PR can edit any gate here away; restoring `cache: true` in its own
copy of `go-lint/action.yml` is enough. What this change removes is the
**default-on** writes — the ones an ordinary fork run makes without trying, and
the ones a maintainer running `/ok-to-test` on a plausible-looking PR would not
notice. The control that actually holds against a crafted PR is job-level
skipping in `qualification.yaml`, which is why `cli-e2e` and `security-scan` are
gated there; `lint` and `e2e` cannot be skipped without gutting the point of
`/ok-to-test`. Closing that properly means changing where the decision is made,
not adding more gates below the checkout. Tracked as #2681.

This is recorded in `go-test/action.yml` and `.github/actions/README.md` so the
next reader does not mistake the gate for a boundary.

### Restore-only rather than a gated save

#2670 proposed giving `lint` and `e2e` a `privileged_ci`-gated save. They are
restore-only instead, with no save step at all.

They share `go-test`'s `go-` key, and entries are immutable — whichever job
saves first owns it until `go.sum` moves. `go-test` gates its save on `make
test` having run, precisely so the banked `GOCACHE` holds the `-race` test
objects. A `lint` run reaching the key first would bank one without them, and
every later `go-test` run would rebuild all of `./...` under `-race` —
reintroducing what #2663 was filed to fix. Separate key prefixes avoid the
collision but add multi-GB entries to a scope already over its ceiling
(`gh api repos/NVIDIA/aicr/actions/cache/usage` reports ~12.6 GB across 61
entries, i.e. actively evicting).

Restore-only is affordable because of the prefix fallback #2663 added: a
`go.sum` change degrades to near-warm rather than cold. The cost is that three
jobs now depend on one conditional writer — when `go-test` does not reach the
end of `make test`, nothing banks the new `go.sum` and the readers fall back to
progressively older entries. It self-heals on the next completed run, so this
degrades rather than breaks; it is noted in `go-lint/action.yml`.

### Two writers #2670 does not enumerate

**golangci-lint-action** keeps its own cache (`~/.cache/golangci-lint`) and
saves it by default. `skip-save-cache` suppresses only the write, so
unprivileged runs still restore. Its key namespace does not collide with `go-`.

**install-e2e-tools** saved seven executables from `/usr/local/bin` via combined
`actions/cache`, ungated, from the fork-reachable `e2e` job. That is a worse
payload than a content-addressed Go cache: entries are restored by path and run
directly. It is now split into restore plus a gated save, which also closes
#2679.

#2679 originally judged this unexploitable on the grounds that `--upgrade`
overwrites restored binaries before use. That is wrong, and the issue has been
corrected: `tools/setup-tools:229` runs `yq --version` on the **restored**
binary (via `is_mikefarah_yq`, defined at `:224-226`) before the reinstall at
`:238`, and a failed download calls `log_error`, which prints and returns
without exiting (`tools/common:56-58`), leaving the restored binary in place.

### cli-e2e

Included for storage, not trust — it is already skipped on the fork path. Its
`setup-go` was banking a second copy of the same two directories under
`setup-go-*` on every `go.sum` change, and that duplicate competes for eviction
with the single `go-` entry `lint` and `e2e` now depend on entirely.

## Testing

```bash
unset GITLAB_TOKEN
make qualify          # QUALIFY_EXIT=0
```

Audited rather than assumed:

- No `cache: true` remains in any action reachable from `qualification.yaml`
  (`go-test`, `go-lint`, `e2e`, `cli-e2e`, `load-versions`, `security-scan`).
- The only cache writers left in that reachable set are the two gated saves in
  `go-test` and `install-e2e-tools`. The other writers in the repo
  (`kwok-test`, `install-karpenter-kwok`, `kwok-recipes`, `mirror-e2e`) are not
  reachable from `qualification.yaml`.
- `skip-save-cache` was confirmed to exist on the pinned
  `golangci-lint-action@1e7e51e` and to gate only the save.
- The `key`/`restore-keys` blocks are byte-identical across all four actions, and
  `go_version` reaches each from the same `load-versions` output.

Cache behavior itself cannot be exercised locally; on this PR's own run, `lint`,
`e2e` and `cli-e2e` should show a restore from the `go-` key with no
corresponding save.

## Risk Assessment

- [ ] **Low** — Isolated change, well-tested, easy to revert
- [x] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

Medium because it changes cache behavior for four jobs on the merge-gate path.
The failure mode is a slower job rather than a wrong result: a missed restore
means Go refetches and rebuilds.

**Rollout notes:** `lint`, `e2e` and `cli-e2e` stop writing `setup-go-*`
entries, and `install-e2e-tools` stops writing on fork runs. `go-test`'s `go-`
entries already exist from #2673, so the first run after merge restores rather
than starting cold. Net effect on the over-ceiling cache scope is a reduction.

## Checklist

- [x] Tests pass locally (`make test` with `-race`)
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality (N/A — CI configuration; no Go code changed)
- [x] I updated docs if user-facing behavior changed (`.github/actions/README.md`)
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)

