### PR TITLE
ci: add a dispatchable DGXC Go proxy diagnostic for #2667

### DIFF
--- a/.github/workflows/goproxy-diagnostics.yaml
+++ b/.github/workflows/goproxy-diagnostics.yaml
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Answers two questions about the DGXC Artifactory Go proxy that nothing else
+# in this repo can, because setup-dgxc-goproxy only ever runs on a tag push.
+#
+# 1. **Does the repository proxy the checksum database?** GOPROXY and GOSUMDB
+#    are independent paths. Routing modules through Artifactory does not by
+#    itself route checksum lookups: the go command requests
+#    /sumdb/sum.golang.org/... from the proxy and, on 404 or 410, falls back to
+#    a DIRECT connection to sum.golang.org — including under `enforced` mode,
+#    where GOPROXY carries no `,direct`. A repository that serves modules but
+#    not sumdb therefore leaves every build dependent on sum.golang.org being
+#    up, while looking fully routed.
+#
+# 2. **Can it serve modules outside this repo's go.mod?** The remaining
+#    `go install pkg@version` calls in .github/actions build outside the main
+#    module, so their transitive dependencies appear in no go.sum here. A tag
+#    build proves Artifactory serves this repo's own graph; it proves nothing
+#    about those.
+#
+# Together those decide #2667: whether the surviving `go install` calls can be
+# made outage-proof by routing, or whether they have to move to pinned binaries
+# the way oasdiff did in #2673.
+#
+# Diagnostic only. It changes nothing and gates nothing, so it is
+# workflow_dispatch rather than wired into the merge gate — the answer changes
+# when Artifactory's configuration changes, not when this repo does.
+
+name: Go Proxy Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'setup-dgxc-goproxy mode to probe under'
+        required: false
+        default: routed
+        type: choice
+        options: [routed, enforced]
+
+permissions:
+  contents: read
+
+jobs:
+
+  probe:
+    name: Probe the DGXC Go proxy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Minting the Artifactory credential via GitHub OIDC. The proxy action
+      # needs this; nothing else in this workflow does.
+      id-token: write
+    steps:
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        id: versions
+        uses: ./.github/actions/load-versions
+
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
+        with:
+          go-version: '${{ steps.versions.outputs.go }}'
+          cache: false
+
+      - name: Configure the DGXC Go proxy
+        id: proxy
+        uses: ./.github/actions/setup-dgxc-goproxy
+        with:
+          mode: ${{ inputs.mode }}
+
+      # Probes from here rather than from inside the action: the kit is
+      # vendored verbatim from NVIDIA-dev/dgxc-depproxy and an in-place edit
+      # forks it silently, which tools/check-depproxy-kit exists to prevent.
+      # GOAUTH is exported to the environment, so the same credential helper
+      # the go command will use is available to a caller.
+      - name: Is the checksum database proxied?
+        id: sumdb
+        env:
+          # Taken from the action's own output rather than restating its
+          # host/repo-key defaults, so the probe cannot drift from the endpoint
+          # the go command was actually pointed at.
+          GOPROXY_CONFIGURED: ${{ steps.proxy.outputs.goproxy }}
+        run: |
+          set -euo pipefail
+          auth_header="$("${GOAUTH}" < /dev/null | sed -n 's/^Authorization: //p' | head -1)"
+
+          # routed mode appends ",direct"; the probe wants the Artifactory base.
+          base="${GOPROXY_CONFIGURED%%,*}"
+
+          # /supported is the endpoint the go command itself probes to decide
+          # whether a proxy speaks the checksum-database protocol.
+          url="${base}/sumdb/sum.golang.org/supported"
+          status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+            -H "Authorization: ${auth_header}" "${url}" || echo 000)"
+          echo "sumdb_status=${status}" >> "$GITHUB_OUTPUT"
+
+          echo "### Checksum database" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${status}" == "200" ]]; then
+            echo "PROXIED (HTTP 200). Checksum lookups resolve through Artifactory." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "#2667 can be closed by routing: sum.golang.org is not on the path." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "NOT PROXIED (HTTP ${status}). The go command falls back to sum.golang.org directly." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "#2667 cannot be closed by routing alone; the remaining go installs need pinned binaries." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # The four tools #2667 is about. Each builds outside the main module, so
+      # this is the only way to learn whether Artifactory can serve their
+      # dependency graphs — a tag build never exercises them.
+      - name: Can it serve the out-of-module tools?
+        env:
+          SETUP_ENVTEST_VERSION: ${{ steps.versions.outputs.setup_envtest }}
+          APIDIFF_VERSION: ${{ steps.versions.outputs.apidiff }}
+          GO_LICENSES_VERSION: ${{ steps.versions.outputs.go_licenses }}
+          ADDLICENSE_VERSION: ${{ steps.versions.outputs.addlicense }}
+        run: |
+          set -uo pipefail
+          {
+            echo "### Out-of-module go install"
+            echo "GOPROXY=$(go env GOPROXY)"
+            echo ""
+            echo "| tool | result |"
+            echo "|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          probe() {
+            local name="$1" pkg="$2"
+            # GOFLAGS is emptied for the same reason tools/setup-tools empties
+            # it: -mod=readonly is meaningless outside the main module. Written
+            # GOFLAGS="" rather than bare GOFLAGS= so shellcheck does not read
+            # it as a mistyped assignment (SC1007).
+            if GOFLAGS="" go install "${pkg}" 2>/tmp/err.txt; then
+              echo "| ${name} | ok |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${name} | FAILED — $(head -1 /tmp/err.txt) |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+
+          probe setup-envtest "sigs.k8s.io/controller-runtime/tools/setup-envtest@${SETUP_ENVTEST_VERSION}"
+          probe apidiff       "golang.org/x/exp/cmd/apidiff@${APIDIFF_VERSION}"
+          probe go-licenses   "github.com/google/go-licenses/v2@${GO_LICENSES_VERSION}"
+          probe addlicense    "github.com/google/addlicense@${ADDLICENSE_VERSION}"
+
+      - name: Verdict
+        env:
+          SUMDB_STATUS: ${{ steps.sumdb.outputs.sumdb_status }}
+        run: |
+          echo "sumdb probe: HTTP ${SUMDB_STATUS}"
+          echo "See the job summary for the full result."

--- a/.github/workflows/goproxy-diagnostics.yaml
+++ b/.github/workflows/goproxy-diagnostics.yaml
@@ -101,40 +101,107 @@ jobs:
         run: |
           set -euo pipefail
           auth_header="$("${GOAUTH}" < /dev/null | sed -n 's/^Authorization: //p' | head -1)"
+          if [[ -z "${auth_header}" ]]; then
+            echo "::error::GOAUTH helper produced no Authorization header."
+            exit 1
+          fi
 
           # routed mode appends ",direct"; the probe wants the Artifactory base.
           base="${GOPROXY_CONFIGURED%%,*}"
 
-          # /supported is the endpoint the go command itself probes to decide
-          # whether a proxy speaks the checksum-database protocol.
-          url="${base}/sumdb/sum.golang.org/supported"
-          status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
-            -H "Authorization: ${auth_header}" "${url}" || echo 000)"
-          echo "sumdb_status=${status}" >> "$GITHUB_OUTPUT"
+          probe_status() {
+            # curl's -w already prints 000 on a connection failure, and it also
+            # exits non-zero -- `|| echo 000` would append a second one and
+            # record 000000. Disarm errexit instead of adding a fallback value.
+            local url="$1" code
+            code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+              -H "Authorization: ${auth_header}" "${url}")" || true
+            printf '%s' "${code:-000}"
+          }
 
