### PR TITLE
chore(evidence): vr200 training-kubeflow three-phase attestation

### DIFF
--- a/recipes/evidence/vr200-rke2-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-cab912550bf2999744b2c685f40cd96ec010bf7e615da59847ce55090cae4bae.yaml
+++ b/recipes/evidence/vr200-rke2-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-cab912550bf2999744b2c685f40cd96ec010bf7e615da59847ce55090cae4bae.yaml
@@ -1,0 +1,12 @@
+attestations:
+  - attestedAt: 2026-09-11T16:57:44Z
+    bundle:
+      digest: sha256:cab912550bf2999744b2c685f40cd96ec010bf7e615da59847ce55090cae4bae
+      oci: ghcr.io/yuanchen8911/aicr-evidence:vr200-rke2-ubuntu-training-kubeflow-87aaa94df2cd
+      predicateType: https://aicr.run/recipe-evidence/v1
+    signer:
+      identity: https://github.com/yuanchen8911/aicr/.github/workflows/evidence-publish.yaml@refs/heads/evidence/aks-h100-training-inference
+      issuer: https://token.actions.githubusercontent.com
+      rekorLogIndex: 105832365
+recipe: vr200-rke2-ubuntu-training-kubeflow
+schemaVersion: 1.0.0


### PR DESCRIPTION
## Summary

Adds the signed recipe-evidence pointer for `vr200-rke2-ubuntu-training-kubeflow`, the coordinate introduced by #2717.

## Motivation / Context

#2564 asks each new `training-kubeflow` leaf to be hardware-validated rather than added on resolution alone, and singles out VR200's Kubeflow path as never having been exercised on VR silicon. This is the evidence for that run.

It also closes the tension #2717 leaves behind: the Preview contract in `docs/integrator/recipe-development.md` promises published evidence for Preview coordinates, and the new row currently reads `pending`. Rather than relax that contract, #2717 kept it intact and this PR supplies the missing evidence.

Fixes: N/A
Related: #2717, #2564

**Merge order: this PR must land after #2717.** The predicate attests recipe `vr200-rke2-ubuntu-training-kubeflow`, which does not exist in the catalog until #2717 merges. Merging this first would commit evidence for a coordinate `main` does not contain.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling

## Component(s) Affected

- [ ] CLI (`cmd/aicr`, `pkg/cli`)
- [ ] API server (`cmd/aicrd`, `pkg/server`)
- [ ] Recipe engine / data (`pkg/recipe`)
- [ ] Bundlers (`pkg/bundler`, `pkg/component/*`)
- [ ] Collectors / snapshotter (`pkg/collector`, `pkg/snapshotter`)
- [ ] Validator (`pkg/validator`)
- [ ] Core libraries (`pkg/errors`, `pkg/k8s`)
- [ ] Docs/examples (`docs/`, `examples/`)
- [x] Other: `recipes/evidence/`

## Implementation Notes

**Validation run.** Cluster `vr200-aicr-cluster-2` (VR200 NVL72, 2 GPU workers x 4, RKE2 `v1.35.6+rke2r1`, Ubuntu 26.04 on the `7.0.0-2008-nvidia-bos-64k` arm64 64k-page kernel). All four readiness constraints were checked against the live cluster, then all three phases ran in a single invocation:

| Phase | Result |
|---|---|
| deployment | 4/4 passed |
| conformance | 9/9 passed |
| performance | 1/1 passed — `nccl-all-reduce-bw-nvls` at 742.65 GB/s against the `>= 600` floor |

Conformance included `robust-controller`, which is the check #2564 flagged as unexercised on VR hardware. It took the `kubeflow-trainer` branch rather than skipping: controller Deployment 1/1 (`trainer-controller-manager:v2.2.0`) in namespace `kubeflow`, `validator.trainer.kubeflow.org` webhook reachable with live endpoint slices, `trainjobs.trainer.kubeflow.org` CRD present, and an invalid TrainJob rejected with a real `403 Forbidden` from the admission webhook.

**Signing.** Signed by the fork's `evidence-publish` workflow using the runner's ambient OIDC identity, so the source slug is the already-allowlisted `5bf9e82f0e90a11528ac85f4bcb866c8` and no personal identity is written into the public Rekor log. Rekor log index `105832365`.

**Follow-up, deliberately not in this PR.** The `pkg/testgrid/presence.yaml` entry and the doc change from `pending` to a live `validation.aicr.run` link come after this merges — the dashboard only serves the coordinate once `Evidence: Ingest` runs on merge, and `presence.yaml` requires confirming the route serves real data before adding it.

## Testing

```bash
aicr evidence verify recipes/evidence/vr200-rke2-ubuntu-training-kubeflow/5bf9e82f0e90a11528ac85f4bcb866c8/sha256-cab912550bf2999744b2c685f40cd96ec010bf7e615da59847ce55090cae4bae.yaml
```

All five steps pass — materialize-bundle, signature-verify, predicate-parse, manifest-hash-check, render-summary. **Verdict: bundle valid (exit 0).** The `Enforce per-source pointer contract` gate has since run in CI and **passed**, as did `Verify recipe evidence`.

No `make qualify` run: this PR adds a single machine-generated YAML pointer and changes no Go, recipe, or build input, so the code gates cannot regress from it. The evidence-specific gates in CI are the meaningful checks here.

## Risk Assessment

- [x] **Low** — Isolated change, well-tested, easy to revert
- [ ] **Medium** — Touches multiple components or has broader impact
- [ ] **High** — Breaking change, affects critical paths, or complex rollout

**Rollout notes:** Additive. One new pointer file under an existing allowlisted source slug; no existing evidence, recipe, or doc changes. On merge, `Evidence: Ingest` publishes to GCS and re-dispatches the dashboard build.

## Checklist

- [ ] Tests pass locally (`make test` with `-race`) — N/A, no code change
- [ ] Linter passes (`make lint`) — N/A, machine-generated pointer
- [x] I did not skip/disable tests to make CI green
- [ ] I added/updated tests for new functionality — N/A
- [x] I updated docs if user-facing behavior changed — doc link follows once the dashboard serves the coordinate, see above
- [x] Changes follow existing patterns in the codebase
- [x] Commits are cryptographically signed (`git commit -S`)