-          echo "### Checksum database" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "${status}" == "200" ]]; then
-            echo "PROXIED (HTTP 200). Checksum lookups resolve through Artifactory." | tee -a "$GITHUB_STEP_SUMMARY"
-            echo "#2667 can be closed by routing: sum.golang.org is not on the path." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "NOT PROXIED (HTTP ${status}). The go command falls back to sum.golang.org directly." | tee -a "$GITHUB_STEP_SUMMARY"
-            echo "#2667 cannot be closed by routing alone; the remaining go installs need pinned binaries." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          # /supported is the endpoint the go command itself fetches to decide
+          # whether a proxy speaks the checksum-database protocol.
+          supported="$(probe_status "${base}/sumdb/sum.golang.org/supported")"
+          echo "sumdb_status=${supported}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Checksum database"
+            echo ""
+            echo "\`/sumdb/sum.golang.org/supported\` -> HTTP ${supported}"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Three outcomes, not two. From cmd/go/internal/modfetch/sumdb.go:
+          # 200 commits the client to the proxy and it NEVER falls back; 404 or
+          # 410 sends it to the next proxy and then direct; "any other response
+          # is treated as the database being unavailable" -- a hard failure.
+          # Collapsing those last two would misreport a 403 (which the vendored
+          # kit records edge returning, FINDINGS F-018) as a benign fallback.
+          case "${supported}" in
+            200)
+              # A 200 is the dangerous direction: it removes the direct fallback
+              # for the whole build, so protocol support alone is not enough.
+              # Confirm a real lookup resolves before calling this closed.
+              lookup="$(probe_status "${base}/sumdb/sum.golang.org/lookup/golang.org/x/text@v0.3.0")"
+              echo "\`/sumdb/sum.golang.org/lookup/...\` -> HTTP ${lookup}" >> "$GITHUB_STEP_SUMMARY"
+              echo "lookup_status=${lookup}" >> "$GITHUB_OUTPUT"
+              if [[ "${lookup}" == "200" ]]; then
+                echo "verdict=proxied" >> "$GITHUB_OUTPUT"
+                echo "PROXIED. Checksum lookups resolve through Artifactory, so #2667 can be closed by routing." >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "verdict=broken" >> "$GITHUB_OUTPUT"
+                {
+                  echo "**DANGEROUS.** \`/supported\` answers 200, so the go command commits to"
+                  echo "the proxy and never falls back -- but a real lookup returned ${lookup}."
+                  echo "Enforced builds would hard-fail on checksum verification."
+                  echo "Do not route until this is fixed upstream."
+                } >> "$GITHUB_STEP_SUMMARY"
+              fi
+              ;;
+            404|410)
+              echo "verdict=not-proxied" >> "$GITHUB_OUTPUT"
+              {
+                echo "NOT PROXIED. The go command falls back to a direct connection to"
+                echo "sum.golang.org, so routing alone does not remove the outage exposure"
+                echo "in #2667 -- the remaining \`go install\` calls need pinned binaries."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "verdict=unavailable" >> "$GITHUB_OUTPUT"
+              {
+                echo "**INCONCLUSIVE.** HTTP ${supported} is neither 200 nor 404/410, which the"
+                echo "go command treats as the database being unavailable -- it would fail"
+                echo "rather than fall back. Most likely a credential or WAF answer (the kit's"
+                echo "FINDINGS F-018/F-019), not a statement about sumdb support. Resolve it"
+                echo "before drawing a #2667 conclusion."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+          esac
 
       # The four tools #2667 is about. Each builds outside the main module, so
       # this is the only way to learn whether Artifactory can serve their
-      # dependency graphs — a tag build never exercises them.
+      # dependency graphs -- a tag build never exercises them.
       - name: Can it serve the out-of-module tools?
         env:
+          GOPROXY_CONFIGURED: ${{ steps.proxy.outputs.goproxy }}
           SETUP_ENVTEST_VERSION: ${{ steps.versions.outputs.setup_envtest }}
           APIDIFF_VERSION: ${{ steps.versions.outputs.apidiff }}
           GO_LICENSES_VERSION: ${{ steps.versions.outputs.go_licenses }}
           ADDLICENSE_VERSION: ${{ steps.versions.outputs.addlicense }}
         run: |
           set -uo pipefail
+
+          # Always probe against the Artifactory base alone, never the routed
+          # form. GOPROXY is an ordered list consulted left to right on 404/410,
+          # so a `,direct` suffix makes every install succeed from the origin
+          # and the table would report `ok` for modules Artifactory cannot
+          # serve -- a fail-open answer to the one question this step asks.
+          base="${GOPROXY_CONFIGURED%%,*}"
+
           {
-            echo "### Out-of-module go install"
-            echo "GOPROXY=$(go env GOPROXY)"
+            echo "### Out-of-module \`go install\`"
+            echo ""
+            echo "Probed against \`${base}\` with no \`direct\` fallback."
             echo ""
             echo "| tool | result |"
             echo "|---|---|"
@@ -142,15 +209,22 @@ jobs:
 
           probe() {
             local name="$1" pkg="$2"
+            local err="${RUNNER_TEMP}/probe-${name}.err"
             # GOFLAGS is emptied for the same reason tools/setup-tools empties
             # it: -mod=readonly is meaningless outside the main module. Written
             # GOFLAGS="" rather than bare GOFLAGS= so shellcheck does not read
             # it as a mistyped assignment (SC1007).
-            if GOFLAGS="" go install "${pkg}" 2>/tmp/err.txt; then
+            if GOFLAGS="" GOPROXY="${base}" go install "${pkg}" 2>"${err}"; then
               echo "| ${name} | ok |" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "| ${name} | FAILED — $(head -1 /tmp/err.txt) |" >> "$GITHUB_STEP_SUMMARY"
+              return
             fi
+            # Full stderr to the log, last line to the table: `go install`
+            # prints "go: downloading ..." progress before the real error, so
+            # the first line is usually not the cause.
+            echo "::group::${name} failed"
+            cat "${err}"
+            echo "::endgroup::"
+            echo "| ${name} | FAILED -- $(tail -1 "${err}") |" >> "$GITHUB_STEP_SUMMARY"
           }
 
           probe setup-envtest "sigs.k8s.io/controller-runtime/tools/setup-envtest@${SETUP_ENVTEST_VERSION}"
@@ -161,6 +235,14 @@ jobs:
       - name: Verdict
         env:
           SUMDB_STATUS: ${{ steps.sumdb.outputs.sumdb_status }}
+          VERDICT: ${{ steps.sumdb.outputs.verdict }}
         run: |
-          echo "sumdb probe: HTTP ${SUMDB_STATUS}"
+          echo "sumdb /supported: HTTP ${SUMDB_STATUS} -> ${VERDICT}"
           echo "See the job summary for the full result."
+
+      # Required, not tidy: setup-dgxc-goproxy writes a live bearer token to
+      # RUNNER_TEMP and a composite action has no teardown hook, so every
+      # caller removes it. Matches all three call sites in on-tag.yaml.
+      - name: Remove the Artifactory credential
+        if: always()
+        run: rm -f "${RUNNER_TEMP}/dgxc-goauth"


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` diagnostic that answers the two questions #2667's fix
depends on. It gates nothing and changes no existing behavior.

## Motivation / Context

#2667 proposes routing the surviving `go install` calls in `.github/actions`
through the DGXC Artifactory proxy so a `sum.golang.org` outage stops failing
the gate. **That plan rests on an assumption this repo cannot currently check.**

`GOPROXY` and `GOSUMDB` are independent paths. Pointing `GOPROXY` at Artifactory
does not by itself route checksum lookups: the go command fetches
`<proxy>/sumdb/sum.golang.org/supported` and decides from the response. I
confirmed that empirically — a local logging proxy shows the go command
requesting exactly that path during `go install` — and against
`cmd/go/internal/modfetch/sumdb.go`, whose contract is three-way:

| `/supported` | behavior |
|---|---|
| `200` | use the proxy **only**, *never* falling back |
| `404` / `410` | try the next proxy, then connect directly |
| anything else | database treated as **unavailable** — the build fails |

So if `dgxc-go-virtual` does not proxy the checksum database, wiring the action
into the gate would close #2667 on paper and leave the exact outage exposure
that cost v0.21.1 three attempts.

Nothing in the repo could settle it. `setup-dgxc-goproxy` runs only on a tag
push; its own verify step probes module listing, never `/sumdb/`; and
`dependency-resolvability.yaml` deliberately stays unauthenticated so Dependabot
PRs work. Unauthenticated probing cannot distinguish either — the endpoint
returns 404 for a supported and an unsupported repository alike.

Related: #2667

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Build/CI/tooling

## Component(s) Affected

- [x] Other: `.github/workflows/goproxy-diagnostics.yaml` (new file, nothing else touched)

## Implementation Notes

**The probe lives in the caller, not the action.** `setup-dgxc-goproxy` is
vendored verbatim from `NVIDIA-dev/dgxc-depproxy` and `tools/check-depproxy-kit`
fails on an in-place edit — correctly; I tried it first and the gate caught me.
`GOAUTH` is exported to the environment, so the caller can reuse the same
credential helper the go command will use, and the endpoint is derived from the
action's own `goproxy` output rather than restating its host/repo-key defaults.

**It reports three outcomes, not two**, matching Go's contract above. Collapsing
the last two would misreport a `403` — which the kit records edge returning
(FINDINGS F-018) — as a benign fallback, when the build would actually fail.

**A `200` is not sufficient on its own.** Because a `200` removes the direct
fallback for the whole build, protocol support alone is the dangerous direction:
a proxy that answers `/supported` but not `lookup/...` would hard-fail enforced
builds. The probe confirms a real lookup before reporting success.

**The `go install` half pins `GOPROXY` to the Artifactory base with no
`,direct`.** Under the workflow's `routed` default the go command falls through
to the origin on 404, so every tool would report `ok` regardless of what
Artifactory can serve — a fail-open answer to the only question that step asks.

**Scope correction for #2667:** it lists three remaining `go install` calls, but
there is a fourth on the same PR-gate path — `addlicense` in
`go-lint/action.yml:128`. The probe covers all four.

## Testing

```bash
make lint          # exit 0 (actionlint + yamllint + license + depproxy-kit)
```

- The `/sumdb/.../supported` request was **observed**, not assumed: a local
  forwarding proxy logged the go command fetching that exact path during
  `go install github.com/google/addlicense@v1.1.1`.
- The three-way status contract was read from
  `cmd/go/internal/modfetch/sumdb.go` at the pinned toolchain, not recalled.
- The curl idiom was checked against an unreachable host: it yields `000`, not
  the `000000` an earlier `|| echo 000` form produced.

This cannot be dry-run further from a branch — `workflow_dispatch` requires the
file on the default branch, which is why it needs to merge before it can answer
anything.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

One new file. `workflow_dispatch` only, so it never runs on a PR, a push, or a
tag; it is in no required check and blocks nothing.

On the `id-token: write` grant: dispatch is restricted to repo writers, no
untrusted or fork ref is checked out, every `${{ }}` lands in `with:`/`env:` and
none reaches a shell body, and the token is masked by the vendored kit and never
written to `GITHUB_ENV`, `GITHUB_OUTPUT`, or the step summary. It is not a
privilege widening — the JFrog mapping is org-scoped, so any writer could
already mint one from a branch workflow. The job removes the credential from
`RUNNER_TEMP` under `if: always()`, matching all three call sites in
`on-tag.yaml`.

**Rollout notes:** merge, then dispatch it once (try `enforced`, then `routed`
if you want the contrast) and read the job summary. The result decides #2667:
routing if the checksum database is proxied, pinned binaries if not.

## Checklist

- [x] Tests pass locally (`make test` with `-race`) — N/A, no Go code changed
- [x] Linter passes (`make lint`)
- [x] I did not skip/disable tests to make CI green
- [x] I added/updated tests for new functionality — N/A, the workflow is itself a diagnostic
- [x] I updated docs if user-facing behavior changed — N/A, no user-facing behavior
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
